### PR TITLE
Fix keyboard layout switching on MATE

### DIFF
--- a/docking/applets/keyboardlayout/state.py
+++ b/docking/applets/keyboardlayout/state.py
@@ -13,7 +13,6 @@ Fcitx5 input methods use ``keyboard-LAYOUT`` (e.g. ``keyboard-br``).
 from __future__ import annotations
 
 import ast
-import os
 import re
 import shutil
 import subprocess
@@ -22,6 +21,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from docking.log import get_logger, with_context
+from docking.platform import environment
 
 log = with_context(get_logger(name="keyboardlayout"))
 
@@ -227,29 +227,6 @@ def _parse_gsettings_string(raw: str | None) -> str:
     return value if isinstance(value, str) else ""
 
 
-def _desktop_tokens() -> set[str]:
-    values = [
-        os.environ.get("XDG_CURRENT_DESKTOP", ""),
-        os.environ.get("XDG_SESSION_DESKTOP", ""),
-    ]
-    tokens: set[str] = set()
-    for value in values:
-        for token in re.split(r"[:;]", value):
-            normalized = token.strip().lower()
-            if normalized:
-                tokens.add(normalized)
-    return tokens
-
-
-def _is_mate_session() -> bool:
-    return "mate" in _desktop_tokens()
-
-
-def _is_gnome_session() -> bool:
-    tokens = _desktop_tokens()
-    return "gnome" in tokens or "ubuntu" in tokens
-
-
 class LayoutBackend(ABC):
     """Common interface for keyboard layout backends."""
 
@@ -306,7 +283,7 @@ class GnomeBackend(LayoutBackend):
     name = "gnome"
 
     def is_available(self) -> bool:
-        if not _is_gnome_session():
+        if not environment.is_gnome_session():
             return False
         return bool(self._sources())
 
@@ -512,7 +489,7 @@ class MateBackend(LayoutBackend):
     name = "mate"
 
     def is_available(self) -> bool:
-        if not _is_mate_session():
+        if not environment.is_mate_session():
             return False
         return bool(self._layouts())
 
@@ -577,7 +554,7 @@ class XkbBackend(LayoutBackend):
 def detect_backend() -> LayoutBackend:
     """Return the first available backend, falling back to XKB."""
     backends: list[type[LayoutBackend]]
-    if _is_gnome_session():
+    if environment.is_gnome_session():
         backends = [
             GnomeBackend,
             IBusBackend,
@@ -586,13 +563,22 @@ def detect_backend() -> LayoutBackend:
             XkbBackend,
         ]
     else:
-        backends = [
-            IBusBackend,
-            Fcitx5Backend,
-            MateBackend,
-            GnomeBackend,
-            XkbBackend,
-        ]
+        if environment.is_mate_session():
+            backends = [
+                MateBackend,
+                IBusBackend,
+                Fcitx5Backend,
+                GnomeBackend,
+                XkbBackend,
+            ]
+        else:
+            backends = [
+                IBusBackend,
+                Fcitx5Backend,
+                MateBackend,
+                GnomeBackend,
+                XkbBackend,
+            ]
     for cls in backends:
         backend = cls()
         if backend.is_available():

--- a/docking/platform/environment.py
+++ b/docking/platform/environment.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import enum
 import os
+import re
 import shutil
 import subprocess
 
@@ -79,9 +80,9 @@ _DESKTOP_MAP: dict[str, Desktop] = {
 
 
 def _parse_desktop(value: str) -> Desktop:
-    """Parse a desktop string, handling semicolon-separated values."""
+    """Parse a desktop string, handling XDG desktop list separators."""
     result = Desktop.UNKNOWN
-    for part in value.split(";"):
+    for part in re.split(r"[:;]", value):
         part = part.strip().lower()
         if part:
             result |= _DESKTOP_MAP.get(part, Desktop.UNKNOWN)
@@ -109,6 +110,18 @@ def detect_desktop() -> Desktop:
 def is_wayland_session() -> bool:
     """Return True when the desktop session itself is Wayland."""
     return os.environ.get("XDG_SESSION_TYPE", "").strip().lower() == "wayland"
+
+
+def is_gnome_session(*, desktop: Desktop | None = None) -> bool:
+    """Return True for GNOME-shell-like sessions."""
+    resolved = desktop if desktop is not None else detect_desktop()
+    return bool(resolved & (Desktop.GNOME | Desktop.UBUNTU))
+
+
+def is_mate_session(*, desktop: Desktop | None = None) -> bool:
+    """Return True for MATE sessions."""
+    resolved = desktop if desktop is not None else detect_desktop()
+    return bool(resolved & Desktop.MATE)
 
 
 def is_x11_backend(*, display: object | None = None) -> bool:

--- a/tests/applets/test_deskpresence.py
+++ b/tests/applets/test_deskpresence.py
@@ -259,7 +259,11 @@ class TestHistoryPrefs:
             ],
         )
         payload = prefs_payload(state=state)
-        back = prefs_from_mapping(payload)
+        with patch(
+            "docking.applets.deskpresence.state._today_utc",
+            return_value=state.today,
+        ):
+            back = prefs_from_mapping(payload)
         assert len(back.history) == 2
         assert back.history[0].date == "2026-04-23"
         assert back.history[0].at_desk_seconds == 3600.0

--- a/tests/applets/test_keyboardlayout.py
+++ b/tests/applets/test_keyboardlayout.py
@@ -37,6 +37,12 @@ from docking.applets.keyboardlayout.state import (
     show_current_layout,
     tooltip_text,
 )
+from docking.platform.environment import Desktop
+
+
+def _set_desktop(monkeypatch: pytest.MonkeyPatch, desktop: Desktop) -> None:
+    monkeypatch.setattr(kbl_state.environment, "detect_desktop", lambda: desktop)
+
 
 SETXKBMAP_MULTI = """\
 rules:      evdev
@@ -227,7 +233,7 @@ class TestMateBackend:
         assert _parse_gsettings_string("") == ""
 
     def test_query_returns_mate_layouts(self, monkeypatch):
-        monkeypatch.setenv("XDG_CURRENT_DESKTOP", "MATE")
+        _set_desktop(monkeypatch, Desktop.MATE)
 
         def mock_run(cmd):
             if cmd == [
@@ -248,7 +254,7 @@ class TestMateBackend:
         assert state.available == ["gb", "br", "us"]
 
     def test_switch_preserves_mate_model_and_options(self, monkeypatch):
-        monkeypatch.setenv("XDG_CURRENT_DESKTOP", "MATE")
+        _set_desktop(monkeypatch, Desktop.MATE)
         commands = []
 
         def mock_run(cmd):
@@ -291,8 +297,7 @@ class TestMateBackend:
         ] in commands
 
     def test_is_available_requires_mate_session(self, monkeypatch):
-        monkeypatch.delenv("XDG_CURRENT_DESKTOP", raising=False)
-        monkeypatch.delenv("XDG_SESSION_DESKTOP", raising=False)
+        _set_desktop(monkeypatch, Desktop.UNKNOWN)
         monkeypatch.setattr(kbl_state, "_run", lambda cmd: "['gb', 'br', 'us']")
 
         assert not MateBackend().is_available()
@@ -304,7 +309,7 @@ class TestGnomeBackend:
         assert _parse_input_sources("@a(ss) []") == []
 
     def test_query_returns_gnome_sources(self, monkeypatch):
-        monkeypatch.setenv("XDG_CURRENT_DESKTOP", "ubuntu:GNOME")
+        _set_desktop(monkeypatch, Desktop.UBUNTU | Desktop.GNOME)
         monkeypatch.setattr(kbl_state.shutil, "which", lambda cmd: "/usr/bin/gdbus")
 
         def mock_run(cmd):
@@ -337,7 +342,7 @@ class TestGnomeBackend:
         assert state.available == ["us", "br"]
 
     def test_switch_calls_gdbus_eval(self, monkeypatch):
-        monkeypatch.setenv("XDG_CURRENT_DESKTOP", "ubuntu:GNOME")
+        _set_desktop(monkeypatch, Desktop.UBUNTU | Desktop.GNOME)
         monkeypatch.setattr(kbl_state.shutil, "which", lambda cmd: "/usr/bin/gdbus")
         commands = []
 
@@ -375,7 +380,7 @@ class TestGnomeBackend:
         ] in commands
 
     def test_is_available_requires_gnome_and_gdbus(self, monkeypatch):
-        monkeypatch.setenv("XDG_CURRENT_DESKTOP", "ubuntu:GNOME")
+        _set_desktop(monkeypatch, Desktop.UBUNTU | Desktop.GNOME)
         monkeypatch.setattr(kbl_state.shutil, "which", lambda cmd: None)
         monkeypatch.setattr(
             kbl_state,
@@ -428,7 +433,7 @@ class TestDetectBackend:
         assert isinstance(backend, IBusBackend)
 
     def test_prefers_gnome_over_ibus_in_gnome_session(self, monkeypatch):
-        monkeypatch.setenv("XDG_CURRENT_DESKTOP", "ubuntu:GNOME")
+        _set_desktop(monkeypatch, Desktop.UBUNTU | Desktop.GNOME)
 
         def mock_run(cmd):
             if cmd == [
@@ -489,7 +494,7 @@ class TestDetectBackend:
         assert isinstance(backend, XkbBackend)
 
     def test_prefers_mate_before_xkb(self, monkeypatch):
-        monkeypatch.setenv("XDG_CURRENT_DESKTOP", "MATE")
+        _set_desktop(monkeypatch, Desktop.MATE)
 
         def mock_run(cmd):
             if cmd == ["ibus", "engine"]:
@@ -511,8 +516,29 @@ class TestDetectBackend:
         backend = detect_backend()
         assert isinstance(backend, MateBackend)
 
+    def test_prefers_mate_before_ibus_in_mate_session(self, monkeypatch):
+        _set_desktop(monkeypatch, Desktop.MATE)
+
+        def mock_run(cmd):
+            if cmd == ["ibus", "engine"]:
+                return "xkb:us::eng"
+            if cmd == [
+                "gsettings",
+                "get",
+                "org.mate.peripherals-keyboard-xkb.kbd",
+                "layouts",
+            ]:
+                return "['gb', 'br', 'us']"
+            if cmd == ["setxkbmap", "-query"]:
+                return "layout:     gb,br,us"
+            return None
+
+        monkeypatch.setattr(kbl_state, "_run", mock_run)
+        backend = detect_backend()
+        assert isinstance(backend, MateBackend)
+
     def test_prefers_gnome_before_xkb(self, monkeypatch):
-        monkeypatch.setenv("XDG_CURRENT_DESKTOP", "ubuntu:GNOME")
+        _set_desktop(monkeypatch, Desktop.UBUNTU | Desktop.GNOME)
 
         def mock_run(cmd):
             if cmd == ["ibus", "engine"]:

--- a/tests/platform/test_environment.py
+++ b/tests/platform/test_environment.py
@@ -8,6 +8,8 @@ from docking.platform.environment import (
     _check_compositor,
     _parse_desktop,
     detect_desktop,
+    is_gnome_session,
+    is_mate_session,
     is_wayland_session,
     is_x11_backend,
     is_xwayland_session,
@@ -23,10 +25,10 @@ class TestParseDesktop:
     def test_case_insensitive(self):
         assert _parse_desktop("XFCE") == Desktop.XFCE
 
-    def test_semicolon_separated(self):
+    def test_desktop_list_separators(self):
         result = _parse_desktop("ubuntu:GNOME;ubuntu")
-        # "ubuntu:GNOME" is unknown, "ubuntu" maps to UBUNTU
         assert result & Desktop.UBUNTU
+        assert result & Desktop.GNOME
 
     def test_xdg_current_desktop_multi(self):
         # Real-world: XDG_CURRENT_DESKTOP=MATE;MATE
@@ -85,6 +87,15 @@ class TestDetectDesktop:
     def test_no_env_returns_unknown(self):
         with patch.dict("os.environ", {}, clear=True):
             assert detect_desktop() == Desktop.UNKNOWN
+
+    def test_gnome_session_helper_includes_ubuntu(self):
+        assert is_gnome_session(desktop=Desktop.GNOME) is True
+        assert is_gnome_session(desktop=Desktop.UBUNTU) is True
+        assert is_gnome_session(desktop=Desktop.MATE) is False
+
+    def test_mate_session_helper(self):
+        assert is_mate_session(desktop=Desktop.MATE) is True
+        assert is_mate_session(desktop=Desktop.GNOME) is False
 
 
 class TestSessionBackendDetection:


### PR DESCRIPTION
## Summary
- prefer the MATE keyboard backend before IBus when running in a MATE session
- move desktop/session checks behind docking.platform.environment so applets do not read XDG_CURRENT_DESKTOP or XDG_SESSION_DESKTOP directly
- add regression coverage for MATE sessions where IBus is running but only reports one engine
- pin a date-sensitive desk-presence history test so the commit hook stays stable

## Investigation
On one of my machines, the session is MATE/X11 and setxkbmap reports the real layouts as gb,br,us. IBus is also running and reports xkb:us::eng only. The applet picked IBus first for non-GNOME desktops, so it never used the MATE/XKB layout list that actually changes the desktop layout.