### PR TITLE
Skip Bluetooth logs for missing optional values

### DIFF
--- a/docking/applets/bluetooth/state.py
+++ b/docking/applets/bluetooth/state.py
@@ -742,6 +742,12 @@ def _as_bool(value: Any) -> bool:
 
 def _as_int(value: Any, default: int | None = 0) -> int | None:
     unpacked = _unpack(value)
+    if unpacked is None:
+        return default
+    if isinstance(unpacked, str):
+        unpacked = unpacked.strip()
+        if not unpacked:
+            return default
     try:
         return int(unpacked)
     except (TypeError, ValueError) as exc:

--- a/tests/applets/test_bluetooth.py
+++ b/tests/applets/test_bluetooth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from dataclasses import replace
 from types import SimpleNamespace
@@ -716,6 +717,13 @@ class TestBluezBackend:
         assert bluetooth_state_mod._as_bool("true") is False
         assert bluetooth_state_mod._as_int(_Variant("7")) == 7
         assert bluetooth_state_mod._as_int("bad", default=None) is None
+
+    def test_as_int_skips_debug_log_for_absent_optional_values(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="docking.bluetooth"):
+            assert bluetooth_state_mod._as_int(None, default=None) is None
+            assert bluetooth_state_mod._as_int("  ", default=None) is None
+
+        assert "Failed to coerce Bluetooth value" not in caplog.text
 
 
 class _StubBackend:


### PR DESCRIPTION
## Summary
- treat missing optional Bluetooth numeric properties as absent rather than invalid
- avoid debug-log spam when BlueZ omits values like RSSI or battery percentage
- add regression coverage for the quiet missing-value path