### PR TITLE
Add folder stacks popup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,7 @@ jobs:
           PYTHON_PKG="$(choose_pkg python313 python312 python311 python3)"
           PYTHON_DEV_PKG="$(choose_pkg python313-devel python312-devel python311-devel python3-devel)"
           PYTHON_PIP_PKG="$(choose_pkg python313-pip python312-pip python311-pip python3-pip)"
+          PANGOCAIRO_TYPELIB_PKG="$(choose_pkg typelib-1_0-PangoCairo-1_0 || true)"
           zypper --non-interactive install --no-recommends \
             git \
             gcc \
@@ -394,7 +395,8 @@ jobs:
             typelib-1_0-Wnck-3_0 \
             gdk-pixbuf-loader-rsvg librsvg \
             xauth xorg-x11-server-Xvfb \
-            adwaita-icon-theme hicolor-icon-theme
+            adwaita-icon-theme hicolor-icon-theme \
+            ${PANGOCAIRO_TYPELIB_PKG:+$PANGOCAIRO_TYPELIB_PKG}
 
       - name: Install project
         run: |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Docking is built around a few core capabilities:
 - Fast launcher workflow with running-state indicators and preview interactions.
 - Flexible layout with multi-position, multi-monitor, auto-hide, and drag-and-drop organization.
 - Broad customization through themes, icon sizing, menu options, and tooltip controls.
-- Native support for pinned files/folders, including stack-style folder menus.
+- Native support for pinned files/folders, including left-click folder stacks.
 - Extensible applet surface for system status, productivity, media, and utilities.
 
 Highlights:

--- a/docking/locale/af/LC_MESSAGES/docking.po
+++ b/docking/locale/af/LC_MESSAGES/docking.po
@@ -1088,6 +1088,15 @@ msgid "Folder is empty"
 msgstr "Folder is empty"
 
 #: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
 msgid "Open Folder"
 msgstr "Open Folder"
 

--- a/docking/locale/af/LC_MESSAGES/docking.po
+++ b/docking/locale/af/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Speel: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Soek stad"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Tik stadnaam in..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Skerm {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/am/LC_MESSAGES/docking.po
+++ b/docking/locale/am/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "በማጫወት ላይ: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "መተግበሪያዎች"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "ብሩህነት: {pct}%"
 msgid "Show Level"
 msgstr "ደረጃ አሳይ"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "ቀን መቁጠሪያ"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "ኔትወርክ: አልተገናኘም"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "ማሳወቂያዎች"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "ምንም የማሳወቂያ ባክኤንድ አይገኝም"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "አትረብሽ"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "በመጠባበቅ ላይ: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "ታሪክ አጽዳ"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "ማሳወቂያዎችን አጽዳ"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "ድምጽ ተዘግቷል"
 msgid "Volume: {pct}%"
 msgstr "ድምጽ: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "የአየር ሁኔታ"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "ሙቀት አሳይ"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "ከተማ ፈልግ"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "የከተማ ስም ይተይቡ..."
 
@@ -1059,84 +1059,101 @@ msgstr "ድረ-ገጽ"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "ከዶክ አስወግድ"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "በዶክ ውስጥ አቆይ"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "ሁሉንም ዝጋ"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "ዝጋ"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "አፕሌቶች"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "የኃይል መገለጫዎች አይገኙም"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "መለያ ጨምር"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "ስለ"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "ውጣ"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "መስኮት"
 
@@ -1145,137 +1162,137 @@ msgstr "መስኮት"
 msgid "Display {display}: {width}x{height}"
 msgstr "ማሳያ {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "አፕሌቶች"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "በራስ-ደበቅ"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "የአዶ መጠን"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "የመስኮት ቅድመ-እይታ"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "ቦታ"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "ጠቋሚን ተከተል"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "የአሁኑ የሥራ ቦታ ብቻ"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "አፕሌቶችን ወደ መጨረሻ ሰካ"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "ምክሮች"
+

--- a/docking/locale/am/LC_MESSAGES/docking.po
+++ b/docking/locale/am/LC_MESSAGES/docking.po
@@ -1088,6 +1088,15 @@ msgid "Folder is empty"
 msgstr "Folder is empty"
 
 #: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
 msgid "Open Folder"
 msgstr "Open Folder"
 

--- a/docking/locale/ar/LC_MESSAGES/docking.po
+++ b/docking/locale/ar/LC_MESSAGES/docking.po
@@ -1088,6 +1088,15 @@ msgid "Folder is empty"
 msgstr "Folder is empty"
 
 #: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
 msgid "Open Folder"
 msgstr "Open Folder"
 

--- a/docking/locale/ar/LC_MESSAGES/docking.po
+++ b/docking/locale/ar/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "تشغيل: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "تطبيقات"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "السطوع: {pct}%"
 msgid "Show Level"
 msgstr "عرض المستوى"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "تقويم"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "الشبكة: غير متصل"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "إشعارات"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "لا يوجد نظام إشعارات"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "عدم الإزعاج"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "معلق: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "مسح السجل"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "مسح الإشعارات"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "صامت"
 msgid "Volume: {pct}%"
 msgstr "مستوى الصوت: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "الطقس"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "عرض الحرارة"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "البحث عن المدينة"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "اكتب اسم المدينة..."
 
@@ -1059,84 +1059,101 @@ msgstr "موقع إلكتروني"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "إزالة من الشريط"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "الاحتفاظ في الشريط"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "إغلاق الكل"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "إغلاق"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "تطبيقات مصغرة"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "ملفات الطاقة غير متاحة"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "إضافة فاصل"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "حول"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "خروج"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "نافذة"
 
@@ -1145,137 +1162,137 @@ msgstr "نافذة"
 msgid "Display {display}: {width}x{height}"
 msgstr "شاشة {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "تطبيقات مصغرة"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "إخفاء تلقائي"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "حجم الأيقونة"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "معاينة النوافذ"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "موضع"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "تتبع المؤشر"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "مساحة العمل الحالية فقط"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "تثبيت التطبيقات المصغرة في النهاية"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1296,3 +1313,4 @@ msgstr ""
 #, python-brace-format
 #~ msgid "WiFi: {ssid}"
 #~ msgstr "واي فاي: {ssid}"
+

--- a/docking/locale/az/LC_MESSAGES/docking.po
+++ b/docking/locale/az/LC_MESSAGES/docking.po
@@ -1087,6 +1087,15 @@ msgid "Folder is empty"
 msgstr "Folder is empty"
 
 #: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
 msgid "Open Folder"
 msgstr "Open Folder"
 

--- a/docking/locale/az/LC_MESSAGES/docking.po
+++ b/docking/locale/az/LC_MESSAGES/docking.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,38 +20,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -110,7 +110,7 @@ msgstr "Oxunur: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Tətbiqlər"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -291,12 +291,12 @@ msgstr "Parlaqlıq: {pct}%"
 msgid "Show Level"
 msgstr "Səviyyəni Göstər"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Təqvim"
 
@@ -547,30 +547,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Şəbəkə: Qoşulmayıb"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Bildirişlər"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "Bildiriş arxa planı mövcud deyil"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Narahat Etməyin"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Gözləyən: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Tarixçəni Təmizlə"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Bildirişləri Təmizlə"
 
@@ -935,16 +935,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -984,28 +984,28 @@ msgstr "Səssiz"
 msgid "Volume: {pct}%"
 msgstr "Səs: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Hava"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Temperaturu Göstər"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Şəhər axtar"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Şəhər adını yazın..."
 
@@ -1058,84 +1058,101 @@ msgstr "Veb-sayt"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Dokdan Sil"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Dokda Saxla"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Hamısını Bağla"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Bağla"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Appletlər"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Enerji Profilləri mövcud deyil"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Ayırıcı Əlavə Et"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "Haqqında"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Çıx"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Pəncərə"
 
@@ -1144,137 +1161,137 @@ msgstr "Pəncərə"
 msgid "Display {display}: {width}x{height}"
 msgstr "Ekran {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Appletlər"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Avtogizlə"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Nişan Ölçüsü"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Pəncərə Önbaxışları"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Mövqe"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Kursoru İzlə"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Yalnız Cari İş Sahəsi"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Appletləri Sona Bərkid"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1291,3 +1308,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "İpucları"
+

--- a/docking/locale/be/LC_MESSAGES/docking.po
+++ b/docking/locale/be/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Прайграванне: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Пошук горада"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Увядзіце назву горада..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Дысплей {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/be/LC_MESSAGES/docking.po
+++ b/docking/locale/be/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/bg/LC_MESSAGES/docking.po
+++ b/docking/locale/bg/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/bg/LC_MESSAGES/docking.po
+++ b/docking/locale/bg/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Възпроизвежда се: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Търсене на град"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Въведете име на град..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Дисплей {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/bn/LC_MESSAGES/docking.po
+++ b/docking/locale/bn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/bn/LC_MESSAGES/docking.po
+++ b/docking/locale/bn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "চলছে: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "শহর খুঁজুন"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "শহরের নাম লিখুন..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "ডিসপ্লে {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/bs/LC_MESSAGES/docking.po
+++ b/docking/locale/bs/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/bs/LC_MESSAGES/docking.po
+++ b/docking/locale/bs/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Reproducira se: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Traži grad"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Unesite ime grada..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Ekran {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/ca/LC_MESSAGES/docking.po
+++ b/docking/locale/ca/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Reproduint: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Cerca la ciutat"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Escriu el nom de la ciutat..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Pantalla {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/ca/LC_MESSAGES/docking.po
+++ b/docking/locale/ca/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/cs/LC_MESSAGES/docking.po
+++ b/docking/locale/cs/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Přehrávání: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Aplikace"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Jas: {pct}%"
 msgid "Show Level"
 msgstr "Zobrazit úroveň"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Kalendář"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Síť: Nepřipojeno"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Oznámení"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "Žádný backend pro oznámení"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Nerušit"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Čekající: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Vymazat historii"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Vymazat oznámení"
 
@@ -937,16 +937,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -986,28 +986,28 @@ msgstr "Ztlumeno"
 msgid "Volume: {pct}%"
 msgstr "Hlasitost: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Počasí"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Zobrazit teplotu"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Hledat město"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Zadejte název města..."
 
@@ -1060,84 +1060,101 @@ msgstr "Webové stránky"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Odebrat z doku"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Ponechat v doku"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Zavřít vše"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Zavřít"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Aplety"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Profily napájení nedostupné"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Přidat oddělovač"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "O aplikaci"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Ukončit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Okno"
 
@@ -1146,137 +1163,137 @@ msgstr "Okno"
 msgid "Display {display}: {width}x{height}"
 msgstr "Displej {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Aplety"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Automaticky skrývat"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Velikost ikon"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Náhledy oken"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Pozice"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Sledovat kurzor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Pouze aktuální plocha"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Ukotvit aplety na konec"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1293,3 +1310,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Popisky"
+

--- a/docking/locale/cs/LC_MESSAGES/docking.po
+++ b/docking/locale/cs/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1088,73 +1088,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Odebrat z doku"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Ponechat v doku"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Zavřít vše"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Zavřít"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Aplety"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Profily napájení nedostupné"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Přidat oddělovač"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "O aplikaci"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Ukončit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Okno"
 

--- a/docking/locale/cy/LC_MESSAGES/docking.po
+++ b/docking/locale/cy/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/cy/LC_MESSAGES/docking.po
+++ b/docking/locale/cy/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Chwarae: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Chwilio am ddinas"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Teipiwch enw'r ddinas..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Arddangosfa {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/da/LC_MESSAGES/docking.po
+++ b/docking/locale/da/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/da/LC_MESSAGES/docking.po
+++ b/docking/locale/da/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Afspiller: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Søg efter by"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Indtast bynavn..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Skærm {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/de/LC_MESSAGES/docking.po
+++ b/docking/locale/de/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Aus Dock entfernen"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Im Dock behalten"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Alle schließen"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Schließen"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Energieprofile nicht verfügbar"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Trennlinie hinzufügen"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "Über"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Beenden"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Fenster"
 

--- a/docking/locale/de/LC_MESSAGES/docking.po
+++ b/docking/locale/de/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Wiedergabe: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Anwendungen"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Helligkeit: {pct}%"
 msgid "Show Level"
 msgstr "Stufe anzeigen"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Kalender"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Netzwerk: Nicht verbunden"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Benachrichtigungen"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "Kein Benachrichtigungs-Backend"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Nicht stören"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Ausstehend: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Verlauf leeren"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Benachrichtigungen leeren"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Stumm"
 msgid "Volume: {pct}%"
 msgstr "Lautstärke: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Wetter"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Temperatur anzeigen"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Stadt suchen"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Stadtname eingeben..."
 
@@ -1059,84 +1059,101 @@ msgstr "Webseite"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Aus Dock entfernen"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Im Dock behalten"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Alle schließen"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Schließen"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Energieprofile nicht verfügbar"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Trennlinie hinzufügen"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "Über"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Beenden"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Fenster"
 
@@ -1145,137 +1162,137 @@ msgstr "Fenster"
 msgid "Display {display}: {width}x{height}"
 msgstr "Bildschirm {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Automatisch ausblenden"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Symbolgröße"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Fenstervorschau"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Cursor folgen"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Nur aktueller Arbeitsbereich"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Applets am Ende verankern"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1296,3 +1313,4 @@ msgstr ""
 #, python-brace-format
 #~ msgid "WiFi: {ssid}"
 #~ msgstr "WiFi: {ssid}"
+

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1088,73 +1088,83 @@ msgstr ""
 msgid "Folder is empty"
 msgstr ""
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr ""
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr ""
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr ""
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr ""
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr ""
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr ""
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr ""
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr ""
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr ""
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr ""
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr ""
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr ""
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr ""
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr ""
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr ""
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr ""
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr ""
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr ""
 

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,38 +22,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr ""
@@ -112,7 +112,7 @@ msgstr ""
 msgid "Applications"
 msgstr ""
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr ""
 
@@ -293,12 +293,12 @@ msgstr ""
 msgid "Show Level"
 msgstr ""
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr ""
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr ""
 
@@ -549,30 +549,30 @@ msgstr ""
 msgid "Network: Not connected"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr ""
 
@@ -937,16 +937,16 @@ msgstr ""
 msgid "Correct: {answer}"
 msgstr ""
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr ""
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr ""
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr ""
 
@@ -986,28 +986,28 @@ msgstr ""
 msgid "Volume: {pct}%"
 msgstr ""
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr ""
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr ""
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr ""
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr ""
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr ""
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr ""
 
@@ -1060,84 +1060,101 @@ msgstr ""
 msgid "Docking"
 msgstr ""
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr ""
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr ""
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr ""
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr ""
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr ""
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr ""
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr ""
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr ""
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr ""
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr ""
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr ""
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr ""
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr ""
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr ""
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr ""
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr ""
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr ""
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr ""
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr ""
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr ""
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr ""
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr ""
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr ""
 
@@ -1146,136 +1163,136 @@ msgstr ""
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr ""
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr ""
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr ""
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr ""
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr ""
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/el/LC_MESSAGES/docking.po
+++ b/docking/locale/el/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Αναπαραγωγή: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Αναζήτηση πόλης"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Πληκτρολογήστε όνομα πόλης..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Οθόνη {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/el/LC_MESSAGES/docking.po
+++ b/docking/locale/el/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/en_GB/LC_MESSAGES/docking.po
+++ b/docking/locale/en_GB/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/en_GB/LC_MESSAGES/docking.po
+++ b/docking/locale/en_GB/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Playing: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Search for the city"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Type city name..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Display {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/eo/LC_MESSAGES/docking.po
+++ b/docking/locale/eo/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/eo/LC_MESSAGES/docking.po
+++ b/docking/locale/eo/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Ludante: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Serĉi urbon"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Tajpu urbonomon..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Ekrano {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/es/LC_MESSAGES/docking.po
+++ b/docking/locale/es/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Reproduciendo: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Aplicaciones"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brillo: {pct}%"
 msgid "Show Level"
 msgstr "Mostrar Nivel"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendario"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Red: No conectada"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notificaciones"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "Sin backend de notificaciones"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "No Molestar"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pendientes: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Limpiar Historial"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Limpiar Notificaciones"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Silenciado"
 msgid "Volume: {pct}%"
 msgstr "Volumen: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Clima"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Mostrar Temperatura"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Buscar ciudad"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Escribir nombre de ciudad..."
 
@@ -1059,84 +1059,101 @@ msgstr "Sitio Web"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Quitar del Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Mantener en el Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Cerrar Todo"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Cerrar"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Perfiles de Energía no disponibles"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Agregar Separador"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "Acerca de"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Salir"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Ventana"
 
@@ -1145,137 +1162,137 @@ msgstr "Ventana"
 msgid "Display {display}: {width}x{height}"
 msgstr "Pantalla {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Ocultar automáticamente"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Tamaño del Ícono"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Vista Previa de Ventanas"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Posición"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Seguir cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Solo espacio de trabajo actual"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anclar applets al final"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1296,3 +1313,4 @@ msgstr ""
 #, python-brace-format
 #~ msgid "WiFi: {ssid}"
 #~ msgstr "WiFi: {ssid}"
+

--- a/docking/locale/es/LC_MESSAGES/docking.po
+++ b/docking/locale/es/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Quitar del Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Mantener en el Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Cerrar Todo"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Cerrar"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Perfiles de Energía no disponibles"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Agregar Separador"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "Acerca de"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Salir"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Ventana"
 

--- a/docking/locale/et/LC_MESSAGES/docking.po
+++ b/docking/locale/et/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/et/LC_MESSAGES/docking.po
+++ b/docking/locale/et/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Esitamine: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Otsi linna"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Sisesta linna nimi..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Kuvar {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/eu/LC_MESSAGES/docking.po
+++ b/docking/locale/eu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/eu/LC_MESSAGES/docking.po
+++ b/docking/locale/eu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Erreproduzitzen: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Bilatu hiria"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Idatzi hiri izena..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Pantaila {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/fa/LC_MESSAGES/docking.po
+++ b/docking/locale/fa/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/fa/LC_MESSAGES/docking.po
+++ b/docking/locale/fa/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "در حال پخش: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "جستجوی شهر"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "نام شهر را وارد کنید..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "نمایشگر {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/fi/LC_MESSAGES/docking.po
+++ b/docking/locale/fi/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/fi/LC_MESSAGES/docking.po
+++ b/docking/locale/fi/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Toistetaan: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Etsi kaupunki"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Kirjoita kaupungin nimi..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Näyttö {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/fil/LC_MESSAGES/docking.po
+++ b/docking/locale/fil/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/fil/LC_MESSAGES/docking.po
+++ b/docking/locale/fil/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Nagpe-play: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Maghanap ng lungsod"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "I-type ang pangalan ng lungsod..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Display {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/fr/LC_MESSAGES/docking.po
+++ b/docking/locale/fr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Retirer du Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Garder dans le Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Tout Fermer"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Fermer"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Profils d'énergie indisponibles"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Ajouter un Séparateur"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "À propos"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quitter"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Fenêtre"
 

--- a/docking/locale/fr/LC_MESSAGES/docking.po
+++ b/docking/locale/fr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Lecture : {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Luminosité : {pct}%"
 msgid "Show Level"
 msgstr "Afficher le Niveau"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendrier"
 
@@ -548,30 +548,30 @@ msgstr "IP : {ip}"
 msgid "Network: Not connected"
 msgstr "Réseau : Non connecté"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "Aucun backend de notification"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Ne Pas Déranger"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "En attente : {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Effacer l'Historique"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Effacer les Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muet"
 msgid "Volume: {pct}%"
 msgstr "Volume : {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Météo"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Afficher la Température"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Rechercher la ville"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Saisir le nom de la ville..."
 
@@ -1059,84 +1059,101 @@ msgstr "Site Web"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Retirer du Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Garder dans le Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Tout Fermer"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Fermer"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Profils d'énergie indisponibles"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Ajouter un Séparateur"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "À propos"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quitter"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Fenêtre"
 
@@ -1145,137 +1162,137 @@ msgstr "Fenêtre"
 msgid "Display {display}: {width}x{height}"
 msgstr "Écran {display} : {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Masquer automatiquement"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Taille des Icônes"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Aperçu des Fenêtres"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Suivre le curseur"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Espace de travail actuel uniquement"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Ancrer les applets à la fin"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1296,3 +1313,4 @@ msgstr ""
 #, python-brace-format
 #~ msgid "WiFi: {ssid}"
 #~ msgstr "WiFi : {ssid}"
+

--- a/docking/locale/ga/LC_MESSAGES/docking.po
+++ b/docking/locale/ga/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/ga/LC_MESSAGES/docking.po
+++ b/docking/locale/ga/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Ag seinm: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Cuardaigh cathair"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Clóscríobh ainm cathrach..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Scáileán {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/gl/LC_MESSAGES/docking.po
+++ b/docking/locale/gl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/gl/LC_MESSAGES/docking.po
+++ b/docking/locale/gl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Reproducindo: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Buscar cidade"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Escribir nome da cidade..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Pantalla {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/gu/LC_MESSAGES/docking.po
+++ b/docking/locale/gu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/gu/LC_MESSAGES/docking.po
+++ b/docking/locale/gu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "વગાડી રહ્યું છે: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "શહેર શોધો"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "શહેરનું નામ લખો..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "ડિસ્પ્લે {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/he/LC_MESSAGES/docking.po
+++ b/docking/locale/he/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/he/LC_MESSAGES/docking.po
+++ b/docking/locale/he/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "מנגן: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "חפש עיר"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "הקלד שם עיר..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "מסך {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/hi/LC_MESSAGES/docking.po
+++ b/docking/locale/hi/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "डॉक से हटाएँ"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "डॉक में रखें"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "सभी बंद करें"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "बंद करें"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "एप्लेट"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "पावर प्रोफाइल अनुपलब्ध"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "विभाजक जोड़ें"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "के बारे में"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "बाहर निकलें"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "विंडो"
 

--- a/docking/locale/hi/LC_MESSAGES/docking.po
+++ b/docking/locale/hi/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "चल रहा है: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "अनुप्रयोग"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "चमक: {pct}%"
 msgid "Show Level"
 msgstr "स्तर दिखाएँ"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "कैलेंडर"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "नेटवर्क: कनेक्ट नहीं"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "सूचनाएँ"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "कोई सूचना बैकएंड नहीं"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "परेशान न करें"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "लंबित: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "इतिहास साफ़ करें"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "सूचनाएँ साफ़ करें"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "म्यूट"
 msgid "Volume: {pct}%"
 msgstr "ध्वनि: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "मौसम"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "तापमान दिखाएँ"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "शहर खोजें"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "शहर का नाम लिखें..."
 
@@ -1059,84 +1059,101 @@ msgstr "वेबसाइट"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "डॉक से हटाएँ"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "डॉक में रखें"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "सभी बंद करें"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "बंद करें"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "एप्लेट"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "पावर प्रोफाइल अनुपलब्ध"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "विभाजक जोड़ें"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "के बारे में"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "बाहर निकलें"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "विंडो"
 
@@ -1145,137 +1162,137 @@ msgstr "विंडो"
 msgid "Display {display}: {width}x{height}"
 msgstr "डिस्प्ले {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "एप्लेट"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "स्वतः छिपाएँ"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "आइकन आकार"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "विंडो पूर्वावलोकन"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "स्थिति"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "कर्सर का अनुसरण करें"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "केवल वर्तमान कार्यक्षेत्र"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "ऐपलेट्स को अंत में एंकर करें"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1296,3 +1313,4 @@ msgstr ""
 #, python-brace-format
 #~ msgid "WiFi: {ssid}"
 #~ msgstr "WiFi: {ssid}"
+

--- a/docking/locale/hr/LC_MESSAGES/docking.po
+++ b/docking/locale/hr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Reproducira se: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Traži grad"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Unesite ime grada..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Zaslon {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/hr/LC_MESSAGES/docking.po
+++ b/docking/locale/hr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/hu/LC_MESSAGES/docking.po
+++ b/docking/locale/hu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/hu/LC_MESSAGES/docking.po
+++ b/docking/locale/hu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Lejátszás: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Város keresése"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Város nevének beírása..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Kijelző {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/id/LC_MESSAGES/docking.po
+++ b/docking/locale/id/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1086,73 +1086,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/id/LC_MESSAGES/docking.po
+++ b/docking/locale/id/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Memutar: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -935,16 +935,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -984,28 +984,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Cari kota"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Ketik nama kota..."
 
@@ -1058,84 +1058,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1144,137 +1161,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Layar {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1291,3 +1308,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/is/LC_MESSAGES/docking.po
+++ b/docking/locale/is/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/is/LC_MESSAGES/docking.po
+++ b/docking/locale/is/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Spilar: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Leita að borg"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Sláðu inn borgarheiti..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Skjár {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/it/LC_MESSAGES/docking.po
+++ b/docking/locale/it/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: 2026-03-06 12:00+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Rimuovi dal Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Mantieni nel Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Chiudi tutto"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Chiudi"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applet"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Profili energetici non disponibili"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Aggiungi separatore"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "Informazioni"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Esci"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Finestra"
 

--- a/docking/locale/it/LC_MESSAGES/docking.po
+++ b/docking/locale/it/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: 2026-03-06 12:00+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Riproduzione: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applicazioni"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Luminosita: {pct}%"
 msgid "Show Level"
 msgstr "Mostra livello"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendario"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Rete: Non connesso"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifiche"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "Nessun backend di notifica disponibile"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Non disturbare"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "In attesa: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Cancella cronologia"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Cancella notifiche"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Disattivato"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Meteo"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Mostra temperatura"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Cerca la citta"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Digita il nome della citta..."
 
@@ -1059,84 +1059,101 @@ msgstr "Sito web"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Rimuovi dal Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Mantieni nel Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Chiudi tutto"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Chiudi"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applet"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Profili energetici non disponibili"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Aggiungi separatore"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "Informazioni"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Esci"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Finestra"
 
@@ -1145,137 +1162,137 @@ msgstr "Finestra"
 msgid "Display {display}: {width}x{height}"
 msgstr "Schermo {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applet"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Nascondi automaticamente"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Dimensione icone"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Anteprime finestre"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Posizione"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Segui cursore"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Solo area di lavoro corrente"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Ancora applet alla fine"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Suggerimenti"
+

--- a/docking/locale/ja/LC_MESSAGES/docking.po
+++ b/docking/locale/ja/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1086,73 +1086,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Dockから削除"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Dockに残す"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "すべて閉じる"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "閉じる"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "アプレット"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "電力プロファイル利用不可"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "セパレーターを追加"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "について"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "終了"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "ウィンドウ"
 

--- a/docking/locale/ja/LC_MESSAGES/docking.po
+++ b/docking/locale/ja/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "再生中: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "アプリケーション"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "明るさ：{pct}%"
 msgid "Show Level"
 msgstr "レベルを表示"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "カレンダー"
 
@@ -548,30 +548,30 @@ msgstr "IP：{ip}"
 msgid "Network: Not connected"
 msgstr "ネットワーク：未接続"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "通知"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "通知バックエンドなし"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "おやすみモード"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "保留中：{n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "履歴をクリア"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "通知をクリア"
 
@@ -935,16 +935,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -984,28 +984,28 @@ msgstr "ミュート"
 msgid "Volume: {pct}%"
 msgstr "音量：{pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "天気"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "温度を表示"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "都市を検索"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "都市名を入力..."
 
@@ -1058,84 +1058,101 @@ msgstr "ウェブサイト"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Dockから削除"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Dockに残す"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "すべて閉じる"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "閉じる"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "アプレット"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "電力プロファイル利用不可"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "セパレーターを追加"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "について"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "終了"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "ウィンドウ"
 
@@ -1144,137 +1161,137 @@ msgstr "ウィンドウ"
 msgid "Display {display}: {width}x{height}"
 msgstr "ディスプレイ {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "アプレット"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "自動非表示"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "アイコンサイズ"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "ウィンドウプレビュー"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "位置"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "カーソルに追従"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "現在のワークスペースのみ"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "アプレットを末尾に固定"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1295,3 +1312,4 @@ msgstr ""
 #, python-brace-format
 #~ msgid "WiFi: {ssid}"
 #~ msgstr "WiFi：{ssid}"
+

--- a/docking/locale/jv/LC_MESSAGES/docking.po
+++ b/docking/locale/jv/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/jv/LC_MESSAGES/docking.po
+++ b/docking/locale/jv/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Muter: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Goleki kutha"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Ketik jeneng kutha..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Layar {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/kk/LC_MESSAGES/docking.po
+++ b/docking/locale/kk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/kk/LC_MESSAGES/docking.po
+++ b/docking/locale/kk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Ойнатылуда: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Қала іздеу"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Қала атын жазыңыз..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Дисплей {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/km/LC_MESSAGES/docking.po
+++ b/docking/locale/km/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/km/LC_MESSAGES/docking.po
+++ b/docking/locale/km/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "កំពុងចាក់: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "ស្វែងរកក្រុង"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "វាយឈ្មោះក្រុង..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "អេក្រង់ {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/kn/LC_MESSAGES/docking.po
+++ b/docking/locale/kn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/kn/LC_MESSAGES/docking.po
+++ b/docking/locale/kn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "ಪ್ಲೇ ಆಗುತ್ತಿದೆ: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "ನಗರ ಹುಡುಕಿ"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "ನಗರದ ಹೆಸರು ಟೈಪ್ ಮಾಡಿ..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "ಡಿಸ್ಪ್ಲೇ {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/ko/LC_MESSAGES/docking.po
+++ b/docking/locale/ko/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1086,73 +1086,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Dock에서 제거"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Dock에 유지"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "모두 닫기"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "닫기"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "애플릿"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "전원 프로필 사용 불가"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "구분선 추가"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "정보"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "종료"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "창"
 

--- a/docking/locale/ko/LC_MESSAGES/docking.po
+++ b/docking/locale/ko/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "재생 중: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "애플리케이션"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "밝기: {pct}%"
 msgid "Show Level"
 msgstr "레벨 표시"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "달력"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "네트워크: 연결 안 됨"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "알림"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "알림 백엔드 없음"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "방해 금지"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "대기 중: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "기록 지우기"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "알림 지우기"
 
@@ -935,16 +935,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -984,28 +984,28 @@ msgstr "음소거"
 msgid "Volume: {pct}%"
 msgstr "볼륨: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "날씨"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "온도 표시"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "도시 검색"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "도시 이름 입력..."
 
@@ -1058,84 +1058,101 @@ msgstr "웹사이트"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Dock에서 제거"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Dock에 유지"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "모두 닫기"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "닫기"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "애플릿"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "전원 프로필 사용 불가"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "구분선 추가"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "정보"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "종료"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "창"
 
@@ -1144,137 +1161,137 @@ msgstr "창"
 msgid "Display {display}: {width}x{height}"
 msgstr "디스플레이 {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "애플릿"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "자동 숨기기"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "아이콘 크기"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "창 미리보기"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "위치"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "커서 따라가기"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "현재 작업 공간만"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "애플릿을 끝에 고정"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1295,3 +1312,4 @@ msgstr ""
 #, python-brace-format
 #~ msgid "WiFi: {ssid}"
 #~ msgstr "WiFi: {ssid}"
+

--- a/docking/locale/lt/LC_MESSAGES/docking.po
+++ b/docking/locale/lt/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/lt/LC_MESSAGES/docking.po
+++ b/docking/locale/lt/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Groja: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Ieškoti miesto"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Įveskite miesto pavadinimą..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Ekranas {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/lv/LC_MESSAGES/docking.po
+++ b/docking/locale/lv/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/lv/LC_MESSAGES/docking.po
+++ b/docking/locale/lv/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Atskaņo: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Meklēt pilsētu"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Ievadiet pilsētas nosaukumu..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Displejs {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/mk/LC_MESSAGES/docking.po
+++ b/docking/locale/mk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/mk/LC_MESSAGES/docking.po
+++ b/docking/locale/mk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Репродукција: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Пребарај град"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Внесете име на град..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Екран {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/ml/LC_MESSAGES/docking.po
+++ b/docking/locale/ml/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "പ്ലേ ചെയ്യുന്നു: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "നഗരം തിരയുക"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "നഗരത്തിന്റെ പേര് ടൈപ്പ് ചെയ്യുക..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "ഡിസ്പ്ലേ {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/ml/LC_MESSAGES/docking.po
+++ b/docking/locale/ml/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/mn/LC_MESSAGES/docking.po
+++ b/docking/locale/mn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/mn/LC_MESSAGES/docking.po
+++ b/docking/locale/mn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Тоглуулж байна: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Хот хайх"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Хотын нэр бичнэ үү..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Дэлгэц {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/mr/LC_MESSAGES/docking.po
+++ b/docking/locale/mr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/mr/LC_MESSAGES/docking.po
+++ b/docking/locale/mr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "प्ले होत आहे: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "शहर शोधा"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "शहराचे नाव टाइप करा..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "डिस्प्ले {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/ms/LC_MESSAGES/docking.po
+++ b/docking/locale/ms/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1086,73 +1086,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/ms/LC_MESSAGES/docking.po
+++ b/docking/locale/ms/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Memainkan: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -935,16 +935,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -984,28 +984,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Cari bandar"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Taip nama bandar..."
 
@@ -1058,84 +1058,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1144,137 +1161,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Paparan {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1291,3 +1308,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/mt/LC_MESSAGES/docking.po
+++ b/docking/locale/mt/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/mt/LC_MESSAGES/docking.po
+++ b/docking/locale/mt/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Qed jintlaab: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Fittex belt"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Ikteb isem il-belt..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Skrin {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/nb/LC_MESSAGES/docking.po
+++ b/docking/locale/nb/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/nb/LC_MESSAGES/docking.po
+++ b/docking/locale/nb/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Spiller: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Søk etter by"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Skriv inn bynavn..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Skjerm {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/ne/LC_MESSAGES/docking.po
+++ b/docking/locale/ne/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/ne/LC_MESSAGES/docking.po
+++ b/docking/locale/ne/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "बजिरहेको छ: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "शहर खोज्नुहोस्"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "शहरको नाम टाइप गर्नुहोस्..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "डिस्प्ले {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/nl/LC_MESSAGES/docking.po
+++ b/docking/locale/nl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Verwijderen van dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Bewaren in dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Alles sluiten"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Sluiten"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Energieprofielen niet beschikbaar"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Scheidingsteken toevoegen"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "Over"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Afsluiten"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Venster"
 

--- a/docking/locale/nl/LC_MESSAGES/docking.po
+++ b/docking/locale/nl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Afspelen: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Toepassingen"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Helderheid: {pct}%"
 msgid "Show Level"
 msgstr "Niveau tonen"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Kalender"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Netwerk: Niet verbonden"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Meldingen"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "Geen meldingsbackend beschikbaar"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Niet storen"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "In wachtrij: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Geschiedenis wissen"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Meldingen wissen"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Gedempt"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weer"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Temperatuur tonen"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Zoek de stad"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Typ stadsnaam..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Verwijderen van dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Bewaren in dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Alles sluiten"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Sluiten"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Energieprofielen niet beschikbaar"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Scheidingsteken toevoegen"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "Over"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Afsluiten"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Venster"
 
@@ -1145,137 +1162,137 @@ msgstr "Venster"
 msgid "Display {display}: {width}x{height}"
 msgstr "Beeldscherm {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Automatisch verbergen"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Pictogramgrootte"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Venstervoorbeelden"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Positie"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Cursor volgen"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Alleen huidige werkruimte"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Applets aan einde verankeren"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/nn/LC_MESSAGES/docking.po
+++ b/docking/locale/nn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Spelar: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Søk etter by"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Skriv inn bynamn..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Skjerm {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/nn/LC_MESSAGES/docking.po
+++ b/docking/locale/nn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/pa/LC_MESSAGES/docking.po
+++ b/docking/locale/pa/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/pa/LC_MESSAGES/docking.po
+++ b/docking/locale/pa/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "ਚੱਲ ਰਿਹਾ: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "ਸ਼ਹਿਰ ਖੋਜੋ"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "ਸ਼ਹਿਰ ਦਾ ਨਾਮ ਲਿਖੋ..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "ਡਿਸਪਲੇ {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/pl/LC_MESSAGES/docking.po
+++ b/docking/locale/pl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,38 +22,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -112,7 +112,7 @@ msgstr "Odtwarzanie: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Aplikacje"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -293,12 +293,12 @@ msgstr "Jasność: {pct}%"
 msgid "Show Level"
 msgstr "Pokaż poziom"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Kalendarz"
 
@@ -549,30 +549,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Sieć: Nie połączono"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Powiadomienia"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "Brak dostępnego backendu powiadomień"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Nie przeszkadzać"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Oczekujące: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Wyczyść historię"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Wyczyść powiadomienia"
 
@@ -938,16 +938,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -987,28 +987,28 @@ msgstr "Wyciszono"
 msgid "Volume: {pct}%"
 msgstr "Głośność: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Pogoda"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Pokaż temperaturę"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Szukaj miasta"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Wpisz nazwę miasta..."
 
@@ -1061,84 +1061,101 @@ msgstr "Strona internetowa"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Usuń z docka"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Zachowaj w docku"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Zamknij wszystko"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Zamknij"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Aplety"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Profile zasilania niedostępne"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Dodaj separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "O programie"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Zakończ"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Okno"
 
@@ -1147,137 +1164,137 @@ msgstr "Okno"
 msgid "Display {display}: {width}x{height}"
 msgstr "Wyświetlacz {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Aplety"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Automatyczne ukrywanie"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Rozmiar ikon"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Podgląd okien"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Pozycja"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Podążaj za kursorem"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Tylko bieżąca przestrzeń"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Zakotwicz aplety na końcu"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1294,3 +1311,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Podpowiedzi"
+

--- a/docking/locale/pl/LC_MESSAGES/docking.po
+++ b/docking/locale/pl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1089,73 +1089,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Usuń z docka"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Zachowaj w docku"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Zamknij wszystko"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Zamknij"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Aplety"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Profile zasilania niedostępne"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Dodaj separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "O programie"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Zakończ"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Okno"
 

--- a/docking/locale/pt_BR/LC_MESSAGES/docking.po
+++ b/docking/locale/pt_BR/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remover do Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Manter no Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Fechar Todas"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Fechar"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Perfis de Energia indisponíveis"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Adicionar Separador"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "Sobre"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Sair"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Janela"
 

--- a/docking/locale/pt_BR/LC_MESSAGES/docking.po
+++ b/docking/locale/pt_BR/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Reproduzindo: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Aplicativos"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brilho: {pct}%"
 msgid "Show Level"
 msgstr "Mostrar Nível"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendário"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Rede: Não conectada"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notificações"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "Nenhum backend de notificação"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Não Perturbe"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pendentes: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Limpar Histórico"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Limpar Notificações"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Mudo"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Clima"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Mostrar Temperatura"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Buscar cidade"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Digite o nome da cidade..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remover do Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Manter no Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Fechar Todas"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Fechar"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Perfis de Energia indisponíveis"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Adicionar Separador"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "Sobre"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Sair"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Janela"
 
@@ -1145,137 +1162,137 @@ msgstr "Janela"
 msgid "Display {display}: {width}x{height}"
 msgstr "Tela {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Ocultar automaticamente"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Tamanho do Ícone"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Pré-visualização de Janelas"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Posição"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Seguir cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Somente área de trabalho atual"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Ancorar applets ao final"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1296,3 +1313,4 @@ msgstr ""
 #, python-brace-format
 #~ msgid "WiFi: {ssid}"
 #~ msgstr "WiFi: {ssid}"
+

--- a/docking/locale/pt_PT/LC_MESSAGES/docking.po
+++ b/docking/locale/pt_PT/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/pt_PT/LC_MESSAGES/docking.po
+++ b/docking/locale/pt_PT/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "A reproduzir: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Procurar cidade"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Escreva o nome da cidade..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Ecrã {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/ro/LC_MESSAGES/docking.po
+++ b/docking/locale/ro/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Redare: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Căutare oraș"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Introduceți numele orașului..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Afișaj {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/ro/LC_MESSAGES/docking.po
+++ b/docking/locale/ro/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/ru/LC_MESSAGES/docking.po
+++ b/docking/locale/ru/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1089,73 +1089,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Убрать из дока"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Оставить в доке"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Закрыть все"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Закрыть"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Апплеты"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Профили питания недоступны"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Добавить разделитель"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "О программе"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Выход"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Окно"
 

--- a/docking/locale/ru/LC_MESSAGES/docking.po
+++ b/docking/locale/ru/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -22,38 +22,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -112,7 +112,7 @@ msgstr "Воспроизведение: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Приложения"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -293,12 +293,12 @@ msgstr "Яркость: {pct}%"
 msgid "Show Level"
 msgstr "Показать уровень"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Календарь"
 
@@ -549,30 +549,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Сеть: Не подключена"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Уведомления"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "Нет сервиса уведомлений"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Не беспокоить"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Ожидает: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Очистить историю"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Очистить уведомления"
 
@@ -938,16 +938,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -987,28 +987,28 @@ msgstr "Без звука"
 msgid "Volume: {pct}%"
 msgstr "Громкость: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Погода"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Показать температуру"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Поиск города"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Введите название города..."
 
@@ -1061,84 +1061,101 @@ msgstr "Сайт"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Убрать из дока"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Оставить в доке"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Закрыть все"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Закрыть"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Апплеты"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Профили питания недоступны"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Добавить разделитель"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "О программе"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Выход"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Окно"
 
@@ -1147,137 +1164,137 @@ msgstr "Окно"
 msgid "Display {display}: {width}x{height}"
 msgstr "Дисплей {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Апплеты"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Автоскрытие"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Размер значков"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Предпросмотр окон"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Расположение"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Следовать за курсором"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Только текущее рабочее пространство"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Закреплять апплеты в конце"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1298,3 +1315,4 @@ msgstr ""
 #, python-brace-format
 #~ msgid "WiFi: {ssid}"
 #~ msgstr "WiFi: {ssid}"
+

--- a/docking/locale/sk/LC_MESSAGES/docking.po
+++ b/docking/locale/sk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Prehrávanie: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Aplikácie"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Jas: {pct}%"
 msgid "Show Level"
 msgstr "Zobraziť úroveň"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Kalendár"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Sieť: Nepripojené"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Oznámenia"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "Žiadny backend pre oznámenia"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Nerušiť"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Čakajúce: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Vymazať históriu"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Vymazať oznámenia"
 
@@ -937,16 +937,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -986,28 +986,28 @@ msgstr "Stlmené"
 msgid "Volume: {pct}%"
 msgstr "Hlasitosť: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Počasie"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Zobraziť teplotu"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Hľadať mesto"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Zadajte názov mesta..."
 
@@ -1060,84 +1060,101 @@ msgstr "Webová stránka"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Odstrániť z doku"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Ponechať v doku"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Zavrieť všetko"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Zavrieť"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Aplety"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Profily napájania nedostupné"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Pridať oddeľovač"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "O aplikácii"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Ukončiť"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Okno"
 
@@ -1146,137 +1163,137 @@ msgstr "Okno"
 msgid "Display {display}: {width}x{height}"
 msgstr "Displej {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Aplety"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Automaticky skrývať"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Veľkosť ikon"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Náhľady okien"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Pozícia"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Sledovať kurzor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Iba aktuálna plocha"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Ukotviť aplety na koniec"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1293,3 +1310,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Popisky"
+

--- a/docking/locale/sk/LC_MESSAGES/docking.po
+++ b/docking/locale/sk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1088,73 +1088,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Odstrániť z doku"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Ponechať v doku"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Zavrieť všetko"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Zavrieť"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Aplety"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Profily napájania nedostupné"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Pridať oddeľovač"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "O aplikácii"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Ukončiť"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Okno"
 

--- a/docking/locale/sl/LC_MESSAGES/docking.po
+++ b/docking/locale/sl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/sl/LC_MESSAGES/docking.po
+++ b/docking/locale/sl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Predvajanje: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Iskanje mesta"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Vnesite ime mesta..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Zaslon {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/sq/LC_MESSAGES/docking.po
+++ b/docking/locale/sq/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Luhet: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Kërko qytetin"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Shkruaj emrin e qytetit..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Ekrani {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/sq/LC_MESSAGES/docking.po
+++ b/docking/locale/sq/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/sr/LC_MESSAGES/docking.po
+++ b/docking/locale/sr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/sr/LC_MESSAGES/docking.po
+++ b/docking/locale/sr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Репродукција: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Претрага града"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Унесите име града..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Екран {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/sv/LC_MESSAGES/docking.po
+++ b/docking/locale/sv/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/sv/LC_MESSAGES/docking.po
+++ b/docking/locale/sv/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Spelar: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Sök stad"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Ange stadsnamn..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Skärm {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/sw/LC_MESSAGES/docking.po
+++ b/docking/locale/sw/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/sw/LC_MESSAGES/docking.po
+++ b/docking/locale/sw/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Inacheza: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Tafuta mji"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Andika jina la mji..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Skrini {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/ta/LC_MESSAGES/docking.po
+++ b/docking/locale/ta/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/ta/LC_MESSAGES/docking.po
+++ b/docking/locale/ta/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "இயக்கப்படுகிறது: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "நகரத்தைத் தேடு"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "நகரத்தின் பெயரை உள்ளிடு..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "காட்சி {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/te/LC_MESSAGES/docking.po
+++ b/docking/locale/te/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/te/LC_MESSAGES/docking.po
+++ b/docking/locale/te/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "ప్లే అవుతోంది: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "నగరాన్ని వెతకండి"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "నగరం పేరు టైప్ చేయండి..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "డిస్‌ప్లే {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/th/LC_MESSAGES/docking.po
+++ b/docking/locale/th/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1086,73 +1086,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/th/LC_MESSAGES/docking.po
+++ b/docking/locale/th/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "กำลังเล่น: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -935,16 +935,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -984,28 +984,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "ค้นหาเมือง"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "พิมพ์ชื่อเมือง..."
 
@@ -1058,84 +1058,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1144,137 +1161,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "จอแสดงผล {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1291,3 +1308,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/tr/LC_MESSAGES/docking.po
+++ b/docking/locale/tr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/tr/LC_MESSAGES/docking.po
+++ b/docking/locale/tr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Çalınıyor: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Şehir ara"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Şehir adı yazın..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Ekran {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/uk/LC_MESSAGES/docking.po
+++ b/docking/locale/uk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/uk/LC_MESSAGES/docking.po
+++ b/docking/locale/uk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Відтворення: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Пошук міста"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Введіть назву міста..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Дисплей {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/ur/LC_MESSAGES/docking.po
+++ b/docking/locale/ur/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "چل رہا ہے: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "شہر تلاش کریں"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "شہر کا نام لکھیں..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "ڈسپلے {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/ur/LC_MESSAGES/docking.po
+++ b/docking/locale/ur/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/uz/LC_MESSAGES/docking.po
+++ b/docking/locale/uz/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/uz/LC_MESSAGES/docking.po
+++ b/docking/locale/uz/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Ijro: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Shaharni qidiring"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Shahar nomini kiriting..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Displey {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/vi/LC_MESSAGES/docking.po
+++ b/docking/locale/vi/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Đang phát: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -935,16 +935,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -984,28 +984,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Tìm thành phố"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Nhập tên thành phố..."
 
@@ -1058,84 +1058,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1144,137 +1161,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Màn hình {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1291,3 +1308,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/vi/LC_MESSAGES/docking.po
+++ b/docking/locale/vi/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1086,73 +1086,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/xh/LC_MESSAGES/docking.po
+++ b/docking/locale/xh/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/locale/xh/LC_MESSAGES/docking.po
+++ b/docking/locale/xh/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Kuyadlalwa: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Khangela idolophu"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Chwetheza igama ledolophu..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Isikrini {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/zh_CN/LC_MESSAGES/docking.po
+++ b/docking/locale/zh_CN/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "播放中: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "应用程序"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "亮度：{pct}%"
 msgid "Show Level"
 msgstr "显示级别"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "日历"
 
@@ -548,30 +548,30 @@ msgstr "IP：{ip}"
 msgid "Network: Not connected"
 msgstr "网络：未连接"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "通知"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "无通知后端"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "勿扰模式"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "待处理：{n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "清除历史"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "清除通知"
 
@@ -935,16 +935,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -984,28 +984,28 @@ msgstr "已静音"
 msgid "Volume: {pct}%"
 msgstr "音量：{pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "天气"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "显示温度"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "搜索城市"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "输入城市名称..."
 
@@ -1058,84 +1058,101 @@ msgstr "网站"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "从Dock中移除"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "保留在Dock中"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "全部关闭"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "关闭"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "小程序"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "电源配置不可用"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "添加分隔符"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "关于"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "退出"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "窗口"
 
@@ -1144,137 +1161,137 @@ msgstr "窗口"
 msgid "Display {display}: {width}x{height}"
 msgstr "显示器 {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "小程序"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "自动隐藏"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "图标大小"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "窗口预览"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "位置"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "跟随光标"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "仅当前工作区"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "将小程序锚定到末尾"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1295,3 +1312,4 @@ msgstr ""
 #, python-brace-format
 #~ msgid "WiFi: {ssid}"
 #~ msgstr "WiFi：{ssid}"
+

--- a/docking/locale/zh_CN/LC_MESSAGES/docking.po
+++ b/docking/locale/zh_CN/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1086,73 +1086,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "从Dock中移除"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "保留在Dock中"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "全部关闭"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "关闭"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "小程序"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "电源配置不可用"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "添加分隔符"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "关于"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "退出"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "窗口"
 

--- a/docking/locale/zu/LC_MESSAGES/docking.po
+++ b/docking/locale/zu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-27 21:16+0100\n"
+"POT-Creation-Date: 2026-03-29 01:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,38 +21,38 @@ msgstr ""
 msgid "AI Usage"
 msgstr "AI Usage"
 
-#: docking/applets/aiusage/applet.py:145
+#: docking/applets/aiusage/applet.py:146
 msgid "Auto"
 msgstr "Auto"
 
-#: docking/applets/aiusage/applet.py:146
+#: docking/applets/aiusage/applet.py:147
 msgid "Claude"
 msgstr "Claude"
 
-#: docking/applets/aiusage/applet.py:147
+#: docking/applets/aiusage/applet.py:148
 msgid "Codex"
 msgstr "Codex"
 
-#: docking/applets/aiusage/applet.py:148
+#: docking/applets/aiusage/applet.py:149
 msgid "OpenCode"
 msgstr "OpenCode"
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:161
 msgid "Reset Today"
 msgstr "Reset Today"
 
-#: docking/applets/aiusage/applet.py:206 docking/applets/aiusage/applet.py:221
+#: docking/applets/aiusage/applet.py:213 docking/applets/aiusage/applet.py:228
 #: docking/applets/aiusage/state.py:413
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr "{name}: no usage today"
 
-#: docking/applets/aiusage/applet.py:230
+#: docking/applets/aiusage/applet.py:237
 #, python-brace-format
 msgid "<b>{name}: {cost}</b>"
 msgstr "<b>{name}: {cost}</b>"
 
-#: docking/applets/aiusage/applet.py:259
+#: docking/applets/aiusage/applet.py:266
 #, python-brace-format
 msgid "This week: {cost}"
 msgstr "This week: {cost}"
@@ -111,7 +111,7 @@ msgstr "Kudlalwa: {sound} ({pct}%)"
 msgid "Applications"
 msgstr "Applications"
 
-#: docking/applets/applications/applet.py:53
+#: docking/applets/applications/applet.py:74
 msgid "Search applications..."
 msgstr "Search applications..."
 
@@ -292,12 +292,12 @@ msgstr "Brightness: {pct}%"
 msgid "Show Level"
 msgstr "Show Level"
 
-#: docking/applets/calculator/applet.py:68
-#: docking/applets/calculator/applet.py:85
+#: docking/applets/calculator/applet.py:67
+#: docking/applets/calculator/applet.py:84
 msgid "Calculator"
 msgstr "Calculator"
 
-#: docking/applets/calendar/applet.py:37 docking/applets/calendar/applet.py:43
+#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -548,30 +548,30 @@ msgstr "IP: {ip}"
 msgid "Network: Not connected"
 msgstr "Network: Not connected"
 
-#: docking/applets/notifications/applet.py:56
+#: docking/applets/notifications/applet.py:59
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr "Notifications"
 
-#: docking/applets/notifications/applet.py:123
+#: docking/applets/notifications/applet.py:126
 msgid "No notification backend available"
 msgstr "No notification backend available"
 
-#: docking/applets/notifications/applet.py:129
+#: docking/applets/notifications/applet.py:132
 msgid "Do Not Disturb"
 msgstr "Do Not Disturb"
 
-#: docking/applets/notifications/applet.py:136
+#: docking/applets/notifications/applet.py:139
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr "Pending: {n}"
 
-#: docking/applets/notifications/applet.py:141
+#: docking/applets/notifications/applet.py:144
 msgid "Clear History"
 msgstr "Clear History"
 
-#: docking/applets/notifications/applet.py:146
+#: docking/applets/notifications/applet.py:149
 msgid "Clear Notifications"
 msgstr "Clear Notifications"
 
@@ -936,16 +936,16 @@ msgstr "Hard"
 msgid "Correct: {answer}"
 msgstr "Correct: {answer}"
 
-#: docking/applets/unitconverter/applet.py:78
-#: docking/applets/unitconverter/applet.py:105
+#: docking/applets/unitconverter/applet.py:77
+#: docking/applets/unitconverter/applet.py:104
 msgid "Unit Converter"
 msgstr "Unit Converter"
 
-#: docking/applets/unitconverter/applet.py:220
+#: docking/applets/unitconverter/applet.py:197
 msgid "Swap units"
 msgstr "Swap units"
 
-#: docking/applets/unitconverter/applet.py:237
+#: docking/applets/unitconverter/applet.py:214
 msgid "Value"
 msgstr "Value"
 
@@ -985,28 +985,28 @@ msgstr "Muted"
 msgid "Volume: {pct}%"
 msgstr "Volume: {pct}%"
 
-#: docking/applets/weather/applet.py:56
+#: docking/applets/weather/applet.py:58
 msgid "Weather"
 msgstr "Weather"
 
-#: docking/applets/weather/applet.py:126
+#: docking/applets/weather/applet.py:128
 msgid "Show Temperature"
 msgstr "Show Temperature"
 
-#: docking/applets/weather/applet.py:131
+#: docking/applets/weather/applet.py:133
 msgid "Add City..."
 msgstr "Add City..."
 
-#: docking/applets/weather/applet.py:137
+#: docking/applets/weather/applet.py:139
 #, python-brace-format
 msgid "Remove {city}"
 msgstr "Remove {city}"
 
-#: docking/applets/weather/applet.py:169
+#: docking/applets/weather/applet.py:171
 msgid "Search for the city"
 msgstr "Sesha idolobha"
 
-#: docking/applets/weather/applet.py:183
+#: docking/applets/weather/applet.py:185
 msgid "Type city name..."
 msgstr "Thayipha igama ledolobha..."
 
@@ -1059,84 +1059,101 @@ msgstr "Website"
 msgid "Docking"
 msgstr "Docking"
 
-#: docking/ui/menu.py:182
+#: docking/ui/menu.py:187
 msgid "Name"
 msgstr "Name"
 
-#: docking/ui/menu.py:183
+#: docking/ui/menu.py:188
 msgid "Kind"
 msgstr "Kind"
 
-#: docking/ui/menu.py:184
+#: docking/ui/menu.py:189
 msgid "Size"
 msgstr "Size"
 
-#: docking/ui/menu.py:185
+#: docking/ui/menu.py:190
 msgid "Created"
 msgstr "Created"
 
-#: docking/ui/menu.py:186
+#: docking/ui/menu.py:191
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:401 docking/ui/menu.py:421 docking/ui/menu.py:437
-#: docking/ui/menu.py:490
+#: docking/ui/menu.py:772
+msgid "Folder not found"
+msgstr "Folder not found"
+
+#: docking/ui/menu.py:806
+msgid "Folder is empty"
+msgstr "Folder is empty"
+
+#: docking/ui/menu.py:1207
+msgid "Open Folder"
+msgstr "Open Folder"
+
+#: docking/ui/menu.py:1209
+#, python-format
+msgid "%d More in Folder"
+msgstr "%d More in Folder"
+
+#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
+#: docking/ui/menu.py:1419
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:414
+#: docking/ui/menu.py:1343
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:444
+#: docking/ui/menu.py:1373
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:453
+#: docking/ui/menu.py:1382
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:470
+#: docking/ui/menu.py:1399
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:478
+#: docking/ui/menu.py:1407
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:483
+#: docking/ui/menu.py:1412
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:1449
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:558
+#: docking/ui/menu.py:1487
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:565
+#: docking/ui/menu.py:1494
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:575 docking/ui/settings.py:152
+#: docking/ui/menu.py:1504 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:580
+#: docking/ui/menu.py:1509
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:585
+#: docking/ui/menu.py:1514
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:1551
 msgid "Window"
 msgstr "Window"
 
@@ -1145,137 +1162,137 @@ msgstr "Window"
 msgid "Display {display}: {width}x{height}"
 msgstr "Isikrini {display}: {width}x{height}"
 
-#: docking/ui/settings.py:176
+#: docking/ui/settings.py:175
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:177
+#: docking/ui/settings.py:176
 msgid "Applets"
 msgstr "Applets"
 
-#: docking/ui/settings.py:195
+#: docking/ui/settings.py:194
 msgid "Don't Hide"
 msgstr "Don't Hide"
 
-#: docking/ui/settings.py:196
+#: docking/ui/settings.py:195
 msgid "Auto-hide"
 msgstr "Auto-hide"
 
-#: docking/ui/settings.py:197
+#: docking/ui/settings.py:196
 msgid "Intelligent"
 msgstr "Intelligent"
 
-#: docking/ui/settings.py:198
+#: docking/ui/settings.py:197
 msgid "Dodge Active Window"
 msgstr "Dodge Active Window"
 
-#: docking/ui/settings.py:199
+#: docking/ui/settings.py:198
 msgid "Dodge All Windows"
 msgstr "Dodge All Windows"
 
-#: docking/ui/settings.py:200
+#: docking/ui/settings.py:199
 msgid "Dodge Maximized"
 msgstr "Dodge Maximized"
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:255
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:257
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:258
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:259
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:260
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:261
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:262
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:274
 msgid "Behavior"
 msgstr "Behavior"
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:276
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:277
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:278
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:284
+#: docking/ui/settings.py:283
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:285
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:286
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:287
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:292
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:294
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:295
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:296
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:663
+#: docking/ui/settings.py:662
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:664
+#: docking/ui/settings.py:663
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:665
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:667
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:669
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:673
+#: docking/ui/settings.py:672
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
@@ -1292,3 +1309,4 @@ msgstr ""
 
 #~ msgid "Tooltips"
 #~ msgstr "Tooltips"
+

--- a/docking/locale/zu/LC_MESSAGES/docking.po
+++ b/docking/locale/zu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-03-29 01:11+0100\n"
+"POT-Creation-Date: 2026-03-29 01:21+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1087,73 +1087,83 @@ msgstr "Folder not found"
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1207
+#: docking/ui/menu.py:1213
+#, python-format
+msgid "Open in %s"
+msgstr "Open in %s"
+
+#: docking/ui/menu.py:1215
+#, python-format
+msgid "%d More in %s"
+msgstr "%d More in %s"
+
+#: docking/ui/menu.py:1218
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1209
+#: docking/ui/menu.py:1220
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1330 docking/ui/menu.py:1350 docking/ui/menu.py:1366
-#: docking/ui/menu.py:1419
+#: docking/ui/menu.py:1341 docking/ui/menu.py:1361 docking/ui/menu.py:1377
+#: docking/ui/menu.py:1430
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1343
+#: docking/ui/menu.py:1354
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1373
+#: docking/ui/menu.py:1384
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1382
+#: docking/ui/menu.py:1393
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1399
+#: docking/ui/menu.py:1410
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1407
+#: docking/ui/menu.py:1418
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1412
+#: docking/ui/menu.py:1423
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1449
+#: docking/ui/menu.py:1460
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1487
+#: docking/ui/menu.py:1498
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1494
+#: docking/ui/menu.py:1505
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1504 docking/ui/settings.py:151
+#: docking/ui/menu.py:1515 docking/ui/settings.py:151
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1509
+#: docking/ui/menu.py:1520
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1514
+#: docking/ui/menu.py:1525
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1551
+#: docking/ui/menu.py:1562
 msgid "Window"
 msgstr "Window"
 

--- a/docking/platform/launcher.py
+++ b/docking/platform/launcher.py
@@ -252,7 +252,7 @@ class Launcher:
         try:
             gfile = Gio.File.new_for_uri(uri)
             info = gfile.query_info(
-                "standard::display-name,standard::icon,standard::type",
+                "standard::display-name,standard::icon,standard::type,standard::content-type",
                 Gio.FileQueryInfoFlags.NONE,
                 None,
             )
@@ -274,9 +274,49 @@ class Launcher:
             or Path(unquote(urlparse(uri).path)).name
             or uri,
             icon_name=icon_name,
-            icon=self.load_gicon(gicon=icon, size=size)
-            or self.load_icon(icon_name=icon_name, size=size),
+            icon=self.resolve_file_icon(
+                target=uri,
+                gicon=icon,
+                content_type=info.get_content_type() or "",
+                size=size,
+                is_dir=info.get_file_type() == Gio.FileType.DIRECTORY,
+            ),
             is_dir=info.get_file_type() == Gio.FileType.DIRECTORY,
+        )
+
+    def resolve_file_icon(
+        self,
+        *,
+        target: str,
+        gicon: Gio.Icon | None,
+        content_type: str,
+        size: int,
+        is_dir: bool,
+    ) -> GdkPixbuf.Pixbuf | None:
+        """Resolve a file target icon, preferring image thumbnails when possible."""
+        if not is_dir and content_type.lower().startswith("image/"):
+            uri = normalize_file_target(target)
+            if uri is not None:
+                path = Path(unquote(urlparse(uri).path))
+                if path.exists():
+                    try:
+                        return GdkPixbuf.Pixbuf.new_from_file_at_scale(
+                            str(path),
+                            size,
+                            size,
+                            True,
+                        )
+                    except GLib.Error as exc:
+                        log.bind(target=target, action="resolve_file_icon").debug(
+                            "Failed to load image thumbnail %s: %s",
+                            path,
+                            exc,
+                        )
+
+        icon_name = "folder" if is_dir else "text-x-generic"
+        return self.load_gicon(gicon=gicon, size=size) or self.load_icon(
+            icon_name=icon_name,
+            size=size,
         )
 
     def _try_load_gicon(self, gicon: Gio.Icon, size: int) -> GdkPixbuf.Pixbuf | None:

--- a/docking/platform/launcher.py
+++ b/docking/platform/launcher.py
@@ -319,6 +319,20 @@ class Launcher:
             size=size,
         )
 
+    def default_directory_app_name(self) -> str | None:
+        """Return the display name of the default app that opens folders."""
+        try:
+            app_info = Gio.AppInfo.get_default_for_type("inode/directory", False)
+        except GLib.Error as exc:
+            log.bind(action="default_directory_app_name").warning(
+                "Failed to resolve default directory app: %s",
+                exc,
+            )
+            return None
+        if app_info is None:
+            return None
+        return app_info.get_display_name() or None
+
     def _try_load_gicon(self, gicon: Gio.Icon, size: int) -> GdkPixbuf.Pixbuf | None:
         theme = Gtk.IconTheme.get_default()
         if theme is None:

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -566,6 +566,13 @@ class DockWindow(Gtk.Window):
         self._current_geometry_frame = frame
         self.update_input_region(frame=frame)
         widget.queue_draw()
+        if self._menu is not None:
+            stack_item_id = self._menu.open_folder_stack_item_id()
+            hovered_item = frame.item_at_point(event.x, event.y)
+            if stack_item_id is not None and (
+                hovered_item is None or hovered_item.desktop_id != stack_item_id
+            ):
+                self._menu.close_folder_stack()
         if frame.cursor_rect.contains(event.x, event.y):
             self.interaction.on_effective_enter()
             cursor_main = (
@@ -650,7 +657,28 @@ class DockWindow(Gtk.Window):
 
             if item.kind == FOLDER_KIND:
                 if self._menu:
-                    self._menu.show_item(event, item)
+                    item_geometry = frame.geometry_for_item(item)
+                    if item_geometry is not None:
+                        win_x, win_y = self.get_position()
+                        anchor_x, anchor_y = hover_anchor_from_draw_rect(
+                            win_x=win_x,
+                            win_y=win_y,
+                            draw_rect=item_geometry.draw_rect,
+                            position=self.config.pos,
+                        )
+                        icon_w = int(item_geometry.draw_rect.w)
+                    else:
+                        win_x, win_y = self.get_position()
+                        anchor_x = win_x + int(event.x)
+                        anchor_y = win_y + int(event.y)
+                        icon_w = int(self.config.icon_size)
+                    self._menu.show_folder_stack(
+                        item=item,
+                        anchor_x=anchor_x,
+                        anchor_y=anchor_y,
+                        icon_w=icon_w,
+                        position=self.config.pos,
+                    )
                 self._hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
                 return True
 

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -217,6 +217,8 @@ FOLDER_STACK_ARC_LINEAR_BLEND = 0.34
 FOLDER_STACK_RIGHT_BLEED_PX = 24
 FOLDER_STACK_LABEL_RADIUS_PX = 6
 FOLDER_STACK_LABEL_TEXT_MARGIN_PX = 8
+FOLDER_STACK_ACTION_ARROW_GAP_PX = 7
+FOLDER_STACK_ACTION_ARROW_SIZE_PX = 7
 FOLDER_STACK_ROTATION_MAX_DEG = 5.5
 FOLDER_STACK_REVEAL_DURATION_MS = 160
 FOLDER_STACK_REVEAL_STAGGER_MS = 28
@@ -255,6 +257,10 @@ class FolderStackCardGeometry:
     icon_center_y: float
     label_x: float
     label_y: float
+
+
+def _is_folder_stack_action_card(card: FolderStackCard) -> bool:
+    return card.centered and card.target is not None and card.icon is None
 
 
 def _ease_out_cubic(value: float) -> float:
@@ -1027,6 +1033,7 @@ class MenuHandler:
         )
         if geometry is None:
             return
+        is_action_card = _is_folder_stack_action_card(card)
 
         if card.icon is not None and card.icon_size > 0:
             pixbuf = card.icon
@@ -1111,8 +1118,13 @@ class MenuHandler:
         desc.set_size(10 * Pango.SCALE)
         layout.set_font_description(desc)
         layout.set_ellipsize(Pango.EllipsizeMode.END)
+        arrow_reserve = (
+            FOLDER_STACK_ACTION_ARROW_GAP_PX + FOLDER_STACK_ACTION_ARROW_SIZE_PX
+            if is_action_card
+            else 0
+        )
         available_text_w = max(
-            int(card.label_w - 2 * FOLDER_STACK_LABEL_TEXT_MARGIN_PX),
+            int(card.label_w - 2 * FOLDER_STACK_LABEL_TEXT_MARGIN_PX - arrow_reserve),
             1,
         )
         layout.set_width(available_text_w * Pango.SCALE)
@@ -1125,6 +1137,21 @@ class MenuHandler:
         cr.rotate(geometry.rotation_radians * 0.85)
         cr.move_to(text_x, text_y)
         PangoCairo.show_layout(cr, layout)
+        if is_action_card:
+            arrow_center_x = (
+                card.label_w / 2
+                - FOLDER_STACK_LABEL_TEXT_MARGIN_PX
+                - FOLDER_STACK_ACTION_ARROW_SIZE_PX / 2
+            )
+            arrow_center_y = 0.0
+            half = FOLDER_STACK_ACTION_ARROW_SIZE_PX / 2
+            cr.set_line_width(1.4)
+            cr.set_line_cap(cairo.LineCap.ROUND)
+            cr.set_line_join(cairo.LineJoin.ROUND)
+            cr.move_to(arrow_center_x - half, arrow_center_y - half)
+            cr.line_to(arrow_center_x, arrow_center_y)
+            cr.line_to(arrow_center_x - half, arrow_center_y + half)
+            cr.stroke()
         cr.restore()
 
     def _folder_stack_card_at(self, x: float, y: float) -> FolderStackCard | None:
@@ -1203,6 +1230,17 @@ class MenuHandler:
         return False
 
     def _folder_stack_action_label(self, *, hidden_count: int) -> str:
+        app_name = (
+            self._launcher.default_directory_app_name()
+            if self._launcher is not None
+            else None
+        )
+        if app_name:
+            return (
+                _("Open in %s") % app_name
+                if hidden_count == 0
+                else _("%d More in %s") % (hidden_count, app_name)
+            )
         return (
             _("Open Folder")
             if hidden_count == 0
@@ -1212,7 +1250,11 @@ class MenuHandler:
     def _folder_stack_action_width(self, *, label: str) -> int:
         return min(
             FOLDER_STACK_ACTION_MAX_WIDTH_PX,
-            _measure_stack_text_px(label) + 2 * FOLDER_STACK_LABEL_TEXT_MARGIN_PX + 10,
+            _measure_stack_text_px(label)
+            + 2 * FOLDER_STACK_LABEL_TEXT_MARGIN_PX
+            + FOLDER_STACK_ACTION_ARROW_GAP_PX
+            + FOLDER_STACK_ACTION_ARROW_SIZE_PX
+            + 10,
         )
 
     def _folder_stack_label_width(self, *, label: str) -> int:

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -134,15 +134,20 @@ concerns in practice.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+import cairo
 import gi
 
 gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
 gi.require_version("GdkPixbuf", "2.0")
 gi.require_version("Gio", "2.0")
-from gi.repository import Gdk, GdkPixbuf, Gio, GLib, Gtk, Pango
+gi.require_version("PangoCairo", "1.0")
+from gi.repository import Gdk, GdkPixbuf, Gio, GLib, Gtk, Pango, PangoCairo
 
 import docking.platform.launcher as launcher_mod
 from docking.applets import get_applet_catalog
@@ -162,7 +167,9 @@ from docking.log import get_logger
 from docking.ui.about import AboutDialogController
 from docking.ui.geometry import DockGeometryBuilder, DockGeometryFrame
 from docking.ui.preview import capture_window
+from docking.ui.runtime import DockRuntime, clamp_to_screen
 from docking.ui.settings import SettingsWindowController
+from docking.ui.shelf import rounded_rect
 
 if TYPE_CHECKING:
     from docking.core.config import Config
@@ -170,7 +177,6 @@ if TYPE_CHECKING:
     from docking.platform.launcher import Launcher
     from docking.platform.model import DockModel
     from docking.platform.window_tracker import WindowTracker
-    from docking.ui.runtime import DockRuntime
 
 
 ICON_SIZE_OPTIONS = (32, 48, 64, 80)
@@ -192,7 +198,110 @@ WINDOW_MENU_CLOSE_MARGIN_END_PX = 12
 FOLDER_MENU_REFRESH_DEBOUNCE_MS = 120
 FOLDER_SMALL_ICON_PX = 16
 FOLDER_LARGE_ICON_PX = 24
+FOLDER_STACK_MAX_VISIBLE_ROWS = 9
+FOLDER_STACK_GAP_PX = 8
+FOLDER_STACK_POPUP_SIDE_PADDING_PX = 14
+FOLDER_STACK_TOP_PADDING_PX = 6
+FOLDER_STACK_ACTION_GAP_PX = 18
+FOLDER_STACK_ICON_GAP_PX = 10
+FOLDER_STACK_LABEL_HEIGHT_PX = 24
+FOLDER_STACK_LABEL_MAX_WIDTH_PX = 148
+FOLDER_STACK_LABEL_CHAR_PX = 7
+FOLDER_STACK_ACTION_MAX_WIDTH_PX = 240
+FOLDER_STACK_ACTION_CHAR_PX = 8
+FOLDER_STACK_ROW_STEP_PX = 54
+FOLDER_STACK_CURVE_X_PX = 40
+FOLDER_STACK_ARC_BASE_SHIFT_PX = 8
+FOLDER_STACK_ARC_RADIUS_FACTOR = 2.45
+FOLDER_STACK_ARC_LINEAR_BLEND = 0.34
+FOLDER_STACK_RIGHT_BLEED_PX = 24
+FOLDER_STACK_LABEL_RADIUS_PX = 6
+FOLDER_STACK_LABEL_TEXT_MARGIN_PX = 8
+FOLDER_STACK_ROTATION_MAX_DEG = 5.5
+FOLDER_STACK_REVEAL_DURATION_MS = 160
+FOLDER_STACK_REVEAL_STAGGER_MS = 28
+FOLDER_STACK_ANIM_FRAME_MS = 16
+FOLDER_STACK_HOVER_SCALE = 1.14
+FOLDER_STACK_HOVER_EASE = 0.35
 log = get_logger("menu")
+
+
+@dataclass(frozen=True)
+class FolderStackCard:
+    label: str
+    target: str | None
+    icon: GdkPixbuf.Pixbuf | None
+    icon_x: int
+    icon_y: int
+    icon_size: int
+    label_x: int
+    label_y: int
+    label_w: int
+    label_h: int
+    centered: bool = False
+    stack_progress: float = 0.0
+    arc_span: float = 0.0
+
+
+@dataclass(frozen=True)
+class FolderStackCardGeometry:
+    reveal: float
+    hover_value: float
+    rotation_radians: float
+    icon_x: float
+    icon_y: float
+    icon_size: float
+    icon_center_x: float
+    icon_center_y: float
+    label_x: float
+    label_y: float
+
+
+def _ease_out_cubic(value: float) -> float:
+    value = min(max(value, 0.0), 1.0)
+    return 1.0 - (1.0 - value) ** 3
+
+
+def _folder_stack_arc_offset(progress: float, span: float) -> float:
+    progress = min(max(progress, 0.0), 1.0)
+    max_offset = max(FOLDER_STACK_CURVE_X_PX, span * 0.08)
+    linear = max_offset * progress
+    if span <= 0:
+        curved = linear
+    else:
+        radius = max(span * FOLDER_STACK_ARC_RADIUS_FACTOR, span + 1.0)
+        y = progress * span
+        curved = radius - math.sqrt(max(radius * radius - y * y, 0.0))
+        max_curved = radius - math.sqrt(max(radius * radius - span * span, 0.0))
+        curved = max_offset * (curved / max_curved) if max_curved > 0 else linear
+    offset = (
+        FOLDER_STACK_ARC_LINEAR_BLEND * linear
+        + (1.0 - FOLDER_STACK_ARC_LINEAR_BLEND) * curved
+    )
+    return FOLDER_STACK_ARC_BASE_SHIFT_PX + offset
+
+
+def _folder_stack_rotation(progress: float, position: Any, span: float) -> float:
+    progress = min(max(progress, 0.0), 1.0)
+    direction = 1.0 if position in {"bottom", "left"} else -1.0
+    degrees = min(
+        (0.2 + 0.8 * progress) * FOLDER_STACK_ROTATION_MAX_DEG,
+        FOLDER_STACK_ROTATION_MAX_DEG,
+    )
+    return math.radians(degrees * direction)
+
+
+def _measure_stack_text_px(text: str) -> int:
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 1, 1)
+    cr = cairo.Context(surface)
+    layout = PangoCairo.create_layout(cr)
+    layout.set_text(text, -1)
+    desc = Pango.FontDescription()
+    desc.set_family("Sans")
+    desc.set_size(10 * Pango.SCALE)
+    layout.set_font_description(desc)
+    _ink, logical = layout.get_pixel_extents()
+    return max(int(logical.width), 0)
 
 
 def _make_menu_header(label: str) -> Gtk.MenuItem:
@@ -340,6 +449,23 @@ class MenuHandler:
         self._folder_menu_context: dict[int, tuple[Gtk.Menu, DockItem, str, bool]] = {}
         self._folder_menu_refresh_sources: dict[int, int] = {}
         self._folder_menu_signal_connected: set[int] = set()
+        self._folder_stack_window: Gtk.Window | None = None
+        self._folder_stack_revealer: Gtk.Revealer | None = None
+        self._folder_stack_item: DockItem | None = None
+        self._folder_stack_anchor_x: int = 0
+        self._folder_stack_anchor_y: int = 0
+        self._folder_stack_icon_w: int = 0
+        self._folder_stack_fold_center_x: int = 0
+        self._folder_stack_position_value = self._config.pos
+        self._folder_stack_area: Gtk.DrawingArea | None = None
+        self._folder_stack_cards: list[FolderStackCard] = []
+        self._folder_stack_monitor: Gio.FileMonitor | None = None
+        self._folder_stack_refresh_source: int = 0
+        self._folder_stack_anim_source: int = 0
+        self._folder_stack_show_started_us: int = 0
+        self._folder_stack_hover_target: str | None = None
+        self._folder_stack_hover_values: dict[str, float] = {}
+        self._folder_stack_pressed_target: str | None = None
 
     def show(self, event: Gdk.EventButton, cursor_main: float) -> None:
         """Build and show the right-click context menu.
@@ -350,6 +476,7 @@ class MenuHandler:
         """
         frame = self._geometry_builder.build_frame(cursor_x=event.x, cursor_y=event.y)
         item = frame.item_at_point(event.x, event.y)
+        self._close_folder_stack()
 
         if item:
             menu = self._new_popup_menu()
@@ -364,10 +491,66 @@ class MenuHandler:
 
     def show_item(self, event: Gdk.EventButton, item: DockItem) -> None:
         """Show a context menu for a known item."""
+        self._close_folder_stack()
         menu = self._new_popup_menu()
         self._build_item_menu(menu=menu, item=item)
         menu.show_all()
         menu.popup_at_pointer(event)
+
+    def show_folder_stack(
+        self,
+        *,
+        item: DockItem,
+        anchor_x: int,
+        anchor_y: int,
+        icon_w: int,
+        position: Any,
+    ) -> None:
+        """Show or toggle the left-click folder stack popup for a pinned folder."""
+        if (
+            self._folder_stack_window is not None
+            and self._folder_stack_window.get_visible()
+            and self._folder_stack_item is not None
+            and self._folder_stack_item.desktop_id == item.desktop_id
+        ):
+            self._close_folder_stack()
+            return
+
+        self._close_folder_stack()
+        self._runtime.hide_hover_ui()
+        self._runtime.menu_popup_opened()
+
+        window = self._ensure_folder_stack_window()
+        revealer = self._folder_stack_revealer
+        assert revealer is not None
+
+        self._replace_folder_stack_content(item=item)
+
+        self._folder_stack_anchor_x = int(anchor_x)
+        self._folder_stack_anchor_y = int(anchor_y)
+        self._folder_stack_icon_w = max(int(icon_w), 1)
+        self._folder_stack_position_value = position
+        self._folder_stack_item = item
+        self._track_folder_stack(target=item.target)
+        self._restart_folder_stack_animation()
+        self._position_folder_stack_window()
+        revealer.set_reveal_child(True)
+        window.show_all()
+
+    def close_folder_stack(self) -> None:
+        """Close the left-click folder stack if it is currently visible."""
+        self._close_folder_stack()
+
+    def open_folder_stack_item_id(self) -> str | None:
+        """Return the folder item id that currently owns the visible stack."""
+        window = self._folder_stack_window
+        if (
+            window is None
+            or not window.get_visible()
+            or self._folder_stack_item is None
+        ):
+            return None
+        return self._folder_stack_item.desktop_id
 
     def _new_popup_menu(self) -> Gtk.Menu:
         menu = Gtk.Menu()
@@ -379,6 +562,753 @@ class MenuHandler:
     def _on_menu_popup_closed(self, _menu: Gtk.Menu) -> None:
         self._cleanup_folder_menu_tree(_menu)
         self._runtime.menu_popup_closed()
+
+    def _close_folder_stack(self) -> None:
+        window = self._folder_stack_window
+        if window is None or not window.get_visible():
+            return
+        revealer = self._folder_stack_revealer
+        if revealer is not None:
+            revealer.set_reveal_child(False)
+        window.hide()
+        self._cleanup_folder_stack()
+        self._runtime.menu_popup_closed()
+
+    def _cleanup_folder_stack(self) -> None:
+        if self._folder_stack_refresh_source:
+            GLib.source_remove(self._folder_stack_refresh_source)
+            self._folder_stack_refresh_source = 0
+        if self._folder_stack_anim_source:
+            GLib.source_remove(self._folder_stack_anim_source)
+            self._folder_stack_anim_source = 0
+        if self._folder_stack_monitor is not None:
+            self._folder_stack_monitor.cancel()
+            self._folder_stack_monitor = None
+        self._folder_stack_area = None
+        self._folder_stack_item = None
+        self._folder_stack_anchor_x = 0
+        self._folder_stack_anchor_y = 0
+        self._folder_stack_icon_w = 0
+        self._folder_stack_fold_center_x = 0
+        self._folder_stack_show_started_us = 0
+        self._folder_stack_hover_target = None
+        self._folder_stack_hover_values.clear()
+        self._folder_stack_pressed_target = None
+
+    def _ensure_folder_stack_window(self) -> Gtk.Window:
+        if self._folder_stack_window is not None:
+            return self._folder_stack_window
+
+        window = Gtk.Window(type=Gtk.WindowType.POPUP)
+        window.set_decorated(False)
+        window.set_skip_taskbar_hint(True)
+        window.set_resizable(False)
+        window.set_type_hint(Gdk.WindowTypeHint.TOOLTIP)
+        window.set_app_paintable(True)
+
+        screen = window.get_screen()
+        visual = screen.get_rgba_visual()
+        if visual:
+            window.set_visual(visual)
+
+        revealer = Gtk.Revealer()
+        revealer.set_transition_type(self._folder_stack_transition_type())
+        revealer.set_transition_duration(140)
+        revealer.set_reveal_child(False)
+        window.add(revealer)
+
+        self._folder_stack_window = window
+        self._folder_stack_revealer = revealer
+        return window
+
+    def _folder_stack_transition_type(self):
+        pos = self._config.pos
+        if pos == "bottom":
+            return Gtk.RevealerTransitionType.SLIDE_UP
+        if pos == "top":
+            return Gtk.RevealerTransitionType.SLIDE_DOWN
+        if pos == "left":
+            return Gtk.RevealerTransitionType.SLIDE_RIGHT
+        return Gtk.RevealerTransitionType.SLIDE_LEFT
+
+    def _replace_folder_stack_content(self, item: DockItem) -> None:
+        revealer = self._folder_stack_revealer
+        if revealer is None:
+            return
+        child = revealer.get_child()
+        if child is not None:
+            revealer.remove(child)
+        content = self._build_folder_stack_content(item=item)
+        revealer.add(content)
+        content.show_all()
+
+    def _position_folder_stack_window(self) -> None:
+        window = self._folder_stack_window
+        revealer = self._folder_stack_revealer
+        if window is None or revealer is None:
+            return
+        child = revealer.get_child()
+        if child is None:
+            return
+
+        preferred = child.get_preferred_size()[1]
+        popup_w = max(int(preferred.width), 1)
+        popup_h = max(int(preferred.height), 1)
+        anchor_x = self._folder_stack_anchor_x
+        anchor_y = self._folder_stack_anchor_y
+        icon_w = max(self._folder_stack_icon_w, 1)
+        pos = self._folder_stack_position_value
+        local_icon_center_x = max(self._folder_stack_fold_center_x, 1)
+
+        if pos == "bottom":
+            popup_x = int(anchor_x + icon_w / 2 - local_icon_center_x)
+            popup_y = int(anchor_y - popup_h - FOLDER_STACK_GAP_PX)
+        elif pos == "top":
+            popup_x = int(anchor_x + icon_w / 2 - local_icon_center_x)
+            popup_y = int(anchor_y + FOLDER_STACK_GAP_PX)
+        elif pos == "left":
+            popup_x = int(anchor_x + FOLDER_STACK_GAP_PX)
+            popup_y = int(anchor_y + icon_w / 2 - popup_h / 2)
+        else:
+            popup_x = int(anchor_x - popup_w - FOLDER_STACK_GAP_PX)
+            popup_y = int(anchor_y + icon_w / 2 - popup_h / 2)
+
+        screen = window.get_screen()
+        screen_w = screen.get_width()
+        screen_h = screen.get_height()
+        popup_x, popup_y = clamp_to_screen(
+            popup_x,
+            popup_y,
+            popup_w,
+            popup_h,
+            screen_w,
+            screen_h,
+        )
+        window.move(popup_x, popup_y)
+
+    def _track_folder_stack(self, target: str) -> None:
+        uri = launcher_mod.normalize_file_target(target)
+        if uri is None:
+            return
+        try:
+            folder = Gio.File.new_for_uri(uri)
+            monitor = folder.monitor_directory(Gio.FileMonitorFlags.NONE, None)
+            monitor.connect("changed", self._on_folder_stack_changed)
+            self._folder_stack_monitor = monitor
+        except GLib.Error as exc:
+            log.warning("Failed to monitor folder stack target %s: %s", target, exc)
+
+    def _on_folder_stack_changed(
+        self,
+        _monitor: Gio.FileMonitor,
+        _file: Gio.File,
+        _other_file: Gio.File | None,
+        _event_type: Gio.FileMonitorEvent,
+    ) -> None:
+        if self._folder_stack_refresh_source:
+            GLib.source_remove(self._folder_stack_refresh_source)
+        self._folder_stack_refresh_source = GLib.timeout_add(
+            FOLDER_MENU_REFRESH_DEBOUNCE_MS,
+            self._refresh_folder_stack,
+        )
+
+    def _refresh_folder_stack(self) -> bool:
+        self._folder_stack_refresh_source = 0
+        window = self._folder_stack_window
+        item = self._folder_stack_item
+        if window is None or item is None:
+            return False
+        self._replace_folder_stack_content(item=item)
+        self._restart_folder_stack_animation()
+        self._position_folder_stack_window()
+        window.show_all()
+        return False
+
+    def _build_folder_stack_content(self, item: DockItem) -> Gtk.Widget:
+        cards, popup_w, popup_h = self._folder_stack_cards_for_item(item)
+        self._folder_stack_cards = cards
+
+        area = Gtk.DrawingArea()
+        area.set_size_request(popup_w, popup_h)
+        area.add_events(
+            Gdk.EventMask.BUTTON_PRESS_MASK
+            | Gdk.EventMask.BUTTON_RELEASE_MASK
+            | Gdk.EventMask.POINTER_MOTION_MASK
+            | Gdk.EventMask.LEAVE_NOTIFY_MASK
+        )
+        area.connect("draw", self._on_folder_stack_draw)
+        area.connect("button-press-event", self._on_folder_stack_button_press)
+        area.connect("button-release-event", self._on_folder_stack_button_release)
+        area.connect("motion-notify-event", self._on_folder_stack_motion_notify)
+        area.connect("leave-notify-event", self._on_folder_stack_leave_notify)
+        self._folder_stack_area = area
+        return area
+
+    def _folder_stack_cards_for_item(
+        self, item: DockItem
+    ) -> tuple[list[FolderStackCard], int, int]:
+        cards: list[FolderStackCard] = []
+        icon_px = max(int(self._config.icon_size), 1)
+        label_h = FOLDER_STACK_LABEL_HEIGHT_PX
+        row_step = max(FOLDER_STACK_ROW_STEP_PX, int(round(icon_px * 1.08)))
+        curve_extent = max(FOLDER_STACK_CURVE_X_PX, int(round(icon_px * 0.65)))
+        right_bleed = max(
+            FOLDER_STACK_RIGHT_BLEED_PX,
+            int(round(curve_extent + icon_px * FOLDER_STACK_HOVER_SCALE * 0.35)),
+        )
+        fold_center_x = int(
+            FOLDER_STACK_POPUP_SIDE_PADDING_PX
+            + FOLDER_STACK_LABEL_MAX_WIDTH_PX
+            + FOLDER_STACK_ICON_GAP_PX
+            + icon_px / 2
+        )
+        self._folder_stack_fold_center_x = fold_center_x
+
+        state = self._folder_target_state(item.target)
+        if state == "missing":
+            label_w = 190
+            cards.append(
+                FolderStackCard(
+                    label=_("Folder not found"),
+                    target=None,
+                    icon=None,
+                    icon_x=0,
+                    icon_y=0,
+                    icon_size=0,
+                    label_x=max(
+                        FOLDER_STACK_POPUP_SIDE_PADDING_PX,
+                        int(fold_center_x - label_w / 2),
+                    ),
+                    label_y=FOLDER_STACK_TOP_PADDING_PX,
+                    label_w=label_w,
+                    label_h=label_h,
+                    centered=True,
+                )
+            )
+            popup_w = int(
+                max(
+                    fold_center_x + label_w / 2 + FOLDER_STACK_POPUP_SIDE_PADDING_PX,
+                    fold_center_x + icon_px / 2 + right_bleed,
+                )
+            )
+            popup_h = label_h + 2 * FOLDER_STACK_TOP_PADDING_PX
+            return cards, popup_w, popup_h
+
+        rows = self._list_directory(
+            folder_item=item,
+            target=item.target,
+            icon_px=icon_px,
+        )
+        if not rows:
+            label_w = 190
+            cards.append(
+                FolderStackCard(
+                    label=_("Folder is empty"),
+                    target=None,
+                    icon=None,
+                    icon_x=0,
+                    icon_y=0,
+                    icon_size=0,
+                    label_x=max(
+                        FOLDER_STACK_POPUP_SIDE_PADDING_PX,
+                        int(fold_center_x - label_w / 2),
+                    ),
+                    label_y=FOLDER_STACK_TOP_PADDING_PX,
+                    label_w=label_w,
+                    label_h=label_h,
+                    centered=True,
+                )
+            )
+            popup_w = int(
+                max(
+                    fold_center_x + label_w / 2 + FOLDER_STACK_POPUP_SIDE_PADDING_PX,
+                    fold_center_x + icon_px / 2 + right_bleed,
+                )
+            )
+            popup_h = label_h + 2 * FOLDER_STACK_TOP_PADDING_PX
+            return cards, popup_w, popup_h
+
+        visible_rows = rows[:FOLDER_STACK_MAX_VISIBLE_ROWS]
+        hidden_count = max(len(rows) - len(visible_rows), 0)
+        action_label = self._folder_stack_action_label(hidden_count=hidden_count)
+        chip_w = self._folder_stack_action_width(label=action_label)
+        chip_h = label_h
+        total_rows = len(visible_rows)
+        top_progress = 1.0 if total_rows > 0 else 0.0
+        total_span = (total_rows - 1) * row_step
+        top_center_x = int(
+            round(fold_center_x + _folder_stack_arc_offset(top_progress, total_span))
+        )
+        chip_x = max(
+            FOLDER_STACK_POPUP_SIDE_PADDING_PX,
+            int(top_center_x - chip_w / 2 + curve_extent * 0.1),
+        )
+        chip_y = FOLDER_STACK_TOP_PADDING_PX
+        cards.append(
+            FolderStackCard(
+                label=action_label,
+                target=item.target,
+                icon=None,
+                icon_x=0,
+                icon_y=0,
+                icon_size=0,
+                label_x=chip_x,
+                label_y=chip_y,
+                label_w=chip_w,
+                label_h=chip_h,
+                centered=True,
+                stack_progress=1.0,
+                arc_span=float(total_span),
+            )
+        )
+
+        stack_top = chip_y + chip_h + FOLDER_STACK_ACTION_GAP_PX
+        max_right = chip_x + chip_w
+        bottom_center_y = (
+            stack_top + (total_rows - 1) * row_step + icon_px / 2 if total_rows else 0
+        )
+        for index, child in enumerate(visible_rows):
+            raw_progress = (
+                (total_rows - 1 - index) / max(total_rows - 1, 1)
+                if total_rows > 1
+                else 1.0
+            )
+            arc_progress = raw_progress
+            icon_center_x = fold_center_x + _folder_stack_arc_offset(
+                arc_progress,
+                total_span,
+            )
+            icon_center_y = bottom_center_y - total_span * raw_progress
+            icon_x = int(round(icon_center_x - icon_px / 2))
+            icon_y = int(round(icon_center_y - icon_px / 2))
+            label_w = self._folder_stack_label_width(label=str(child["name"]))
+            label_pull = int(round(arc_progress * 10))
+            label_x = max(
+                FOLDER_STACK_POPUP_SIDE_PADDING_PX,
+                icon_x - FOLDER_STACK_ICON_GAP_PX - label_w - label_pull,
+            )
+            cards.append(
+                FolderStackCard(
+                    label=str(child["name"]),
+                    target=str(child["target"]),
+                    icon=child["icon"],
+                    icon_x=icon_x,
+                    icon_y=icon_y,
+                    icon_size=icon_px,
+                    label_x=label_x,
+                    label_y=icon_y + max(int((icon_px - label_h) / 2), 0),
+                    label_w=label_w,
+                    label_h=label_h,
+                    centered=False,
+                    stack_progress=arc_progress,
+                    arc_span=float(total_span),
+                )
+            )
+            max_right = max(max_right, icon_x + icon_px)
+
+        popup_w = int(
+            max(
+                max_right + right_bleed,
+                fold_center_x
+                + _folder_stack_arc_offset(1.0, total_span)
+                + icon_px / 2
+                + right_bleed,
+            )
+        )
+        popup_h = (
+            stack_top
+            + (total_rows - 1) * row_step
+            + icon_px
+            + FOLDER_STACK_TOP_PADDING_PX
+        )
+        return cards, popup_w, popup_h
+
+    def _on_folder_stack_draw(self, widget: Gtk.DrawingArea, cr: cairo.Context) -> bool:
+        cr.set_operator(cairo.OPERATOR_CLEAR)
+        cr.paint()
+        cr.set_operator(cairo.OPERATOR_OVER)
+        now_us = GLib.get_monotonic_time()
+        total_cards = len(self._folder_stack_cards)
+        for draw_index, card in enumerate(self._folder_stack_cards):
+            self._draw_folder_stack_card(
+                cr=cr,
+                card=card,
+                sequence_index=total_cards - 1 - draw_index,
+                now_us=now_us,
+            )
+        return False
+
+    def _folder_stack_card_geometry(
+        self,
+        *,
+        card: FolderStackCard,
+        sequence_index: int,
+        now_us: int,
+    ) -> FolderStackCardGeometry | None:
+        reveal = self._folder_stack_reveal_progress(
+            sequence_index=sequence_index,
+            now_us=now_us,
+        )
+        if reveal <= 0:
+            return None
+
+        hover_value = (
+            self._folder_stack_hover_values.get(card.target, 0.0)
+            if card.target is not None and not card.centered
+            else 0.0
+        )
+        y_offset = (1.0 - reveal) * 18.0
+        rotation_radians = (
+            _folder_stack_rotation(
+                card.stack_progress,
+                self._folder_stack_position_value,
+                card.arc_span,
+            )
+            * reveal
+        )
+        open_label_center_x = card.label_x + card.label_w / 2
+        label_center_x = (
+            self._folder_stack_fold_center_x
+            + (open_label_center_x - self._folder_stack_fold_center_x) * reveal
+        )
+        label_x = label_center_x - card.label_w / 2
+        label_y = card.label_y + y_offset
+
+        icon_size = 0.0
+        icon_x = 0.0
+        icon_y = 0.0
+        icon_center_x = 0.0
+        icon_center_y = 0.0
+        if card.icon is not None and card.icon_size > 0:
+            icon_size = max(
+                (
+                    card.icon_size
+                    * (0.82 + 0.18 * reveal)
+                    * (1.0 + hover_value * (FOLDER_STACK_HOVER_SCALE - 1.0))
+                ),
+                1.0,
+            )
+            open_icon_center_x = card.icon_x + card.icon_size / 2
+            icon_center_x = (
+                self._folder_stack_fold_center_x
+                + (open_icon_center_x - self._folder_stack_fold_center_x) * reveal
+            )
+            icon_center_y = (
+                card.icon_y + card.icon_size / 2 + y_offset - hover_value * 4.0
+            )
+            icon_x = icon_center_x - icon_size / 2
+            icon_y = icon_center_y - icon_size / 2
+
+        return FolderStackCardGeometry(
+            reveal=reveal,
+            hover_value=hover_value,
+            rotation_radians=rotation_radians,
+            icon_x=icon_x,
+            icon_y=icon_y,
+            icon_size=icon_size,
+            icon_center_x=icon_center_x,
+            icon_center_y=icon_center_y,
+            label_x=label_x,
+            label_y=label_y,
+        )
+
+    def _draw_folder_stack_card(
+        self,
+        *,
+        cr: cairo.Context,
+        card: FolderStackCard,
+        sequence_index: int,
+        now_us: int,
+    ) -> None:
+        geometry = self._folder_stack_card_geometry(
+            card=card,
+            sequence_index=sequence_index,
+            now_us=now_us,
+        )
+        if geometry is None:
+            return
+
+        if card.icon is not None and card.icon_size > 0:
+            pixbuf = card.icon
+            draw_icon_size = max(int(round(geometry.icon_size)), 1)
+            if (
+                pixbuf.get_width() != draw_icon_size
+                or pixbuf.get_height() != draw_icon_size
+            ):
+                scaled = pixbuf.scale_simple(
+                    draw_icon_size,
+                    draw_icon_size,
+                    GdkPixbuf.InterpType.BILINEAR,
+                )
+                if scaled is not None:
+                    pixbuf = scaled
+
+            cr.save()
+            cr.translate(geometry.icon_center_x + 2, geometry.icon_center_y + 2)
+            cr.rotate(geometry.rotation_radians)
+            Gdk.cairo_set_source_pixbuf(
+                cr,
+                pixbuf,
+                -draw_icon_size / 2,
+                -draw_icon_size / 2,
+            )
+            cr.paint_with_alpha(0.16 * geometry.reveal)
+            cr.restore()
+
+            cr.save()
+            cr.translate(geometry.icon_center_x, geometry.icon_center_y)
+            cr.rotate(geometry.rotation_radians)
+            Gdk.cairo_set_source_pixbuf(
+                cr,
+                pixbuf,
+                -draw_icon_size / 2,
+                -draw_icon_size / 2,
+            )
+            cr.paint_with_alpha(0.55 + 0.45 * geometry.reveal)
+            cr.restore()
+
+        radius = FOLDER_STACK_LABEL_RADIUS_PX
+        label_center_x = geometry.label_x + card.label_w / 2
+        label_center_y = geometry.label_y + card.label_h / 2
+        cr.save()
+        cr.translate(label_center_x, label_center_y + 1)
+        cr.rotate(geometry.rotation_radians * 0.85)
+        rounded_rect(
+            cr,
+            -card.label_w / 2,
+            -card.label_h / 2,
+            card.label_w,
+            card.label_h,
+            radius,
+        )
+        cr.set_source_rgba(0, 0, 0, 0.08 * geometry.reveal)
+        cr.fill()
+        cr.restore()
+
+        cr.save()
+        cr.translate(label_center_x, label_center_y)
+        cr.rotate(geometry.rotation_radians * 0.85)
+        rounded_rect(
+            cr,
+            -card.label_w / 2,
+            -card.label_h / 2,
+            card.label_w,
+            card.label_h,
+            radius,
+        )
+        cr.set_source_rgba(0.98, 0.98, 0.98, 0.95)
+        cr.fill_preserve()
+        cr.set_source_rgba(0, 0, 0, 0.08)
+        cr.set_line_width(1.0)
+        cr.stroke()
+        cr.restore()
+
+        cr.save()
+        layout = PangoCairo.create_layout(cr)
+        layout.set_text(card.label, -1)
+        desc = Pango.FontDescription()
+        desc.set_family("Sans")
+        desc.set_size(10 * Pango.SCALE)
+        layout.set_font_description(desc)
+        layout.set_ellipsize(Pango.EllipsizeMode.END)
+        available_text_w = max(
+            int(card.label_w - 2 * FOLDER_STACK_LABEL_TEXT_MARGIN_PX),
+            1,
+        )
+        layout.set_width(available_text_w * Pango.SCALE)
+        layout.set_alignment(Pango.Alignment.CENTER)
+        _, logical = layout.get_pixel_extents()
+        text_y = int(-card.label_h / 2 + (card.label_h - logical.height) / 2)
+        text_x = -card.label_w / 2 + FOLDER_STACK_LABEL_TEXT_MARGIN_PX
+        cr.set_source_rgba(0.16, 0.2, 0.26, 1.0)
+        cr.translate(label_center_x, label_center_y)
+        cr.rotate(geometry.rotation_radians * 0.85)
+        cr.move_to(text_x, text_y)
+        PangoCairo.show_layout(cr, layout)
+        cr.restore()
+
+    def _folder_stack_card_at(self, x: float, y: float) -> FolderStackCard | None:
+        now_us = GLib.get_monotonic_time()
+        total_cards = len(self._folder_stack_cards)
+        for index in range(total_cards - 1, -1, -1):
+            card = self._folder_stack_cards[index]
+            geometry = self._folder_stack_card_geometry(
+                card=card,
+                sequence_index=total_cards - 1 - index,
+                now_us=now_us,
+            )
+            if geometry is None:
+                continue
+            within_label = (
+                geometry.label_x <= x <= geometry.label_x + card.label_w
+                and geometry.label_y <= y <= geometry.label_y + card.label_h
+            )
+            within_icon = (
+                geometry.icon_size > 0
+                and geometry.icon_x <= x <= geometry.icon_x + geometry.icon_size
+                and geometry.icon_y <= y <= geometry.icon_y + geometry.icon_size
+            )
+            if within_label or within_icon:
+                return card
+        return None
+
+    def _on_folder_stack_button_press(
+        self, _widget: Gtk.DrawingArea, event: Gdk.EventButton
+    ) -> bool:
+        if int(getattr(event, "button", 1)) != 1:
+            self._folder_stack_pressed_target = None
+            return False
+        card = self._folder_stack_card_at(event.x, event.y)
+        self._folder_stack_pressed_target = (
+            card.target if card is not None and card.target is not None else None
+        )
+        return self._folder_stack_pressed_target is not None
+
+    def _on_folder_stack_button_release(
+        self, _widget: Gtk.DrawingArea, event: Gdk.EventButton
+    ) -> bool:
+        if int(getattr(event, "button", 1)) != 1:
+            self._folder_stack_pressed_target = None
+            return False
+        card = self._folder_stack_card_at(event.x, event.y)
+        target = card.target if card is not None and card.target is not None else None
+        pressed_target = self._folder_stack_pressed_target
+        self._folder_stack_pressed_target = None
+        if target is not None and (pressed_target is None or pressed_target == target):
+            self._open_folder_stack_target(target)
+            return True
+        return False
+
+    def _on_folder_stack_motion_notify(
+        self, _widget: Gtk.DrawingArea, event: Gdk.EventMotion
+    ) -> bool:
+        card = self._folder_stack_card_at(event.x, event.y)
+        target = (
+            card.target
+            if card is not None and card.target is not None and not card.centered
+            else None
+        )
+        if target != self._folder_stack_hover_target:
+            self._folder_stack_hover_target = target
+            self._ensure_folder_stack_animating()
+        return False
+
+    def _on_folder_stack_leave_notify(
+        self, _widget: Gtk.DrawingArea, _event: Gdk.EventCrossing
+    ) -> bool:
+        if self._folder_stack_hover_target is not None:
+            self._folder_stack_hover_target = None
+            self._ensure_folder_stack_animating()
+        self._folder_stack_pressed_target = None
+        return False
+
+    def _folder_stack_action_label(self, *, hidden_count: int) -> str:
+        return (
+            _("Open Folder")
+            if hidden_count == 0
+            else _("%d More in Folder") % hidden_count
+        )
+
+    def _folder_stack_action_width(self, *, label: str) -> int:
+        return min(
+            FOLDER_STACK_ACTION_MAX_WIDTH_PX,
+            _measure_stack_text_px(label) + 2 * FOLDER_STACK_LABEL_TEXT_MARGIN_PX + 10,
+        )
+
+    def _folder_stack_label_width(self, *, label: str) -> int:
+        return min(
+            FOLDER_STACK_LABEL_MAX_WIDTH_PX,
+            max(
+                24,
+                _measure_stack_text_px(label)
+                + 2 * FOLDER_STACK_LABEL_TEXT_MARGIN_PX
+                + 10,
+            ),
+        )
+
+    def _restart_folder_stack_animation(self) -> None:
+        self._folder_stack_show_started_us = GLib.get_monotonic_time()
+        self._folder_stack_hover_target = None
+        self._folder_stack_hover_values.clear()
+        self._ensure_folder_stack_animating()
+
+    def _ensure_folder_stack_animating(self) -> None:
+        area = self._folder_stack_area
+        if area is None:
+            return
+        area.queue_draw()
+        if self._folder_stack_anim_source == 0:
+            self._folder_stack_anim_source = GLib.timeout_add(
+                FOLDER_STACK_ANIM_FRAME_MS,
+                self._on_folder_stack_animation_frame,
+            )
+
+    def _on_folder_stack_animation_frame(self) -> bool:
+        area = self._folder_stack_area
+        window = self._folder_stack_window
+        if area is None or window is None or not window.get_visible():
+            self._folder_stack_anim_source = 0
+            return False
+
+        active = False
+        now_us = GLib.get_monotonic_time()
+        elapsed_ms = max((now_us - self._folder_stack_show_started_us) / 1000.0, 0.0)
+        reveal_budget_ms = (
+            FOLDER_STACK_REVEAL_DURATION_MS
+            + max(
+                len(self._folder_stack_cards) - 1,
+                0,
+            )
+            * FOLDER_STACK_REVEAL_STAGGER_MS
+        )
+        if elapsed_ms < reveal_budget_ms:
+            active = True
+
+        for card in self._folder_stack_cards:
+            if card.target is None or card.centered:
+                continue
+            current = self._folder_stack_hover_values.get(card.target, 0.0)
+            target = 1.0 if self._folder_stack_hover_target == card.target else 0.0
+            updated = current + (target - current) * FOLDER_STACK_HOVER_EASE
+            if abs(updated - target) < 0.02:
+                updated = target
+            if updated <= 0.0 and target == 0.0:
+                self._folder_stack_hover_values.pop(card.target, None)
+            else:
+                self._folder_stack_hover_values[card.target] = updated
+            if updated != target:
+                active = True
+
+        area.queue_draw()
+        if not active:
+            self._folder_stack_anim_source = 0
+            return False
+        return True
+
+    def _folder_stack_reveal_progress(
+        self, *, sequence_index: int, now_us: int
+    ) -> float:
+        if self._folder_stack_show_started_us <= 0:
+            return 1.0
+        elapsed_ms = max((now_us - self._folder_stack_show_started_us) / 1000.0, 0.0)
+        elapsed_ms -= sequence_index * FOLDER_STACK_REVEAL_STAGGER_MS
+        if elapsed_ms <= 0:
+            return 0.0
+        return _ease_out_cubic(elapsed_ms / FOLDER_STACK_REVEAL_DURATION_MS)
+
+    def _open_folder_stack_target(self, target: str) -> None:
+        launcher_mod.open_target(target)
+        self._close_folder_stack()
+
+    def _folder_target_state(self, target: str) -> str:
+        uri = launcher_mod.normalize_file_target(target)
+        if uri is None:
+            return "missing"
+        try:
+            folder = Gio.File.new_for_uri(uri)
+            return "ok" if folder.query_exists(None) else "missing"
+        except Exception:
+            return "missing"
 
     def _build_item_menu(self, menu: Gtk.Menu, item: DockItem) -> None:
         """Build context menu for a specific dock item.
@@ -1008,7 +1938,10 @@ class MenuHandler:
         self._folder_menu_signal_connected.discard(menu_id)
 
     def _list_directory(
-        self, folder_item: DockItem, target: str
+        self,
+        folder_item: DockItem,
+        target: str,
+        icon_px: int | None = None,
     ) -> list[dict[str, Any]]:
         uri = launcher_mod.normalize_file_target(target)
         if uri is None:
@@ -1022,6 +1955,7 @@ class MenuHandler:
                         "standard::display-name",
                         "standard::icon",
                         "standard::type",
+                        "standard::content-type",
                         "standard::is-hidden",
                         "standard::size",
                         "time::created",
@@ -1036,6 +1970,11 @@ class MenuHandler:
             return []
 
         prefs = self._folder_prefs(folder_item)
+        resolved_icon_px = (
+            self._folder_icon_px(folder_item=folder_item)
+            if icon_px is None
+            else max(int(icon_px), 1)
+        )
         rows: list[dict[str, Any]] = []
         while True:
             info = enumerator.next_file(None)
@@ -1065,17 +2004,12 @@ class MenuHandler:
                     "created": int(info.get_attribute_uint64("time::created")),
                     "modified": int(info.get_attribute_uint64("time::modified")),
                     "icon": (
-                        self._launcher.load_gicon(
+                        self._launcher.resolve_file_icon(
+                            target=child_uri,
                             gicon=icon,
-                            size=self._folder_icon_px(folder_item=folder_item),
-                        )
-                        or self._launcher.load_icon(
-                            icon_name=(
-                                "folder"
-                                if info.get_file_type() == Gio.FileType.DIRECTORY
-                                else "text-x-generic"
-                            ),
-                            size=self._folder_icon_px(folder_item=folder_item),
+                            content_type=info.get_content_type() or "",
+                            size=resolved_icon_px,
+                            is_dir=is_dir,
                         )
                     )
                     if self._launcher
@@ -1132,7 +2066,6 @@ class MenuHandler:
         prefs = self._folder_prefs(item)
         prefs[key] = value
         self._save_folder_prefs(item, prefs)
-        self._model.refresh_folder_preview(desktop_id=item.desktop_id, notify=False)
 
     def _on_folder_sort_changed(
         self, widget: Gtk.MenuItem, item: DockItem, value: str

--- a/tests/platform/test_launcher.py
+++ b/tests/platform/test_launcher.py
@@ -236,6 +236,35 @@ class TestResolve:
         # Then
         assert info is None
 
+    def test_resolve_file_uses_image_thumbnail_for_images(self, monkeypatch):
+        from docking.platform import launcher as launcher_mod
+
+        launcher = Launcher()
+        gicon = MagicMock()
+        info = MagicMock()
+        info.get_icon.return_value = gicon
+        info.get_file_type.return_value = launcher_mod.Gio.FileType.REGULAR
+        info.get_display_name.return_value = "Photo"
+        info.get_content_type.return_value = "image/png"
+        gfile = MagicMock()
+        gfile.query_info.return_value = info
+        monkeypatch.setattr(launcher_mod.Gio.File, "new_for_uri", lambda _uri: gfile)
+
+        thumb = object()
+        pixbuf_cls = MagicMock()
+        pixbuf_cls.new_from_file_at_scale.return_value = thumb
+        monkeypatch.setattr(launcher_mod.GdkPixbuf, "Pixbuf", pixbuf_cls, raising=False)
+        monkeypatch.setattr(launcher_mod.Path, "exists", lambda self: True)
+        launcher.load_gicon = MagicMock(return_value="gicon-pixbuf")
+        launcher.load_icon = MagicMock(return_value="fallback-pixbuf")
+
+        resolved = launcher.resolve_file("/tmp/photo.png", 48)
+
+        assert resolved is not None
+        assert resolved.icon is thumb
+        launcher.load_gicon.assert_not_called()
+        launcher.load_icon.assert_not_called()
+
 
 class TestTryLoadIcon:
     def test_loads_icon_from_absolute_path(self, monkeypatch):

--- a/tests/platform/test_launcher.py
+++ b/tests/platform/test_launcher.py
@@ -73,6 +73,30 @@ class TestIconCache:
         assert ("application-x-executable", 48) in launcher._icon_cache
         assert ("application-x-executable", 96) in launcher._icon_cache
 
+    def test_default_directory_app_name_returns_display_name(self):
+        launcher = Launcher()
+        app_info = MagicMock()
+        app_info.get_display_name.return_value = "Caja"
+
+        with patch(
+            "docking.platform.launcher.Gio.AppInfo.get_default_for_type",
+            return_value=app_info,
+        ):
+            name = launcher.default_directory_app_name()
+
+        assert name == "Caja"
+
+    def test_default_directory_app_name_returns_none_without_default(self):
+        launcher = Launcher()
+
+        with patch(
+            "docking.platform.launcher.Gio.AppInfo.get_default_for_type",
+            return_value=None,
+        ):
+            name = launcher.default_directory_app_name()
+
+        assert name is None
+
 
 class TestDesktopActions:
     def test_get_actions_returns_pairs(self):

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -30,6 +30,8 @@ def _make_stub(item: DockItem | None = None):
     stub.theme = SimpleNamespace(item_padding=8, h_padding=10, urgent_glow_time_ms=500)
     stub.window_tracker = MagicMock()
     stub._menu = MagicMock()
+    stub._menu.open_folder_stack_item_id.return_value = None
+    stub._menu.close_folder_stack = MagicMock()
     stub.tooltip = MagicMock()
     stub._hover = MagicMock()
     stub._hover.hovered_item = item
@@ -45,6 +47,7 @@ def _make_stub(item: DockItem | None = None):
     stub.hit_test = MagicMock(return_value=item)
     stub.update_input_region = MagicMock()
     stub.drawing_area = MagicMock()
+    stub.get_position = MagicMock(return_value=(100, 200))
     stub._test_geometry_frame = frame
     stub._current_geometry_frame = frame
     stub._applied_input_frame = frame
@@ -170,13 +173,16 @@ class TestButtonReleaseFlow:
         assert opened == ["file:///tmp/notes.txt"]
         assert item.last_launched == 3030
 
-    def test_left_click_folder_item_opens_item_menu(self, monkeypatch):
+    def test_left_click_folder_item_opens_folder_stack(self, monkeypatch):
         item = DockItem(
             desktop_id="file:///tmp/docs",
             kind=FOLDER_KIND,
             target="file:///tmp/docs",
         )
         stub, _ = _make_stub(item=item)
+        stub._test_geometry_frame.geometry_for_item.return_value = SimpleNamespace(
+            draw_rect=SimpleNamespace(x=4, y=5, w=48, h=48)
+        )
         event = SimpleNamespace(
             x=12.0, y=6.0, button=dock_window_mod.MOUSE_LEFT, state=0
         )
@@ -187,7 +193,13 @@ class TestButtonReleaseFlow:
         )
 
         assert handled is True
-        stub._menu.show_item.assert_called_once_with(event, item)
+        stub._menu.show_folder_stack.assert_called_once()
+        kwargs = stub._menu.show_folder_stack.call_args.kwargs
+        assert kwargs["item"] is item
+        assert kwargs["anchor_x"] == 104
+        assert kwargs["anchor_y"] == 205
+        assert kwargs["icon_w"] == 48
+        assert kwargs["position"] == Position.BOTTOM
 
     def test_drag_delta_above_threshold_is_ignored(self):
         # Given
@@ -820,14 +832,20 @@ class TestDockWindowDrawAndHelpers:
     def test_on_motion_updates_cursor_and_hover(self):
         # Given
         widget = MagicMock()
+        menu = MagicMock()
+        menu.open_folder_stack_item_id.return_value = None
         stub = SimpleNamespace(
             cursor_x=-1.0,
             cursor_y=-1.0,
             dock_hovered=False,
             config=SimpleNamespace(pos=Position.BOTTOM),
-            _test_geometry_frame=SimpleNamespace(cursor_rect=Rect(0, 0, 100, 100)),
+            _test_geometry_frame=SimpleNamespace(
+                cursor_rect=Rect(0, 0, 100, 100),
+                item_at_point=MagicMock(return_value=None),
+            ),
             update_input_region=MagicMock(),
             _hover=SimpleNamespace(update=MagicMock()),
+            _menu=menu,
             autohide=None,
             zoom_animator=MagicMock(),
             geometry=SimpleNamespace(
@@ -848,6 +866,41 @@ class TestDockWindowDrawAndHelpers:
         stub.update_input_region.assert_called_once()
         stub._hover.update.assert_called_once_with(7.0, frame=stub._test_geometry_frame)
         widget.queue_draw.assert_called_once()
+
+    def test_on_motion_closes_folder_stack_after_leaving_source_folder(self):
+        item = DockItem(
+            desktop_id="file:///tmp/docs",
+            kind=FOLDER_KIND,
+            target="file:///tmp/docs",
+        )
+        other_item = DockItem(desktop_id="firefox.desktop")
+        widget = MagicMock()
+        menu = MagicMock()
+        menu.open_folder_stack_item_id.return_value = item.desktop_id
+        frame = SimpleNamespace(
+            cursor_rect=Rect(0, 0, 100, 100),
+            item_at_point=MagicMock(return_value=other_item),
+        )
+        stub = SimpleNamespace(
+            cursor_x=-1.0,
+            cursor_y=-1.0,
+            dock_hovered=True,
+            config=SimpleNamespace(pos=Position.BOTTOM),
+            _test_geometry_frame=frame,
+            update_input_region=MagicMock(),
+            _hover=SimpleNamespace(update=MagicMock()),
+            _menu=menu,
+            autohide=None,
+            zoom_animator=MagicMock(),
+            geometry=SimpleNamespace(build_frame=lambda **_kwargs: frame),
+        )
+        stub.interaction = DockInteractionCoordinator(stub)
+        event = SimpleNamespace(x=12.0, y=9.0)
+
+        handled = dock_window_mod.DockWindow._on_motion(stub, widget, event)
+
+        assert handled is False
+        menu.close_folder_stack.assert_called_once_with()
 
     def test_on_button_press_records_click_state(self):
         # Given

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -22,6 +22,70 @@ from docking.core.items import FILE_KIND, FOLDER_KIND
 from docking.platform.model import DockItem
 
 
+class FakeFontDescription:
+    def __init__(self) -> None:
+        self.family = ""
+        self.size = 0
+
+    def set_family(self, family: str) -> None:
+        self.family = family
+
+    def set_size(self, size: int) -> None:
+        self.size = size
+
+
+class FakePangoLayout:
+    def __init__(self) -> None:
+        self.text = ""
+        self.width = -1
+        self.alignment = None
+
+    def set_text(self, text: str, _length: int) -> None:
+        self.text = text
+
+    def set_font_description(self, _desc) -> None:
+        return
+
+    def set_ellipsize(self, _mode) -> None:
+        return
+
+    def set_width(self, width: int) -> None:
+        self.width = width
+
+    def set_alignment(self, alignment) -> None:
+        self.alignment = alignment
+
+    def get_pixel_extents(self):
+        width = max(len(self.text) * 7, 1)
+        if self.width > 0:
+            width = min(width, max(int(self.width / 1024), 1))
+        logical = SimpleNamespace(width=width, height=12)
+        ink = SimpleNamespace(width=width, height=12)
+        return ink, logical
+
+
+class FakePangoCairo:
+    @staticmethod
+    def create_layout(_cr):
+        return FakePangoLayout()
+
+    @staticmethod
+    def show_layout(_cr, _layout) -> None:
+        return
+
+
+class FakePango:
+    SCALE = 1024
+
+    class EllipsizeMode:
+        END = 0
+
+    class Alignment:
+        CENTER = 0
+
+    FontDescription = FakeFontDescription
+
+
 def _catalog_entry(*, applet_id, name: str, category=None):
     return menu_mod.AppletMeta(
         id=str(applet_id),
@@ -612,6 +676,8 @@ def _frame(*, item=None, item_index: int = -1, insert_index: int = 0):
 @pytest.fixture
 def handler(monkeypatch):
     monkeypatch.setattr(menu_mod, "Gtk", FakeGtk)
+    monkeypatch.setattr(menu_mod, "Pango", FakePango)
+    monkeypatch.setattr(menu_mod, "PangoCairo", FakePangoCairo)
     monkeypatch.setattr(menu_mod, "load_catalog_icon", lambda applet_id, size: None)
     about = MagicMock()
     settings = MagicMock()
@@ -644,6 +710,8 @@ def handler(monkeypatch):
     tracker = MagicMock()
     tracker.get_windows_for.return_value = []
     tracker.get_window_title_for_xid.side_effect = lambda xid: f"Window {xid}"
+    launcher = MagicMock()
+    launcher.default_directory_app_name.return_value = None
     return menu_mod.MenuHandler(
         about=about,
         settings=settings,
@@ -651,7 +719,7 @@ def handler(monkeypatch):
         model=model,
         config=config,
         window_tracker=tracker,
-        launcher=MagicMock(),
+        launcher=launcher,
         geometry_builder=SimpleNamespace(build_frame=lambda **_kwargs: frame),
     )
 

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -216,6 +216,7 @@ class FakeBox:
     def __init__(self, **_kwargs) -> None:
         self.children: list[object] = []
         self.parent = None
+        self.shown = False
 
     def pack_start(self, child, *_args) -> None:
         self.children.append(child)
@@ -238,6 +239,19 @@ class FakeBox:
 
     def set_margin_bottom(self, _value: int) -> None:
         return
+
+    def set_size_request(self, _width: int, _height: int) -> None:
+        return
+
+    def show_all(self) -> None:
+        self.shown = True
+
+    def get_preferred_size(self):
+        height = max(34 * max(len(self.children), 1), 34)
+        return (
+            SimpleNamespace(width=240, height=height),
+            SimpleNamespace(width=240, height=height),
+        )
 
 
 class FakeLabel:
@@ -286,6 +300,7 @@ class FakeButton(FakeMenuItem):
         self.can_focus = True
         self.hexpand = False
         self.halign = None
+        self.size_request = None
 
     def set_relief(self, relief) -> None:
         self.relief = relief
@@ -301,6 +316,9 @@ class FakeButton(FakeMenuItem):
 
     def get_parent(self):
         return self.parent
+
+    def set_size_request(self, width: int, height: int) -> None:
+        self.size_request = (width, height)
 
 
 class FakeScrolledWindow:
@@ -351,35 +369,88 @@ class FakeComboBoxText:
         self._signals.setdefault(signal, []).append((callback, args))
 
 
-class FakePopover:
+class FakeScreen:
+    def get_rgba_visual(self):
+        return None
+
+    def get_width(self) -> int:
+        return 1920
+
+    def get_height(self) -> int:
+        return 1080
+
+
+class FakeWindow:
     last_created = None
 
-    def __init__(self, relative_to=None) -> None:
-        self.relative_to = relative_to
+    def __init__(self, **_kwargs) -> None:
         self.child = None
-        self.modal = False
-        self.position = None
-        self.pointing_to = None
-        self.popped = False
+        self.visible = False
+        self.moved_to = None
         self.parent = None
-        self._signals: dict[str, list[tuple[object, tuple[object, ...]]]] = {}
-        FakePopover.last_created = self
+        self.screen = FakeScreen()
+        FakeWindow.last_created = self
 
-    @classmethod
-    def new(cls, relative_to):
-        return cls(relative_to=relative_to)
+    def get_child(self):
+        return self.child
 
-    def set_modal(self, value: bool) -> None:
-        self.modal = value
+    def set_decorated(self, _value: bool) -> None:
+        return
 
-    def set_position(self, value) -> None:
-        self.position = value
+    def set_skip_taskbar_hint(self, _value: bool) -> None:
+        return
 
-    def connect(self, signal: str, callback, *args) -> None:
-        self._signals.setdefault(signal, []).append((callback, args))
+    def set_resizable(self, _value: bool) -> None:
+        return
 
-    def set_pointing_to(self, rect) -> None:
-        self.pointing_to = rect
+    def set_type_hint(self, _value) -> None:
+        return
+
+    def set_app_paintable(self, _value: bool) -> None:
+        return
+
+    def set_visual(self, _visual) -> None:
+        return
+
+    def remove(self, _child) -> None:
+        self.child = None
+
+    def add(self, child) -> None:
+        self.child = child
+        if hasattr(child, "parent"):
+            child.parent = self
+
+    def show_all(self) -> None:
+        self.visible = True
+
+    def hide(self) -> None:
+        self.visible = False
+
+    def get_visible(self) -> bool:
+        return self.visible
+
+    def move(self, x: int, y: int) -> None:
+        self.moved_to = (x, y)
+
+    def get_screen(self):
+        return self.screen
+
+
+class FakeRevealer:
+    def __init__(self) -> None:
+        self.child = None
+        self.transition_type = None
+        self.transition_duration = 0
+        self.reveal_child = False
+
+    def set_transition_type(self, value) -> None:
+        self.transition_type = value
+
+    def set_transition_duration(self, value: int) -> None:
+        self.transition_duration = value
+
+    def set_reveal_child(self, value: bool) -> None:
+        self.reveal_child = value
 
     def get_child(self):
         return self.child
@@ -392,20 +463,82 @@ class FakePopover:
         if hasattr(child, "parent"):
             child.parent = self
 
+
+class FakeFixed:
+    def __init__(self) -> None:
+        self.children: list[tuple[object, int, int]] = []
+        self.size_request = (1, 1)
+        self.parent = None
+
+    def put(self, child, x: int, y: int) -> None:
+        self.children.append((child, x, y))
+        if hasattr(child, "parent"):
+            child.parent = self
+
+    def set_size_request(self, width: int, height: int) -> None:
+        self.size_request = (width, height)
+
     def show_all(self) -> None:
         return
 
-    def popup(self) -> None:
-        self.popped = True
+    def get_preferred_size(self):
+        width, height = self.size_request
+        return (
+            SimpleNamespace(width=width, height=height),
+            SimpleNamespace(width=width, height=height),
+        )
 
-    def popdown(self) -> None:
-        self.popped = False
-        for callback, args in self._signals.get("closed", []):
-            callback(self, *args)
+
+class FakeDrawingArea:
+    def __init__(self) -> None:
+        self.size_request = (1, 1)
+        self.events = 0
+        self._signals: dict[str, list[tuple[object, tuple[object, ...]]]] = {}
+        self.parent = None
+        self.shown = False
+        self.draw_queued = False
+
+    def set_size_request(self, width: int, height: int) -> None:
+        self.size_request = (width, height)
+
+    def add_events(self, events: int) -> None:
+        self.events = events
+
+    def connect(self, signal: str, callback, *args) -> None:
+        self._signals.setdefault(signal, []).append((callback, args))
+
+    def show_all(self) -> None:
+        self.shown = True
+
+    def queue_draw(self) -> None:
+        self.draw_queued = True
+
+    def get_preferred_size(self):
+        width, height = self.size_request
+        return (
+            SimpleNamespace(width=width, height=height),
+            SimpleNamespace(width=width, height=height),
+        )
+
+
+class FakeWindowType:
+    POPUP = 0
+
+
+class FakeWindowTypeHint:
+    TOOLTIP = 0
+
+
+class FakeRevealerTransitionType:
+    SLIDE_UP = 0
+    SLIDE_DOWN = 1
+    SLIDE_RIGHT = 2
+    SLIDE_LEFT = 3
 
 
 class FakeAlign:
     FILL = 0
+    CENTER = 1
 
 
 class FakePolicyType:
@@ -432,6 +565,7 @@ class FakeOrientation:
 class FakeGtk:
     Menu = FakeMenu
     MenuItem = FakeMenuItem
+    Window = FakeWindow
     Button = FakeButton
     CheckMenuItem = FakeCheckMenuItem
     CheckButton = FakeCheckButton
@@ -440,15 +574,20 @@ class FakeGtk:
     Separator = FakeSeparator
     ScrolledWindow = FakeScrolledWindow
     ComboBoxText = FakeComboBoxText
-    Popover = FakePopover
     Image = FakeImage
     Box = FakeBox
     Label = FakeLabel
+    Fixed = FakeFixed
+    DrawingArea = FakeDrawingArea
+    Revealer = FakeRevealer
     Orientation = FakeOrientation
     Align = FakeAlign
     PolicyType = FakePolicyType
     ReliefStyle = FakeReliefStyle
     PositionType = FakePositionType
+    WindowType = FakeWindowType
+    WindowTypeHint = FakeWindowTypeHint
+    RevealerTransitionType = FakeRevealerTransitionType
     main_quit = MagicMock()
 
 
@@ -704,6 +843,7 @@ class TestItemMenus:
         info.get_name.return_value = "docs"
         info.get_display_name.return_value = "docs"
         info.get_icon.return_value = gicon
+        info.get_content_type.return_value = "inode/directory"
         info.get_file_type.return_value = menu_mod.Gio.FileType.DIRECTORY
         info.get_is_hidden.return_value = False
         info.get_size.return_value = 0
@@ -719,8 +859,7 @@ class TestItemMenus:
         monkeypatch.setattr(
             handler, "_directory_has_visible_children", lambda **_kwargs: False
         )
-        handler._launcher.load_gicon.return_value = "folder-pixbuf"
-        handler._launcher.load_icon.return_value = "fallback-pixbuf"
+        handler._launcher.resolve_file_icon.return_value = "folder-pixbuf"
         item = DockItem(
             desktop_id="file:///tmp/root",
             kind=FOLDER_KIND,
@@ -731,7 +870,13 @@ class TestItemMenus:
         rows = handler._list_directory(folder_item=item, target="file:///tmp/root")
 
         assert rows[0]["icon"] == "folder-pixbuf"
-        handler._launcher.load_gicon.assert_called_once()
+        handler._launcher.resolve_file_icon.assert_called_once_with(
+            target="file:///tmp/docs",
+            gicon=gicon,
+            content_type="inode/directory",
+            size=16,
+            is_dir=True,
+        )
 
     def test_file_item_menu_opens_target(self, handler, monkeypatch):
         menu = FakeMenu()
@@ -1218,3 +1363,308 @@ class TestMenuCallbacks:
         assert result is False
         assert called == ["file:///tmp/docs"]
         assert menu.shown is True
+
+    def test_show_folder_stack_builds_popup_window(self, handler, monkeypatch):
+        item = DockItem(
+            desktop_id="file:///tmp/docs",
+            kind=FOLDER_KIND,
+            target="file:///tmp/docs",
+        )
+        monkeypatch.setattr(menu_mod.GLib, "timeout_add", lambda *_args: 1)
+        monkeypatch.setattr(handler, "_folder_target_state", lambda _target: "ok")
+        monkeypatch.setattr(
+            handler,
+            "_list_directory",
+            lambda **_kwargs: [
+                {
+                    "target": "file:///tmp/docs/readme.txt",
+                    "name": "readme.txt",
+                    "is_dir": False,
+                    "icon": None,
+                }
+            ],
+        )
+        tracked: list[str] = []
+        monkeypatch.setattr(
+            handler, "_track_folder_stack", lambda target: tracked.append(target)
+        )
+
+        handler.show_folder_stack(
+            item=item,
+            anchor_x=120,
+            anchor_y=800,
+            icon_w=48,
+            position="bottom",
+        )
+
+        window = FakeWindow.last_created
+        assert window is not None
+        assert window.visible is True
+        assert window.moved_to is not None
+        assert tracked == ["file:///tmp/docs"]
+        handler._runtime.menu_popup_opened.assert_called_once()
+        handler._runtime.hide_hover_ui.assert_called_once()
+
+    def test_show_folder_stack_second_click_toggles_closed(self, handler, monkeypatch):
+        item = DockItem(
+            desktop_id="file:///tmp/docs",
+            kind=FOLDER_KIND,
+            target="file:///tmp/docs",
+        )
+        monkeypatch.setattr(menu_mod.GLib, "timeout_add", lambda *_args: 1)
+        monkeypatch.setattr(handler, "_folder_target_state", lambda _target: "ok")
+        monkeypatch.setattr(handler, "_list_directory", lambda **_kwargs: [])
+        monkeypatch.setattr(handler, "_track_folder_stack", lambda target: None)
+
+        handler.show_folder_stack(
+            item=item,
+            anchor_x=120,
+            anchor_y=800,
+            icon_w=48,
+            position="bottom",
+        )
+        window = FakeWindow.last_created
+
+        handler.show_folder_stack(
+            item=item,
+            anchor_x=120,
+            anchor_y=800,
+            icon_w=48,
+            position="bottom",
+        )
+
+        assert window is not None
+        assert window.visible is False
+        assert handler._runtime.menu_popup_opened.call_count == 1
+        handler._runtime.menu_popup_closed.assert_called_once()
+
+    def test_folder_stack_requests_dock_sized_icons(self, handler, monkeypatch):
+        handler._config.icon_size = 52
+        item = DockItem(
+            desktop_id="file:///tmp/docs",
+            kind=FOLDER_KIND,
+            target="file:///tmp/docs",
+        )
+        requested_icon_sizes: list[int] = []
+
+        monkeypatch.setattr(handler, "_folder_target_state", lambda _target: "ok")
+        monkeypatch.setattr(
+            handler,
+            "_list_directory",
+            lambda **kwargs: (
+                requested_icon_sizes.append(kwargs["icon_px"])
+                or [
+                    {
+                        "target": "file:///tmp/docs/readme.txt",
+                        "name": "readme.txt",
+                        "is_dir": False,
+                        "icon": object(),
+                    }
+                ]
+            ),
+        )
+
+        cards, _popup_w, _popup_h = handler._folder_stack_cards_for_item(item)
+
+        assert requested_icon_sizes == [52]
+        assert cards[1].icon_size == 52
+        assert cards[1].label_w <= menu_mod.FOLDER_STACK_LABEL_MAX_WIDTH_PX
+
+    def test_folder_stack_action_chip_allows_wider_more_label(
+        self, handler, monkeypatch
+    ):
+        item = DockItem(
+            desktop_id="file:///tmp/docs",
+            kind=FOLDER_KIND,
+            target="file:///tmp/docs",
+        )
+        monkeypatch.setattr(handler, "_folder_target_state", lambda _target: "ok")
+        monkeypatch.setattr(
+            handler,
+            "_list_directory",
+            lambda **_kwargs: [
+                {
+                    "target": f"file:///tmp/docs/{i}.txt",
+                    "name": f"Item {i}",
+                    "is_dir": False,
+                    "icon": object(),
+                }
+                for i in range(14)
+            ],
+        )
+
+        cards, _popup_w, _popup_h = handler._folder_stack_cards_for_item(item)
+
+        assert cards[0].label == "5 More in Folder"
+        assert cards[0].label_w == handler._folder_stack_action_width(
+            label="5 More in Folder"
+        )
+        assert cards[0].label_w <= menu_mod.FOLDER_STACK_ACTION_MAX_WIDTH_PX
+
+    def test_folder_stack_short_labels_fit_chip_width(self, handler, monkeypatch):
+        item = DockItem(
+            desktop_id="file:///tmp/docs",
+            kind=FOLDER_KIND,
+            target="file:///tmp/docs",
+        )
+        monkeypatch.setattr(handler, "_folder_target_state", lambda _target: "ok")
+        monkeypatch.setattr(
+            handler,
+            "_list_directory",
+            lambda **_kwargs: [
+                {
+                    "target": "file:///tmp/docs/doc",
+                    "name": "doc",
+                    "is_dir": True,
+                    "icon": object(),
+                }
+            ],
+        )
+
+        cards, _popup_w, _popup_h = handler._folder_stack_cards_for_item(item)
+
+        assert cards[1].label == "doc"
+        assert cards[1].label_w < 50
+
+    def test_folder_stack_arc_starts_from_first_visible_item(
+        self, handler, monkeypatch
+    ):
+        item = DockItem(
+            desktop_id="file:///tmp/docs",
+            kind=FOLDER_KIND,
+            target="file:///tmp/docs",
+        )
+        monkeypatch.setattr(handler, "_folder_target_state", lambda _target: "ok")
+        monkeypatch.setattr(
+            handler,
+            "_list_directory",
+            lambda **_kwargs: [
+                {
+                    "target": f"file:///tmp/docs/{i}.txt",
+                    "name": f"Item {i}",
+                    "is_dir": False,
+                    "icon": object(),
+                }
+                for i in range(4)
+            ],
+        )
+
+        cards, popup_w, _popup_h = handler._folder_stack_cards_for_item(item)
+
+        icon_cards = [card for card in cards if card.icon_size > 0]
+        assert len(icon_cards) == 4
+        fold_center_x = handler._folder_stack_fold_center_x
+        for card in icon_cards:
+            icon_center_x = card.icon_x + card.icon_size / 2
+            assert icon_center_x > fold_center_x
+        assert icon_cards[0].icon_x > icon_cards[-1].icon_x
+        assert popup_w > icon_cards[0].icon_x + icon_cards[0].icon_size
+
+    def test_folder_stack_keeps_uniform_vertical_spacing(self, handler, monkeypatch):
+        item = DockItem(
+            desktop_id="file:///tmp/docs",
+            kind=FOLDER_KIND,
+            target="file:///tmp/docs",
+        )
+        monkeypatch.setattr(handler, "_folder_target_state", lambda _target: "ok")
+        monkeypatch.setattr(
+            handler,
+            "_list_directory",
+            lambda **_kwargs: [
+                {
+                    "target": f"file:///tmp/docs/{i}.txt",
+                    "name": f"Item {i}",
+                    "is_dir": False,
+                    "icon": object(),
+                }
+                for i in range(5)
+            ],
+        )
+
+        cards, _popup_w, _popup_h = handler._folder_stack_cards_for_item(item)
+
+        icon_cards = [card for card in cards if card.icon_size > 0]
+        centers = [card.icon_y + card.icon_size / 2 for card in icon_cards]
+        gaps = [round(centers[index + 1] - centers[index], 3) for index in range(4)]
+        assert len(set(gaps)) == 1
+
+    def test_folder_stack_change_debounces_refresh(self, handler, monkeypatch):
+        removed: list[int] = []
+        timeout_calls: list[tuple[int, object, tuple[object, ...]]] = []
+        monkeypatch.setattr(
+            menu_mod.GLib, "source_remove", lambda source: removed.append(source)
+        )
+        monkeypatch.setattr(
+            menu_mod.GLib,
+            "timeout_add",
+            lambda delay, cb, *args: timeout_calls.append((delay, cb, args)) or 77,
+        )
+        handler._folder_stack_refresh_source = 12
+
+        handler._on_folder_stack_changed(MagicMock(), MagicMock(), None, MagicMock())
+
+        assert removed == [12]
+        assert timeout_calls[0][0] == 120
+        assert handler._folder_stack_refresh_source == 77
+
+    def test_folder_stack_click_opens_target(self, handler):
+        target = "file:///tmp/docs/readme.txt"
+        handler._folder_stack_cards = [
+            menu_mod.FolderStackCard(
+                label="readme.txt",
+                target=target,
+                icon=None,
+                icon_x=80,
+                icon_y=40,
+                icon_size=48,
+                label_x=10,
+                label_y=52,
+                label_w=90,
+                label_h=24,
+                centered=False,
+            )
+        ]
+        opened: list[str] = []
+        with patch.object(handler, "_open_folder_stack_target", opened.append):
+            press = SimpleNamespace(x=32.0, y=60.0, button=1)
+            release = SimpleNamespace(x=32.0, y=60.0, button=1)
+
+            assert (
+                handler._on_folder_stack_button_press(FakeDrawingArea(), press) is True
+            )
+            assert (
+                handler._on_folder_stack_button_release(FakeDrawingArea(), release)
+                is True
+            )
+
+        assert opened == [target]
+
+    def test_refresh_folder_stack_rebuilds_popup_content(self, handler, monkeypatch):
+        item = DockItem(
+            desktop_id="file:///tmp/docs",
+            kind=FOLDER_KIND,
+            target="file:///tmp/docs",
+        )
+        window = FakeWindow()
+        revealer = FakeRevealer()
+        old_child = object()
+        revealer.add(old_child)
+        built: list[object] = []
+        monkeypatch.setattr(
+            handler,
+            "_replace_folder_stack_content",
+            lambda item: built.append(object()),
+        )
+        monkeypatch.setattr(
+            handler,
+            "_position_folder_stack_window",
+            lambda: built.append(object()) or built[-1],
+        )
+        handler._folder_stack_window = window
+        handler._folder_stack_revealer = revealer
+        handler._folder_stack_item = item
+
+        result = handler._refresh_folder_stack()
+
+        assert result is False
+        assert window.visible is True

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -1479,6 +1479,47 @@ class TestMenuCallbacks:
             target="file:///tmp/docs",
         )
         monkeypatch.setattr(handler, "_folder_target_state", lambda _target: "ok")
+        handler._launcher.default_directory_app_name.return_value = "Caja"
+        monkeypatch.setattr(
+            handler,
+            "_list_directory",
+            lambda **_kwargs: [
+                {
+                    "target": f"file:///tmp/docs/{i}.txt",
+                    "name": f"Item {i}",
+                    "is_dir": False,
+                    "icon": object(),
+                }
+                for i in range(14)
+            ],
+        )
+
+        cards, _popup_w, _popup_h = handler._folder_stack_cards_for_item(item)
+
+        assert cards[0].label == "5 More in Caja"
+        expected_width = (
+            menu_mod._measure_stack_text_px("5 More in Caja")
+            + 2 * menu_mod.FOLDER_STACK_LABEL_TEXT_MARGIN_PX
+            + menu_mod.FOLDER_STACK_ACTION_ARROW_GAP_PX
+            + menu_mod.FOLDER_STACK_ACTION_ARROW_SIZE_PX
+            + 10
+        )
+        assert cards[0].label_w == handler._folder_stack_action_width(
+            label="5 More in Caja"
+        )
+        assert cards[0].label_w == expected_width
+        assert cards[0].label_w <= menu_mod.FOLDER_STACK_ACTION_MAX_WIDTH_PX
+
+    def test_folder_stack_action_chip_falls_back_without_directory_app(
+        self, handler, monkeypatch
+    ):
+        item = DockItem(
+            desktop_id="file:///tmp/docs",
+            kind=FOLDER_KIND,
+            target="file:///tmp/docs",
+        )
+        monkeypatch.setattr(handler, "_folder_target_state", lambda _target: "ok")
+        handler._launcher.default_directory_app_name.return_value = None
         monkeypatch.setattr(
             handler,
             "_list_directory",
@@ -1496,10 +1537,6 @@ class TestMenuCallbacks:
         cards, _popup_w, _popup_h = handler._folder_stack_cards_for_item(item)
 
         assert cards[0].label == "5 More in Folder"
-        assert cards[0].label_w == handler._folder_stack_action_width(
-            label="5 More in Folder"
-        )
-        assert cards[0].label_w <= menu_mod.FOLDER_STACK_ACTION_MAX_WIDTH_PX
 
     def test_folder_stack_short_labels_fit_chip_width(self, handler, monkeypatch):
         item = DockItem(


### PR DESCRIPTION
## Summary
- add a left-click folder stack popup for pinned folders with live refresh and stack interactions
- add image thumbnails for image files in folder stacks and tighten dock hover behavior so stacks close when leaving the source folder icon
- update docs, tests, and translation catalogs for the new folder stack strings