### PR TITLE
Add most-recent left-click action

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Config is stored at `~/.config/docking/dock.json` (auto-created on first run). N
 | `anchor_files` | false | Keep file and folder entries anchored at the end independently |
 | `tooltips_enabled` | true | Show hover tooltips for dock items |
 | `active_display` | false | Follow the active monitor instead of staying on one display |
-| `left_click_action` | toggle | Running-app left click: `toggle` or `cycle` |
+| `left_click_action` | toggle | Running-app left click: `toggle`, `cycle`, or `most-recent` |
 | `middle_click_action` | new-window | Application middle click: `new-window`, `minimize`, or `close-focused` |
 | `theme` | default | Theme name (loads from `assets/themes/{name}.json`) |
 | `transparency` | 1.0 | Multiplier applied to theme alpha from `0.15` to `1.0` (`1.0` = full theme opacity) |
@@ -209,7 +209,7 @@ Config is stored at `~/.config/docking/dock.json` (auto-created on first run). N
 - `window-dodge`: Dock hides when any window on the current workspace overlaps the dock.
 - `dodge-maximized`: Dock hides when the focused window is maximized or a dialog overlaps the dock.
 
-All settings are also configurable via the dock's right-click menu. On multi-monitor setups, use **Display** to move the dock to another monitor. The preferences window also exposes **Mouse** actions so left click can either toggle or cycle running windows, and middle click can open a new window, minimize the app windows, or close the app's focused window.
+All settings are also configurable via the dock's right-click menu. On multi-monitor setups, use **Display** to move the dock to another monitor. The preferences window also exposes **Mouse** actions so left click can toggle, cycle, or focus the most recently used window of the running app, and middle click can open a new window, minimize the app windows, or close the app's focused window. Pick the left-click mode under right-click -> **Preferences** -> **Behavior** -> **Mouse**.
 
 ## Managing Dock Items
 

--- a/docking/core/config.py
+++ b/docking/core/config.py
@@ -395,14 +395,17 @@ def _normalize_hide_mode(value: object) -> str:
 class LeftClickAction(str, Enum):
     """Primary-click behavior for running applications.
 
-    Action  Behavior
-    ──────  ─────────────────────────────────────────────────────────────
-    TOGGLE  Focuses the app, or minimizes its windows if already focused.
-    CYCLE   Advances focus through the app's open windows.
+    Action       Behavior
+    ───────────  ─────────────────────────────────────────────────────────
+    TOGGLE       Focuses the app, or minimizes its windows if already focused.
+    CYCLE        Advances focus through the app's open windows.
+    MOST_RECENT  Focuses the app's most recently used window (stacking order).
+                 Minimizes if the app is already active.
     """
 
     TOGGLE = "toggle"
     CYCLE = "cycle"
+    MOST_RECENT = "most-recent"
 
 
 class MiddleClickAction(str, Enum):

--- a/docking/locale/af/LC_MESSAGES/docking.po
+++ b/docking/locale/af/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Gekoppeld {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Gekoppelde toestelle"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Gepaarde toestelle"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Ontdekte toestelle"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Battery: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Soek stad"
 msgid "Type city name..."
 msgstr "Tik stadnaam in..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Webwerf"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Skerm {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Voorkoms"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Gedrag"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Voorkoms"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Zoem persentasie"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Wys nutswenke"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Plasing"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Uitleg"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Sluit posisies"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Anker leers na einde"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Wegsteekmodus"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Wegsteekvertraging"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Onverbergvertraging"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/am/LC_MESSAGES/docking.po
+++ b/docking/locale/am/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "ብሉቱዝ"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "ብሉቱዝ አይገኝም"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "ብሉቱዝ አስማሚ የለም"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "በርቷል"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "ጠፍቷል"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - ተገናኝቷል {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "ቀጣይ ፍለጋ"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "አሁን አድስ"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "አስማሚ"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "የተገናኙ መሣሪያዎች"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "የተጣመሩ መሣሪያዎች"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "የተገኙ መሣሪያዎች"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "ግንኙነት ያቋርጡ"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "ያገናኙ"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "አጣምር"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "ጥምረት አስወግድ"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "የታመነ"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "ባትሪ: {percent}%"
@@ -508,11 +508,11 @@ msgstr "የደረጃ ስም አሳይ"
 msgid "Refresh"
 msgstr "አድስ"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "አዲስ"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "ሙሉ"
 
@@ -550,27 +550,27 @@ msgstr "ከአዲስ ጨረቃ በኋላ {days} ቀናት"
 msgid "{days} days after full moon"
 msgstr "ከሙሉ ጨረቃ በኋላ {days} ቀናት"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "እያደገ ግማሽ ጨረቃ"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "እያደገ ሰፊ ጨረቃ"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "እየቀነሰ ሰፊ ጨረቃ"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "እየቀነሰ ግማሽ ጨረቃ"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1ኛ ሩብ"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3ኛ ሩብ"
 
@@ -1170,17 +1170,22 @@ msgstr "ከተማ ፈልግ"
 msgid "Type city name..."
 msgstr "የከተማ ስም ይተይቡ..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "አየር: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "የአየር ሁኔታ (ከተማ አልተመረጠም)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "የሥራ ቦታዎች"
 msgid "Website"
 msgstr "ድረ-ገጽ"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "ማሳያ {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "መልክ"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "ባህሪ"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "መልክ"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "ገጽታ"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "የአዶ መጠን"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "የማጉያ መቶኛ"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "ጠቃሚ ምክሮችን አሳይ"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "የመስኮት ቅድመ-እይታ"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "አቀማመጥ"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "ቦታ"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "ጠቋሚን ተከተል"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "የአሁኑ የሥራ ቦታ ብቻ"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "አቀማመጥ"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "ቦታዎችን ቆልፍ"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "አፕሌቶችን ወደ መጨረሻ ሰካ"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "ፋይሎችን ወደ መጨረሻ ሰካ"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "የመደበቂያ ሁኔታ"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "የመደበቂያ ዘግይት"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "የማሳያ ዘግይት"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/ar/LC_MESSAGES/docking.po
+++ b/docking/locale/ar/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "بلوتوث"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "بلوتوث غير متاح"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "لا يوجد محول بلوتوث"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "تشغيل"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "إيقاف"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - متصل {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "اكتشاف مستمر"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "تحديث الآن"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "محول"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "الأجهزة المتصلة"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "الأجهزة المقترنة"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "الأجهزة المكتشفة"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "قطع الاتصال"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "اتصال"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "إقران"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "إزالة الاقتران"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "موثوق"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "البطارية: {percent}%"
@@ -508,11 +508,11 @@ msgstr "عرض الطور"
 msgid "Refresh"
 msgstr "تحديث"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "محاق"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "بدر"
 
@@ -550,27 +550,27 @@ msgstr "{days} يوم بعد المحاق"
 msgid "{days} days after full moon"
 msgstr "{days} يوم بعد البدر"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "هلال متزايد"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "أحدب متزايد"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "أحدب متناقص"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "هلال متناقص"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "الربع الأول"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "الربع الأخير"
 
@@ -1170,17 +1170,22 @@ msgstr "البحث عن المدينة"
 msgid "Type city name..."
 msgstr "اكتب اسم المدينة..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp} درجة، {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "الهواء: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "الطقس (لم يتم اختيار مدينة)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "مساحات العمل"
 msgid "Website"
 msgstr "موقع إلكتروني"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "شاشة {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "المظهر"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "السلوك"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "المظهر"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "السمة"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "حجم الأيقونة"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "نسبة التكبير"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "إظهار التلميحات"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "معاينة النوافذ"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "الموضع"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "موضع"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "تتبع المؤشر"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "مساحة العمل الحالية فقط"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "التخطيط"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "قفل المواضع"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "تثبيت التطبيقات المصغرة في النهاية"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "تثبيت الملفات في النهاية"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "وضع الإخفاء"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "تأخير الإخفاء"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "تأخير الظهور"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "الرصيف مرئي دائما ويحجز مساحة من الشاشة."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "يختفي عندما يغادر مؤشر الماوس الرصيف."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "يختفي عندما تتداخل النافذة النشطة مع منطقة الرصيف."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "يختفي عندما تتداخل أي نافذة على مساحة العمل الحالية مع منطقة الرصيف."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/az/LC_MESSAGES/docking.po
+++ b/docking/locale/az/LC_MESSAGES/docking.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -163,111 +163,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth mövcud deyil"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "Bluetooth adapteri yoxdur"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "Açıq"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Bağlı"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Qoşulub {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Davamlı Axtarış"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "İndi Yenilə"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Qoşulmuş Cihazlar"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Cütlənmiş Cihazlar"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Aşkar Edilmiş Cihazlar"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Ayır"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Qoşul"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Cütlə"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Cütləməni Sil"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Etibarlı"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batareya: {percent}%"
@@ -507,11 +507,11 @@ msgstr "Faza Adını Göstər"
 msgid "Refresh"
 msgstr "Yenilə"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "Yeni"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Tam"
 
@@ -549,27 +549,27 @@ msgstr "yeni aydan {days} gün sonra"
 msgid "{days} days after full moon"
 msgstr "bütöv aydan {days} gün sonra"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Böyüyən Aypara"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Böyüyən Dolğun"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Azalan Dolğun"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Azalan Aypara"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1-ci Rüb"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3-cü Rüb"
 
@@ -1169,17 +1169,22 @@ msgstr "Şəhər axtar"
 msgid "Type city name..."
 msgstr "Şəhər adını yazın..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Hava: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1192,11 +1197,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Hava (şəhər seçilməyib)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1219,7 +1219,7 @@ msgstr "İş Sahələri"
 msgid "Website"
 msgstr "Veb-sayt"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1344,7 +1344,7 @@ msgstr "Ekran {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Gorunus"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Davranis"
 
@@ -1384,129 +1384,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Gorunus"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Nişan Ölçüsü"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Boyutme faizi"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Ipuclari goster"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Pəncərə Önbaxışları"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Yerlesdirme"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Mövqe"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Kursoru İzlə"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Yalnız Cari İş Sahəsi"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Duzen"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Movqeleri kilidle"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Appletləri Sona Bərkid"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Fayllari sona bagla"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Gizletme rejimi"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Gizletme gecikdirmesi"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Gosterme gecikdirmesi"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/be/LC_MESSAGES/docking.po
+++ b/docking/locale/be/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Падлучана {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Падлучаныя прылады"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Спалучаныя прылады"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Выяўленыя прылады"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Батарэя: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Пошук горада"
 msgid "Type city name..."
 msgstr "Увядзіце назву горада..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Вэб-сайт"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Дысплей {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Знешнi выгляд"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Паводзiны"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Выгляд"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Тэма"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Адсотак маштабу"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Паказаць падказкi"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Размяшчэнне"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Раскладка"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Заблакiраваць пазiцыi"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Замацаваць файлы ў канцы"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Рэжым хавання"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Затрымка хавання"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Затрымка паказу"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/bg/LC_MESSAGES/docking.po
+++ b/docking/locale/bg/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Свързани {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Свързани устройства"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Сдвоени устройства"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Открити устройства"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Батерия: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Търсене на град"
 msgid "Type city name..."
 msgstr "Въведете име на град..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Уебсайт"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Дисплей {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Външен вид"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Поведение"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Изглед"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Тема"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Процент на увеличение"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Покажи подсказки"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Позиция"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Подредба"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Заключи позиции"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Закотви файлове в края"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Режим на скриване"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Забавяне при скриване"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Забавяне при показване"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/bn/LC_MESSAGES/docking.po
+++ b/docking/locale/bn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - সংযুক্ত {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "সংযুক্ত ডিভাইস"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "যুক্ত ডিভাইস"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "আবিষ্কৃত ডিভাইস"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "ব্যাটারি: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "শহর খুঁজুন"
 msgid "Type city name..."
 msgstr "শহরের নাম লিখুন..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "ওয়েবসাইট"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "ডিসপ্লে {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "চেহারা"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "আচরণ"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "চেহারা"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "থিম"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "জুম শতাংশ"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "টুলটিপ দেখান"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "স্থাপন"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "লেআউট"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "অবস্থান লক করুন"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "ফাইল শেষে নোঙর করুন"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "লুকানোর মোড"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "লুকানোর বিলম্ব"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "প্রদর্শনের বিলম্ব"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/bs/LC_MESSAGES/docking.po
+++ b/docking/locale/bs/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Povezano {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Povezani uređaji"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Upareni uređaji"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Otkriveni uređaji"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Baterija: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Traži grad"
 msgid "Type city name..."
 msgstr "Unesite ime grada..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Web stranica"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Ekran {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Izgled"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Ponašanje"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Izgled"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Procenat uvećanja"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Prikaži opise"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Pozicija"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Raspored"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Zaključaj pozicije"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Zakači fajlove na kraj"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Način skrivanja"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Kašnjenje skrivanja"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Kašnjenje prikazivanja"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/ca/LC_MESSAGES/docking.po
+++ b/docking/locale/ca/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Connectats {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Dispositius connectats"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Dispositius vinculats"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Dispositius descoberts"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Bateria: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Cerca la ciutat"
 msgid "Type city name..."
 msgstr "Escriu el nom de la ciutat..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Lloc web"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Pantalla {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Aparenca"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Comportament"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Aspecte"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Percentatge de zoom"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Mostra indicadors"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Col-locacio"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Disposicio"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Bloqueja posicions"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Ancora fitxers al final"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Mode d'ocultacio"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Retard d'ocultacio"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Retard de mostrar"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/cs/LC_MESSAGES/docking.po
+++ b/docking/locale/cs/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth nedostupný"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "Žádný Bluetooth adaptér"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "Zapnuto"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Vypnuto"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Připojeno {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Průběžné vyhledávání"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Obnovit nyní"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adaptér"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Připojená zařízení"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Spárovaná zařízení"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Objevená zařízení"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Odpojit"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Připojit"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Spárovat"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Zrušit párování"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Důvěryhodné"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Baterie: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Zobrazit název fáze"
 msgid "Refresh"
 msgstr "Obnovit"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "Nov"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Úplněk"
 
@@ -550,27 +550,27 @@ msgstr "{days} dnů po novu"
 msgid "{days} days after full moon"
 msgstr "{days} dnů po úplňku"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Dorůstající srpek"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Dorůstající měsíc"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Couvající měsíc"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Couvající srpek"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "První čtvrť"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "Třetí čtvrť"
 
@@ -1171,17 +1171,22 @@ msgstr "Hledat město"
 msgid "Type city name..."
 msgstr "Zadejte název města..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Vzduch: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1194,11 +1199,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Počasí (město nevybráno)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1221,7 +1221,7 @@ msgstr "Pracovní plochy"
 msgid "Website"
 msgstr "Webové stránky"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1346,7 +1346,7 @@ msgstr "Displej {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Vzhled"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Chovani"
 
@@ -1386,130 +1386,134 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Vzhled"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Motiv"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Velikost ikon"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Procento priblizeni"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Zobrazit napovedy"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Náhledy oken"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Umisteni"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Pozice"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Sledovat kurzor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Pouze aktuální plocha"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Rozlozeni"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Zamknout pozice"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Ukotvit aplety na konec"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Pripnout soubory na konec"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Rezim skryvani"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Prodleva skryti"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Prodleva zobrazeni"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Dok je vzdy viditelny a rezervuje misto na obrazovce."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Skryje se, kdyz kurzor mysi opusti dok."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Skryje se, kdyz aktivni okno prekryva dok."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Skryje se, kdyz jakekoli okno na aktualnim pracovnim prostoru prekryva dok."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/cy/LC_MESSAGES/docking.po
+++ b/docking/locale/cy/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Wedi cysylltu {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Dyfeisiau Cysylltiedig"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Dyfeisiau Pâr"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Dyfeisiau a Ddarganfuwyd"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batri: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Chwilio am ddinas"
 msgid "Type city name..."
 msgstr "Teipiwch enw'r ddinas..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Gwefan"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Arddangosfa {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Ymddangosiad"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Ymddygiad"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Golwg"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Thema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Canran chwyddo"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Dangos awgrymiadau"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Lleoliad"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Cynllun"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Cloi safleoedd"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Angori ffeiliau i'r diwedd"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Modd cuddio"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Oedi cuddio"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Oedi dangos"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/da/LC_MESSAGES/docking.po
+++ b/docking/locale/da/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Forbundne {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Forbundne enheder"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Parrede enheder"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Opdagede enheder"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batteri: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Søg efter by"
 msgid "Type city name..."
 msgstr "Indtast bynavn..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Websted"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Skærm {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Udseende"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Adfærd"
 
@@ -1385,130 +1385,134 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Udseende"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Zoomprocent"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Vis værktøjstip"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Placering"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Lås positioner"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Fastgør filer til slutningen"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Skjuletilstand"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Skjuleforsinkelse"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Visningsforsinkelse"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Docken er altid synlig og reserverer skærmplads."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Skjules når musemarkøren forlader docken."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Skjules når det fokuserede vindue overlapper dockområdet."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Skjules når et vindue på det aktuelle arbejdsområde overlapper dockområdet."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/de/LC_MESSAGES/docking.po
+++ b/docking/locale/de/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth nicht verfügbar"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "Kein Bluetooth-Adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "Ein"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Aus"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Verbunden {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Dauerhafte Suche"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Jetzt aktualisieren"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Verbundene Geräte"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Gekoppelte Geräte"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Entdeckte Geräte"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Trennen"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Verbinden"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Koppeln"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Kopplung entfernen"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Vertraut"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Akku: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Mondphase anzeigen"
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "Neumond"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Vollmond"
 
@@ -550,27 +550,27 @@ msgstr "{days} Tage nach Neumond"
 msgid "{days} days after full moon"
 msgstr "{days} Tage nach Vollmond"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Zunehmende Sichel"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Zunehmender Dreiviertelmond"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Abnehmender Dreiviertelmond"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Abnehmende Sichel"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "Erstes Viertel"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "Letztes Viertel"
 
@@ -1170,17 +1170,22 @@ msgstr "Stadt suchen"
 msgid "Type city name..."
 msgstr "Stadtname eingeben..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Luft: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Wetter (keine Stadt ausgewählt)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Arbeitsflächen"
 msgid "Website"
 msgstr "Webseite"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Bildschirm {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Aussehen"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Verhalten"
 
@@ -1385,131 +1385,135 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Aussehen"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Thema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Symbolgröße"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Zoom-Prozent"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Tooltips anzeigen"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Fenstervorschau"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Platzierung"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Cursor folgen"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Nur aktueller Arbeitsbereich"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Positionen sperren"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Applets am Ende verankern"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Dateien am Ende verankern"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Verbergmodus"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Verzoegerung beim Verbergen"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Verzoegerung beim Einblenden"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Das Dock ist immer sichtbar und reserviert Bildschirmplatz."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Verbirgt sich wenn der Mauszeiger das Dock verlaesst."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Verbirgt sich wenn das fokussierte Fenster das Dock ueberlappt."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Verbirgt sich wenn ein Fenster auf der aktuellen Arbeitsflaeche das Dock "
 "ueberlappt."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -165,111 +165,111 @@ msgstr ""
 msgid "Bluetooth"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr ""
@@ -509,11 +509,11 @@ msgstr ""
 msgid "Refresh"
 msgstr ""
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr ""
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr ""
 
@@ -551,27 +551,27 @@ msgstr ""
 msgid "{days} days after full moon"
 msgstr ""
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr ""
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr ""
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr ""
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr ""
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr ""
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr ""
 
@@ -1171,17 +1171,22 @@ msgstr ""
 msgid "Type city name..."
 msgstr ""
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr ""
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr ""
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr ""
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr ""
@@ -1193,11 +1198,6 @@ msgstr ""
 
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
-msgstr ""
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
 msgstr ""
 
 #: docking/applets/weather/state.py:131
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr ""
 
@@ -1346,7 +1346,7 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr ""
 
@@ -1386,128 +1386,132 @@ msgstr ""
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:235
-msgid "New Window"
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
 msgstr ""
 
 #: docking/ui/settings.py:236
-msgid "Minimize Windows"
+msgid "New Window"
 msgstr ""
 
 #: docking/ui/settings.py:237
+msgid "Minimize Windows"
+msgstr ""
+
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr ""
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr ""
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr ""
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr ""
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr ""
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/el/LC_MESSAGES/docking.po
+++ b/docking/locale/el/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Συνδεδεμένα {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Συνδεδεμένες συσκευές"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Συζευγμένες συσκευές"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Ανακαλυφθείσες συσκευές"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Μπαταρία: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Αναζήτηση πόλης"
 msgid "Type city name..."
 msgstr "Πληκτρολογήστε όνομα πόλης..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Ιστοσελίδα"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Οθόνη {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Εμφάνιση"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Συμπεριφορά"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Εμφάνιση"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Θέμα"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Ποσοστό μεγέθυνσης"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Εμφάνιση συμβουλών"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Τοποθέτηση"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Διάταξη"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Κλείδωμα θέσεων"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Αγκύρωση αρχείων στο τέλος"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Λειτουργία απόκρυψης"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Καθυστέρηση απόκρυψης"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Καθυστέρηση εμφάνισης"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Το dock είναι πάντα ορατό και δεσμεύει χώρο στην οθόνη."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/en_GB/LC_MESSAGES/docking.po
+++ b/docking/locale/en_GB/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Connected {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Connected Devices"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Paired Devices"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Discovered Devices"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Battery: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Search for the city"
 msgid "Type city name..."
 msgstr "Type city name..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Website"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Display {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Appearance"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Behavior"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Look"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Zoom Percent"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Show Tooltips"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Lock Positions"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Anchor Files to End"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Hide Mode"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Hide Delay"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Unhide Delay"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/eo/LC_MESSAGES/docking.po
+++ b/docking/locale/eo/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Konektitaj {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Konektitaj Aparatoj"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Parigitaj Aparatoj"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Malkovritaj Aparatoj"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Baterio: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Serĉi urbon"
 msgid "Type city name..."
 msgstr "Tajpu urbonomon..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Retejo"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Ekrano {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Aspekto"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Konduto"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Aspekto"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Etoso"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Zomprocento"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Montru helpotekstojn"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Pozicio"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Aranĝo"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Ŝlosu poziciojn"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Ankru dosierojn al fino"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Kaŝa reĝimo"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Kaŝa prokrasto"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Malkaŝa prokrasto"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/es/LC_MESSAGES/docking.po
+++ b/docking/locale/es/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth no disponible"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "Sin adaptador Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "Encendido"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Apagado"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Conectados {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Descubrimiento Continuo"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Actualizar Ahora"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adaptador"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Dispositivos conectados"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Dispositivos emparejados"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Dispositivos descubiertos"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Conectar"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Emparejar"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Quitar Emparejamiento"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Confiable"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batería: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Mostrar Fase"
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "Nueva"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Llena"
 
@@ -550,27 +550,27 @@ msgstr "{days} días después de luna nueva"
 msgid "{days} days after full moon"
 msgstr "{days} días después de luna llena"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Creciente Cóncava"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Creciente Convexa"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Menguante Convexa"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Menguante Cóncava"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "Cuarto Creciente"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "Cuarto Menguante"
 
@@ -1170,17 +1170,22 @@ msgstr "Buscar ciudad"
 msgid "Type city name..."
 msgstr "Escribir nombre de ciudad..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Aire: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Clima (sin ciudad seleccionada)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Espacios de Trabajo"
 msgid "Website"
 msgstr "Sitio Web"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Pantalla {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Apariencia"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Comportamiento"
 
@@ -1385,131 +1385,135 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Aspecto"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Tamaño del Ícono"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Porcentaje de Zoom"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Mostrar Sugerencias"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Vista Previa de Ventanas"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Ubicacion"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Posición"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Seguir cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Solo espacio de trabajo actual"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Disposicion"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Bloquear Posiciones"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anclar applets al final"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Fijar Archivos al Final"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Modo de Ocultacion"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Retraso al Ocultar"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Retraso al Mostrar"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "El dock siempre es visible y reserva espacio en pantalla."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Se oculta cuando el cursor sale del dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Se oculta cuando la ventana enfocada se superpone al dock."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Se oculta cuando cualquier ventana del escritorio actual se superpone al "
 "dock."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/et/LC_MESSAGES/docking.po
+++ b/docking/locale/et/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Ühendatud {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Ühendatud seadmed"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Seotud seadmed"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Avastatud seadmed"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Aku: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Otsi linna"
 msgid "Type city name..."
 msgstr "Sisesta linna nimi..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Veebisait"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Kuvar {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Valimus"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Kaitumine"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Valimus"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Teema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Suumi protsent"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Naita kohtspikrid"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Paigutus"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Paigutus"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Lukusta positsioonid"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Ankurda failid loppu"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Peitmise rezsiim"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Peitmise viivitus"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Naitamise viivitus"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/eu/LC_MESSAGES/docking.po
+++ b/docking/locale/eu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Konektatuak {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Konektatutako gailuak"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Parekatutako gailuak"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Aurkitutako gailuak"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Bateria: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Bilatu hiria"
 msgid "Type city name..."
 msgstr "Idatzi hiri izena..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Webgunea"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Pantaila {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Itxura"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Portaera"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Itxura"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Gaia"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Zoom ehunekoa"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Erakutsi argibideak"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Kokapena"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Diseinua"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Blokeatu posizioak"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Aingurartu fitxategiak amaieran"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Ezkutatze modua"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Ezkutatzeko atzerapena"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Erakusteko atzerapena"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/fa/LC_MESSAGES/docking.po
+++ b/docking/locale/fa/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - متصل {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "دستگاه‌های متصل"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "دستگاه‌های جفت‌شده"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "دستگاه‌های کشف‌شده"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "باتری: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "جستجوی شهر"
 msgid "Type city name..."
 msgstr "نام شهر را وارد کنید..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "وب‌سایت"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "نمایشگر {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "ظاهر"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "رفتار"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "ظاهر"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "پوسته"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "درصد بزرگنمایی"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "نمایش راهنما"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "جایگذاری"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "چیدمان"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "قفل موقعیت‌ها"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "فایل‌ها را به انتها لنگر کن"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "حالت مخفی‌سازی"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "تاخیر مخفی‌سازی"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "تاخیر نمایش"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/fi/LC_MESSAGES/docking.po
+++ b/docking/locale/fi/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Yhdistetty {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Yhdistetyt laitteet"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Paritetut laitteet"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Löydetyt laitteet"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Akku: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Etsi kaupunki"
 msgid "Type city name..."
 msgstr "Kirjoita kaupungin nimi..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Verkkosivu"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Näyttö {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Ulkoasu"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Toiminta"
 
@@ -1385,131 +1385,135 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Ulkonäkö"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Teema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Zoomausprosentti"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Näytä työkaluvihjeet"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Sijoitus"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Asettelu"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Lukitse sijainnit"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Kiinnitä tiedostot loppuun"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Piilotustila"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Piilotusviive"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Näyttöviive"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Telakka on aina näkyvissä ja varaa näyttötilaa."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Piiloutuu kun hiiren osoitin poistuu telakasta."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Piiloutuu kun aktiivinen ikkuna peittää telakka-alueen."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Piiloutuu kun mikä tahansa ikkuna nykyisellä työtilalla peittää telakka-"
 "alueen."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/fil/LC_MESSAGES/docking.po
+++ b/docking/locale/fil/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Nakakonekta {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Mga Nakakonektang Device"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Mga Naka-pair na Device"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Mga Natuklasang Device"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Baterya: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Maghanap ng lungsod"
 msgid "Type city name..."
 msgstr "I-type ang pangalan ng lungsod..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Website"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Display {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Hitsura"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Kilos"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Hitsura"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Porsyento ng Zoom"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Ipakita ang mga Tooltip"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Paglalagay"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "I-lock ang mga Posisyon"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "I-angkla ang mga File sa Dulo"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Mode ng Pagtago"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Pagkaantala ng Pagtago"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Pagkaantala ng Pagpapakita"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/fr/LC_MESSAGES/docking.po
+++ b/docking/locale/fr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth indisponible"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "Aucun adaptateur Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "Allumé"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Éteint"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Connectés {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Découverte Continue"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Actualiser Maintenant"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adaptateur"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Appareils connectés"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Appareils appairés"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Appareils découverts"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Déconnecter"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connecter"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Appairer"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Supprimer l'Appairage"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Fiable"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batterie : {percent}%"
@@ -508,11 +508,11 @@ msgstr "Afficher la Phase"
 msgid "Refresh"
 msgstr "Actualiser"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "Nouvelle"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Pleine"
 
@@ -550,27 +550,27 @@ msgstr "{days} jours après la nouvelle lune"
 msgid "{days} days after full moon"
 msgstr "{days} jours après la pleine lune"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Premier Croissant"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Gibbeuse Croissante"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Gibbeuse Décroissante"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Dernier Croissant"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "Premier Quartier"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "Dernier Quartier"
 
@@ -1170,17 +1170,22 @@ msgstr "Rechercher la ville"
 msgid "Type city name..."
 msgstr "Saisir le nom de la ville..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air : {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Météo (aucune ville sélectionnée)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Espaces de Travail"
 msgid "Website"
 msgstr "Site Web"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Écran {display} : {width}x{height}"
 msgid "Appearance"
 msgstr "Apparence"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Comportement"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Aspect"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Theme"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Taille des Icônes"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Pourcentage de zoom"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Afficher les infobulles"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Aperçu des Fenêtres"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Placement"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Suivre le curseur"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Espace de travail actuel uniquement"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Disposition"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Verrouiller les positions"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Ancrer les applets à la fin"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Ancrer les fichiers a la fin"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Mode de masquage"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Delai de masquage"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Delai d'apparition"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Le dock est toujours visible et reserve de l'espace a l'ecran."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Se masque quand le curseur quitte le dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Se masque quand la fenetre active chevauche le dock."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Se masque quand une fenetre du bureau actuel chevauche le dock."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/ga/LC_MESSAGES/docking.po
+++ b/docking/locale/ga/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Ceangailte {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Gléasanna Ceangailte"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Gléasanna Péireáilte"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Gléasanna Aimsithe"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Ceallra: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Cuardaigh cathair"
 msgid "Type city name..."
 msgstr "Clóscríobh ainm cathrach..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Suíomh gréasáin"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Scáileán {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Cuma"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Iompar"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Cuma"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Téama"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Céatadán zúmála"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Taispeáin leideanna"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Suíomh"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Leagan amach"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Glasáil suíomhanna"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Ancairi comhaid go dti an deireadh"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Mód folaithe"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Moill folaithe"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Moill nochta"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/gl/LC_MESSAGES/docking.po
+++ b/docking/locale/gl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Conectados {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Dispositivos conectados"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Dispositivos emparellados"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Dispositivos descubertos"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batería: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Buscar cidade"
 msgid "Type city name..."
 msgstr "Escribir nome da cidade..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Sitio web"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Pantalla {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Aparencia"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Comportamento"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Aspecto"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Porcentaxe de zoom"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Amosar consellos"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Colocación"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Disposición"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Bloquear posicións"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Ancorar ficheiros ao final"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Modo de ocultación"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Atraso de ocultación"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Atraso de mostrar"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/gu/LC_MESSAGES/docking.po
+++ b/docking/locale/gu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - જોડાયેલ {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "જોડાયેલ ઉપકરણો"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "જોડી કરેલ ઉપકરણો"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "શોધાયેલ ઉપકરણો"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "બેટરી: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "શહેર શોધો"
 msgid "Type city name..."
 msgstr "શહેરનું નામ લખો..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "વેબસાઇટ"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "ડિસ્પ્લે {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "દેખાવ"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "વર્તન"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "દેખાવ"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "થીમ"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "ઝૂમ ટકા"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "ટૂલટિપ્સ બતાવો"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "સ્થાન"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "લેઆઉટ"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "સ્થાનો લૉક કરો"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "ફાઇલોને અંતમાં એન્કર કરો"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "છુપાવવાનો મોડ"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "છુપાવવાનો વિલંબ"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "દર્શાવવાનો વિલંબ"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/he/LC_MESSAGES/docking.po
+++ b/docking/locale/he/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - מחובר {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "מכשירים מחוברים"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "מכשירים מזווגים"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "מכשירים שנמצאו"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "סוללה: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "חפש עיר"
 msgid "Type city name..."
 msgstr "הקלד שם עיר..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "אתר"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "מסך {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "מראה"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "התנהגות"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "מראה"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "ערכת נושא"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "אחוז זום"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "הצג תיאורים"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "מיקום"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "פריסה"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "נעל מיקומים"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "עגן קבצים לסוף"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "מצב הסתרה"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "השהיית הסתרה"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "השהיית הצגה"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/hi/LC_MESSAGES/docking.po
+++ b/docking/locale/hi/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "ब्लूटूथ"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "ब्लूटूथ अनुपलब्ध"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "कोई ब्लूटूथ एडेप्टर नहीं"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "चालू"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "बंद"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - जुड़े {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "निरंतर खोज"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "अभी रिफ्रेश करें"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "एडेप्टर"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "जुड़े उपकरण"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "युग्मित उपकरण"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "खोजे गए उपकरण"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "डिस्कनेक्ट"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "कनेक्ट"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "जोड़ी बनाएँ"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "जोड़ी हटाएँ"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "विश्वसनीय"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "बैटरी: {percent}%"
@@ -508,11 +508,11 @@ msgstr "चरण दिखाएँ"
 msgid "Refresh"
 msgstr "रिफ्रेश"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "अमावस्या"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "पूर्ण"
 
@@ -550,27 +550,27 @@ msgstr "अमावस्या के {days} दिन बाद"
 msgid "{days} days after full moon"
 msgstr "पूर्णिमा के {days} दिन बाद"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "बढ़ता अर्धचंद्र"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "बढ़ता उन्नतोदर"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "क्षीण उन्नतोदर"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "क्षीण अर्धचंद्र"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "प्रथम चतुर्थांश"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "तृतीय चतुर्थांश"
 
@@ -1170,17 +1170,22 @@ msgstr "शहर खोजें"
 msgid "Type city name..."
 msgstr "शहर का नाम लिखें..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "वायु: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "मौसम (कोई शहर नहीं चुना)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "कार्यक्षेत्र"
 msgid "Website"
 msgstr "वेबसाइट"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "डिस्प्ले {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "दिखावट"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "व्यवहार"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "दिखावट"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "थीम"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "आइकन आकार"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "ज़ूम प्रतिशत"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "टूलटिप दिखाएं"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "विंडो पूर्वावलोकन"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "स्थान"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "स्थिति"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "कर्सर का अनुसरण करें"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "केवल वर्तमान कार्यक्षेत्र"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "लेआउट"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "स्थिति लॉक करें"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "ऐपलेट्स को अंत में एंकर करें"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "फाइलें अंत में पिन करें"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "छिपाने का तरीका"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "छिपाने की देरी"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "दिखाने की देरी"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "डॉक हमेशा दिखाई देता है और स्क्रीन स्थान आरक्षित करता है।"
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "माउस कर्सर डॉक छोड़े तो छिप जाता है।"
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "सक्रिय विंडो डॉक क्षेत्र को ओवरलैप करे तो छिप जाता है।"
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "वर्तमान कार्यस्थान पर कोई भी विंडो डॉक क्षेत्र को ओवरलैप करे तो छिप जाता है।"
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/hr/LC_MESSAGES/docking.po
+++ b/docking/locale/hr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Povezano {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Povezani uređaji"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Upareni uređaji"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Otkriveni uređaji"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Baterija: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Traži grad"
 msgid "Type city name..."
 msgstr "Unesite ime grada..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Web stranica"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Zaslon {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Izgled"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Ponašanje"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Izgled"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Postotak uvećanja"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Prikaži opise"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Položaj"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Raspored"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Zaključaj pozicije"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Usidri datoteke na kraj"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Način skrivanja"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Kašnjenje skrivanja"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Kašnjenje prikazivanja"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/hu/LC_MESSAGES/docking.po
+++ b/docking/locale/hu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Csatlakoztatva {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Csatlakoztatott eszközök"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Párosított eszközök"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Felfedezett eszközök"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Akkumulátor: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Város keresése"
 msgid "Type city name..."
 msgstr "Város nevének beírása..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Weboldal"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Kijelző {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Megjelenés"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Viselkedés"
 
@@ -1385,131 +1385,135 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Kinézet"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Téma"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Nagyítási százalék"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Eszköztippek mutatása"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Elhelyezés"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Elrendezés"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Pozíciók zárolása"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Fájlok rögzítése a végére"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Elrejtési mód"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Elrejtési késleltetés"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Megjelenési késleltetés"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "A dock mindig látható és képernyőterületet foglal."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Elrejti magát, ha az egérmutató elhagyja a dockot."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Elrejti magát, ha a fókuszált ablak átfedi a dock területét."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Elrejti magát, ha bármely ablak az aktuális munkaterületen átfedi a dock "
 "területét."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/id/LC_MESSAGES/docking.po
+++ b/docking/locale/id/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Terhubung {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Perangkat Terhubung"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Perangkat Berpasangan"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Perangkat Ditemukan"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Baterai: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1169,17 +1169,22 @@ msgstr "Cari kota"
 msgid "Type city name..."
 msgstr "Ketik nama kota..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1192,11 +1197,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1219,7 +1219,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Situs web"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1344,7 +1344,7 @@ msgstr "Layar {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Tampilan"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Perilaku"
 
@@ -1384,131 +1384,135 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Tampilan"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Persen zoom"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Tampilkan tooltip"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Penempatan"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Tata letak"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Kunci posisi"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Kunci file di akhir"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Mode sembunyi"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Jeda sembunyi"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Jeda tampil"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Dok selalu terlihat dan memesan ruang layar."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Bersembunyi saat kursor meninggalkan dok."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Bersembunyi saat jendela aktif tumpang tindih dengan area dok."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Bersembunyi saat jendela apa pun di ruang kerja saat ini tumpang tindih "
 "dengan area dok."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/is/LC_MESSAGES/docking.po
+++ b/docking/locale/is/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Tengd {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Tengd tæki"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Pöruð tæki"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Uppgötvuð tæki"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Rafhlaða: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Leita að borg"
 msgid "Type city name..."
 msgstr "Sláðu inn borgarheiti..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Vefsíða"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Skjár {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Útlit"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Hegðun"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Útlit"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Þema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Aðdráttarprósenta"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Sýna ábendingar"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Staðsetning"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Uppsetning"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Læsa stöður"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Festa skrár í enda"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Feluhamur"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Töf við felu"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Töf við birtingu"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/it/LC_MESSAGES/docking.po
+++ b/docking/locale/it/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: 2026-03-06 12:00+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth non disponibile"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "Nessun adattatore Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "Attivo"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Disattivo"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Connessi {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Ricerca continua"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Aggiorna ora"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adattatore"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Dispositivi connessi"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Dispositivi associati"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Dispositivi rilevati"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnetti"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connetti"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Associa"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Rimuovi associazione"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Attendibile"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batteria: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Mostra nome fase"
 msgid "Refresh"
 msgstr "Aggiorna"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "Nuova"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Piena"
 
@@ -550,27 +550,27 @@ msgstr "{days} giorni dopo la luna nuova"
 msgid "{days} days after full moon"
 msgstr "{days} giorni dopo la luna piena"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Luna crescente"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Gibbosa crescente"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Gibbosa calante"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Luna calante"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "Primo quarto"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "Ultimo quarto"
 
@@ -1170,17 +1170,22 @@ msgstr "Cerca la citta"
 msgid "Type city name..."
 msgstr "Digita il nome della citta..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Aria: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Meteo (nessuna citta selezionata)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Aree di lavoro"
 msgid "Website"
 msgstr "Sito web"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Schermo {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Aspetto"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Comportamento"
 
@@ -1385,131 +1385,135 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Aspetto"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Dimensione icone"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Percentuale Zoom"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Mostra Suggerimenti"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Anteprime finestre"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Posizionamento"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Posizione"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Segui cursore"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Solo area di lavoro corrente"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Disposizione"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Blocca Posizioni"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Ancora applet alla fine"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Ancora File alla Fine"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Modalita Nascondimento"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Ritardo Nascondimento"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Ritardo Apparizione"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Il dock e sempre visibile e riserva spazio sullo schermo."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Si nasconde quando il cursore esce dal dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Si nasconde quando la finestra attiva sovrappone il dock."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Si nasconde quando una finestra dello spazio di lavoro attuale sovrappone il "
 "dock."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/ja/LC_MESSAGES/docking.po
+++ b/docking/locale/ja/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth利用不可"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "Bluetoothアダプターなし"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "オン"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "オフ"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - 接続数 {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "継続的な検出"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "今すぐ更新"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "アダプター"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "接続済みデバイス"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "ペアリング済みデバイス"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "検出されたデバイス"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "切断"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "接続"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "ペアリング"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "ペアリング解除"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "信頼済み"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "バッテリー: {percent}%"
@@ -508,11 +508,11 @@ msgstr "月相を表示"
 msgid "Refresh"
 msgstr "更新"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "新月"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "満月"
 
@@ -550,27 +550,27 @@ msgstr "新月から{days}日後"
 msgid "{days} days after full moon"
 msgstr "満月から{days}日後"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "三日月"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "十日夜月"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "更待月"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "暁月"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "上弦の月"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "下弦の月"
 
@@ -1169,17 +1169,22 @@ msgstr "都市を検索"
 msgid "Type city name..."
 msgstr "都市名を入力..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C、{desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "空気：{label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1192,11 +1197,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "天気（都市未選択）"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1219,7 +1219,7 @@ msgstr "ワークスペース"
 msgid "Website"
 msgstr "ウェブサイト"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1344,7 +1344,7 @@ msgstr "ディスプレイ {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "外観"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "動作"
 
@@ -1384,130 +1384,134 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "外観"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "テーマ"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "アイコンサイズ"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "ズーム"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "ズーム率"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "ツールチップを表示"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "ウィンドウプレビュー"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "配置"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "位置"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "カーソルに追従"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "現在のワークスペースのみ"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "レイアウト"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "位置をロック"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "アプレットを末尾に固定"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "ファイルを末尾に固定"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "非表示モード"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "非表示の遅延"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "表示の遅延"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "ドックは常に表示され、画面スペースを確保します。"
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "マウスカーソルがドックから離れると非表示になります。"
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "フォーカスされたウィンドウがドック領域に重なると非表示になります。"
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "現在のワークスペースのウィンドウがドック領域に重なると非表示になります。"
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/jv/LC_MESSAGES/docking.po
+++ b/docking/locale/jv/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Nyambung {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Piranti Nyambung"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Piranti Dipasangake"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Piranti Ditemokake"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Baterei: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Goleki kutha"
 msgid "Type city name..."
 msgstr "Ketik jeneng kutha..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Website"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Layar {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Tampilan"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Kelakuan"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Tampilan"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Persen Zoom"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Tampilake Tooltip"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Panggonan"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Tata Letak"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Kunci Posisi"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Jangkar File menyang Pungkasan"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Mode Ndhelikake"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Tundha Ndhelikake"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Tundha Tampilake"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/kk/LC_MESSAGES/docking.po
+++ b/docking/locale/kk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Қосылған {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Қосылған құрылғылар"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Жұпталған құрылғылар"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Табылған құрылғылар"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Батарея: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Қала іздеу"
 msgid "Type city name..."
 msgstr "Қала атын жазыңыз..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Веб-сайт"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Дисплей {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Сыртқы түрі"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Мінез-құлық"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Көрініс"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Тақырып"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Масштаб пайызы"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Кеңестерді көрсету"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Орналастыру"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Орналасу"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Орындарды құлыптау"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Файлдарды соңына бекіту"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Жасыру режимі"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Жасыру кідірісі"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Көрсету кідірісі"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/km/LC_MESSAGES/docking.po
+++ b/docking/locale/km/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - ភ្ជាب់ {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "ឧបករណ៍ដែលភ្ជាប់"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "ឧបករណ៍ដែលផ្គូរផ្គង"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "ឧបករណ៍ដែលរកឃើញ"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "ថ្ម: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "ស្វែងរកក្រុង"
 msgid "Type city name..."
 msgstr "វាយឈ្មោះក្រុង..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "គេហទំព័រ"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "អេក្រង់ {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "រូបរាង"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "ឥរិយាបថ"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "រូបរាង"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "ស្បែក"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "ភាគរយពង្រីក"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "បង្ហាញព័ត៌មានជំនួយ"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "ទីតាំង"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "ប្លង់"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "ចាក់សោទីតាំង"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "យុថ្កាឯកសារទៅចុង"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "របៀបលាក់"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "ពន្យឺតលាក់"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "ពន្យឺតបង្ហាញ"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/kn/LC_MESSAGES/docking.po
+++ b/docking/locale/kn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - ಸಂಪರ್ಕಿತ {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "ಸಂಪರ್ಕಿತ ಸಾಧನಗಳು"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "ಜೋಡಿಯಾದ ಸಾಧನಗಳು"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "ಪತ್ತೆಯಾದ ಸಾಧನಗಳು"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "ಬ್ಯಾಟರಿ: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "ನಗರ ಹುಡುಕಿ"
 msgid "Type city name..."
 msgstr "ನಗರದ ಹೆಸರು ಟೈಪ್ ಮಾಡಿ..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "ವೆಬ್‌ಸೈಟ್"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "ಡಿಸ್ಪ್ಲೇ {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "ನೋಟ"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "ನಡವಳಿಕೆ"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "ನೋಟ"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "ಥೀಮ್"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "ಝೂಮ್ ಶೇಕಡಾ"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "ಟೂಲ್‌ಟಿಪ್‌ಗಳನ್ನು ತೋರಿಸಿ"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "ಸ್ಥಳ"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "ವಿನ್ಯಾಸ"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "ಸ್ಥಾನಗಳನ್ನು ಲಾಕ್ ಮಾಡಿ"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "ಫೈಲ್‌ಗಳನ್ನು ಕೊನೆಗೆ ಆಂಕರ್ ಮಾಡಿ"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "ಮರೆಮಾಡುವ ಮೋಡ್"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "ಮರೆಮಾಡುವ ವಿಳಂಬ"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "ತೋರಿಸುವ ವಿಳಂಬ"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/ko/LC_MESSAGES/docking.po
+++ b/docking/locale/ko/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "블루투스"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "블루투스 사용 불가"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "블루투스 어댑터 없음"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "켜짐"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "꺼짐"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - 연결됨 {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "지속적 검색"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "지금 새로고침"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "어댑터"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "연결된 장치"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "페어링된 장치"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "검색된 장치"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "연결 해제"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "연결"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "페어링"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "페어링 제거"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "신뢰됨"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "배터리: {percent}%"
@@ -508,11 +508,11 @@ msgstr "달의 위상 표시"
 msgid "Refresh"
 msgstr "새로고침"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "삭"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "보름달"
 
@@ -550,27 +550,27 @@ msgstr "삭 후 {days}일"
 msgid "{days} days after full moon"
 msgstr "보름달 후 {days}일"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "초승달"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "상현 철월"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "하현 철월"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "그믐달"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "상현달"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "하현달"
 
@@ -1169,17 +1169,22 @@ msgstr "도시 검색"
 msgid "Type city name..."
 msgstr "도시 이름 입력..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "공기: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1192,11 +1197,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "날씨 (도시 미선택)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1219,7 +1219,7 @@ msgstr "작업 공간"
 msgid "Website"
 msgstr "웹사이트"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1344,7 +1344,7 @@ msgstr "디스플레이 {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "모양"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "동작"
 
@@ -1384,129 +1384,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "모양"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "테마"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "아이콘 크기"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "확대 비율"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "툴팁 표시"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "창 미리보기"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "배치"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "위치"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "커서 따라가기"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "현재 작업 공간만"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "레이아웃"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "위치 잠금"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "애플릿을 끝에 고정"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "파일을 끝에 고정"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "숨기기 모드"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "숨기기 지연"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "표시 지연"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "독이 항상 표시되며 화면 공간을 확보합니다."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "마우스 커서가 독을 벗어나면 숨깁니다."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "포커스된 창이 독 영역과 겹치면 숨깁니다."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "현재 작업 공간의 창이 독 영역과 겹치면 숨깁니다."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/lt/LC_MESSAGES/docking.po
+++ b/docking/locale/lt/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Prijungta {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Prijungti įrenginiai"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Susieti įrenginiai"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Aptikti įrenginiai"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Baterija: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Ieškoti miesto"
 msgid "Type city name..."
 msgstr "Įveskite miesto pavadinimą..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Svetainė"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Ekranas {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Išvaizda"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Elgsena"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Išvaizda"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Priartinimo procentas"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Rodyti paaiškinimus"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Vieta"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Išdėstymas"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Užrakinti pozicijas"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Pritvirtinti failus gale"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Slėpimo režimas"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Slėpimo delsa"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Rodymo delsa"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/lv/LC_MESSAGES/docking.po
+++ b/docking/locale/lv/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Savienots {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Savienotās ierīces"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Sapārotās ierīces"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Atrastās ierīces"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Akumulators: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Meklēt pilsētu"
 msgid "Type city name..."
 msgstr "Ievadiet pilsētas nosaukumu..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Tīmekļa vietne"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Displejs {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Izskats"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Uzvedība"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Izskats"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tēma"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Tālummaiņas procents"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Rādīt padomus"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Izvietojums"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Izkārtojums"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Bloķēt pozīcijas"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Noenkurot failus beigās"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Slēpšanas režīms"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Slēpšanas aizkave"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Parādīšanas aizkave"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/mk/LC_MESSAGES/docking.po
+++ b/docking/locale/mk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Поврзано {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Поврзани уреди"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Спарени уреди"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Откриени уреди"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Батерија: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Пребарај град"
 msgid "Type city name..."
 msgstr "Внесете име на град..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Веб-страница"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Екран {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Изглед"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Однесување"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Изглед"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Тема"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Процент на зумирање"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Покажи совети"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Позиција"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Распоред"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Заклучи позиции"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Закотви датотеки на крај"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Режим на криење"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Задоцнување на криење"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Задоцнување на прикажување"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/ml/LC_MESSAGES/docking.po
+++ b/docking/locale/ml/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - ബന്ധിപ്പിച്ചിരിക്കുന്നു {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "ബന്ധിപ്പിച്ച ഉപകരണങ്ങൾ"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "ജോഡിയാക്കിയ ഉപകരണങ്ങൾ"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "കണ്ടെത്തിയ ഉപകരണങ്ങൾ"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "ബാറ്ററി: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "നഗരം തിരയുക"
 msgid "Type city name..."
 msgstr "നഗരത്തിന്റെ പേര് ടൈപ്പ് ചെയ്യുക..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "വെബ്‌സൈറ്റ്"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "ഡിസ്പ്ലേ {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "രൂപം"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "പെരുമാറ്റം"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "രൂപം"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "തീം"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "സൂം ശതമാനം"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "ടൂള്‍ടിപ്പുകള്‍ കാണിക്കുക"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "സ്ഥാനം"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "ലേഔട്ട്"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "സ്ഥാനങ്ങള്‍ ലോക്ക് ചെയ്യുക"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "ഫയലുകള്‍ അവസാനത്തേക്ക് ആങ്കര്‍ ചെയ്യുക"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "മറയ്ക്കല്‍ മോഡ്"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "മറയ്ക്കല്‍ കാലതാമസം"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "കാണിക്കല്‍ കാലതാമസം"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/mn/LC_MESSAGES/docking.po
+++ b/docking/locale/mn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Холбogdсон {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Холбogdсон төхөөрөмжүүд"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Хослуулсан төхөөрөмжүүд"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Олдсон төхөөрөмжүүд"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Батерей: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Хот хайх"
 msgid "Type city name..."
 msgstr "Хотын нэр бичнэ үү..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Вэбсайт"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Дэлгэц {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Харагдах байдал"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Зан байдал"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Харагдах байдал"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Загвар"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Томруулалтын хувь"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Зөвлөмж харуулах"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Байршил"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Зохион байгуулалт"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Байрлалыг түгжих"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Файлуудыг төгсгөлд бэхлэх"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Нуух горим"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Нуух хугацаа"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Харуулах хугацаа"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/mr/LC_MESSAGES/docking.po
+++ b/docking/locale/mr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - जोडलेले {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "जोडलेली उपकरणे"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "जोडी केलेली उपकरणे"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "शोधलेली उपकरणे"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "बॅटरी: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "शहर शोधा"
 msgid "Type city name..."
 msgstr "शहराचे नाव टाइप करा..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "वेबसाइट"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "डिस्प्ले {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "स्वरूप"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "वर्तन"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "स्वरूप"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "थीम"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "झूम टक्केवारी"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "टूलटिप्स दाखवा"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "स्थान"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "मांडणी"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "स्थाने लॉक करा"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "फाइल्स शेवटी अँकर करा"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "लपवण्याचा मोड"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "लपवण्याचा विलंब"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "दाखवण्याचा विलंब"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/ms/LC_MESSAGES/docking.po
+++ b/docking/locale/ms/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Disambung {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Peranti Disambung"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Peranti Dipasangkan"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Peranti Ditemui"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Bateri: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1169,17 +1169,22 @@ msgstr "Cari bandar"
 msgid "Type city name..."
 msgstr "Taip nama bandar..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1192,11 +1197,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1219,7 +1219,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Laman Web"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1344,7 +1344,7 @@ msgstr "Paparan {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Penampilan"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Kelakuan"
 
@@ -1384,129 +1384,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Rupa"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Peratus Zum"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Tunjuk Petua"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Penempatan"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Susun Atur"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Kunci Kedudukan"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Sauh Fail ke Hujung"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Mod Sembunyi"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Kelewatan Sembunyi"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Kelewatan Tunjuk"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/mt/LC_MESSAGES/docking.po
+++ b/docking/locale/mt/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Konnessi {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Apparat Konnessi"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Apparat Ipperjajt"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Apparat Skoperti"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batterija: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Fittex belt"
 msgid "Type city name..."
 msgstr "Ikteb isem il-belt..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Websajt"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Skrin {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Dehra"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Imġiba"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Dehra"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Persentaġġ taż-żum"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Uri tooltips"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Pożizzjoni"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Sakkar pożizzjonijiet"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Ankra fajls fl-aħħar"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Mod tal-ħabi"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Dewmien tal-ħabi"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Dewmien tal-wiri"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/nb/LC_MESSAGES/docking.po
+++ b/docking/locale/nb/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Tilkoblede {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Tilkoblede enheter"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Sammenkoblede enheter"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Oppdagede enheter"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batteri: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Søk etter by"
 msgid "Type city name..."
 msgstr "Skriv inn bynavn..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Nettsted"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Skjerm {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Utseende"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Oppførsel"
 
@@ -1385,130 +1385,134 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Utseende"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Zoomprosent"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Vis verktøytips"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Plassering"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Oppsett"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Lås posisjoner"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Fest filer til slutten"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Skjulemodus"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Skjuleforsinkelse"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Visningsforsinkelse"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Docken er alltid synlig og reserverer skjermplass."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Skjules når musepekeren forlater docken."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Skjules når det fokuserte vinduet overlapper dockområdet."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Skjules når et vindu på gjeldende arbeidsområde overlapper dockområdet."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/ne/LC_MESSAGES/docking.po
+++ b/docking/locale/ne/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - जोडिएको {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "जोडिएका उपकरणहरू"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "जोडा मिलाइएका उपकरणहरू"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "पत्ता लागेका उपकरणहरू"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "ब्याट्री: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "शहर खोज्नुहोस्"
 msgid "Type city name..."
 msgstr "शहरको नाम टाइप गर्नुहोस्..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "वेबसाइट"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "डिस्प्ले {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "रूप"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "व्यवहार"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "रूप"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "थिम"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "जुम प्रतिशत"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "टुलटिपहरू देखाउनुहोस्"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "स्थान"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "लेआउट"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "स्थानहरू लक गर्नुहोस्"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "फाइलहरू अन्तमा एन्कर गर्नुहोस्"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "लुकाउने मोड"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "लुकाउने ढिलाइ"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "देखाउने ढिलाइ"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/nl/LC_MESSAGES/docking.po
+++ b/docking/locale/nl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth niet beschikbaar"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "Geen Bluetooth-adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "Aan"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Uit"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Verbonden {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Doorlopend zoeken"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Nu vernieuwen"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Verbonden apparaten"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Gekoppelde apparaten"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Ontdekte apparaten"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Loskoppelen"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Verbinden"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Koppelen"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Koppeling verwijderen"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Vertrouwd"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batterij: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Fasenaam tonen"
 msgid "Refresh"
 msgstr "Vernieuwen"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "Nieuw"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Vol"
 
@@ -550,27 +550,27 @@ msgstr "{days} dagen na nieuwe maan"
 msgid "{days} days after full moon"
 msgstr "{days} dagen na volle maan"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Wassende sikkel"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Wassende bol"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Afnemende bol"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Afnemende sikkel"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "Eerste kwartier"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "Laatste kwartier"
 
@@ -1170,17 +1170,22 @@ msgstr "Zoek de stad"
 msgid "Type city name..."
 msgstr "Typ stadsnaam..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Lucht: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weer (geen stad geselecteerd)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Werkruimten"
 msgid "Website"
 msgstr "Website"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Beeldscherm {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Uiterlijk"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Gedrag"
 
@@ -1385,130 +1385,134 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Uiterlijk"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Thema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Pictogramgrootte"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Zoompercentage"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Tooltips tonen"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Venstervoorbeelden"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Plaatsing"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Positie"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Cursor volgen"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Alleen huidige werkruimte"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Indeling"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Posities vergrendelen"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Applets aan einde verankeren"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Bestanden aan einde vastzetten"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Verbergmodus"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Verbergvertraging"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Zichtbaarheidsvertraging"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Het dock is altijd zichtbaar en reserveert schermruimte."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Verbergt wanneer de muiscursor het dock verlaat."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Verbergt wanneer het actieve venster het dock overlapt."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Verbergt wanneer een venster op de huidige werkruimte het dock overlapt."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/nn/LC_MESSAGES/docking.po
+++ b/docking/locale/nn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Tilkopla {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Tilkopla einingar"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Samankopla einingar"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Oppdaga einingar"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batteri: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Søk etter by"
 msgid "Type city name..."
 msgstr "Skriv inn bynamn..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Nettstad"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Skjerm {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Utsjånad"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Åtferd"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Utsjånad"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Zoomprosent"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Vis verktøytips"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Plassering"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Utforming"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Lås posisjonar"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Fest filer til slutten"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Gøymemodus"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Gøymeforsinking"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Visingsforsinking"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/pa/LC_MESSAGES/docking.po
+++ b/docking/locale/pa/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - ਜੁੜਿਆ {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "ਜੁੜੇ ਉਪਕਰਨ"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "ਜੋੜੇ ਉਪਕਰਨ"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "ਖੋਜੇ ਉਪਕਰਨ"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "ਬੈਟਰੀ: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "ਸ਼ਹਿਰ ਖੋਜੋ"
 msgid "Type city name..."
 msgstr "ਸ਼ਹਿਰ ਦਾ ਨਾਮ ਲਿਖੋ..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "ਵੈੱਬਸਾਈਟ"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "ਡਿਸਪਲੇ {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "ਦਿੱਖ"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "ਵਿਹਾਰ"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "ਦਿੱਖ"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "ਥੀਮ"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "ਜ਼ੂਮ ਪ੍ਰਤੀਸ਼ਤ"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "ਟੂਲਟਿਪ ਦਿਖਾਓ"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "ਸਥਿਤੀ"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "ਲੇਆਉਟ"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "ਸਥਿਤੀਆਂ ਲਾਕ ਕਰੋ"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "ਫਾਈਲਾਂ ਨੂੰ ਅੰਤ ਵਿੱਚ ਐਂਕਰ ਕਰੋ"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "ਲੁਕਾਉਣ ਦਾ ਮੋਡ"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "ਲੁਕਾਉਣ ਦੀ ਦੇਰੀ"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "ਦਿਖਾਉਣ ਦੀ ਦੇਰੀ"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/pl/LC_MESSAGES/docking.po
+++ b/docking/locale/pl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -165,111 +165,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth niedostępny"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "Brak adaptera Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "Wł."
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Wył."
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Połączonych {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Ciągłe wykrywanie"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Odśwież teraz"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Połączone urządzenia"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Sparowane urządzenia"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Wykryte urządzenia"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Rozłącz"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Połącz"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Sparuj"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Usuń parowanie"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Zaufane"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Bateria: {percent}%"
@@ -509,11 +509,11 @@ msgstr "Pokaż nazwę fazy"
 msgid "Refresh"
 msgstr "Odśwież"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "Nów"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Pełnia"
 
@@ -551,27 +551,27 @@ msgstr "{days} dni po nowiu"
 msgid "{days} days after full moon"
 msgstr "{days} dni po pełni"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Przybywający sierp"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Przybywający garb"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Ubywający garb"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Ubywający sierp"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "Pierwsza kwadra"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "Ostatnia kwadra"
 
@@ -1172,17 +1172,22 @@ msgstr "Szukaj miasta"
 msgid "Type city name..."
 msgstr "Wpisz nazwę miasta..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Powietrze: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1195,11 +1200,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Pogoda (nie wybrano miasta)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1222,7 +1222,7 @@ msgstr "Przestrzenie robocze"
 msgid "Website"
 msgstr "Strona internetowa"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1347,7 +1347,7 @@ msgstr "Wyświetlacz {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Wyglad"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Zachowanie"
 
@@ -1387,129 +1387,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Wyglad"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Motyw"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Rozmiar ikon"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Procent powiekszenia"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Pokaz podpowiedzi"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Podgląd okien"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Rozmieszczenie"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Pozycja"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Podążaj za kursorem"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Tylko bieżąca przestrzeń"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Uklad"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Zablokuj pozycje"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Zakotwicz aplety na końcu"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Przypnij pliki na koncu"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Tryb ukrywania"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Opoznienie ukrywania"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Opoznienie pokazywania"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Dok jest zawsze widoczny i rezerwuje miejsce na ekranie."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Ukrywa sie, gdy kursor myszy opusci dok."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Ukrywa sie, gdy aktywne okno naklada sie na dok."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Ukrywa sie, gdy dowolne okno na biezacym pulpicie naklada sie na dok."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/pt_BR/LC_MESSAGES/docking.po
+++ b/docking/locale/pt_BR/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth indisponível"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "Sem adaptador Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "Ligado"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Desligado"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Conectados {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Descoberta Contínua"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Atualizar Agora"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adaptador"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Dispositivos conectados"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Dispositivos pareados"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Dispositivos descobertos"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Desconectar"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Conectar"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Parear"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remover Pareamento"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Confiável"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Bateria: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Mostrar Fase"
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "Nova"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Cheia"
 
@@ -550,27 +550,27 @@ msgstr "{days} dias após lua nova"
 msgid "{days} days after full moon"
 msgstr "{days} dias após lua cheia"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Crescente Côncava"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Crescente Convexa"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Minguante Convexa"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Minguante Côncava"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "Quarto Crescente"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "Quarto Minguante"
 
@@ -1170,17 +1170,22 @@ msgstr "Buscar cidade"
 msgid "Type city name..."
 msgstr "Digite o nome da cidade..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Ar: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Clima (nenhuma cidade selecionada)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Áreas de Trabalho"
 msgid "Website"
 msgstr "Site"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Tela {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Aparencia"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Comportamento"
 
@@ -1385,130 +1385,134 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Visual"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Tamanho do Ícone"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Porcentagem do Zoom"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Mostrar Dicas"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Pré-visualização de Janelas"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Posicionamento"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Posição"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Seguir cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Somente área de trabalho atual"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Travar Posicoes"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Ancorar applets ao final"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Fixar Arquivos no Final"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Modo de Ocultacao"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Atraso ao Ocultar"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Atraso ao Mostrar"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "O dock esta sempre visivel e reserva espaco na tela."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Oculta quando o cursor sai do dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Oculta quando a janela focada sobrepoe o dock."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Oculta quando qualquer janela na area de trabalho atual sobrepoe o dock."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/pt_PT/LC_MESSAGES/docking.po
+++ b/docking/locale/pt_PT/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Ligados {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Dispositivos ligados"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Dispositivos emparelhados"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Dispositivos descobertos"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Bateria: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Procurar cidade"
 msgid "Type city name..."
 msgstr "Escreva o nome da cidade..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Sítio web"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Ecrã {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Aparência"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Comportamento"
 
@@ -1385,131 +1385,135 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Aparência"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Percentagem de zoom"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Mostrar dicas"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Posicionamento"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Disposição"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Bloquear posições"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Fixar ficheiros no fim"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Modo de ocultação"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Atraso ao ocultar"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Atraso ao mostrar"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "O dock está sempre visível e reserva espaço no ecrã."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Oculta quando o cursor sai do dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Oculta quando a janela ativa sobrepõe a área do dock."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Oculta quando qualquer janela na área de trabalho atual sobrepõe a área do "
 "dock."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/ro/LC_MESSAGES/docking.po
+++ b/docking/locale/ro/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Conectate {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Dispozitive conectate"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Dispozitive asociate"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Dispozitive descoperite"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Baterie: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Căutare oraș"
 msgid "Type city name..."
 msgstr "Introduceți numele orașului..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Site web"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Afișaj {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Aspect"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Comportament"
 
@@ -1385,131 +1385,135 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Aspect"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Procent zoom"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Afiseaza indicatoarele"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Plasare"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Configuratie"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Blocheaza pozitiile"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Fixeaza fisierele la sfarsit"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Mod ascundere"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Intarziere ascundere"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Intarziere aparitie"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Dock-ul este mereu vizibil si rezerva spatiu pe ecran."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Se ascunde cand cursorul paraseste dock-ul."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Se ascunde cand fereastra activa suprapune zona dock-ului."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Se ascunde cand orice fereastra de pe spatiul de lucru curent suprapune zona "
 "dock-ului."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/ru/LC_MESSAGES/docking.po
+++ b/docking/locale/ru/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -165,111 +165,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth недоступен"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "Нет Bluetooth-адаптера"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "Вкл"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Выкл"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Подключено {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Постоянный поиск"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Обновить сейчас"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Адаптер"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Подключённые устройства"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Сопряжённые устройства"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Обнаруженные устройства"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Отключить"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Подключить"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Сопряжение"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Удалить сопряжение"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Доверенное"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Батарея: {percent}%"
@@ -509,11 +509,11 @@ msgstr "Показать фазу"
 msgid "Refresh"
 msgstr "Обновить"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "Новолуние"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Полнолуние"
 
@@ -551,27 +551,27 @@ msgstr "{days} дней после новолуния"
 msgid "{days} days after full moon"
 msgstr "{days} дней после полнолуния"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Растущий серп"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Растущая выпуклая"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Убывающая выпуклая"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Убывающий серп"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "Первая четверть"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "Последняя четверть"
 
@@ -1172,17 +1172,22 @@ msgstr "Поиск города"
 msgid "Type city name..."
 msgstr "Введите название города..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Воздух: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1195,11 +1200,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Погода (город не выбран)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1222,7 +1222,7 @@ msgstr "Рабочие области"
 msgid "Website"
 msgstr "Сайт"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1347,7 +1347,7 @@ msgstr "Дисплей {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Внешний вид"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Поведение"
 
@@ -1387,130 +1387,134 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Вид"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Тема"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Размер значков"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Процент масштаба"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Показать подсказки"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Предпросмотр окон"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Размещение"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Расположение"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Следовать за курсором"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Только текущее рабочее пространство"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Раскладка"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Заблокировать позиции"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Закреплять апплеты в конце"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Закрепить файлы в конце"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Режим скрытия"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Задержка скрытия"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Задержка появления"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Док всегда виден и резервирует место на экране."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Скрывается когда курсор покидает док."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Скрывается когда активное окно перекрывает док."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Скрывается когда любое окно текущего рабочего пространства перекрывает док."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/sk/LC_MESSAGES/docking.po
+++ b/docking/locale/sk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth nedostupný"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "Žiadny Bluetooth adaptér"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "Zapnuté"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Vypnuté"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Pripojených {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Priebežné vyhľadávanie"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Obnoviť teraz"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adaptér"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Pripojené zariadenia"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Spárované zariadenia"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Objavené zariadenia"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Odpojiť"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Pripojiť"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Spárovať"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Zrušiť párovanie"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Dôveryhodné"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batéria: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Zobraziť názov fázy"
 msgid "Refresh"
 msgstr "Obnoviť"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "Nov"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Spln"
 
@@ -550,27 +550,27 @@ msgstr "{days} dní po nove"
 msgid "{days} days after full moon"
 msgstr "{days} dní po splne"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Dorastajúci srpok"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Dorastajúci mesiac"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Cúvajúci mesiac"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Cúvajúci srpok"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "Prvá štvrť"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "Tretia štvrť"
 
@@ -1171,17 +1171,22 @@ msgstr "Hľadať mesto"
 msgid "Type city name..."
 msgstr "Zadajte názov mesta..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Vzduch: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1194,11 +1199,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Počasie (mesto nevybrané)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1221,7 +1221,7 @@ msgstr "Pracovné plochy"
 msgid "Website"
 msgstr "Webová stránka"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1346,7 +1346,7 @@ msgstr "Displej {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Vzhlad"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Spravanie"
 
@@ -1386,129 +1386,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Vzhlad"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Motiv"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Veľkosť ikon"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Percento priblizenia"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Zobrazit napovedy"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Náhľady okien"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Umiestnenie"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Pozícia"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Sledovať kurzor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Iba aktuálna plocha"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Rozlozenie"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Zamknut pozicie"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Ukotviť aplety na koniec"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Pripnut subory na koniec"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Rezim skryvania"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Oneskorenie skrytia"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Oneskorenie zobrazenia"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Dok je vzdy viditelny a rezervuje miesto na obrazovke."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Skryje sa, ked kurzor mysi opusti dok."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Skryje sa, ked aktivne okno prekryva dok."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Skryje sa, ked hociake okno na aktualnej ploche prekryva dok."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/sl/LC_MESSAGES/docking.po
+++ b/docking/locale/sl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Povezanih {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Povezane naprave"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Seznanjene naprave"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Odkrite naprave"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Baterija: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Iskanje mesta"
 msgid "Type city name..."
 msgstr "Vnesite ime mesta..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Spletna stran"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Zaslon {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Videz"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Obnašanje"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Videz"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Odstotek povečave"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Prikaži namige"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Postavitev"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Razporeditev"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Zakleni položaje"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Zasidraj datoteke na konec"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Način skrivanja"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Zakasnitev skrivanja"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Zakasnitev prikaza"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/sq/LC_MESSAGES/docking.po
+++ b/docking/locale/sq/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Të lidhur {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Pajisjet e lidhura"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Pajisjet e çiftuara"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Pajisjet e zbuluara"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Bateria: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Kërko qytetin"
 msgid "Type city name..."
 msgstr "Shkruaj emrin e qytetit..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Faqe interneti"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Ekrani {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Pamja"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Sjellja"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Pamja"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Përqindja e zmadhimit"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Shfaq këshillat"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Vendosja"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Paraqitja"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Kyç pozicionet"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Ankoro skedarët në fund"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Mënyra e fshehjes"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Vonesa e fshehjes"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Vonesa e shfaqjes"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/sr/LC_MESSAGES/docking.po
+++ b/docking/locale/sr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Повезано {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Повезани уређаји"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Упарени уређаји"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Откривени уређаји"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Батерија: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Претрага града"
 msgid "Type city name..."
 msgstr "Унесите име града..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Веб страница"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Екран {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Изглед"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Понашање"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Изглед"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Тема"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Проценат увећања"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Прикажи описе"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Положај"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Распоред"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Закључај позиције"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Закачи датотеке на крај"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Режим сакривања"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Кашњење сакривања"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Кашњење приказивања"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/sv/LC_MESSAGES/docking.po
+++ b/docking/locale/sv/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Anslutna {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Anslutna enheter"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Parkopplade enheter"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Upptäckta enheter"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batteri: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Sök stad"
 msgid "Type city name..."
 msgstr "Ange stadsnamn..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Webbplats"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Skärm {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Utseende"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Beteende"
 
@@ -1385,130 +1385,134 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Utseende"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Zoomprocent"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Visa verktygstips"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Placering"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Layout"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Lås positioner"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Fäst filer i slutet"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Döljläge"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Döljfördröjning"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Visningsfördröjning"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Dockan är alltid synlig och reserverar skärmutrymme."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Döljs när muspekaren lämnar dockan."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Döljs när det fokuserade fönstret överlappar dockningsområdet."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Döljs när något fönster på aktuell arbetsyta överlappar dockningsområdet."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/sw/LC_MESSAGES/docking.po
+++ b/docking/locale/sw/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Imeunganishwa {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Vifaa Vilivyounganishwa"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Vifaa Vilivyooanishwa"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Vifaa Vilivyogunduliwa"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Betri: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Tafuta mji"
 msgid "Type city name..."
 msgstr "Andika jina la mji..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Tovuti"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Skrini {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Muonekano"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Tabia"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Muonekano"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Mandhari"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Asilimia ya Kukuza"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Onyesha Vidokezo"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Uwekaji"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Mpangilio"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Funga Nafasi"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Nanga Faili hadi Mwisho"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Hali ya Kuficha"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Ucheleweshaji wa Kuficha"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Ucheleweshaji wa Kuonyesha"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/ta/LC_MESSAGES/docking.po
+++ b/docking/locale/ta/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - இணைக்கப்பட்டது {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "இணைக்கப்பட்ட சாதனங்கள்"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "ஜோடிக்கப்பட்ட சாதனங்கள்"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "கண்டறியப்பட்ட சாதனங்கள்"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "பேட்டரி: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "நகரத்தைத் தேடு"
 msgid "Type city name..."
 msgstr "நகரத்தின் பெயரை உள்ளிடு..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "இணையதளம்"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "காட்சி {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "தோற்றம்"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "நடத்தை"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "தோற்றம்"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "தீம்"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "பெரிதாக்கும் சதவீதம்"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "உதவிக்குறிப்புகள் காட்டு"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "இடம்"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "அமைப்பு"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "நிலைகளை பூட்டு"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "கோப்புகளை இறுதியில் நங்கூரமிடு"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "மறைப்பு முறை"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "மறைப்பு தாமதம்"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "காட்டும் தாமதம்"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/te/LC_MESSAGES/docking.po
+++ b/docking/locale/te/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - కనెక్ట్ {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "కనెక్ట్ చేసిన పరికరాలు"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "జతచేసిన పరికరాలు"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "కనుగొన్న పరికరాలు"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "బ్యాటరీ: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "నగరాన్ని వెతకండి"
 msgid "Type city name..."
 msgstr "నగరం పేరు టైప్ చేయండి..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "వెబ్‌సైట్"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "డిస్‌ప్లే {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "రూపం"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "ప్రవర్తన"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "రూపం"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "థీమ్"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "జూమ్ శాతం"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "టూల్‌టిప్‌లు చూపించు"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "స్థానం"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "లేఅవుట్"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "స్థానాలు లాక్ చేయి"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "ఫైళ్లను చివరికి యాంకర్ చేయి"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "దాచే మోడ్"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "దాచే ఆలస్యం"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "చూపించే ఆలస్యం"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/th/LC_MESSAGES/docking.po
+++ b/docking/locale/th/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - เชื่อมต่อ {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "อุปกรณ์ที่เชื่อมต่อ"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "อุปกรณ์ที่จับคู่"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "อุปกรณ์ที่ค้นพบ"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "แบตเตอรี่: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1169,17 +1169,22 @@ msgstr "ค้นหาเมือง"
 msgid "Type city name..."
 msgstr "พิมพ์ชื่อเมือง..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1192,11 +1197,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1219,7 +1219,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "เว็บไซต์"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1344,7 +1344,7 @@ msgstr "จอแสดงผล {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "รูปลักษณ์"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "พฤติกรรม"
 
@@ -1384,129 +1384,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "รูปลักษณ์"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "ธีม"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "เปอร์เซ็นต์ซูม"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "แสดงคำแนะนำ"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "ตำแหน่ง"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "รูปแบบ"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "ล็อกตำแหน่ง"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "ตรึงไฟล์ไว้ท้ายสุด"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "โหมดซ่อน"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "หน่วงเวลาซ่อน"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "หน่วงเวลาแสดง"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Dock แสดงตลอดเวลาและจองพื้นที่หน้าจอ"
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/tr/LC_MESSAGES/docking.po
+++ b/docking/locale/tr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Bağlı {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Bağlı Cihazlar"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Eşleştirilmiş Cihazlar"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Keşfedilen Cihazlar"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Pil: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Şehir ara"
 msgid "Type city name..."
 msgstr "Şehir adı yazın..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Web Sitesi"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Ekran {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Görünüm"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Davranış"
 
@@ -1385,131 +1385,135 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Görünüş"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Tema"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Yakınlaştırma Yüzdesi"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "İpuçlarını Göster"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Yerleşim"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Düzen"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Konumları Kilitle"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Dosyaları Sona Sabitle"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Gizleme Modu"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Gizleme Gecikmesi"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Gösterme Gecikmesi"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Dock her zaman görünürdür ve ekran alanı ayırır."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Fare imleci docktan ayrıldığında gizlenir."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Odaklanan pencere dock alanını kapattığında gizlenir."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 "Mevcut çalışma alanındaki herhangi bir pencere dock alanını kapattığında "
 "gizlenir."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/uk/LC_MESSAGES/docking.po
+++ b/docking/locale/uk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Підключено {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Підключені пристрої"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Спарені пристрої"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Виявлені пристрої"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Батарея: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Пошук міста"
 msgid "Type city name..."
 msgstr "Введіть назву міста..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Вебсайт"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Дисплей {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Вигляд"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Поведінка"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Вигляд"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Тема"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Відсоток масштабу"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Показати підказки"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Розміщення"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Розкладка"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Заблокувати позиції"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Закріпити файли в кінці"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Режим ховання"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Затримка ховання"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Затримка появи"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Док завжди видимий і резервує місце на екрані."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/ur/LC_MESSAGES/docking.po
+++ b/docking/locale/ur/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - جڑا ہوا {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "جڑے ہوئے آلات"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "جوڑے گئے آلات"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "دریافت شدہ آلات"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "بیٹری: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "شہر تلاش کریں"
 msgid "Type city name..."
 msgstr "شہر کا نام لکھیں..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "ویب سائٹ"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "ڈسپلے {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "ظاہری شکل"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "رویہ"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "شکل"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "تھیم"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "زوم فیصد"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "ٹول ٹپس دکھائیں"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "جگہ"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "لے آؤٹ"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "پوزیشنز لاک کریں"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "فائلوں کو آخر میں اینکر کریں"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "چھپانے کا موڈ"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "چھپانے کی تاخیر"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "دکھانے کی تاخیر"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/uz/LC_MESSAGES/docking.po
+++ b/docking/locale/uz/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Ulangan {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Ulangan qurilmalar"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Juftlangan qurilmalar"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Topilgan qurilmalar"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Batareya: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Shaharni qidiring"
 msgid "Type city name..."
 msgstr "Shahar nomini kiriting..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Veb-sayt"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Displey {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Ko'rinish"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Xatti-harakat"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Ko'rinish"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Mavzu"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Kattalashtirish foizi"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Maslahatlarni ko'rsatish"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Joylashuv"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Tartib"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Joylashuvlarni qulflash"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Fayllarni oxiriga biriktirish"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Yashirish rejimi"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Yashirish kechikishi"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Ko'rsatish kechikishi"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/vi/LC_MESSAGES/docking.po
+++ b/docking/locale/vi/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Đã kết nối {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Thiết bị đã kết nối"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Thiết bị đã ghép nối"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Thiết bị đã phát hiện"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Pin: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1169,17 +1169,22 @@ msgstr "Tìm thành phố"
 msgid "Type city name..."
 msgstr "Nhập tên thành phố..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1192,11 +1197,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1219,7 +1219,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Trang web"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1344,7 +1344,7 @@ msgstr "Màn hình {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Giao dien"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Hanh vi"
 
@@ -1384,129 +1384,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Giao dien"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Chu de"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Phan tram thu phong"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Hien tooltip"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Vi tri"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Bo cuc"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Khoa vi tri"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Ghim tep xuong cuoi"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Che do an"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Do tre an"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Do tre hien"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "Dock luon hien thi va chiem khong gian man hinh."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/xh/LC_MESSAGES/docking.po
+++ b/docking/locale/xh/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Kuxhunyiwe {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Izixhobo Ezixhunyiweyo"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Izixhobo Ezidityanisiweyo"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Izixhobo Ezifunyenweyo"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Ibhetri: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Khangela idolophu"
 msgid "Type city name..."
 msgstr "Chwetheza igama ledolophu..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Iwebhusayithi"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Isikrini {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Imbonakalo"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Ukuziphatha"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Imbonakalo"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Umxholo"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Ipesenti Yokukhulisa"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Bonisa Izincomo"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Indawo"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Isimo"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Tshixa Izikhundla"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Bophelela Iifayile Ekupheleni"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Imowudi Yokufihla"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Ukulibaziseka Kokufihla"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Ukulibaziseka Kokubonisa"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/zh_CN/LC_MESSAGES/docking.po
+++ b/docking/locale/zh_CN/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "蓝牙"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "蓝牙不可用"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "无蓝牙适配器"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "开"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "关"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - 已连接 {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "持续发现"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "立即刷新"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "适配器"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "已连接设备"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "已配对设备"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "已发现设备"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "断开连接"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "连接"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "配对"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "取消配对"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "已信任"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "电池: {percent}%"
@@ -508,11 +508,11 @@ msgstr "显示月相"
 msgid "Refresh"
 msgstr "刷新"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "新月"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "满月"
 
@@ -550,27 +550,27 @@ msgstr "新月后{days}天"
 msgid "{days} days after full moon"
 msgstr "满月后{days}天"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "蛾眉月"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "盈凸月"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "亏凸月"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "残月"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "上弦月"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "下弦月"
 
@@ -1169,17 +1169,22 @@ msgstr "搜索城市"
 msgid "Type city name..."
 msgstr "输入城市名称..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C，{desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "空气：{label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1192,11 +1197,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "天气（未选择城市）"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1219,7 +1219,7 @@ msgstr "工作区"
 msgid "Website"
 msgstr "网站"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1344,7 +1344,7 @@ msgstr "显示器 {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "外观"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "行为"
 
@@ -1384,129 +1384,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "外观"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "主题"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "图标大小"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "缩放"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "缩放百分比"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "显示提示"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "窗口预览"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "位置"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "位置"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "跟随光标"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "仅当前工作区"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "布局"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "锁定位置"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "将小程序锚定到末尾"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "将文件固定到末尾"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "隐藏模式"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "隐藏延迟"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "显示延迟"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "停靠栏始终可见并保留屏幕空间。"
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "鼠标离开停靠栏时隐藏。"
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "焦点窗口与停靠栏重叠时隐藏。"
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "当前工作区的任何窗口与停靠栏重叠时隐藏。"
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/zu/LC_MESSAGES/docking.po
+++ b/docking/locale/zu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-08 23:50+0200\n"
+"POT-Creation-Date: 2026-04-21 08:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -164,111 +164,111 @@ msgstr "{minutes}m"
 msgid "Bluetooth"
 msgstr "Bluetooth"
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:167
 msgid "Bluetooth unavailable"
 msgstr "Bluetooth unavailable"
 
-#: docking/applets/bluetooth/applet.py:179
+#: docking/applets/bluetooth/applet.py:174
 msgid "No Bluetooth adapter"
 msgstr "No Bluetooth adapter"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "On"
 msgstr "On"
 
-#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/applet.py:182
 #: docking/applets/bluetooth/state.py:142
 msgid "Off"
 msgstr "Off"
 
-#: docking/applets/bluetooth/applet.py:195
+#: docking/applets/bluetooth/applet.py:190
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr "{alias} ({powered}) - Kuxhunyiwe {connected}"
 
-#: docking/applets/bluetooth/applet.py:204
+#: docking/applets/bluetooth/applet.py:199
 msgid "Continuous Discovery"
 msgstr "Continuous Discovery"
 
-#: docking/applets/bluetooth/applet.py:215
+#: docking/applets/bluetooth/applet.py:210
 msgid "Refresh Now"
 msgstr "Refresh Now"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth Off"
 msgstr "Turn Bluetooth Off"
 
-#: docking/applets/bluetooth/applet.py:229
+#: docking/applets/bluetooth/applet.py:224
 msgid "Turn Bluetooth On"
 msgstr "Turn Bluetooth On"
 
-#: docking/applets/bluetooth/applet.py:245
+#: docking/applets/bluetooth/applet.py:240
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr "Disconnect {device}"
 
-#: docking/applets/bluetooth/applet.py:259
+#: docking/applets/bluetooth/applet.py:254
 msgid "Send Files to Device..."
 msgstr "Send Files to Device..."
 
-#: docking/applets/bluetooth/applet.py:267
+#: docking/applets/bluetooth/applet.py:262
 msgid "Devices..."
 msgstr "Devices..."
 
-#: docking/applets/bluetooth/applet.py:273
+#: docking/applets/bluetooth/applet.py:268
 msgid "Adapters..."
 msgstr "Adapters..."
 
-#: docking/applets/bluetooth/applet.py:279
+#: docking/applets/bluetooth/applet.py:274
 msgid "Local Services..."
 msgstr "Local Services..."
 
-#: docking/applets/bluetooth/applet.py:286
+#: docking/applets/bluetooth/applet.py:281
 msgid "Recent Connections"
 msgstr "Recent Connections"
 
-#: docking/applets/bluetooth/applet.py:291
+#: docking/applets/bluetooth/applet.py:286
 msgid "No recent connections"
 msgstr "No recent connections"
 
-#: docking/applets/bluetooth/applet.py:314
+#: docking/applets/bluetooth/applet.py:309
 msgid "Adapter"
 msgstr "Adapter"
 
-#: docking/applets/bluetooth/applet.py:340
+#: docking/applets/bluetooth/applet.py:335
 msgid "Connected Devices"
 msgstr "Amadivayisi Axhunyiwe"
 
-#: docking/applets/bluetooth/applet.py:341
+#: docking/applets/bluetooth/applet.py:336
 msgid "Paired Devices"
 msgstr "Amadivayisi Abhanqiwe"
 
-#: docking/applets/bluetooth/applet.py:342
+#: docking/applets/bluetooth/applet.py:337
 msgid "Discovered Devices"
 msgstr "Amadivayisi Atholiwe"
 
-#: docking/applets/bluetooth/applet.py:367
+#: docking/applets/bluetooth/applet.py:362
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:371
 msgid "Connect"
 msgstr "Connect"
 
-#: docking/applets/bluetooth/applet.py:386
+#: docking/applets/bluetooth/applet.py:381
 msgid "Pair"
 msgstr "Pair"
 
-#: docking/applets/bluetooth/applet.py:400
+#: docking/applets/bluetooth/applet.py:395
 msgid "Remove Pairing"
 msgstr "Remove Pairing"
 
-#: docking/applets/bluetooth/applet.py:412
+#: docking/applets/bluetooth/applet.py:407
 msgid "Trusted"
 msgstr "Trusted"
 
-#: docking/applets/bluetooth/applet.py:427
+#: docking/applets/bluetooth/applet.py:422
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr "Ibhethri: {percent}%"
@@ -508,11 +508,11 @@ msgstr "Show Phase Name"
 msgid "Refresh"
 msgstr "Refresh"
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:129
+#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
 msgid "New"
 msgstr "New"
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:131
+#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
 msgid "Full"
 msgstr "Full"
 
@@ -550,27 +550,27 @@ msgstr "{days} days after new moon"
 msgid "{days} days after full moon"
 msgstr "{days} days after full moon"
 
-#: docking/applets/moon/state.py:120
+#: docking/applets/moon/state.py:121
 msgid "Waxing Crescent"
 msgstr "Waxing Crescent"
 
-#: docking/applets/moon/state.py:122
+#: docking/applets/moon/state.py:123
 msgid "Waxing Gibbous"
 msgstr "Waxing Gibbous"
 
-#: docking/applets/moon/state.py:124
+#: docking/applets/moon/state.py:125
 msgid "Waning Gibbous"
 msgstr "Waning Gibbous"
 
-#: docking/applets/moon/state.py:126
+#: docking/applets/moon/state.py:127
 msgid "Waning Crescent"
 msgstr "Waning Crescent"
 
-#: docking/applets/moon/state.py:133
+#: docking/applets/moon/state.py:134
 msgid "1st Quarter"
 msgstr "1st Quarter"
 
-#: docking/applets/moon/state.py:135
+#: docking/applets/moon/state.py:136
 msgid "3rd Quarter"
 msgstr "3rd Quarter"
 
@@ -1170,17 +1170,22 @@ msgstr "Sesha idolobha"
 msgid "Type city name..."
 msgstr "Thayipha igama ledolobha..."
 
-#: docking/applets/weather/applet.py:363
+#: docking/applets/weather/applet.py:338 docking/applets/weather/state.py:130
+#, python-brace-format
+msgid "{city}: unavailable"
+msgstr "{city}: unavailable"
+
+#: docking/applets/weather/applet.py:364
 #, python-brace-format
 msgid "{temp}°C, {desc}"
 msgstr "{temp}°C, {desc}"
 
-#: docking/applets/weather/applet.py:372 docking/applets/weather/state.py:135
+#: docking/applets/weather/applet.py:373 docking/applets/weather/state.py:135
 #, python-brace-format
 msgid "Air: {label}"
 msgstr "Air: {label}"
 
-#: docking/applets/weather/applet.py:384
+#: docking/applets/weather/applet.py:385
 #, python-brace-format
 msgid "{date}: {min_temp}/{max_temp}°C"
 msgstr "{date}: {min_temp}/{max_temp}°C"
@@ -1193,11 +1198,6 @@ msgstr "{city}: {temp}°C"
 #: docking/applets/weather/state.py:127
 msgid "Weather (no city selected)"
 msgstr "Weather (no city selected)"
-
-#: docking/applets/weather/state.py:130
-#, python-brace-format
-msgid "{city}: unavailable"
-msgstr "{city}: unavailable"
 
 #: docking/applets/weather/state.py:131
 #, python-brace-format
@@ -1220,7 +1220,7 @@ msgstr "Workspaces"
 msgid "Website"
 msgstr "Iwebhusayithi"
 
-#: docking/ui/dock_window.py:340
+#: docking/ui/dock_window.py:390
 msgid "Docking"
 msgstr "Docking"
 
@@ -1345,7 +1345,7 @@ msgstr "Isikrini {display}: {width}x{height}"
 msgid "Appearance"
 msgstr "Ukubukeka"
 
-#: docking/ui/settings.py:186 docking/ui/settings.py:351
+#: docking/ui/settings.py:186 docking/ui/settings.py:352
 msgid "Behavior"
 msgstr "Ukuziphatha"
 
@@ -1385,129 +1385,133 @@ msgstr "Toggle Focus"
 msgid "Cycle Windows"
 msgstr "Cycle Windows"
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:229
+msgid "Most Recent Window"
+msgstr "Most Recent Window"
+
+#: docking/ui/settings.py:236
 msgid "New Window"
 msgstr "New Window"
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:237
 msgid "Minimize Windows"
 msgstr "Minimize Windows"
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:238
 msgid "Close Focused Window"
 msgstr "Close Focused Window"
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:296
 msgid "Look"
 msgstr "Ukubukeka"
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Theme"
 msgstr "Indikimba"
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Icon Size"
 msgstr "Icon Size"
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:300
 msgid "Transparency"
 msgstr "Transparency"
 
-#: docking/ui/settings.py:300
+#: docking/ui/settings.py:301
 msgid "Zoom"
 msgstr "Zoom"
 
-#: docking/ui/settings.py:301
+#: docking/ui/settings.py:302
 msgid "Zoom Percent"
 msgstr "Iphesenti Yokusondeza"
 
-#: docking/ui/settings.py:302
+#: docking/ui/settings.py:303
 msgid "Show Tooltips"
 msgstr "Bonisa Izincomo"
 
-#: docking/ui/settings.py:303
+#: docking/ui/settings.py:304
 msgid "Window Previews"
 msgstr "Window Previews"
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:309
 msgid "Placement"
 msgstr "Indawo"
 
-#: docking/ui/settings.py:310
+#: docking/ui/settings.py:311
 msgid "Position"
 msgstr "Position"
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:312
 msgid "Follow Cursor"
 msgstr "Follow Cursor"
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:313
 msgid "Current Workspace Only"
 msgstr "Current Workspace Only"
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:318
 msgid "Layout"
 msgstr "Isakhiwo"
 
-#: docking/ui/settings.py:319
+#: docking/ui/settings.py:320
 msgid "Lock Positions"
 msgstr "Khiya Izikhundla"
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:321
 msgid "Anchor Applets to End"
 msgstr "Anchor Applets to End"
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:322
 msgid "Anchor Files to End"
 msgstr "Bopha Amafayela Ekugcineni"
 
-#: docking/ui/settings.py:343
+#: docking/ui/settings.py:344
 msgid "Mouse"
 msgstr "Mouse"
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:346
 msgid "Left Click"
 msgstr "Left Click"
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:347
 msgid "Middle Click"
 msgstr "Middle Click"
 
-#: docking/ui/settings.py:353
+#: docking/ui/settings.py:354
 msgid "Hide Mode"
 msgstr "Imodi Yokufihla"
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:355
 msgid "Hide Delay"
 msgstr "Ukubambezeleka Kokufihla"
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:356
 msgid "Unhide Delay"
 msgstr "Ukubambezeleka Kokubonisa"
 
-#: docking/ui/settings.py:747
+#: docking/ui/settings.py:771
 msgid "The dock is always visible and reserves screen space."
 msgstr "The dock is always visible and reserves screen space."
 
-#: docking/ui/settings.py:748
+#: docking/ui/settings.py:772
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr "Hides when the mouse cursor leaves the dock."
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:774
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 "Hides when a window from the focused application overlaps the dock area."
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:776
 msgid "Hides when the focused window overlaps the dock area."
 msgstr "Hides when the focused window overlaps the dock area."
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:778
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr "Hides when any window on the current workspace overlaps the dock area."
 
-#: docking/ui/settings.py:757
+#: docking/ui/settings.py:781
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/platform/window_tracker.py
+++ b/docking/platform/window_tracker.py
@@ -459,6 +459,45 @@ class WindowTracker:
             # Activate the most recent window
             self.activate_window(window=windows[0])
 
+    def activate_most_recent(self, desktop_id: str) -> None:
+        """Focus the MRU window for desktop_id, or minimize if already active."""
+        if self._screen is None:
+            return
+
+        windows = self._get_windows_for(desktop_id=desktop_id)
+        if not windows:
+            return
+
+        active_window = self._screen.get_active_window()
+        if active_window and active_window in windows:
+            self.minimize_windows(desktop_id=desktop_id)
+            return
+
+        target = self._most_recent_window(windows=windows)
+        self.activate_window(window=target)
+
+    def _most_recent_window(self, windows: list[Wnck.Window]) -> Wnck.Window:
+        """Return the topmost window in stacking order from the candidates."""
+        if self._screen is None or len(windows) == 1:
+            return windows[0]
+        candidate_xids = {self._xid_for(window=w) for w in windows}
+        candidate_xids.discard(0)
+        if not candidate_xids:
+            return windows[0]
+        try:
+            stacked = self._screen.get_windows_stacked()
+        except _RECOVERABLE_ERRORS as exc:
+            log.bind(action="windows_stacked").warning(
+                f"Failed to read stacked windows: {exc}"
+            )
+            return windows[0]
+        by_xid = {self._xid_for(window=w): w for w in windows}
+        for window in reversed(stacked):
+            xid = self._xid_for(window=window)
+            if xid in candidate_xids:
+                return by_xid.get(xid, windows[0])
+        return windows[0]
+
     def cycle_windows(self, desktop_id: str) -> None:
         """Cycle through windows for a desktop_id, minimizing on wrap."""
         if self._screen is None:

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -878,6 +878,9 @@ class DockWindow(Gtk.Window):
             elif action == LeftClickAction.CYCLE.value:
                 self.window_tracker.cycle_windows(item.desktop_id)
                 self.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
+            elif action == LeftClickAction.MOST_RECENT.value:
+                self.window_tracker.activate_most_recent(item.desktop_id)
+                self.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
             elif action == MiddleClickAction.MINIMIZE.value:
                 self.window_tracker.minimize_windows(item.desktop_id)
                 self.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -226,6 +226,7 @@ class SettingsWindowController:
         for action_value, action_label in [
             (LeftClickAction.TOGGLE.value, _("Toggle Focus")),
             (LeftClickAction.CYCLE.value, _("Cycle Windows")),
+            (LeftClickAction.MOST_RECENT.value, _("Most Recent Window")),
         ]:
             self._left_click_combo.append(action_value, action_label)
 

--- a/tests/platform/test_window_tracker.py
+++ b/tests/platform/test_window_tracker.py
@@ -203,3 +203,97 @@ class TestWindowActions:
 
         assert activated == [1]
         assert tracker._cycle_index["firefox.desktop"] == 0
+
+    def _make_mru_tracker(
+        self,
+        windows: list[_FakeWindow],
+        stacked: list[_FakeWindow],
+        *,
+        active: _FakeWindow | None = None,
+    ):
+        tracker = tracker_mod.WindowTracker.__new__(tracker_mod.WindowTracker)
+        tracker._screen = SimpleNamespace(
+            get_active_window=lambda: active,
+            get_windows_stacked=lambda: list(stacked),
+        )
+        tracker._running_xids_by_desktop = {"firefox.desktop": [w.xid for w in windows]}
+        tracker._cycle_index = {}
+        tracker._cycle_order_by_desktop = {}
+        tracker._get_windows_for = lambda desktop_id: list(windows)
+        tracker._model = MagicMock()
+        tracker._config = None
+        tracker._launcher = MagicMock()
+        return tracker
+
+    def test_activate_most_recent_picks_top_of_stack(self, monkeypatch):
+        first = _FakeWindow(1)
+        second = _FakeWindow(2)
+        third = _FakeWindow(3)
+        unrelated = _FakeWindow(99)
+        tracker = self._make_mru_tracker(
+            windows=[first, second, third],
+            stacked=[first, unrelated, second, third],
+            active=unrelated,
+        )
+        activated: list[int] = []
+        monkeypatch.setattr(
+            tracker_mod.WindowTracker,
+            "activate_window",
+            staticmethod(lambda window: activated.append(window.xid)),
+        )
+
+        tracker_mod.WindowTracker.activate_most_recent(tracker, "firefox.desktop")
+
+        assert activated == [3]
+
+    def test_activate_most_recent_minimizes_when_app_active(self, monkeypatch):
+        first = _FakeWindow(1)
+        second = _FakeWindow(2)
+        tracker = self._make_mru_tracker(
+            windows=[first, second],
+            stacked=[first, second],
+            active=second,
+        )
+        minimize_calls: list[str] = []
+        monkeypatch.setattr(
+            tracker_mod.WindowTracker,
+            "activate_window",
+            staticmethod(lambda window: (_ for _ in ()).throw(AssertionError())),
+        )
+        tracker.minimize_windows = lambda desktop_id: minimize_calls.append(desktop_id)
+
+        tracker_mod.WindowTracker.activate_most_recent(tracker, "firefox.desktop")
+
+        assert minimize_calls == ["firefox.desktop"]
+
+    def test_activate_most_recent_noop_when_no_windows(self, monkeypatch):
+        tracker = self._make_mru_tracker(windows=[], stacked=[], active=None)
+        activated: list[int] = []
+        monkeypatch.setattr(
+            tracker_mod.WindowTracker,
+            "activate_window",
+            staticmethod(lambda window: activated.append(window.xid)),
+        )
+
+        tracker_mod.WindowTracker.activate_most_recent(tracker, "firefox.desktop")
+
+        assert activated == []
+
+    def test_activate_most_recent_falls_back_when_stacking_unavailable(
+        self, monkeypatch
+    ):
+        first = _FakeWindow(1)
+        second = _FakeWindow(2)
+        tracker = self._make_mru_tracker(
+            windows=[first, second], stacked=[], active=None
+        )
+        activated: list[int] = []
+        monkeypatch.setattr(
+            tracker_mod.WindowTracker,
+            "activate_window",
+            staticmethod(lambda window: activated.append(window.xid)),
+        )
+
+        tracker_mod.WindowTracker.activate_most_recent(tracker, "firefox.desktop")
+
+        assert activated == [1]

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -235,6 +235,27 @@ class TestButtonReleaseFlow:
         assert item.last_clicked == 1111
         assert item.last_launched == 0
 
+    def test_left_click_most_recent_dispatches_mru_action(self, monkeypatch):
+        item = DockItem(desktop_id="firefox.desktop", is_running=True)
+        stub, _ = _make_stub(item=item)
+        stub.config.left_click_action = "most-recent"
+        event = SimpleNamespace(
+            x=12.0, y=6.0, button=dock_window_mod.MOUSE_LEFT, state=0
+        )
+        monkeypatch.setattr(dock_window_mod, "is_applet", lambda desktop_id: False)
+        monkeypatch.setattr(dock_window_mod.GLib, "get_monotonic_time", lambda: 1313)
+
+        handled = dock_window_mod.DockWindow._on_button_release(
+            stub, MagicMock(), event
+        )
+
+        assert handled is True
+        stub.window_tracker.activate_most_recent.assert_called_once_with(
+            "firefox.desktop"
+        )
+        stub.window_tracker.toggle_focus.assert_not_called()
+        assert item.last_launched == 0
+
     def test_middle_click_minimizes_when_configured(self, monkeypatch):
         item = DockItem(desktop_id="firefox.desktop", is_running=True)
         stub, _ = _make_stub(item=item)

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -629,12 +629,12 @@ class TestSettingsWindowController:
         )
 
         controller.show()
-        controller._left_click_combo.set_active_id("cycle")
+        controller._left_click_combo.set_active_id("most-recent")
         controller._left_click_combo.emit_changed()
         controller._middle_click_combo.set_active_id("close-focused")
         controller._middle_click_combo.emit_changed()
 
-        assert config.left_click_action == "cycle"
+        assert config.left_click_action == "most-recent"
         assert config.middle_click_action == "close-focused"
         assert config.save.call_count == 2
         runtime.assert_not_called()


### PR DESCRIPTION
## Summary
- add `most-recent` option for `left_click_action` that focuses the most recently used window instead of the oldest one
- when the app is already active, second click minimizes (same as `toggle`)
- falls back to `windows[0]` if `get_windows_stacked()` is unavailable

The existing `toggle` action always activates `windows[0]` from `get_windows()`, which is creation order. So with multiple windows of the same app (several VS Code projects, etc), clicking the dock icon after switching away always brings back the first window opened, not the one you were just in. The comment on that line even says "Activate the most recent window" but the underlying ordering is creation order, not MRU.

`activate_most_recent` reads `get_windows_stacked()` instead (top of stack = most recently focused) and picks the topmost entry belonging to the clicked app. Default stays `toggle`, opt-in via `dock.json`.

## Testing
- .venv/bin/pytest -q tests/platform/test_window_tracker.py tests/ui/test_dock_window_integration.py
- full suite: 2221 passed, 1 skipped