### PR TITLE
Use xz compression for deb packages

### DIFF
--- a/docking/__init__.py
+++ b/docking/__init__.py
@@ -25,4 +25,4 @@ In other words, this module is a package marker and metadata boundary, not an
 alternate application entrypoint.
 """
 
-__version__ = "1.12.0"
+__version__ = "1.12.1"

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -70,6 +70,8 @@ docking
 - **Tests**: skipped during deb build (no pytest in build env); run in CI instead.
 - **CI validation**: the generated architecture-specific package is installed and checked on both x86_64 and ARM64 runners.
 - **Release note**: GitHub Releases publish `linux-x86_64.deb` and `linux-aarch64.deb`.
+- **Compression**: binary `.deb` artifacts are built with `xz` compression for
+  compatibility with older `dpkg` versions that cannot unpack `control.tar.zst`.
 
 ## PPA (Launchpad)
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=docking
-pkgver=1.12.0
+pkgver=1.12.1
 pkgrel=1
 pkgdesc="A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo"
 arch=('x86_64' 'aarch64')

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,9 @@
+docking (1.12.1-1) stable; urgency=medium
+
+  * Release 1.12.1.
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 25 Apr 2026 12:15:34 +0200
+
 docking (1.12.0-1) stable; urgency=medium
 
   * Release 1.12.0.

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -50,3 +50,8 @@ override_dh_python3:
 	# Docking installs into private paths under /usr/lib/docking and uses an
 	# explicit python3 (>= 3.10) dependency in debian/control.
 	:
+
+override_dh_builddeb:
+	# Use xz instead of newer zstd-compressed .deb members so release artifacts
+	# remain installable with older dpkg versions still found on supported hosts.
+	dh_builddeb -- -Zxz

--- a/packaging/flatpak/org.docking.Docking.metainfo.xml
+++ b/packaging/flatpak/org.docking.Docking.metainfo.xml
@@ -35,6 +35,7 @@
   </provides>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.12.1" date="2026-04-25" />
     <release version="1.12.0" date="2026-04-24" />
     <release version="1.11.0" date="2026-04-23" />
     <release version="1.10.0" date="2026-04-21" />

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -5,7 +5,7 @@ let
 in
 pyPkgs.buildPythonApplication rec {
   pname = "docking";
-  version = "1.12.0";
+  version = "1.12.1";
   format = "pyproject";
 
   src = ../..;

--- a/packaging/rpm/docking.spec
+++ b/packaging/rpm/docking.spec
@@ -1,5 +1,5 @@
 Name:           docking
-Version:        %{?pkg_version}%{!?pkg_version:1.12.0}
+Version:        %{?pkg_version}%{!?pkg_version:1.12.1}
 Release:        1%{?dist}
 Summary:        A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo
 
@@ -80,6 +80,9 @@ fi
 /usr/share/icons/hicolor
 
 %changelog
+* Sat Apr 25 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.12.1-1
+- Release 1.12.1.
+
 * Fri Apr 24 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.12.0-1
 - Release 1.12.0.
 

--- a/packaging/snap/snapcraft.yaml
+++ b/packaging/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: docking
 title: Docking
 base: core22
-version: "1.12.0"
+version: "1.12.1"
 summary: Feature-rich Linux dock in Python with GTK 3 and Cairo
 description: |
   A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docking"
-version = "1.12.0"
+version = "1.12.1"
 description = "A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo"
 requires-python = ">=3.10"
 license = {text = "GPL-3.0-or-later"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # The canonical config is in pyproject.toml.
 [metadata]
 name = docking
-version = 1.12.0
+version = 1.12.1
 [options]
 packages = find:
 python_requires = >=3.10


### PR DESCRIPTION
## Summary
- force Debian binary packages to use xz compression instead of zstd
- document the compatibility reason in packaging docs
- bump release version to 1.12.1

## Tests
- manual install verification with dpkg 1.21.8 and 1.21.22