### PR TITLE
Release 1.11.0

### DIFF
--- a/docking/__init__.py
+++ b/docking/__init__.py
@@ -25,4 +25,4 @@ In other words, this module is a package marker and metadata boundary, not an
 alternate application entrypoint.
 """
 
-__version__ = "1.10.0"
+__version__ = "1.11.0"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=docking
-pkgver=1.10.0
+pkgver=1.11.0
 pkgrel=1
 pkgdesc="A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo"
 arch=('x86_64' 'aarch64')

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,9 @@
+docking (1.11.0-1) stable; urgency=medium
+
+  * Release 1.11.0.
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 23 Apr 2026 23:48:01 +0200
+
 docking (1.10.0-1) stable; urgency=medium
 
   * Release 1.10.0.

--- a/packaging/flatpak/org.docking.Docking.metainfo.xml
+++ b/packaging/flatpak/org.docking.Docking.metainfo.xml
@@ -35,6 +35,7 @@
   </provides>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.11.0" date="2026-04-23" />
     <release version="1.10.0" date="2026-04-21" />
     <release version="1.9.13" date="2026-04-20" />
     <release version="1.9.12" date="2026-04-20" />

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -5,7 +5,7 @@ let
 in
 pyPkgs.buildPythonApplication rec {
   pname = "docking";
-  version = "1.10.0";
+  version = "1.11.0";
   format = "pyproject";
 
   src = ../..;

--- a/packaging/rpm/docking.spec
+++ b/packaging/rpm/docking.spec
@@ -1,5 +1,5 @@
 Name:           docking
-Version:        %{?pkg_version}%{!?pkg_version:1.10.0}
+Version:        %{?pkg_version}%{!?pkg_version:1.11.0}
 Release:        1%{?dist}
 Summary:        A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo
 
@@ -80,6 +80,9 @@ fi
 /usr/share/icons/hicolor
 
 %changelog
+* Thu Apr 23 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.11.0-1
+- Release 1.11.0.
+
 * Tue Apr 21 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.10.0-1
 - Release 1.10.0.
 

--- a/packaging/snap/snapcraft.yaml
+++ b/packaging/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: docking
 title: Docking
 base: core22
-version: "1.10.0"
+version: "1.11.0"
 summary: Feature-rich Linux dock in Python with GTK 3 and Cairo
 description: |
   A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docking"
-version = "1.10.0"
+version = "1.11.0"
 description = "A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo"
 requires-python = ">=3.10"
 license = {text = "GPL-3.0-or-later"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # The canonical config is in pyproject.toml.
 [metadata]
 name = docking
-version = 1.10.0
+version = 1.11.0
 [options]
 packages = find:
 python_requires = >=3.10


### PR DESCRIPTION
## Summary
- bump Docking from 1.10.0 to 1.11.0
- update all versioned packaging/release surfaces