### PR TITLE
Refactor worktree cleanups

### DIFF
--- a/docking/applets/bluetooth/applet.py
+++ b/docking/applets/bluetooth/applet.py
@@ -722,6 +722,6 @@ def _as_pref_bool(value: object, *, default: bool) -> bool:
         if lowered in {"0", "false", "no", "off"}:
             return False
         return default
-    if isinstance(value, (int, float)):
+    if isinstance(value, int | float):
         return bool(value)
     return default

--- a/docking/applets/bluetooth/state.py
+++ b/docking/applets/bluetooth/state.py
@@ -320,7 +320,7 @@ class BluezBackend:
                     "(adapter still discovering)."
                 )
                 return False
-            for _ in range(POWER_OFF_RETRY_COUNT):
+            for _attempt in range(POWER_OFF_RETRY_COUNT):
                 if self._set_property(
                     path=adapter_path,
                     interface=ADAPTER_IFACE,
@@ -339,7 +339,7 @@ class BluezBackend:
                 target_discovering=False,
                 timeout_s=DISCOVERY_DISCONNECT_SETTLE_TIMEOUT_S,
             )
-            for _ in range(POWER_OFF_FINAL_RETRY_COUNT):
+            for _attempt in range(POWER_OFF_FINAL_RETRY_COUNT):
                 if self._set_property(
                     path=adapter_path,
                     interface=ADAPTER_IFACE,

--- a/docking/applets/calculator/state.py
+++ b/docking/applets/calculator/state.py
@@ -52,7 +52,7 @@ def _eval_node(node: ast.AST) -> float:
     """Recursively evaluate an AST node, allowing only basic arithmetic."""
     if isinstance(node, ast.Expression):
         return _eval_node(node.body)
-    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+    if isinstance(node, ast.Constant) and isinstance(node.value, int | float):
         return float(node.value)
     if isinstance(node, ast.BinOp):
         op = _BINARY_OPS.get(type(node.op))

--- a/docking/applets/music/state.py
+++ b/docking/applets/music/state.py
@@ -187,7 +187,7 @@ def _metadata_str(metadata: dict[str, Any], key: str) -> str:
 
 def _metadata_artist(metadata: dict[str, Any]) -> str:
     value = _unpack(metadata.get("xesam:artist", []))
-    if isinstance(value, (list, tuple)) and value:
+    if isinstance(value, list | tuple) and value:
         return str(value[0])
     return _as_str(value)
 
@@ -827,7 +827,7 @@ class RhythmboxClientBackend:
         if has_track_payload:
             playback_status = "Playing"
             parts = [*text.split("\t"), "", "", "", ""][:4]
-            title, artist, album, track_url = [part.strip() for part in parts]
+            title, artist, album, track_url = (part.strip() for part in parts)
 
         volume_percent = self._read_volume_percent()
         return MusicState(

--- a/docking/applets/powerprofiles/state.py
+++ b/docking/applets/powerprofiles/state.py
@@ -379,7 +379,7 @@ class PowerProfilesBackend:
         """
         extracted: list[str] = []
         raw_profiles = _unpack(props.get("Profiles"))
-        if isinstance(raw_profiles, (list, tuple)):
+        if isinstance(raw_profiles, list | tuple):
             for entry in raw_profiles:
                 if not isinstance(entry, dict):
                     continue

--- a/docking/applets/separator/applet.py
+++ b/docking/applets/separator/applet.py
@@ -152,7 +152,7 @@ class SeparatorApplet(Applet):
 
 def _normalized_gap(*, value: object) -> int:
     try:
-        if isinstance(value, (bool, int, float)):
+        if isinstance(value, bool | int | float):
             parsed = int(value)
         elif isinstance(value, str):
             parsed = int(value.strip())

--- a/docking/applets/stretchcoach/state.py
+++ b/docking/applets/stretchcoach/state.py
@@ -72,7 +72,7 @@ FALLBACK_CARDS: tuple[StretchCard, ...] = (
 
 def _parse_interval(value: object) -> int:
     try:
-        if isinstance(value, (bool, int, float)):
+        if isinstance(value, bool | int | float):
             minutes = int(value)
         elif isinstance(value, str):
             minutes = int(value.strip())

--- a/docking/applets/unitconverter/state.py
+++ b/docking/applets/unitconverter/state.py
@@ -161,7 +161,7 @@ def fetch_currency_rates() -> tuple[Unit, ...] | None:
         for entry in data:
             code = entry.get("quote", "")
             rate = entry.get("rate")
-            if code and isinstance(rate, (int, float)) and rate > 0:
+            if code and isinstance(rate, int | float) and rate > 0:
                 rates[code] = float(rate)
     elif isinstance(data, dict) and "rates" in data:
         rates = data["rates"]
@@ -176,7 +176,7 @@ def fetch_currency_rates() -> tuple[Unit, ...] | None:
     # factor = 1/1.08 so that converting 100 EUR->USD = 100 * 1.0 / (1/1.08) = 108.
     units = [Unit("Euro", "EUR", 1.0)]
     for code, rate in sorted(rates.items()):
-        if isinstance(rate, (int, float)) and rate > 0:
+        if isinstance(rate, int | float) and rate > 0:
             units.append(Unit(code, code, 1.0 / float(rate)))
     return tuple(units)
 

--- a/docking/core/config.py
+++ b/docking/core/config.py
@@ -134,7 +134,7 @@ import json
 import os
 import tempfile
 import threading
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Any, cast
@@ -543,7 +543,7 @@ def _normalize_int(
     maximum: int | None = None,
 ) -> int:
     try:
-        if isinstance(value, (bool, int, float)):
+        if isinstance(value, bool | int | float):
             parsed = int(value)
         elif isinstance(value, str):
             parsed = int(value.strip())
@@ -573,7 +573,7 @@ def _normalize_float(
     try:
         if isinstance(value, bool):
             parsed = float(int(value))
-        elif isinstance(value, (int, float)):
+        elif isinstance(value, int | float):
             parsed = float(value)
         elif isinstance(value, str):
             parsed = float(value.strip())
@@ -690,6 +690,11 @@ class Config:
     def pos(self) -> Position:
         """Position as enum."""
         return Position(value=self.position)
+
+    @property
+    def scaled_icon_size(self) -> int:
+        """Max icon size after applying the zoom multiplier."""
+        return int(self.icon_size * self.zoom_percent)
 
     @property
     def hide_mode_enum(self) -> HideMode:
@@ -877,32 +882,7 @@ class Config:
         return config
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "icon_size": self.icon_size,
-            "zoom_enabled": self.zoom_enabled,
-            "zoom_percent": self.zoom_percent,
-            "zoom_range": self.zoom_range,
-            "position": self.position,
-            "monitor_index": self.monitor_index,
-            "hide_mode": self.hide_mode,
-            "hide_delay_ms": self.hide_delay_ms,
-            "unhide_delay_ms": self.unhide_delay_ms,
-            "hide_time_ms": self.hide_time_ms,
-            "previews_enabled": self.previews_enabled,
-            "lock_icons": self.lock_icons,
-            "current_workspace_only": self.current_workspace_only,
-            "anchor_applets": self.anchor_applets,
-            "anchor_files": self.anchor_files,
-            "tooltips_enabled": self.tooltips_enabled,
-            "active_display": self.active_display,
-            "left_click_action": self.left_click_action,
-            "middle_click_action": self.middle_click_action,
-            "theme": self.theme,
-            "transparency": self.transparency,
-            "pinned": [entry.to_dict() for entry in self.pinned],
-            "applet_prefs": self.applet_prefs,
-            "item_prefs": self.item_prefs,
-        }
+        return asdict(self)
 
 
 def normalize_pinned_entries(raw_entries: list[object]) -> list[PinnedEntry]:

--- a/docking/platform/model.py
+++ b/docking/platform/model.py
@@ -203,7 +203,7 @@ class DockModel:
                 self.pinned_items.append(item)
 
     def _build_pinned_item(self, entry: PinnedEntry) -> DockItem | None:
-        icon_size = int(self._config.icon_size * self._config.zoom_percent)
+        icon_size = self._config.scaled_icon_size
         if entry.kind == APPLET_KIND:
             did = applet_id_from(desktop_id=entry.target)
             cls = applets.load_applet_class(did)
@@ -285,7 +285,7 @@ class DockModel:
                 f"No class registered for applet: {did}"
             )
             return
-        icon_size = int(self._config.icon_size * self._config.zoom_percent)
+        icon_size = self._config.scaled_icon_size
         try:
             applet = cls(icon_size=icon_size, config=self._config)
         except Exception:
@@ -316,7 +316,7 @@ class DockModel:
         n = max(nums, default=-1) + 1
         desktop_id = applet_desktop_id(applet_id=_separator_meta.id, instance=n)
 
-        icon_size = int(self._config.icon_size * self._config.zoom_percent)
+        icon_size = self._config.scaled_icon_size
         try:
             applet = cls(icon_size=icon_size, config=self._config)
         except Exception:
@@ -461,7 +461,7 @@ class DockModel:
                     new_transient.append(existing)
                 else:
                     resolved = self._launcher.resolve(desktop_id=desktop_id)
-                    icon_size = int(self._config.icon_size * self._config.zoom_percent)
+                    icon_size = self._config.scaled_icon_size
                     icon = self._launcher.load_icon(
                         icon_name=(
                             resolved.icon_name

--- a/docking/ui/dnd.py
+++ b/docking/ui/dnd.py
@@ -636,7 +636,7 @@ class DnDHandler:
     def _item_from_uri(self, uri: str) -> DockItem | None:
         """Build a pinned DockItem from an external URI drop."""
         desktop_id = self._uri_to_desktop_id(uri)
-        icon_size = int(self._config.icon_size * self._config.zoom_percent)
+        icon_size = self._config.scaled_icon_size
         if desktop_id:
             resolved = self._launcher.resolve(desktop_id)
             if resolved is None:

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -188,7 +188,7 @@ from gi.repository import Gdk, GdkX11, GLib, Gtk
 from docking.applets.identity import is_applet_desktop_id as is_applet
 from docking.core.config import LeftClickAction, MiddleClickAction
 from docking.core.items import FILE_KIND, FOLDER_KIND
-from docking.core.position import Position, is_horizontal
+from docking.core.position import is_horizontal
 from docking.i18n import _
 from docking.log import get_logger
 from docking.platform.environment import detect_desktop, log_runtime_snapshot
@@ -207,7 +207,6 @@ from docking.ui.effects import ZoomAnimator
 from docking.ui.geometry import (
     DockGeometryBuilder,
     DockGeometryFrame,
-    Rect,
     current_input_rect,
 )
 from docking.ui.hover import HoverManager
@@ -306,19 +305,6 @@ BOUNCE_ANIMATION_PUMP_MS = 700
 MOUSE_LEFT = 1
 MOUSE_MIDDLE = 2
 MOUSE_RIGHT = 3
-
-
-def hover_anchor_from_draw_rect(
-    *, win_x: int, win_y: int, draw_rect: Rect, position: Position
-) -> tuple[int, int]:
-    """Translate an item draw rect into the preview/hover anchor point."""
-    if position == Position.BOTTOM:
-        return int(win_x + draw_rect.x), int(win_y + draw_rect.y)
-    if position == Position.TOP:
-        return int(win_x + draw_rect.x), int(win_y + draw_rect.y + draw_rect.h)
-    if position == Position.LEFT:
-        return int(win_x + draw_rect.x + draw_rect.w), int(win_y + draw_rect.y)
-    return int(win_x + draw_rect.x), int(win_y + draw_rect.y)
 
 
 class DockWindow(Gtk.Window):
@@ -600,10 +586,9 @@ class DockWindow(Gtk.Window):
         if geometry is None:
             return None
         win_x, win_y = self.get_position()
-        x, y = hover_anchor_from_draw_rect(
+        x, y = geometry.anchor_point(
             win_x=win_x,
             win_y=win_y,
-            draw_rect=geometry.draw_rect,
             position=self.config.pos,
         )
         return x, y, self.config.pos.value
@@ -832,10 +817,9 @@ class DockWindow(Gtk.Window):
                 item_geometry = frame.geometry_for_item(item)
                 if item_geometry is not None:
                     win_x, win_y = self.get_position()
-                    anchor_x, anchor_y = hover_anchor_from_draw_rect(
+                    anchor_x, anchor_y = item_geometry.anchor_point(
                         win_x=win_x,
                         win_y=win_y,
-                        draw_rect=item_geometry.draw_rect,
                         position=self.config.pos,
                     )
                     icon_w = int(item_geometry.draw_rect.w)

--- a/docking/ui/geometry.py
+++ b/docking/ui/geometry.py
@@ -276,6 +276,19 @@ class Rect(NamedTuple):
         return Rect(left, top, right - left, bottom - top)
 
 
+def anchor_from_draw_rect(
+    *, win_x: int, win_y: int, draw_rect: Rect, position: Position
+) -> tuple[int, int]:
+    """Translate an item draw rect into the preview/hover anchor point."""
+    if position == Position.BOTTOM:
+        return int(win_x + draw_rect.x), int(win_y + draw_rect.y)
+    if position == Position.TOP:
+        return int(win_x + draw_rect.x), int(win_y + draw_rect.y + draw_rect.h)
+    if position == Position.LEFT:
+        return int(win_x + draw_rect.x + draw_rect.w), int(win_y + draw_rect.y)
+    return int(win_x + draw_rect.x), int(win_y + draw_rect.y)
+
+
 @dataclass(frozen=True)
 class ItemGeometry:
     """Geometry for a single item in the current dock frame."""
@@ -290,6 +303,17 @@ class ItemGeometry:
     anchor_y: float
     scaled_size: float
     main_pos: float
+
+    def anchor_point(
+        self, *, win_x: int, win_y: int, position: Position
+    ) -> tuple[int, int]:
+        """Absolute preview/hover anchor for this item."""
+        return anchor_from_draw_rect(
+            win_x=win_x,
+            win_y=win_y,
+            draw_rect=self.draw_rect,
+            position=position,
+        )
 
 
 @dataclass(frozen=True)
@@ -315,12 +339,8 @@ class DockGeometryFrame:
     shelf_as_bottom_y: float = 0.0
 
     def item_at_point(self, x: float, y: float) -> DockItem | None:
-        if not self.cursor_rect.contains(x=x, y=y):
-            return None
-        for item_geometry in self.item_geometries:
-            if item_geometry.hit_rect.contains(x=x, y=y):
-                return item_geometry.item
-        return None
+        index = self.item_index_at_point(x=x, y=y)
+        return self.item_geometries[index].item if index >= 0 else None
 
     def hover_item_at_point(self, x: float, y: float) -> DockItem | None:
         if not self.cursor_rect.contains(x=x, y=y):

--- a/docking/ui/preview.py
+++ b/docking/ui/preview.py
@@ -264,7 +264,7 @@ def _looks_unavailable_capture(pixbuf: GdkPixbuf.Pixbuf) -> bool:
 
     if width <= 0 or height <= 0 or channels < 3 or rowstride <= 0:
         return False
-    if not isinstance(data, (bytes, bytearray, memoryview)):
+    if not isinstance(data, bytes | bytearray | memoryview):
         return False
 
     sample_x = max(1, min(CAPTURE_SAMPLE_GRID_MAX, width))

--- a/docking/ui/renderer.py
+++ b/docking/ui/renderer.py
@@ -176,7 +176,6 @@ if TYPE_CHECKING:
     from docking.core.layout import LayoutItem
     from docking.core.theme import Theme
     from docking.platform.model import DockModel
-    from docking.ui.autohide import HideState
 
 
 SHELF_SMOOTH_FACTOR = 0.3

--- a/tests/bdd_support/harness.py
+++ b/tests/bdd_support/harness.py
@@ -100,6 +100,14 @@ def _dnd_frame(*, item_index: int = -1, insert_index: int = 0, count: int = 1):
     )
 
 
+def _item_geometry(*, x: int, y: int, w: int = 48, h: int = 48) -> SimpleNamespace:
+    draw_rect = SimpleNamespace(x=x, y=y, w=w, h=h)
+    return SimpleNamespace(
+        draw_rect=draw_rect,
+        anchor_point=lambda *, win_x, win_y, position: (win_x + x, win_y + y),
+    )
+
+
 def _bind_dock_window_helpers(stub) -> SimpleNamespace:
     stub._geometry_signature = MethodType(
         dock_window_mod.DockWindow._geometry_signature, stub
@@ -160,11 +168,7 @@ class DockHarness:
         self._folder_frame = SimpleNamespace(
             cursor_rect=Rect(0, 0, 100, 100),
             item_at_point=MagicMock(return_value=None),
-            geometry_for_item=MagicMock(
-                return_value=SimpleNamespace(
-                    draw_rect=SimpleNamespace(x=4, y=5, w=48, h=48)
-                )
-            ),
+            geometry_for_item=MagicMock(return_value=_item_geometry(x=4, y=5)),
         )
         self._folder_stub = _bind_dock_window_helpers(
             SimpleNamespace(
@@ -516,11 +520,7 @@ class DockHarness:
         }
         self._hover_frame = SimpleNamespace(
             hover_item_at_point=MagicMock(return_value=None),
-            geometry_for_item=MagicMock(
-                return_value=SimpleNamespace(
-                    draw_rect=SimpleNamespace(x=15, y=4, w=48, h=48)
-                )
-            ),
+            geometry_for_item=MagicMock(return_value=_item_geometry(x=15, y=4)),
             cursor_rect=SimpleNamespace(contains=lambda *_args, **_kwargs: True),
         )
         self._hover_tooltip = SimpleNamespace(

--- a/tests/bdd_support/harness.py
+++ b/tests/bdd_support/harness.py
@@ -436,6 +436,7 @@ class DockHarness:
             pos=Position.BOTTOM,
             icon_size=48,
             zoom_percent=2.0,
+            scaled_icon_size=96,
             pinned=[],
             save=MagicMock(),
         )

--- a/tests/ipc/test_items_service.py
+++ b/tests/ipc/test_items_service.py
@@ -16,7 +16,7 @@ from gi.repository import GLib
 from docking.core.position import Position
 from docking.ipc.introspection import ITEMS_INTERFACE, OBJECT_PATH
 from docking.ipc.items_service import DockItemsService
-from docking.ui.dock_window import hover_anchor_from_draw_rect
+from docking.ui.geometry import anchor_from_draw_rect
 
 
 class _FakeConnection:
@@ -298,25 +298,25 @@ class TestHoverAnchorHelper:
     def test_hover_anchor_matches_edge_rules(self):
         rect = SimpleNamespace(x=10, y=20, w=30, h=40)
 
-        assert hover_anchor_from_draw_rect(
+        assert anchor_from_draw_rect(
             win_x=100,
             win_y=200,
             draw_rect=rect,
             position=Position.BOTTOM,
         ) == (110, 220)
-        assert hover_anchor_from_draw_rect(
+        assert anchor_from_draw_rect(
             win_x=100,
             win_y=200,
             draw_rect=rect,
             position=Position.TOP,
         ) == (110, 260)
-        assert hover_anchor_from_draw_rect(
+        assert anchor_from_draw_rect(
             win_x=100,
             win_y=200,
             draw_rect=rect,
             position=Position.LEFT,
         ) == (140, 220)
-        assert hover_anchor_from_draw_rect(
+        assert anchor_from_draw_rect(
             win_x=100,
             win_y=200,
             draw_rect=rect,

--- a/tests/ui/test_dnd_integration.py
+++ b/tests/ui/test_dnd_integration.py
@@ -48,6 +48,7 @@ def _make_handler(monkeypatch, lock_icons: bool = False):
         pos=Position.BOTTOM,
         icon_size=48,
         zoom_percent=2.0,
+        scaled_icon_size=96,
         pinned=[],
         save=MagicMock(),
     )

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -354,7 +354,8 @@ class TestButtonReleaseFlow:
         )
         stub, _ = _make_stub(item=item)
         stub._test_geometry_frame.geometry_for_item.return_value = SimpleNamespace(
-            draw_rect=SimpleNamespace(x=4, y=5, w=48, h=48)
+            draw_rect=SimpleNamespace(x=4, y=5, w=48, h=48),
+            anchor_point=lambda *, win_x, win_y, position: (win_x + 4, win_y + 5),
         )
         event = SimpleNamespace(
             x=12.0, y=6.0, button=dock_window_mod.MOUSE_LEFT, state=0

--- a/tests/ui/test_pointer_scenarios.py
+++ b/tests/ui/test_pointer_scenarios.py
@@ -62,6 +62,7 @@ class _ScenarioHarness:
             pos=pos,
             icon_size=48,
             zoom_percent=1.5,
+            scaled_icon_size=72,
             zoom_enabled=True,
             previews_enabled=True,
             lock_icons=False,


### PR DESCRIPTION
## Summary
- apply the current worktree cleanups from the local patch-backed changes
- centralize scaled icon size and geometry anchor helpers
- update affected tests and small lint-oriented simplifications
