### PR TITLE
Relax i18n catalog completeness checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         run: bash tools/i18n.sh --check-pot-sync
 
       - name: Validate translation catalogs
-        run: bash tools/i18n.sh --check-catalogs --require-complete
+        run: bash tools/i18n.sh --check-catalogs --allow-incomplete
 
       - name: Compile translations
         run: bash tools/i18n.sh --compile

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,15 +32,9 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
-      - id: i18n-strip-obsolete
-        name: i18n-strip-obsolete
-        entry: bash tools/i18n.sh --strip-obsolete
-        language: system
-        pass_filenames: false
-        always_run: true
-      - id: i18n-complete
-        name: i18n-complete
-        entry: bash tools/i18n.sh --check-catalogs --require-complete
+      - id: i18n-catalogs
+        name: i18n-catalogs
+        entry: bash tools/i18n.sh --check-catalogs --allow-incomplete
         language: system
         pass_filenames: false
         always_run: true

--- a/README.md
+++ b/README.md
@@ -1019,45 +1019,40 @@ After adding or modifying translatable strings in the source code:
 ./tools/i18n.sh --extract
 ```
 
-This regenerates `docking/locale/docking.pot`. Existing `.po` files can then be updated with `msgmerge`.
+This regenerates `docking/locale/docking.pot`. Existing `.po` files are updated separately in translation-refresh pull requests.
 
 ### When CI fails after adding `_()` strings
 
 If you add a new user-visible translatable string such as `_("...")`, CI can fail in two common ways:
 
 - `--check-pot-sync` fails because `docking/locale/docking.pot` is stale
-- `--check-catalogs --require-complete` fails because the locale catalogs were not merged or translated yet
+- `--check-catalogs --allow-incomplete` fails because an existing locale catalog has format errors
 
-If the failure is only the stale POT check, regenerate the template:
+Regenerate the template:
 
 ```bash
 ./tools/i18n.sh --extract
 ```
 
-If the branch added a new translatable string, update every `docking.po` catalog against the new template:
+You do not need to update every `docking.po` catalog or fill in every new `msgstr` on regular feature commits. That creates large translation diffs that obscure the code review. Translation catalogs are refreshed periodically in translation-only pull requests:
 
 ```bash
-while IFS= read -r -d '' po; do
-  msgmerge --update --backup=none "$po" docking/locale/docking.pot >/dev/null
-done < <(find docking/locale -type f -name 'docking.po' -print0)
+./tools/i18n.sh --update-translations
 ```
 
-Then fill in the new `msgstr` values in the `.po` files, because CI runs the strict catalog check and untranslated or fuzzy entries will still fail.
-
-To verify locally with the same gates CI uses:
+To verify locally with the same i18n gates CI uses:
 
 ```bash
 ./tools/i18n.sh --check-pot-sync
-./tools/i18n.sh --check-catalogs --require-complete
+./tools/i18n.sh --check-catalogs --allow-incomplete
 ./tools/i18n.sh --compile
 ```
 
 Practical sequence:
 
 1. `./tools/i18n.sh --extract`
-2. Run `msgmerge` for all `docking.po` files
-3. Fill in the new `msgstr` values
-4. Rerun the three checks above
+2. Rerun the three checks above
+3. Leave `.po` refreshes for a translation-only PR unless this branch is specifically about translations
 
 ### Unified i18n command
 
@@ -1070,11 +1065,14 @@ Practical sequence:
 # Verify docking.pot is in sync with source strings
 ./tools/i18n.sh --check-pot-sync
 
-# Validate locale catalogs (strict, fails on untranslated/fuzzy)
-./tools/i18n.sh --check-catalogs --require-complete
+# Update docking.pot, merge every locale catalog, and strip obsolete entries
+./tools/i18n.sh --update-translations
 
-# Validate locale catalogs but allow incomplete translation backlog
+# Validate locale catalogs while allowing incomplete translation backlog
 ./tools/i18n.sh --check-catalogs --allow-incomplete
+
+# Strict translation-maintenance validation, fails on untranslated/fuzzy
+./tools/i18n.sh --check-catalogs --require-complete
 
 # Compile all .po catalogs to .mo
 ./tools/i18n.sh --compile
@@ -1226,10 +1224,10 @@ Runs automatically on `git commit`:
 - **ruff check** -- linting (E, W, F, I rules)
 - **ty check** -- type checking
 - **i18n-pot-sync** -- ensure `docking/locale/docking.pot` matches source strings (`./tools/i18n.sh --check-pot-sync`)
-- **i18n-complete** -- fail if PO catalogs are out-of-sync, fuzzy, or untranslated (`./tools/i18n.sh --check-catalogs --require-complete`)
+- **i18n-catalogs** -- fail if existing PO catalogs have format errors, while allowing untranslated/fuzzy backlog (`./tools/i18n.sh --check-catalogs --allow-incomplete`)
 - **pytest** -- full test suite
 
-Install/update the strict local hook with:
+Install/update the local hook with:
 
 ```bash
 ./tools/install_precommit_hook.sh

--- a/tools/i18n.sh
+++ b/tools/i18n.sh
@@ -27,11 +27,14 @@
 # A) Developer changes or adds translatable UI strings in Python source.
 # B) Regenerate POT from source:
 #      ./tools/i18n.sh --extract
-# C) Update each PO with msgmerge (translator workflow), then translate new msgids.
+# C) Periodically refresh translation catalogs in a translation-only branch:
+#      ./tools/i18n.sh --update-translations
+#    This regenerates the POT, merges every PO, and strips obsolete entries.
+#    Then translate new msgids.
 # D) Validate catalogs:
 #      strict gate:
 #        ./tools/i18n.sh --check-catalogs --require-complete
-#      backlog-friendly validation:
+#      default/backlog-friendly validation:
 #        ./tools/i18n.sh --check-catalogs --allow-incomplete
 # E) Compile catalogs for runtime/distribution:
 #      ./tools/i18n.sh --compile
@@ -44,16 +47,16 @@
 # Local hooks:
 #   - .pre-commit-config.yaml uses:
 #       --check-pot-sync
-#       --check-catalogs --require-complete
-#   - tools/install_precommit_hook.sh installs a strict .git/hooks/pre-commit
+#       --check-catalogs --allow-incomplete
+#   - tools/install_precommit_hook.sh installs a .git/hooks/pre-commit
 #     that calls this script.
 #
 # CI:
 #   - .github/workflows/ci.yml (quality job) uses:
 #       --check-pot-sync
-#       --check-catalogs --require-complete
+#       --check-catalogs --allow-incomplete
 #       --compile
-#   - This prevents stale templates and incomplete catalogs from landing.
+#   - This prevents stale templates and malformed catalogs from landing.
 #
 # Packaging:
 #   - deb/rpm/flatpak/snap/appimage/arch/nix build scripts invoke:
@@ -68,8 +71,9 @@
 #
 # Quick examples:
 #   ./tools/i18n.sh --extract
+#   ./tools/i18n.sh --update-translations
 #   ./tools/i18n.sh --check-pot-sync
-#   ./tools/i18n.sh --check-catalogs --require-complete
+#   ./tools/i18n.sh --check-catalogs --allow-incomplete
 #   ./tools/i18n.sh --compile
 set -euo pipefail
 
@@ -83,6 +87,7 @@ Docking i18n utility
 
 Operations (you can combine multiple):
   --extract                 Regenerate POT template from Python source.
+  --update-translations     Regenerate POT, merge every PO catalog, and strip obsolete entries.
   --check-pot-sync          Fail if docking.pot is out of date.
   --check-catalogs          Validate all locale PO catalogs.
   --compile                 Compile all PO catalogs into MO binaries.
@@ -97,7 +102,7 @@ Options:
 Environment:
   I18N_REQUIRE_COMPLETE     Default mode for --check-catalogs when no explicit
                             completeness flag is provided.
-                            1 = require complete (default), 0 = allow incomplete.
+                            1 = require complete, 0 = allow incomplete (default).
 EOF
 }
 
@@ -181,10 +186,30 @@ check_pot_sync() {
   echo "[i18n] POT template is in sync with source strings."
 }
 
+update_translations() {
+  require_cmd msgmerge
+  require_cmd msgattrib
+
+  extract_pot "${POT_FILE}"
+  collect_po_files
+
+  local count=0
+  local po_file
+  for po_file in "${PO_FILES[@]}"; do
+    msgmerge --update --backup=none "${po_file}" "${POT_FILE}" >/dev/null
+    count=$((count + 1))
+  done
+
+  echo "[i18n] Updated ${count} translation catalogs from docking.pot."
+  strip_obsolete
+}
+
 check_catalogs() {
   local require_complete="$1"
   require_cmd msgfmt
-  require_cmd msgcmp
+  if [ "${require_complete}" = "1" ]; then
+    require_cmd msgcmp
+  fi
   collect_po_files
 
   if [ ! -f "${POT_FILE}" ]; then
@@ -194,13 +219,16 @@ check_catalogs() {
 
   local status=0
   local msgcmp_log
-  msgcmp_log="$(mktemp)"
+  msgcmp_log=""
+  if [ "${require_complete}" = "1" ]; then
+    msgcmp_log="$(mktemp)"
+  fi
 
   for po_file in "${PO_FILES[@]}"; do
     local rel
     rel="${po_file#${ROOT_DIR}/}"
 
-    if ! msgcmp --use-untranslated --use-fuzzy "${po_file}" "${POT_FILE}" >"${msgcmp_log}" 2>&1; then
+    if [ "${require_complete}" = "1" ] && ! msgcmp --use-untranslated --use-fuzzy "${po_file}" "${POT_FILE}" >"${msgcmp_log}" 2>&1; then
       echo "[i18n] ${rel} is out of sync with docking.pot" >&2
       sed -n '1,6p' "${msgcmp_log}" >&2
       status=1
@@ -237,12 +265,16 @@ check_catalogs() {
   done
 
   if [ "${status}" -ne 0 ]; then
-    rm -f "${msgcmp_log}"
+    if [ -n "${msgcmp_log}" ]; then
+      rm -f "${msgcmp_log}"
+    fi
     echo "[i18n] Translation catalog check failed." >&2
     exit 1
   fi
 
-  rm -f "${msgcmp_log}"
+  if [ -n "${msgcmp_log}" ]; then
+    rm -f "${msgcmp_log}"
+  fi
   echo "[i18n] Translation catalog check passed for ${#PO_FILES[@]} catalogs."
 }
 
@@ -277,17 +309,22 @@ compile_catalogs() {
 }
 
 do_extract=0
+do_update_translations=0
 do_check_pot_sync=0
 do_check_catalogs=0
 do_strip_obsolete=0
 do_compile=0
 extract_output="${POT_FILE}"
-require_complete="${I18N_REQUIRE_COMPLETE:-1}"
+require_complete="${I18N_REQUIRE_COMPLETE:-0}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --extract)
       do_extract=1
+      shift
+      ;;
+    --update-translations)
+      do_update_translations=1
       shift
       ;;
     --check-pot-sync)
@@ -334,7 +371,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-if [ "${do_extract}" -eq 0 ] && [ "${do_check_pot_sync}" -eq 0 ] && [ "${do_check_catalogs}" -eq 0 ] && [ "${do_strip_obsolete}" -eq 0 ] && [ "${do_compile}" -eq 0 ]; then
+if [ "${do_extract}" -eq 0 ] && [ "${do_update_translations}" -eq 0 ] && [ "${do_check_pot_sync}" -eq 0 ] && [ "${do_check_catalogs}" -eq 0 ] && [ "${do_strip_obsolete}" -eq 0 ] && [ "${do_compile}" -eq 0 ]; then
   echo "[i18n] No operation selected." >&2
   usage >&2
   exit 1
@@ -345,8 +382,17 @@ if [ "${do_extract}" -eq 0 ] && [ "${extract_output}" != "${POT_FILE}" ]; then
   exit 1
 fi
 
+if [ "${do_update_translations}" -eq 1 ] && [ "${extract_output}" != "${POT_FILE}" ]; then
+  echo "[i18n] --output cannot be used together with --update-translations." >&2
+  exit 1
+fi
+
 if [ "${do_extract}" -eq 1 ]; then
   extract_pot "${extract_output}"
+fi
+
+if [ "${do_update_translations}" -eq 1 ]; then
+  update_translations
 fi
 
 if [ "${do_check_pot_sync}" -eq 1 ]; then

--- a/tools/install_precommit_hook.sh
+++ b/tools/install_precommit_hook.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Install a strict local Git pre-commit hook for this repository.
+# Install a local Git pre-commit hook for this repository.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -21,8 +21,8 @@ echo "Running ty..."
 .venv/bin/ty check docking/
 echo "Checking i18n template sync..."
 bash tools/i18n.sh --check-pot-sync
-echo "Checking i18n completeness..."
-bash tools/i18n.sh --check-catalogs --require-complete
+echo "Checking i18n catalogs..."
+bash tools/i18n.sh --check-catalogs --allow-incomplete
 echo "Checking package-data sync..."
 python3 tools/check_package_data_sync.py
 echo "Checking translation packaging..."


### PR DESCRIPTION
## Summary
- allow incomplete translation catalogs in CI and pre-commit checks
- add `tools/i18n.sh --update-translations` for translation-only refresh PRs
- document the new translation workflow