### PR TITLE
Match transient launchers by WM_CLASS aliases

### DIFF
--- a/docking/platform/launcher.py
+++ b/docking/platform/launcher.py
@@ -169,12 +169,38 @@ class FileTargetInfo(NamedTuple):
     is_dir: bool
 
 
+def _normalized_exec_basename(exec_line: str) -> str:
+    """Return the lowercase executable basename from a desktop Exec line."""
+    if not exec_line:
+        return ""
+    try:
+        argv = shlex.split(exec_line)
+    except ValueError:
+        return ""
+    if not argv:
+        return ""
+    return Path(argv[0]).name.lower()
+
+
+def _desktop_match_aliases(info: DesktopInfo) -> list[str]:
+    """Return stable lookup aliases for matching runtime windows to desktop IDs."""
+    aliases = [
+        info.wm_class.lower(),
+        info.desktop_id.removesuffix(DESKTOP_SUFFIX).lower(),
+    ]
+    exec_basename = _normalized_exec_basename(info.exec_line)
+    if exec_basename:
+        aliases.append(exec_basename)
+    return list(dict.fromkeys(alias for alias in aliases if alias))
+
+
 class Launcher:
     """Resolves .desktop files via XDG_DATA_DIRS and loads icons."""
 
     def __init__(self) -> None:
         self._desktop_dirs = self._get_desktop_dirs()
         self._icon_cache: dict[tuple[str, int], GdkPixbuf.Pixbuf | None] = {}
+        self._wm_class_index: dict[str, DesktopInfo] | None = None
 
     def resolve(
         self, desktop_id: str, *, log_failures: bool = True
@@ -219,13 +245,28 @@ class Launcher:
         icon = app_info.get_icon()
         icon_name = icon.to_string() if icon else FALLBACK_ICON
 
-        return DesktopInfo(
+        info = DesktopInfo(
             desktop_id=desktop_id,
             name=app_info.get_display_name() or desktop_id,
             icon_name=icon_name,
             wm_class=wm_class,
             exec_line=app_info.get_commandline() or "",
         )
+        if self._wm_class_index is not None:
+            for alias in _desktop_match_aliases(info):
+                self._wm_class_index.setdefault(alias, info)
+        return info
+
+    def resolve_by_wm_class(self, wm_class: str) -> DesktopInfo | None:
+        """Resolve an installed desktop file by runtime WM_CLASS or executable alias."""
+        lookup = wm_class.lower().strip()
+        if not lookup:
+            return None
+        if self._wm_class_index is None:
+            self._build_wm_class_index()
+        if self._wm_class_index is None:
+            return None
+        return self._wm_class_index.get(lookup)
 
     def load_icon(self, icon_name: str, size: int) -> GdkPixbuf.Pixbuf | None:
         """Load an icon by name at the given size, with caching."""
@@ -337,6 +378,25 @@ class Launcher:
         if app_info is None:
             return None
         return app_info.get_display_name() or None
+
+    def _build_wm_class_index(self) -> None:
+        """Index installed desktop entries by WM_CLASS-like runtime aliases."""
+        index: dict[str, DesktopInfo] = {}
+        seen_desktop_ids: set[str] = set()
+        for desktop_dir in self._desktop_dirs:
+            for path in desktop_dir.rglob(f"*{DESKTOP_SUFFIX}"):
+                if not path.is_file():
+                    continue
+                desktop_id = path.relative_to(desktop_dir).as_posix()
+                if desktop_id in seen_desktop_ids:
+                    continue
+                seen_desktop_ids.add(desktop_id)
+                info = self.resolve(desktop_id=desktop_id, log_failures=False)
+                if info is None:
+                    continue
+                for alias in _desktop_match_aliases(info):
+                    index.setdefault(alias, info)
+        self._wm_class_index = index
 
     def _try_load_gicon(self, gicon: Gio.Icon, size: int) -> GdkPixbuf.Pixbuf | None:
         theme = Gtk.IconTheme.get_default()

--- a/docking/platform/window_tracker.py
+++ b/docking/platform/window_tracker.py
@@ -343,13 +343,13 @@ class WindowTracker:
             return self._wm_class_to_desktop[class_lower]
 
         # Try matching class instance name
+        class_instance = None
         try:
             class_instance = window.get_class_instance_name()
         except _RECOVERABLE_ERRORS as exc:
             log.bind(action="class_instance").warning(
                 f"Failed to read class instance name: {exc}"
             )
-            class_instance = None
         if class_instance:
             inst_lower = class_instance.lower()
             if inst_lower in self._wm_class_to_desktop:
@@ -388,6 +388,18 @@ class WindowTracker:
                     class_group,
                     class_lower,
                 )
+
+        runtime_names = [
+            class_lower,
+            class_instance.lower() if class_instance else "",
+        ]
+        for runtime_name in dict.fromkeys(name for name in runtime_names if name):
+            info = self._launcher.resolve_by_wm_class(runtime_name)
+            if info:
+                self._wm_class_to_desktop[class_lower] = info.desktop_id
+                if class_instance:
+                    self._wm_class_to_desktop[class_instance.lower()] = info.desktop_id
+                return info.desktop_id
 
         return None
 

--- a/tests/platform/test_launcher.py
+++ b/tests/platform/test_launcher.py
@@ -16,6 +16,7 @@ except Exception:
 
 from docking.core.config import MiddleClickAction
 from docking.platform.launcher import (
+    DesktopInfo,
     Launcher,
     get_actions,
     launch,
@@ -267,6 +268,32 @@ class TestResolve:
 
         # Then
         assert info is None
+
+    def test_resolve_by_wm_class_indexes_fallback_exec_alias(self, tmp_path):
+        apps_dir = tmp_path / "applications"
+        apps_dir.mkdir()
+        (apps_dir / "org.gnome.Calculator.desktop").write_text("[Desktop Entry]\n")
+
+        launcher = Launcher()
+        launcher._desktop_dirs = [apps_dir]
+        launcher.resolve = MagicMock(
+            side_effect=lambda desktop_id, **_kwargs: (
+                DesktopInfo(
+                    desktop_id="org.gnome.Calculator.desktop",
+                    name="Calculator",
+                    icon_name="org.gnome.Calculator",
+                    wm_class="gnome-calculator",
+                    exec_line="gnome-calculator",
+                )
+                if desktop_id == "org.gnome.Calculator.desktop"
+                else None
+            )
+        )
+
+        info = launcher.resolve_by_wm_class("gnome-calculator")
+
+        assert info is not None
+        assert info.desktop_id == "org.gnome.Calculator.desktop"
 
     def test_resolve_file_uses_image_thumbnail_for_images(self, monkeypatch):
         from docking.platform import launcher as launcher_mod

--- a/tests/platform/test_window_tracker_integration.py
+++ b/tests/platform/test_window_tracker_integration.py
@@ -17,6 +17,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for non-GI environmen
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
 import docking.platform.window_tracker as window_tracker_mod
+from docking.platform.launcher import DesktopInfo
 from docking.platform.model import DockItem
 
 
@@ -120,6 +121,7 @@ def tracker_env(monkeypatch):
         DockItem(desktop_id="no-class.desktop", wm_class=""),
     ]
     launcher = MagicMock()
+    launcher.resolve_by_wm_class.return_value = None
     tracker = window_tracker_mod.WindowTracker(model=model, launcher=launcher)
     return tracker, model, launcher
 
@@ -331,6 +333,24 @@ class TestWindowMatching:
         # When
         # Then
         assert tracker._match_window(win) is None
+
+    def test_match_uses_reverse_wm_class_lookup_for_unpinned_apps(self, tracker_env):
+        tracker, _model, launcher = tracker_env
+        launcher.resolve.return_value = None
+        launcher.resolve_by_wm_class.return_value = DesktopInfo(
+            desktop_id="org.gnome.Calculator.desktop",
+            name="Calculator",
+            icon_name="org.gnome.Calculator",
+            wm_class="gnome-calculator",
+            exec_line="gnome-calculator",
+        )
+        win = FakeWindow(16, class_group="gnome-calculator")
+
+        assert tracker._match_window(win) == "org.gnome.Calculator.desktop"
+        assert (
+            tracker._wm_class_to_desktop["gnome-calculator"]
+            == "org.gnome.Calculator.desktop"
+        )
 
 
 class TestWindowActions:


### PR DESCRIPTION
## Summary
- add a reverse WM_CLASS alias index for installed desktop entries
- use that index when live windows do not map cleanly to a desktop filename
- cover the reverse-lookup path in launcher and window tracker tests