### PR TITLE
Add Cairo-Dock-inspired New Year greeting

### DIFF
--- a/docking/app.py
+++ b/docking/app.py
@@ -70,6 +70,7 @@ from docking.platform.model import DockModel
 from docking.platform.unity import UnityLauncherListener
 from docking.platform.window_tracker import WindowTracker
 from docking.ui.factory import build_dock_window
+from docking.ui.new_year import NewYearGreetingController
 from docking.ui.renderer import DockRenderer
 
 
@@ -96,6 +97,7 @@ def main() -> None:
         launcher=launcher,
     )
     items_service = DockItemsService(model=model, window=window)
+    new_year = NewYearGreetingController(window=window)
 
     # Graceful shutdown on SIGINT/SIGTERM
     GLib.unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGINT, _quit)
@@ -104,10 +106,12 @@ def main() -> None:
     try:
         unity.start()
         window.show_all()
+        new_year.start()
         GLib.idle_add(_start_runtime, items_service, model)
         Gtk.main()
     finally:
         items_service.stop()
+        new_year.stop()
         unity.stop()
         model.stop_applets()
 

--- a/docking/core/greeting.py
+++ b/docking/core/greeting.py
@@ -1,0 +1,169 @@
+"""Persistent greeting state and New Year trigger rules.
+
+This module keeps one tiny piece of process-independent state:
+
+- whether Docking has ever completed one successful launch,
+- which calendar year last received the New Year greeting.
+
+The behavior intentionally mirrors Cairo-Dock's startup greeting policy:
+
+- no greeting on the very first successful launch,
+- greeting only during the first half of January,
+- greeting at most once per calendar year.
+
+That state is not user configuration. It is runtime bookkeeping, so it lives in
+XDG state storage rather than in ``dock.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from docking.log import get_logger
+
+logger = get_logger("greeting")
+
+DEFAULT_STATE_DIR = (
+    Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state")) / "docking"
+)
+DEFAULT_STATE_FILE = DEFAULT_STATE_DIR / "startup.json"
+NEW_YEAR_GREETING_LAST_DAY = 15
+
+
+@dataclass(frozen=True, slots=True)
+class StartupGreetingState:
+    """Persistent state used to decide whether a greeting is due."""
+
+    completed_first_launch: bool = False
+    last_year_greeted: int = 0
+
+
+def load_state(path: Path | str | None = None) -> StartupGreetingState:
+    """Load greeting state, falling back to defaults on missing/corrupt data."""
+    state_path = Path(path) if path else DEFAULT_STATE_FILE
+    if not state_path.exists():
+        return StartupGreetingState()
+
+    try:
+        with state_path.open(encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except Exception as exc:
+        logger.warning("Failed to load greeting state %s: %s", state_path, exc)
+        return StartupGreetingState()
+
+    if not isinstance(raw, dict):
+        logger.warning(
+            "Invalid greeting state payload in %s; using defaults",
+            state_path,
+        )
+        return StartupGreetingState()
+
+    return StartupGreetingState(
+        completed_first_launch=_coerce_bool(
+            raw.get("completed_first_launch"),
+            default=False,
+        ),
+        last_year_greeted=_coerce_int(
+            raw.get("last_year_greeted"),
+            default=0,
+        ),
+    )
+
+
+def save_state(
+    state: StartupGreetingState,
+    *,
+    path: Path | str | None = None,
+) -> None:
+    """Persist greeting state atomically."""
+    state_path = Path(path) if path else DEFAULT_STATE_FILE
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=state_path.parent,
+        prefix=f".{state_path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        tmp_path = Path(handle.name)
+        json.dump(
+            {
+                "completed_first_launch": state.completed_first_launch,
+                "last_year_greeted": state.last_year_greeted,
+            },
+            handle,
+            indent=2,
+            sort_keys=True,
+        )
+        handle.write("\n")
+
+    tmp_path.replace(state_path)
+
+
+def consume_new_year_greeting(
+    *,
+    path: Path | str | None = None,
+    now: datetime | None = None,
+) -> int | None:
+    """Mark one successful launch and return the year to greet, if any.
+
+    Returns the current year when the greeting should be shown on this launch,
+    otherwise *None*.
+    """
+    current = now or datetime.now()
+    state = load_state(path=path)
+
+    show_year: int | None = None
+    current_year = current.year
+
+    if (
+        state.completed_first_launch
+        and current.month == 1
+        and current.day <= NEW_YEAR_GREETING_LAST_DAY
+        and state.last_year_greeted < current_year
+    ):
+        show_year = current_year
+
+    next_state = StartupGreetingState(
+        completed_first_launch=True,
+        last_year_greeted=(
+            show_year if show_year is not None else state.last_year_greeted
+        ),
+    )
+    save_state(next_state, path=path)
+    return show_year
+
+
+def _coerce_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _coerce_int(value: Any, *, default: int) -> int:
+    try:
+        if isinstance(value, bool):
+            return int(value)
+        if isinstance(value, int | float):
+            return int(value)
+        if isinstance(value, str):
+            return int(value.strip())
+    except (TypeError, ValueError):
+        return default
+    return default

--- a/docking/locale/af/LC_MESSAGES/docking.po
+++ b/docking/locale/af/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Geskep"
 msgid "Modified"
 msgstr "Gewysig"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Vouer nie gevind nie"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Vouer is leeg"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Maak oop in %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Meer in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Maak vouer oop"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Meer in vouer"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Maak oop"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sorteer volgens"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Wys verborge leers"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Groot ikone"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Voorkeure"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/am/LC_MESSAGES/docking.po
+++ b/docking/locale/am/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "የተፈጠረ"
 msgid "Modified"
 msgstr "የተቀየረ"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "አቃፊ አልተገኘም"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "አቃፊው ባዶ ነው"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "በ%s ክፈት"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d ተጨማሪ በ%s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "አቃፊ ክፈት"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d ተጨማሪ በአቃፊ"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "ከዶክ አስወግድ"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "ክፈት"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "በዶክ ውስጥ አቆይ"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "ሁሉንም ዝጋ"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "ዝጋ"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "ደርድር በ"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "የተደበቁ ፋይሎችን አሳይ"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "ትልልቅ አዶዎች"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "አፕሌቶች"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "የኃይል መገለጫዎች አይገኙም"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "መለያ ጨምር"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "ምርጫዎች"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "ስለ"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "ውጣ"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "መስኮት"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/ar/LC_MESSAGES/docking.po
+++ b/docking/locale/ar/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1502,97 +1502,102 @@ msgstr "تاريخ الإنشاء"
 msgid "Modified"
 msgstr "تاريخ التعديل"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "المجلد غير موجود"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "المجلد فارغ"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "فتح في %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d المزيد في %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "فتح المجلد"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d المزيد في المجلد"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "إزالة من الشريط"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "فتح"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "الاحتفاظ في الشريط"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "إغلاق الكل"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "إغلاق"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "ترتيب حسب"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "إظهار الملفات المخفية"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "أيقونات كبيرة"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "تطبيقات مصغرة"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "ملفات الطاقة غير متاحة"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "إضافة فاصل"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "التفضيلات"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "حول"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "خروج"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "نافذة"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/az/LC_MESSAGES/docking.po
+++ b/docking/locale/az/LC_MESSAGES/docking.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1501,97 +1501,102 @@ msgstr "Yaradildi"
 msgid "Modified"
 msgstr "Deyisdirildi"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Qovluq tapilmadi"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Qovluq boshdur"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s-da ac"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Qovlugu ac"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Qovluqda daha %d"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Dokdan Sil"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Ac"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Dokda Saxla"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Hamısını Bağla"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Bağla"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sirala"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Gizli fayllari goster"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Boyuk ikonlar"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Appletlər"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Enerji Profilləri mövcud deyil"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Ayırıcı Əlavə Et"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Tercihler"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "Haqqında"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Çıx"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Pəncərə"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/be/LC_MESSAGES/docking.po
+++ b/docking/locale/be/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Створана"
 msgid "Modified"
 msgstr "Зменена"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Тэчка не знойдзена"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Тэчка пустая"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Адкрыць у %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Яшчэ %d у %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Адкрыць тэчку"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Яшчэ %d у тэчцы"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Адкрыць"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Сартаваць па"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Паказаць схаваныя файлы"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Вялiкiя значкi"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Налады"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/bg/LC_MESSAGES/docking.po
+++ b/docking/locale/bg/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Създаден"
 msgid "Modified"
 msgstr "Променен"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Папката не е намерена"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Папката е празна"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Отвори в %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Още %d в %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Отвори папка"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Още %d в папка"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Отвори"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Сортирай по"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Покажи скрити файлове"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Големи икони"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Настройки"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/bn/LC_MESSAGES/docking.po
+++ b/docking/locale/bn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "তৈরি"
 msgid "Modified"
 msgstr "পরিবর্তিত"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "ফোল্ডার পাওয়া যায়নি"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "ফোল্ডার খালি"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s-এ খুলুন"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "ফোল্ডার খুলুন"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "ফোল্ডারে আরো %dটি"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "খুলুন"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "সাজান"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "লুকানো ফাইল দেখান"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "বড় আইকন"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "পছন্দসমূহ"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/bs/LC_MESSAGES/docking.po
+++ b/docking/locale/bs/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Kreirano"
 msgid "Modified"
 msgstr "Izmijenjeno"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Folder nije pronađen"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Folder je prazan"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Otvori u %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Još %d u %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Otvori folder"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Još %d u folderu"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Otvori"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sortiraj po"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Prikaži skrivene fajlove"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Velike ikone"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Postavke"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/ca/LC_MESSAGES/docking.po
+++ b/docking/locale/ca/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Creat"
 msgid "Modified"
 msgstr "Modificat"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Carpeta no trobada"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "La carpeta es buida"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Obre a %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Mes a %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Obre carpeta"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Mes a la carpeta"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Obre"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Ordena per"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Mostra fitxers ocults"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Icones grans"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferencies"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/cs/LC_MESSAGES/docking.po
+++ b/docking/locale/cs/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1503,97 +1503,102 @@ msgstr "Vytvoreno"
 msgid "Modified"
 msgstr "Zmeneno"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Slozka nenalezena"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Slozka je prazdna"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Otevrit v %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Dalsi v %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Otevrit slozku"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Dalsi ve slozce"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Odebrat z doku"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Otevrit"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Ponechat v doku"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Zavřít vše"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Zavřít"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Radit podle"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Zobrazit skryte soubory"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Velke ikony"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Aplety"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Profily napájení nedostupné"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Přidat oddělovač"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Predvolby"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "O aplikaci"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Ukončit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Okno"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/cy/LC_MESSAGES/docking.po
+++ b/docking/locale/cy/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Crewyd"
 msgid "Modified"
 msgstr "Addaswyd"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Ffolder heb ei ganfod"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Mae'r ffolder yn wag"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Agor yn %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Mwy yn %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Agor ffolder"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Mwy yn y ffolder"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Agor"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Trefnu yn ol"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Dangos ffeiliau cudd"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Eiconau mawr"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Dewisiadau"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/da/LC_MESSAGES/docking.po
+++ b/docking/locale/da/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Oprettet"
 msgid "Modified"
 msgstr "Ændret"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Mappe ikke fundet"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Mappen er tom"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Åbn i %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d mere i %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Åbn mappe"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d mere i mappe"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Åbn"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sortér efter"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Vis skjulte filer"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Store ikoner"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Indstillinger"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/de/LC_MESSAGES/docking.po
+++ b/docking/locale/de/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1502,97 +1502,102 @@ msgstr "Erstellt"
 msgid "Modified"
 msgstr "Geaendert"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Ordner nicht gefunden"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Ordner ist leer"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Oeffnen in %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Weitere in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Ordner oeffnen"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Weitere im Ordner"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Aus Dock entfernen"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Oeffnen"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Im Dock behalten"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Alle schließen"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Schließen"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sortieren nach"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Versteckte Dateien anzeigen"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Grosse Symbole"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Energieprofile nicht verfügbar"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Trennlinie hinzufügen"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "Über"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Beenden"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Fenster"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1501,96 +1501,101 @@ msgstr ""
 msgid "Modified"
 msgstr ""
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr ""
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr ""
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr ""
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr ""
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr ""
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr ""
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr ""
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr ""
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr ""
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr ""
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr ""
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr ""
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr ""
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr ""
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr ""
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr ""
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr ""
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr ""
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr ""
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr ""
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
+msgstr ""
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
 msgstr ""
 
 #: docking/ui/placement.py:223

--- a/docking/locale/el/LC_MESSAGES/docking.po
+++ b/docking/locale/el/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Δημιουργήθηκε"
 msgid "Modified"
 msgstr "Τροποποιήθηκε"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Ο φάκελος δεν βρέθηκε"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Ο φάκελος είναι κενός"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Άνοιγμα σε %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Άνοιγμα φακέλου"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Άνοιγμα"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Ταξινόμηση κατά"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Εμφάνιση κρυφών αρχείων"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Μεγάλα εικονίδια"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Προτιμήσεις"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/en_GB/LC_MESSAGES/docking.po
+++ b/docking/locale/en_GB/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Created"
 msgid "Modified"
 msgstr "Modified"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Folder not found"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Folder is empty"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Open in %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Open Folder"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Open"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sort By"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Show Hidden Files"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Large Icons"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/eo/LC_MESSAGES/docking.po
+++ b/docking/locale/eo/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Kreita"
 msgid "Modified"
 msgstr "Modifita"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Dosierujo ne trovita"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Dosierujo estas malplena"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Malfermu en %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Pli en %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Malfermu dosierujon"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Pli en dosierujo"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Malfermu"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Ordigi laŭ"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Montru kaŝitajn dosierojn"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Grandaj bildsimboloj"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferoj"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/es/LC_MESSAGES/docking.po
+++ b/docking/locale/es/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1502,97 +1502,102 @@ msgstr "Creado"
 msgid "Modified"
 msgstr "Modificado"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Carpeta no encontrada"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Carpeta vacia"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Abrir en %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Mas en %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Abrir Carpeta"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Mas en Carpeta"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Quitar del Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Abrir"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Mantener en el Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Cerrar Todo"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Cerrar"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Ordenar Por"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Mostrar Archivos Ocultos"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Iconos Grandes"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Perfiles de Energía no disponibles"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Agregar Separador"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "Acerca de"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Salir"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Ventana"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/et/LC_MESSAGES/docking.po
+++ b/docking/locale/et/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Loodud"
 msgid "Modified"
 msgstr "Muudetud"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Kausta ei leitud"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Kaust on tuhi"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Ava %s-s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d rohkem kataloogis %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Ava kaust"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d rohkem kaustas"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Ava"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sordi"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Naita peidetud faile"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Suured ikoonid"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Eelistused"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/eu/LC_MESSAGES/docking.po
+++ b/docking/locale/eu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Sortua"
 msgid "Modified"
 msgstr "Aldatua"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Karpeta ez da aurkitu"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Karpeta hutsik dago"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Ireki %s-(e)n"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d gehiago %s-(e)n"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Ireki karpeta"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d gehiago karpetan"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Ireki"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Ordenatu"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Erakutsi ezkutuko fitxategiak"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Ikono handiak"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Hobespenak"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/fa/LC_MESSAGES/docking.po
+++ b/docking/locale/fa/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "ایجاد شده"
 msgid "Modified"
 msgstr "تغییر یافته"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "پوشه یافت نشد"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "پوشه خالی است"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "باز کردن در %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d مورد دیگر در %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "باز کردن پوشه"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d مورد دیگر در پوشه"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "باز کردن"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "مرتب‌سازی بر اساس"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "نمایش فایل‌های مخفی"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "آیکون‌های بزرگ"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "ترجیحات"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/fi/LC_MESSAGES/docking.po
+++ b/docking/locale/fi/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Luotu"
 msgid "Modified"
 msgstr "Muokattu"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Kansiota ei löytynyt"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Kansio on tyhjä"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Avaa kohteessa %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d lisää kohteessa %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Avaa kansio"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d lisää kansiossa"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Avaa"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Järjestä"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Näytä piilotetut tiedostot"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Suuret kuvakkeet"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Asetukset"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/fil/LC_MESSAGES/docking.po
+++ b/docking/locale/fil/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Nilikha"
 msgid "Modified"
 msgstr "Binago"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Hindi nahanap ang folder"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Walang laman ang folder"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Buksan sa %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Pa sa %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Buksan ang Folder"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Pa sa Folder"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Buksan"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Ayusin Ayon sa"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Ipakita ang mga Nakatagong File"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Malalaking Icon"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Mga Kagustuhan"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/fr/LC_MESSAGES/docking.po
+++ b/docking/locale/fr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1502,97 +1502,102 @@ msgstr "Cree"
 msgid "Modified"
 msgstr "Modifie"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Dossier introuvable"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Dossier vide"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Ouvrir dans %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d de plus dans %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Ouvrir le dossier"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d de plus dans le dossier"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Retirer du Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Ouvrir"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Garder dans le Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Tout Fermer"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Fermer"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Trier par"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Afficher les fichiers caches"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Grandes icones"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Profils d'énergie indisponibles"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Ajouter un Séparateur"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferences"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "À propos"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quitter"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Fenêtre"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/ga/LC_MESSAGES/docking.po
+++ b/docking/locale/ga/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Cruthaithe"
 msgid "Modified"
 msgstr "Athraithe"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Fillteán gan aimsiú"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Tá an fillteán folamh"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Oscail i %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Nios mo i %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Oscail fillteán"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Nios mo san fhillteán"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Oscail"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sórtáil de réir"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Taispeáin comhaid folaithe"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Deilbhíní móra"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Sainroghanna"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/gl/LC_MESSAGES/docking.po
+++ b/docking/locale/gl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Creado"
 msgid "Modified"
 msgstr "Modificado"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Cartafol non atopado"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "O cartafol está baleiro"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Abrir en %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Máis en %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Abrir cartafol"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Máis no cartafol"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Abrir"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Ordenar por"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Amosar ficheiros ocultos"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Iconas grandes"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/gu/LC_MESSAGES/docking.po
+++ b/docking/locale/gu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "બનાવેલ"
 msgid "Modified"
 msgstr "સુધારેલ"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "ફોલ્ડર મળ્યું નથી"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "ફોલ્ડર ખાલી છે"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s માં ખોલો"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "ફોલ્ડર ખોલો"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "ફોલ્ડરમાં %d વધુ"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "ખોલો"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "ક્રમ"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "છુપાયેલી ફાઇલો બતાવો"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "મોટા આઇકન"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "પસંદગીઓ"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/he/LC_MESSAGES/docking.po
+++ b/docking/locale/he/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "נוצר"
 msgid "Modified"
 msgstr "שונה"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "תיקייה לא נמצאה"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "התיקייה ריקה"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "פתח ב-%s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "עוד %d ב-%s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "פתח תיקייה"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "עוד %d בתיקייה"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "פתח"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "מיין לפי"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "הצג קבצים מוסתרים"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "סמלים גדולים"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "העדפות"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/hi/LC_MESSAGES/docking.po
+++ b/docking/locale/hi/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1502,97 +1502,102 @@ msgstr "बनाया गया"
 msgid "Modified"
 msgstr "संशोधित"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "फोल्डर नहीं मिला"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "फोल्डर खाली है"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s में खोलें"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d और %s में"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "फोल्डर खोलें"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d और फोल्डर में"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "डॉक से हटाएँ"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "खोलें"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "डॉक में रखें"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "सभी बंद करें"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "बंद करें"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "क्रम"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "छिपी फाइलें दिखाएं"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "बड़े आइकन"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "एप्लेट"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "पावर प्रोफाइल अनुपलब्ध"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "विभाजक जोड़ें"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "प्राथमिकताएं"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "के बारे में"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "बाहर निकलें"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "विंडो"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/hr/LC_MESSAGES/docking.po
+++ b/docking/locale/hr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Stvoreno"
 msgid "Modified"
 msgstr "Izmijenjeno"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Mapa nije pronađena"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Mapa je prazna"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Otvori u %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Još %d u %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Otvori mapu"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Još %d u mapi"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Otvori"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sortiraj po"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Prikaži skrivene datoteke"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Velike ikone"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Postavke"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/hu/LC_MESSAGES/docking.po
+++ b/docking/locale/hu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Létrehozva"
 msgid "Modified"
 msgstr "Módosítva"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Mappa nem található"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "A mappa üres"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Megnyitás: %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Még %d a(z) %s helyen"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Mappa megnyitása"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Még %d a mappában"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Megnyitás"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Rendezés"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Rejtett fájlok mutatása"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Nagy ikonok"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Beállítások"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/id/LC_MESSAGES/docking.po
+++ b/docking/locale/id/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1501,97 +1501,102 @@ msgstr "Dibuat"
 msgid "Modified"
 msgstr "Diubah"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Folder tidak ditemukan"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Folder kosong"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Buka di %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d lagi di %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Buka folder"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d lagi di folder"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Buka"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Urutkan berdasarkan"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Tampilkan file tersembunyi"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Ikon besar"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferensi"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/is/LC_MESSAGES/docking.po
+++ b/docking/locale/is/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Búið til"
 msgid "Modified"
 msgstr "Breytt"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Mappa fannst ekki"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Mappa er tóm"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Opna í %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Fleiri í %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Opna möppu"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Fleiri í möppu"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Opna"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Raða eftir"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Sýna faldar skrár"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Stór tákn"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Stillingar"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/it/LC_MESSAGES/docking.po
+++ b/docking/locale/it/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: 2026-03-06 12:00+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1502,97 +1502,102 @@ msgstr "Creato"
 msgid "Modified"
 msgstr "Modificato"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Cartella non trovata"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Cartella vuota"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Apri in %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Altri in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Apri Cartella"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Altri nella Cartella"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Rimuovi dal Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Apri"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Mantieni nel Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Chiudi tutto"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Chiudi"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Ordina Per"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Mostra File Nascosti"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Icone Grandi"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applet"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Profili energetici non disponibili"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Aggiungi separatore"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "Informazioni"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Esci"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Finestra"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/ja/LC_MESSAGES/docking.po
+++ b/docking/locale/ja/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1501,97 +1501,102 @@ msgstr "作成日"
 msgid "Modified"
 msgstr "更新日"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "フォルダが見つかりません"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "フォルダは空です"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s で開く"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "フォルダを開く"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "フォルダに他 %d 件"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Dockから削除"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "開く"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Dockに残す"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "すべて閉じる"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "閉じる"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "並べ替え"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "隠しファイルを表示"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "大きいアイコン"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "アプレット"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "電力プロファイル利用不可"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "セパレーターを追加"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "設定"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "について"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "終了"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "ウィンドウ"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/jv/LC_MESSAGES/docking.po
+++ b/docking/locale/jv/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Digawe"
 msgid "Modified"
 msgstr "Diowahi"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Folder ora ditemokake"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Folder kosong"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Bukak ing %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Liyane ing %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Bukak Folder"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Liyane ing Folder"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Bukak"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Urutake"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Tampilake File Sing Didhelikake"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Ikon Gedhe"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferensi"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/kk/LC_MESSAGES/docking.po
+++ b/docking/locale/kk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Жасалған"
 msgid "Modified"
 msgstr "Өзгертілген"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Қалта табылмады"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Қалта бос"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s ішінде ашу"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Қалтаны ашу"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Қалтада тағы %d"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Ашу"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Сұрыптау"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Жасырын файлдарды көрсету"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Үлкен белгішелер"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Параметрлер"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/km/LC_MESSAGES/docking.po
+++ b/docking/locale/km/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "បានបង្កើត"
 msgid "Modified"
 msgstr "បានកែ"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "រកមិនឃើញថត"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "ថតទទេ"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "បើកក្នុង %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "ថែម %d ក្នុង %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "បើកថត"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "ថែម %d ក្នុងថត"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "បើក"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "តម្រៀបតាម"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "បង្ហាញឯកសារលាក់"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "រូបតំណាងធំ"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "ចំណូលចិត្ត"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/kn/LC_MESSAGES/docking.po
+++ b/docking/locale/kn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "ರಚಿಸಲಾಗಿದೆ"
 msgid "Modified"
 msgstr "ಮಾರ್ಪಡಿಸಲಾಗಿದೆ"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "ಫೋಲ್ಡರ್ ಕಂಡುಬಂದಿಲ್ಲ"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "ಫೋಲ್ಡರ್ ಖಾಲಿಯಾಗಿದೆ"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s ನಲ್ಲಿ ತೆರೆಯಿರಿ"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "ಫೋಲ್ಡರ್ ತೆರೆಯಿರಿ"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "ಫೋಲ್ಡರ್‌ನಲ್ಲಿ %d ಇನ್ನಷ್ಟು"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "ತೆರೆಯಿರಿ"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "ಕ್ರಮಬದ್ಧಗೊಳಿಸಿ"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "ಮರೆಮಾಡಿದ ಫೈಲ್‌ಗಳನ್ನು ತೋರಿಸಿ"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "ದೊಡ್ಡ ಐಕಾನ್‌ಗಳು"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "ಆದ್ಯತೆಗಳು"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/ko/LC_MESSAGES/docking.po
+++ b/docking/locale/ko/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1501,97 +1501,102 @@ msgstr "생성일"
 msgid "Modified"
 msgstr "수정일"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "폴더를 찾을 수 없습니다"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "폴더가 비어 있습니다"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s에서 열기"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "폴더 열기"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "폴더에 %d개 더"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Dock에서 제거"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "열기"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Dock에 유지"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "모두 닫기"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "닫기"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "정렬"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "숨김 파일 표시"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "큰 아이콘"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "애플릿"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "전원 프로필 사용 불가"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "구분선 추가"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "환경설정"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "정보"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "종료"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "창"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/lt/LC_MESSAGES/docking.po
+++ b/docking/locale/lt/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Sukurta"
 msgid "Modified"
 msgstr "Pakeista"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Aplankas nerastas"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Aplankas tuščias"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Atidaryti %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Dar %d kataloge %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Atidaryti aplanką"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Dar %d aplanke"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Atidaryti"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Rūšiuoti pagal"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Rodyti paslėptus failus"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Didelės piktogramos"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Nuostatos"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/lv/LC_MESSAGES/docking.po
+++ b/docking/locale/lv/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Izveidots"
 msgid "Modified"
 msgstr "Mainīts"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Mape nav atrasta"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Mape ir tukša"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Atvērt %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Vēl %d mapē %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Atvērt mapi"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Vēl %d mapē"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Atvērt"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Kārtot pēc"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Rādīt slēptās datnes"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Lielas ikonas"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Iestatījumi"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/mk/LC_MESSAGES/docking.po
+++ b/docking/locale/mk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Создадено"
 msgid "Modified"
 msgstr "Изменето"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Папката не е пронајдена"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Папката е празна"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Отвори во %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Уште %d во %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Отвори папка"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Уште %d во папка"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Отвори"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Сортирај по"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Покажи скриени датотеки"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Големи икони"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Поставки"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/ml/LC_MESSAGES/docking.po
+++ b/docking/locale/ml/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "സൃഷ്ടിച്ചത്"
 msgid "Modified"
 msgstr "പരിഷ്കരിച്ചത്"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "ഫോള്‍ഡര്‍ കണ്ടെത്തിയില്ല"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "ഫോള്‍ഡര്‍ ശൂന്യമാണ്"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s-ല്‍ തുറക്കുക"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "ഫോള്‍ഡര്‍ തുറക്കുക"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "ഫോള്‍ഡറില്‍ %d കൂടുതല്‍"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "തുറക്കുക"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "ക്രമീകരിക്കുക"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "മറഞ്ഞ ഫയലുകള്‍ കാണിക്കുക"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "വലിയ ഐക്കണുകള്‍"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "മുന്‍ഗണനകള്‍"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/mn/LC_MESSAGES/docking.po
+++ b/docking/locale/mn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Үүсгэсэн"
 msgid "Modified"
 msgstr "Өөрчилсөн"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Хавтас олдсонгүй"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Хавтас хоосон"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s-д нээх"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Хавтас нээх"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Хавтаст %d нэмэлт"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Нээх"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Эрэмбэлэх"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Нуугдсан файлуудыг харуулах"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Том дүрсүүд"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Тохиргоо"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/mr/LC_MESSAGES/docking.po
+++ b/docking/locale/mr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "तयार केले"
 msgid "Modified"
 msgstr "बदललेले"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "फोल्डर सापडले नाही"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "फोल्डर रिकामे आहे"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s मध्ये उघडा"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "फोल्डर उघडा"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "फोल्डरमध्ये आणखी %d"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "उघडा"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "क्रमवारी"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "लपवलेल्या फाइल्स दाखवा"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "मोठे चिन्ह"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "प्राधान्ये"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/ms/LC_MESSAGES/docking.po
+++ b/docking/locale/ms/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1501,97 +1501,102 @@ msgstr "Dicipta"
 msgid "Modified"
 msgstr "Diubah"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Folder tidak dijumpai"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Folder kosong"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Buka dalam %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Lagi dalam %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Buka Folder"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Lagi dalam Folder"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Buka"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Isih Mengikut"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Tunjuk Fail Tersembunyi"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Ikon Besar"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Keutamaan"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/mt/LC_MESSAGES/docking.po
+++ b/docking/locale/mt/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Maħluq"
 msgid "Modified"
 msgstr "Modifikat"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Il-fowlder ma nstabx"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Il-fowlder huwa vojt"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Iftaħ f'%s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Aktar f'%s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Iftaħ fowlder"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Aktar fil-fowlder"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Iftaħ"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Issortja skont"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Uri fajls moħbija"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Ikoni kbar"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferenzi"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/nb/LC_MESSAGES/docking.po
+++ b/docking/locale/nb/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Opprettet"
 msgid "Modified"
 msgstr "Endret"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Mappe ikke funnet"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Mappen er tom"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Åpne i %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d til i %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Åpne mappe"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d til i mappe"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Åpne"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sorter etter"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Vis skjulte filer"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Store ikoner"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Innstillinger"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/ne/LC_MESSAGES/docking.po
+++ b/docking/locale/ne/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "सिर्जना गरिएको"
 msgid "Modified"
 msgstr "परिमार्जित"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "फोल्डर फेला परेन"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "फोल्डर खाली छ"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s मा खोल्नुहोस्"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "फोल्डर खोल्नुहोस्"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "फोल्डरमा %d थप"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "खोल्नुहोस्"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "क्रमबद्ध गर्नुहोस्"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "लुकेका फाइलहरू देखाउनुहोस्"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "ठूला आइकनहरू"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "प्राथमिकताहरू"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/nl/LC_MESSAGES/docking.po
+++ b/docking/locale/nl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Aangemaakt"
 msgid "Modified"
 msgstr "Gewijzigd"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Map niet gevonden"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Map is leeg"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Openen in %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Meer in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Map openen"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Meer in map"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Verwijderen van dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Openen"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Bewaren in dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Alles sluiten"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Sluiten"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sorteren op"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Verborgen bestanden tonen"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Grote pictogrammen"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Energieprofielen niet beschikbaar"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Scheidingsteken toevoegen"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "Over"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Afsluiten"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Venster"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/nn/LC_MESSAGES/docking.po
+++ b/docking/locale/nn/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Oppretta"
 msgid "Modified"
 msgstr "Endra"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Mappa vart ikkje funnen"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Mappa er tom"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Opne i %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Meir i %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Opne mappe"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Meir i mappe"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Opne"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sorter etter"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Vis gøymde filer"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Store ikon"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Innstillingar"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/pa/LC_MESSAGES/docking.po
+++ b/docking/locale/pa/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "ਬਣਾਇਆ"
 msgid "Modified"
 msgstr "ਸੋਧਿਆ"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "ਫੋਲਡਰ ਨਹੀਂ ਮਿਲਿਆ"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "ਫੋਲਡਰ ਖਾਲੀ ਹੈ"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s ਵਿੱਚ ਖੋਲ੍ਹੋ"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "ਫੋਲਡਰ ਖੋਲ੍ਹੋ"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "ਫੋਲਡਰ ਵਿੱਚ %d ਹੋਰ"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "ਖੋਲ੍ਹੋ"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "ਕ੍ਰਮਬੱਧ ਕਰੋ"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "ਲੁਕੀਆਂ ਫਾਈਲਾਂ ਦਿਖਾਓ"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "ਵੱਡੇ ਆਈਕਨ"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "ਤਰਜੀਹਾਂ"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/pl/LC_MESSAGES/docking.po
+++ b/docking/locale/pl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1504,97 +1504,102 @@ msgstr "Utworzono"
 msgid "Modified"
 msgstr "Zmodyfikowano"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Nie znaleziono folderu"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Folder jest pusty"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Otworz w %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Wiecej w %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Otworz folder"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Wiecej w folderze"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Usuń z docka"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Otworz"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Zachowaj w docku"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Zamknij wszystko"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Zamknij"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sortuj wg"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Pokaz ukryte pliki"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Duze ikony"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Aplety"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Profile zasilania niedostępne"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Dodaj separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferencje"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "O programie"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Zakończ"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Okno"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/pt_BR/LC_MESSAGES/docking.po
+++ b/docking/locale/pt_BR/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1502,97 +1502,102 @@ msgstr "Criado"
 msgid "Modified"
 msgstr "Modificado"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Pasta nao encontrada"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Pasta vazia"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Abrir em %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Mais em %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Abrir Pasta"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Mais na Pasta"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remover do Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Abrir"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Manter no Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Fechar Todas"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Fechar"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Ordenar Por"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Mostrar Arquivos Ocultos"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Icones Grandes"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Perfis de Energia indisponíveis"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Adicionar Separador"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "Sobre"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Sair"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Janela"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/pt_PT/LC_MESSAGES/docking.po
+++ b/docking/locale/pt_PT/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Criado"
 msgid "Modified"
 msgstr "Modificado"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Pasta não encontrada"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "A pasta está vazia"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Abrir em %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Abrir pasta"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Abrir"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Ordenar por"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Mostrar ficheiros ocultos"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Ícones grandes"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferências"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/ro/LC_MESSAGES/docking.po
+++ b/docking/locale/ro/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Creat"
 msgid "Modified"
 msgstr "Modificat"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Dosarul nu a fost gasit"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Dosarul este gol"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Deschide in %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d in plus in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Deschide dosarul"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d in plus in dosar"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Deschide"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sorteaza dupa"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Afiseaza fisierele ascunse"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Pictograme mari"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferinte"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/ru/LC_MESSAGES/docking.po
+++ b/docking/locale/ru/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1504,97 +1504,102 @@ msgstr "Создан"
 msgid "Modified"
 msgstr "Изменён"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Папка не найдена"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Папка пуста"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Открыть в %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Ещё %d в %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Открыть папку"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Ещё %d в папке"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Убрать из дока"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Открыть"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Оставить в доке"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Закрыть все"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Закрыть"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Сортировка"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Показать скрытые файлы"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Крупные значки"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Апплеты"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Профили питания недоступны"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Добавить разделитель"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Настройки"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "О программе"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Выход"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Окно"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/sk/LC_MESSAGES/docking.po
+++ b/docking/locale/sk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1503,97 +1503,102 @@ msgstr "Vytvorene"
 msgid "Modified"
 msgstr "Zmenene"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Priecinok sa nenasiel"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Priecinok je prazdny"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Otvorit v %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Dalsich v %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Otvorit priecinok"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Dalsich v priecinku"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Odstrániť z doku"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Otvorit"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Ponechať v doku"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Zavrieť všetko"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Zavrieť"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Zoradit podla"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Zobrazit skryte subory"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Velke ikony"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Aplety"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Profily napájania nedostupné"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Pridať oddeľovač"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Nastavenia"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "O aplikácii"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Ukončiť"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Okno"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/sl/LC_MESSAGES/docking.po
+++ b/docking/locale/sl/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Ustvarjeno"
 msgid "Modified"
 msgstr "Spremenjeno"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Mapa ni najdena"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Mapa je prazna"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Odpri v %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Še %d v %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Odpri mapo"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Še %d v mapi"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Odpri"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Razvrsti po"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Prikaži skrite datoteke"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Velike ikone"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Nastavitve"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/sq/LC_MESSAGES/docking.po
+++ b/docking/locale/sq/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Krijuar"
 msgid "Modified"
 msgstr "Ndryshuar"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Dosja nuk u gjet"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Dosja është bosh"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Hap në %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Më shumë në %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Hap dosjen"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Më shumë në dosje"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Hap"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Rendit sipas"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Shfaq skedarët e fshehur"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Ikona të mëdha"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Preferencat"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/sr/LC_MESSAGES/docking.po
+++ b/docking/locale/sr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Креирано"
 msgid "Modified"
 msgstr "Измењено"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Фасцикла није пронађена"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Фасцикла је празна"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Отвори у %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Још %d у %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Отвори фасциклу"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Још %d у фасцикли"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Отвори"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Сортирај по"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Прикажи скривене датотеке"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Велике иконе"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Подешавања"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/sv/LC_MESSAGES/docking.po
+++ b/docking/locale/sv/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Skapad"
 msgid "Modified"
 msgstr "Ändrad"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Mappen hittades inte"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Mappen är tom"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Öppna i %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d till i %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Öppna mapp"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d till i mapp"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Öppna"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sortera efter"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Visa dolda filer"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Stora ikoner"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Inställningar"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/sw/LC_MESSAGES/docking.po
+++ b/docking/locale/sw/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Imeundwa"
 msgid "Modified"
 msgstr "Imebadilishwa"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Folda haipatikani"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Folda ni tupu"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Fungua katika %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d Zaidi katika %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Fungua Folda"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d Zaidi katika Folda"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Fungua"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Panga kwa"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Onyesha Faili Zilizofichwa"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Aikoni Kubwa"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Mapendeleo"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/ta/LC_MESSAGES/docking.po
+++ b/docking/locale/ta/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "உருவாக்கப்பட்டது"
 msgid "Modified"
 msgstr "மாற்றப்பட்டது"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "கோப்புறை காணப்படவில்லை"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "கோப்புறை காலியாக உள்ளது"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s இல் திற"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "கோப்புறை திற"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "கோப்புறையில் மேலும் %d"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "திற"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "வரிசைப்படுத்து"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "மறைந்த கோப்புகளை காட்டு"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "பெரிய சின்னங்கள்"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "விருப்பத்தேர்வுகள்"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/te/LC_MESSAGES/docking.po
+++ b/docking/locale/te/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "సృష్టించబడింది"
 msgid "Modified"
 msgstr "మార్చబడింది"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "ఫోల్డర్ కనుగొనబడలేదు"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "ఫోల్డర్ ఖాళీగా ఉంది"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s లో తెరువు"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "ఫోల్డర్ తెరువు"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "ఫోల్డర్‌లో మరో %d"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "తెరువు"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "క్రమం"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "దాచిన ఫైళ్లు చూపించు"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "పెద్ద చిహ్నాలు"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "ప్రాధాన్యతలు"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/th/LC_MESSAGES/docking.po
+++ b/docking/locale/th/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1501,97 +1501,102 @@ msgstr "สร้างเมื่อ"
 msgid "Modified"
 msgstr "แก้ไขเมื่อ"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "ไม่พบโฟลเดอร์"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "โฟลเดอร์ว่าง"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "เปิดใน %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "เปิดโฟลเดอร์"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "เปิด"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "เรียงตาม"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "แสดงไฟล์ที่ซ่อน"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "ไอคอนใหญ่"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "การตั้งค่า"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/tr/LC_MESSAGES/docking.po
+++ b/docking/locale/tr/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Oluşturulma"
 msgid "Modified"
 msgstr "Değiştirilme"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Klasör bulunamadı"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Klasör boş"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s ile Aç"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Klasörü Aç"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Klasörde %d daha"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Aç"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sıralama"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Gizli Dosyaları Göster"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Büyük Simgeler"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Tercihler"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/uk/LC_MESSAGES/docking.po
+++ b/docking/locale/uk/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Створено"
 msgid "Modified"
 msgstr "Змінено"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Теку не знайдено"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Тека порожня"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Відкрити у %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Відкрити теку"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "%d More in Folder"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Відкрити"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Сортувати за"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Показати приховані файли"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Великі значки"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Налаштування"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/ur/LC_MESSAGES/docking.po
+++ b/docking/locale/ur/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "بنایا گیا"
 msgid "Modified"
 msgstr "تبدیل شدہ"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "فولڈر نہیں ملا"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "فولڈر خالی ہے"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s میں کھولیں"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "فولڈر کھولیں"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "فولڈر میں %d مزید"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "کھولیں"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "ترتیب دیں"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "چھپی ہوئی فائلیں دکھائیں"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "بڑے آئیکن"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "ترجیحات"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/uz/LC_MESSAGES/docking.po
+++ b/docking/locale/uz/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Yaratilgan"
 msgid "Modified"
 msgstr "O'zgartirilgan"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Jild topilmadi"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Jild bo'sh"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "%s da ochish"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Jildni ochish"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Jildda yana %d ta"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Ochish"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Saralash"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Yashirin fayllarni ko'rsatish"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Katta belgilar"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Sozlamalar"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/vi/LC_MESSAGES/docking.po
+++ b/docking/locale/vi/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1501,97 +1501,102 @@ msgstr "Da tao"
 msgid "Modified"
 msgstr "Da sua"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Khong tim thay thu muc"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Thu muc trong"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Mo trong %s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Them %d trong %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Mo thu muc"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Them %d trong thu muc"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Mo"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Sap xep theo"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Hien tep an"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Bieu tuong lon"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Tuy chon"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/xh/LC_MESSAGES/docking.po
+++ b/docking/locale/xh/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Yenziwe"
 msgid "Modified"
 msgstr "Iguquliwe"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Ifolda ayifunyenwanga"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Ifolda ayinanto"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Vula kwi-%s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Ezingaphezulu ezingu-%d kwi-%s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Vula Ifolda"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Ezingaphezulu ezingu-%d kwifolda"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Vula"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Hlela Ngoku"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Bonisa Iifayile Ezifihliweyo"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Iiayikhoni Ezinkulu"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Izikhethelo"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/zh_CN/LC_MESSAGES/docking.po
+++ b/docking/locale/zh_CN/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: 2026-03-05 12:18+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1501,97 +1501,102 @@ msgstr "创建时间"
 msgid "Modified"
 msgstr "修改时间"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "未找到文件夹"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "文件夹为空"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "在 %s 中打开"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "%d More in %s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "打开文件夹"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "文件夹中还有 %d 个"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "从Dock中移除"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "打开"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "保留在Dock中"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "全部关闭"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "关闭"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "排序方式"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "显示隐藏文件"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "大图标"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "小程序"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "电源配置不可用"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "添加分隔符"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "首选项"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "关于"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "退出"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "窗口"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/locale/zu/LC_MESSAGES/docking.po
+++ b/docking/locale/zu/LC_MESSAGES/docking.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-24 20:55+0200\n"
+"POT-Creation-Date: 2026-04-25 11:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1502,97 +1502,102 @@ msgstr "Kwadalwa"
 msgid "Modified"
 msgstr "Kushintshiwe"
 
-#: docking/ui/menu.py:724
+#: docking/ui/menu.py:909
 msgid "Folder not found"
 msgstr "Ifolda ayitholakali"
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:948
 msgid "Folder is empty"
 msgstr "Ifolda ayinalutho"
 
-#: docking/ui/menu.py:1186
+#: docking/ui/menu.py:1403
 #, python-format
 msgid "Open in %s"
 msgstr "Vula ku-%s"
 
-#: docking/ui/menu.py:1188
+#: docking/ui/menu.py:1405
 #, python-format
 msgid "%d More in %s"
 msgstr "Okwengeziwe okungu-%d ku-%s"
 
-#: docking/ui/menu.py:1191
+#: docking/ui/menu.py:1408
 msgid "Open Folder"
 msgstr "Vula Ifolda"
 
-#: docking/ui/menu.py:1193
+#: docking/ui/menu.py:1410
 #, python-format
 msgid "%d More in Folder"
 msgstr "Okwengeziwe okungu-%d kufolda"
 
-#: docking/ui/menu.py:1319 docking/ui/menu.py:1339 docking/ui/menu.py:1355
-#: docking/ui/menu.py:1408
+#: docking/ui/menu.py:1536 docking/ui/menu.py:1556 docking/ui/menu.py:1572
+#: docking/ui/menu.py:1625
 msgid "Remove from Dock"
 msgstr "Remove from Dock"
 
-#: docking/ui/menu.py:1332
+#: docking/ui/menu.py:1549
 msgid "Open"
 msgstr "Vula"
 
-#: docking/ui/menu.py:1362
+#: docking/ui/menu.py:1579
 msgid "Keep in Dock"
 msgstr "Keep in Dock"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close All"
 msgstr "Close All"
 
-#: docking/ui/menu.py:1371
+#: docking/ui/menu.py:1588
 msgid "Close"
 msgstr "Close"
 
-#: docking/ui/menu.py:1388
+#: docking/ui/menu.py:1605
 msgid "Sort By"
 msgstr "Hlelela Nge"
 
-#: docking/ui/menu.py:1396
+#: docking/ui/menu.py:1613
 msgid "Show Hidden Files"
 msgstr "Bonisa Amafayela Afihliwe"
 
-#: docking/ui/menu.py:1401
+#: docking/ui/menu.py:1618
 msgid "Large Icons"
 msgstr "Ama-ayikhoni Amakhulu"
 
-#: docking/ui/menu.py:1438
+#: docking/ui/menu.py:1655
 msgid "Add Applet"
 msgstr "Applets"
 
-#: docking/ui/menu.py:1476
+#: docking/ui/menu.py:1693
 msgid "No Applets Available"
 msgstr "Power Profiles unavailable"
 
-#: docking/ui/menu.py:1483
+#: docking/ui/menu.py:1700
 msgid "Add Separator"
 msgstr "Add Separator"
 
-#: docking/ui/menu.py:1493 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:163
 msgid "Preferences"
 msgstr "Izinketho"
 
-#: docking/ui/menu.py:1498
+#: docking/ui/menu.py:1715
 msgid "About"
 msgstr "About"
 
-#: docking/ui/menu.py:1503
+#: docking/ui/menu.py:1720
 msgid "Get Support"
 msgstr "Get Support"
 
-#: docking/ui/menu.py:1510
+#: docking/ui/menu.py:1727
 msgid "Quit"
 msgstr "Quit"
 
-#: docking/ui/menu.py:1547
+#: docking/ui/menu.py:1764
 msgid "Window"
 msgstr "Window"
+
+#: docking/ui/new_year.py:165
+#, python-brace-format
+msgid "Happy new year {year} !!!"
+msgstr "Happy new year {year} !!!"
 
 #: docking/ui/placement.py:223
 #, python-brace-format

--- a/docking/ui/new_year.py
+++ b/docking/ui/new_year.py
@@ -1,0 +1,344 @@
+"""Temporary dock-anchored New Year greeting popup.
+
+The trigger semantics intentionally follow Cairo-Dock for reference.
+I have fond memories of my time using and contributing to it, and this
+feature is a small homage to all their influence and work on the dock bar
+ecosystem:
+
+- evaluate only after startup succeeds,
+- greet once per year,
+- only during the first 15 days of January,
+- do not greet on the first-ever launch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+
+import gi
+
+gi.require_version("Gdk", "3.0")
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk, GLib, Gtk
+
+from docking.core.greeting import consume_new_year_greeting
+from docking.core.position import Position, is_horizontal
+from docking.i18n import _
+from docking.log import get_logger
+from docking.ui.display import clamp_to_screen
+from docking.ui.tooltip import compute_tooltip_position
+
+log = get_logger("new_year")
+
+STARTUP_GREETING_DELAY_S = 5
+NEW_YEAR_GREETING_DURATION_S = 15
+GREETING_GAP_PX = 16
+GREETING_CONTENT_SPACING_PX = 12
+GREETING_MARGIN_PX = 12
+GREETING_CORNER_RADIUS_PX = 10
+GREETING_TIP_WIDTH_PX = 22
+GREETING_TIP_HEIGHT_PX = 12
+GREETING_BACKGROUND_RGBA = (0.11, 0.11, 0.11, 0.96)
+GREETING_BORDER_RGBA = (1.0, 1.0, 1.0, 0.14)
+
+
+class NewYearGreetingController:
+    """Schedules and displays the dock's annual New Year greeting."""
+
+    def __init__(
+        self,
+        *,
+        window: Gtk.Window,
+        state_path: Path | str | None = None,
+        now_fn: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._window = window
+        self._state_path = Path(state_path) if state_path else None
+        self._now_fn = now_fn or datetime.now
+        self._start_source_id: int = 0
+        self._hide_source_id: int = 0
+        self._popup: Gtk.Window | None = None
+
+    def start(self) -> None:
+        """Start the delayed startup greeting check once per process."""
+        if self._start_source_id:
+            return
+        log.debug(
+            "Scheduling New Year greeting check in %ss",
+            STARTUP_GREETING_DELAY_S,
+        )
+        self._start_source_id = GLib.timeout_add_seconds(
+            STARTUP_GREETING_DELAY_S,
+            self._on_startup_complete,
+        )
+
+    def stop(self) -> None:
+        """Cancel any pending timers and close the popup."""
+        if self._start_source_id:
+            GLib.source_remove(self._start_source_id)
+            self._start_source_id = 0
+        if self._hide_source_id:
+            GLib.source_remove(self._hide_source_id)
+            self._hide_source_id = 0
+        if self._popup is not None:
+            self._popup.destroy()
+            self._popup = None
+
+    def _on_startup_complete(self) -> bool:
+        self._start_source_id = 0
+        now = self._now_fn()
+        year = consume_new_year_greeting(
+            path=self._state_path,
+            now=now,
+        )
+        log.debug("New Year greeting evaluation at %s returned %r", now, year)
+        if year is not None:
+            self._show_popup(year=year)
+        return False
+
+    def _show_popup(self, *, year: int) -> None:
+        if not self._window.get_realized():
+            log.debug("Skipping New Year greeting because dock window is not realized")
+            return
+
+        if self._popup is None:
+            popup = Gtk.Window(type=Gtk.WindowType.POPUP)
+            popup.set_decorated(False)
+            popup.set_skip_taskbar_hint(True)
+            popup.set_resizable(False)
+            popup.set_type_hint(Gdk.WindowTypeHint.NOTIFICATION)
+            popup.set_app_paintable(True)
+            popup.set_transient_for(self._window)
+            popup.connect("button-press-event", self._on_popup_button_press)
+            screen = popup.get_screen()
+            visual = screen.get_rgba_visual()
+            if visual is not None:
+                popup.set_visual(visual)
+            popup.connect("draw", self._on_popup_draw)
+            self._popup = popup
+        else:
+            child = self._popup.get_child()
+            if child is not None:
+                self._popup.remove(child)
+
+        log.debug("Showing New Year greeting popup for year %s", year)
+        self._popup.add(self._build_popup_content(year=year))
+        self._popup.show_all()
+        self._position_popup()
+
+        if self._hide_source_id:
+            GLib.source_remove(self._hide_source_id)
+        self._hide_source_id = GLib.timeout_add_seconds(
+            NEW_YEAR_GREETING_DURATION_S,
+            self._hide_popup,
+        )
+
+    def _build_popup_content(self, *, year: int) -> Gtk.Widget:
+        pos = self._window.config.pos
+        box = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=GREETING_CONTENT_SPACING_PX,
+        )
+        box.set_margin_start(
+            GREETING_MARGIN_PX
+            + (GREETING_TIP_HEIGHT_PX if pos == Position.LEFT else 0)
+        )
+        box.set_margin_end(
+            GREETING_MARGIN_PX
+            + (GREETING_TIP_HEIGHT_PX if pos == Position.RIGHT else 0)
+        )
+        box.set_margin_top(
+            GREETING_MARGIN_PX
+            + (GREETING_TIP_HEIGHT_PX if pos == Position.TOP else 0)
+        )
+        box.set_margin_bottom(
+            GREETING_MARGIN_PX
+            + (GREETING_TIP_HEIGHT_PX if pos == Position.BOTTOM else 0)
+        )
+
+        image = Gtk.Image.new_from_icon_name("face-smile", Gtk.IconSize.DIALOG)
+        image.set_valign(Gtk.Align.CENTER)
+        box.pack_start(image, False, False, 0)
+
+        label = Gtk.Label(label=_("Happy new year {year} !!!").format(year=year))
+        label.set_xalign(0.0)
+        label.set_yalign(0.5)
+        label.override_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(1, 1, 1, 1))
+        box.pack_start(label, False, False, 0)
+        return box
+
+    def _position_popup(self) -> None:
+        if self._popup is None:
+            return
+
+        win_x, win_y = self._window.get_position()
+        win_w, win_h = self._window.get_size()
+        pref = self._popup.get_preferred_size()[1]
+        popup_w = max(pref.width, 1)
+        popup_h = max(pref.height, 1)
+        pos = self._window.config.pos
+
+        if is_horizontal(pos):
+            anchor_x = win_x + win_w / 2
+            anchor_y = win_y if pos.value == "bottom" else win_y + win_h
+        else:
+            anchor_x = win_x + win_w if pos.value == "left" else win_x
+            anchor_y = win_y + win_h / 2
+
+        popup_x, popup_y = compute_tooltip_position(
+            pos=pos,
+            anchor_x=anchor_x,
+            anchor_y=anchor_y,
+            tooltip_w=popup_w,
+            tooltip_h=popup_h,
+            gap=GREETING_GAP_PX,
+        )
+
+        screen = self._popup.get_screen()
+        clamped = clamp_to_screen(
+            popup_x,
+            popup_y,
+            popup_w,
+            popup_h,
+            screen.get_width(),
+            screen.get_height(),
+        )
+        log.debug(
+            "Positioned New Year greeting popup at (%s, %s) "
+            "size=%sx%s dock=(%s,%s %sx%s pos=%s)",
+            clamped.x,
+            clamped.y,
+            popup_w,
+            popup_h,
+            win_x,
+            win_y,
+            win_w,
+            win_h,
+            pos.value,
+        )
+        self._popup.move(clamped.x, clamped.y)
+
+    def _on_popup_draw(self, widget: Gtk.Widget, cr) -> bool:
+        alloc = widget.get_allocation()
+        pos = self._window.config.pos
+        width = alloc.width
+        height = alloc.height
+        radius = GREETING_CORNER_RADIUS_PX
+        tip_w = GREETING_TIP_WIDTH_PX
+        tip_h = GREETING_TIP_HEIGHT_PX
+
+        body_x = 0.0
+        body_y = 0.0
+        body_w = float(width)
+        body_h = float(height)
+        if pos == Position.BOTTOM:
+            body_h -= tip_h
+        elif pos == Position.TOP:
+            body_y += tip_h
+            body_h -= tip_h
+        elif pos == Position.LEFT:
+            body_x += tip_h
+            body_w -= tip_h
+        else:
+            body_w -= tip_h
+
+        tip_half = tip_w / 2
+        if pos in (Position.BOTTOM, Position.TOP):
+            tip_center = body_x + body_w / 2
+        else:
+            tip_center = body_y + body_h / 2
+
+        cr.new_path()
+        if pos == Position.BOTTOM:
+            cr.move_to(tip_center - tip_half, body_y + body_h)
+            cr.line_to(tip_center, body_y + body_h + tip_h)
+            cr.line_to(tip_center + tip_half, body_y + body_h)
+        elif pos == Position.TOP:
+            cr.move_to(tip_center - tip_half, body_y)
+            cr.line_to(tip_center, body_y - tip_h)
+            cr.line_to(tip_center + tip_half, body_y)
+        elif pos == Position.LEFT:
+            cr.move_to(body_x, tip_center - tip_half)
+            cr.line_to(body_x - tip_h, tip_center)
+            cr.line_to(body_x, tip_center + tip_half)
+        else:
+            cr.move_to(body_x + body_w, tip_center - tip_half)
+            cr.line_to(body_x + body_w + tip_h, tip_center)
+            cr.line_to(body_x + body_w, tip_center + tip_half)
+        cr.close_path()
+
+        self._append_rounded_rect(
+            cr,
+            x=body_x,
+            y=body_y,
+            width=body_w,
+            height=body_h,
+            radius=radius,
+        )
+        cr.set_source_rgba(*GREETING_BACKGROUND_RGBA)
+        cr.fill_preserve()
+        cr.set_source_rgba(*GREETING_BORDER_RGBA)
+        cr.set_line_width(1.0)
+        cr.stroke()
+        return False
+
+    def _append_rounded_rect(
+        self,
+        cr,
+        *,
+        x: float,
+        y: float,
+        width: float,
+        height: float,
+        radius: float,
+    ) -> None:
+        radius = min(radius, width / 2, height / 2)
+        cr.new_sub_path()
+        cr.arc(
+            x + width - radius,
+            y + radius,
+            radius,
+            -3.141592653589793 / 2,
+            0,
+        )
+        cr.arc(
+            x + width - radius,
+            y + height - radius,
+            radius,
+            0,
+            3.141592653589793 / 2,
+        )
+        cr.arc(
+            x + radius,
+            y + height - radius,
+            radius,
+            3.141592653589793 / 2,
+            3.141592653589793,
+        )
+        cr.arc(
+            x + radius,
+            y + radius,
+            radius,
+            3.141592653589793,
+            3.141592653589793 * 3 / 2,
+        )
+        cr.close_path()
+
+    def _hide_popup(self) -> bool:
+        self._hide_source_id = 0
+        if self._popup is not None:
+            self._popup.hide()
+        return False
+
+    def _on_popup_button_press(
+        self,
+        _widget: Gtk.Widget,
+        _event: Gdk.EventButton,
+    ) -> bool:
+        if self._hide_source_id:
+            GLib.source_remove(self._hide_source_id)
+            self._hide_source_id = 0
+        self._hide_popup()
+        return True

--- a/docking/ui/new_year.py
+++ b/docking/ui/new_year.py
@@ -142,16 +142,14 @@ class NewYearGreetingController:
             spacing=GREETING_CONTENT_SPACING_PX,
         )
         box.set_margin_start(
-            GREETING_MARGIN_PX
-            + (GREETING_TIP_HEIGHT_PX if pos == Position.LEFT else 0)
+            GREETING_MARGIN_PX + (GREETING_TIP_HEIGHT_PX if pos == Position.LEFT else 0)
         )
         box.set_margin_end(
             GREETING_MARGIN_PX
             + (GREETING_TIP_HEIGHT_PX if pos == Position.RIGHT else 0)
         )
         box.set_margin_top(
-            GREETING_MARGIN_PX
-            + (GREETING_TIP_HEIGHT_PX if pos == Position.TOP else 0)
+            GREETING_MARGIN_PX + (GREETING_TIP_HEIGHT_PX if pos == Position.TOP else 0)
         )
         box.set_margin_bottom(
             GREETING_MARGIN_PX

--- a/tests/core/test_greeting.py
+++ b/tests/core/test_greeting.py
@@ -1,0 +1,142 @@
+"""Tests for greeting state and New Year trigger rules."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from docking.core.greeting import (
+    StartupGreetingState,
+    consume_new_year_greeting,
+    load_state,
+    save_state,
+)
+
+
+class TestLoadState:
+    def test_missing_file_returns_defaults(self, tmp_path):
+        path = tmp_path / "startup.json"
+
+        state = load_state(path=path)
+
+        assert state == StartupGreetingState()
+
+    def test_invalid_payload_returns_defaults(self, tmp_path):
+        path = tmp_path / "startup.json"
+        path.write_text("{not json", encoding="utf-8")
+
+        state = load_state(path=path)
+
+        assert state == StartupGreetingState()
+
+    def test_round_trip(self, tmp_path):
+        path = tmp_path / "startup.json"
+        state = StartupGreetingState(
+            completed_first_launch=True,
+            last_year_greeted=2026,
+        )
+
+        save_state(state, path=path)
+
+        assert load_state(path=path) == state
+
+
+class TestConsumeNewYearGreeting:
+    def test_first_launch_in_january_is_suppressed(self, tmp_path):
+        path = tmp_path / "startup.json"
+
+        year = consume_new_year_greeting(
+            path=path,
+            now=datetime(2026, 1, 3, 9, 0, 0),
+        )
+
+        assert year is None
+        assert load_state(path=path) == StartupGreetingState(
+            completed_first_launch=True,
+            last_year_greeted=0,
+        )
+
+    def test_second_launch_in_january_shows_greeting(self, tmp_path):
+        path = tmp_path / "startup.json"
+        save_state(
+            StartupGreetingState(completed_first_launch=True, last_year_greeted=0),
+            path=path,
+        )
+
+        year = consume_new_year_greeting(
+            path=path,
+            now=datetime(2026, 1, 3, 9, 0, 0),
+        )
+
+        assert year == 2026
+        assert load_state(path=path) == StartupGreetingState(
+            completed_first_launch=True,
+            last_year_greeted=2026,
+        )
+
+    def test_same_year_greeting_is_not_repeated(self, tmp_path):
+        path = tmp_path / "startup.json"
+        save_state(
+            StartupGreetingState(
+                completed_first_launch=True,
+                last_year_greeted=2026,
+            ),
+            path=path,
+        )
+
+        year = consume_new_year_greeting(
+            path=path,
+            now=datetime(2026, 1, 5, 9, 0, 0),
+        )
+
+        assert year is None
+        assert load_state(path=path).last_year_greeted == 2026
+
+    def test_outside_first_half_of_january_is_suppressed(self, tmp_path):
+        path = tmp_path / "startup.json"
+        save_state(
+            StartupGreetingState(completed_first_launch=True, last_year_greeted=2025),
+            path=path,
+        )
+
+        year = consume_new_year_greeting(
+            path=path,
+            now=datetime(2026, 1, 16, 9, 0, 0),
+        )
+
+        assert year is None
+        assert load_state(path=path).last_year_greeted == 2025
+
+    def test_non_january_launch_can_enable_next_new_year(self, tmp_path):
+        path = tmp_path / "startup.json"
+
+        first = consume_new_year_greeting(
+            path=path,
+            now=datetime(2025, 6, 1, 9, 0, 0),
+        )
+        second = consume_new_year_greeting(
+            path=path,
+            now=datetime(2026, 1, 2, 9, 0, 0),
+        )
+
+        assert first is None
+        assert second == 2026
+
+    def test_stringy_state_values_are_coerced(self, tmp_path):
+        path = tmp_path / "startup.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "completed_first_launch": "true",
+                    "last_year_greeted": "2025",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        year = consume_new_year_greeting(
+            path=path,
+            now=datetime(2026, 1, 1, 9, 0, 0),
+        )
+
+        assert year == 2026

--- a/tests/smoke/test_python314_smoke.py
+++ b/tests/smoke/test_python314_smoke.py
@@ -70,6 +70,9 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
         "docking.ui.factory": {
             "build_dock_window": lambda **_kwargs: None,
         },
+        "docking.ui.new_year": {
+            "NewYearGreetingController": type("NewYearGreetingController", (), {}),
+        },
         "docking.ui.renderer": {
             "DockRenderer": type("DockRenderer", (), {}),
         },
@@ -231,6 +234,7 @@ def test_app_main_smoke(monkeypatch):
     renderer = MagicMock()
     tracker = MagicMock()
     unity = MagicMock()
+    new_year = MagicMock()
     window = MagicMock()
     items_service = MagicMock()
 
@@ -247,6 +251,11 @@ def test_app_main_smoke(monkeypatch):
     monkeypatch.setattr(app_mod, "DockRenderer", MagicMock(return_value=renderer))
     monkeypatch.setattr(app_mod, "WindowTracker", MagicMock(return_value=tracker))
     monkeypatch.setattr(app_mod, "UnityLauncherListener", MagicMock(return_value=unity))
+    monkeypatch.setattr(
+        app_mod,
+        "NewYearGreetingController",
+        MagicMock(return_value=new_year),
+    )
     monkeypatch.setattr(app_mod, "build_dock_window", MagicMock(return_value=window))
     monkeypatch.setattr(
         app_mod, "DockItemsService", MagicMock(return_value=items_service)
@@ -258,6 +267,9 @@ def test_app_main_smoke(monkeypatch):
     fake_glib.idle_add.side_effect = idle_add
 
     app_mod.main()
+
+    new_year.start.assert_called_once()
+    new_year.stop.assert_called_once()
 
     fake_gtk.main.assert_called_once()
     assert fake_glib.unix_signal_add.call_count == 2

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -55,6 +55,9 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
         "docking.ui.factory": {
             "build_dock_window": lambda **_kwargs: None,
         },
+        "docking.ui.new_year": {
+            "NewYearGreetingController": type("NewYearGreetingController", (), {}),
+        },
         "docking.ui.renderer": {
             "DockRenderer": type("DockRenderer", (), {}),
         },
@@ -109,12 +112,14 @@ class TestAppMain:
         renderer = MagicMock()
         tracker = MagicMock()
         unity = MagicMock()
+        new_year = MagicMock()
         window = MagicMock()
         items_service = MagicMock()
         call_order: list[str] = []
 
         window.show_all.side_effect = lambda: call_order.append("show_all")
         unity.start.side_effect = lambda: call_order.append("unity_start")
+        new_year.start.side_effect = lambda: call_order.append("new_year_start")
         items_service.start.side_effect = lambda: call_order.append("items_start")
         model.start_applets.side_effect = lambda: call_order.append("applets_start")
 
@@ -140,6 +145,11 @@ class TestAppMain:
             app_mod,
             "UnityLauncherListener",
             MagicMock(return_value=unity),
+        )
+        monkeypatch.setattr(
+            app_mod,
+            "NewYearGreetingController",
+            MagicMock(return_value=new_year),
         )
         factory = MagicMock(return_value=window)
         monkeypatch.setattr(app_mod, "build_dock_window", factory)
@@ -167,6 +177,8 @@ class TestAppMain:
         items_service.stop.assert_called_once()
         unity.start.assert_called_once()
         unity.stop.assert_called_once()
+        new_year.start.assert_called_once()
+        new_year.stop.assert_called_once()
         fake_glib.idle_add.assert_called_once_with(
             app_mod._start_runtime,
             items_service,
@@ -176,6 +188,7 @@ class TestAppMain:
         assert call_order == [
             "unity_start",
             "show_all",
+            "new_year_start",
             "idle_add",
             "items_start",
             "applets_start",
@@ -201,12 +214,14 @@ class TestAppMain:
         renderer = MagicMock()
         tracker = MagicMock()
         unity = MagicMock()
+        new_year = MagicMock()
         window = MagicMock()
         items_service = MagicMock()
         call_order: list[str] = []
 
         window.show_all.side_effect = lambda: call_order.append("show_all")
         unity.start.side_effect = lambda: call_order.append("unity_start")
+        new_year.start.side_effect = lambda: call_order.append("new_year_start")
         items_service.start.side_effect = lambda: call_order.append("items_start")
         model.start_applets.side_effect = lambda: call_order.append("applets_start")
 
@@ -225,6 +240,7 @@ class TestAppMain:
         renderer_cls = MagicMock(return_value=renderer)
         tracker_cls = MagicMock(return_value=tracker)
         unity_cls = MagicMock(return_value=unity)
+        new_year_cls = MagicMock(return_value=new_year)
         factory = MagicMock(return_value=window)
         items_service_cls = MagicMock(return_value=items_service)
 
@@ -244,6 +260,11 @@ class TestAppMain:
         )
         monkeypatch.setattr(
             sys.modules["docking.platform.unity"], "UnityLauncherListener", unity_cls
+        )
+        monkeypatch.setattr(
+            sys.modules["docking.ui.new_year"],
+            "NewYearGreetingController",
+            new_year_cls,
         )
         monkeypatch.setattr(
             sys.modules["docking.ui.factory"], "build_dock_window", factory
@@ -266,9 +287,12 @@ class TestAppMain:
         fake_gtk.main.assert_called_once()
         unity.start.assert_called_once()
         unity.stop.assert_called_once()
+        new_year.start.assert_called_once()
+        new_year.stop.assert_called_once()
         assert call_order == [
             "unity_start",
             "show_all",
+            "new_year_start",
             "idle_add",
             "items_start",
             "applets_start",


### PR DESCRIPTION
## Summary
- add a dock-anchored New Year greeting that follows Cairo-Dock's once-per-year January startup behavior
- persist greeting state outside dock.json and wire the controller into app startup/shutdown
- document the feature and update locale catalogs for the new user-visible string