### PR TITLE
Poll Codex sessions in AI usage applet

### DIFF
--- a/docking/applets/aiusage/applet.py
+++ b/docking/applets/aiusage/applet.py
@@ -31,6 +31,7 @@ from docking.applets.aiusage.state import (
     provider_cost,
     provider_for_model,
     provider_tokens,
+    query_codex_today,
     query_opencode_today,
     reset_today,
     set_session,
@@ -99,6 +100,7 @@ class AiUsageApplet(Applet):
         self._timer_id: int = 0
         self._selected_provider: Provider | None = None
         self._display_mode: DisplayMode = DisplayMode.COST
+        self._codex_poll_error: str | None = None
         self._opencode_poll_error: str | None = None
 
         super().__init__(icon_size, config)
@@ -200,6 +202,23 @@ class AiUsageApplet(Applet):
     def _tick(self) -> bool:
         prefs = _read_prefs_from_disk()
         new_state = state_from_prefs(prefs=prefs)
+
+        try:
+            codex_sessions = query_codex_today()
+            self._codex_poll_error = None
+            for sid, model_usage in codex_sessions.items():
+                new_state = set_session(
+                    state=new_state,
+                    session_id=sid,
+                    model_usage=model_usage,
+                )
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {exc}"
+            if error != self._codex_poll_error:
+                self._codex_poll_error = error
+                log.bind(action="poll_codex").warning(
+                    "Failed to poll Codex usage: %s", error
+                )
 
         # Merge OpenCode sessions from SQLite (no hook, poll-based).
         try:

--- a/docking/applets/aiusage/state.py
+++ b/docking/applets/aiusage/state.py
@@ -592,6 +592,50 @@ def parse_codex_transcript(path: Path) -> dict[str, ModelUsage]:
     }
 
 
+def _codex_session_id(path: Path) -> str:
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            try:
+                entry = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if entry.get("type") != "session_meta":
+                continue
+            session_id = entry.get("payload", {}).get("id", "")
+            if session_id:
+                return str(session_id)
+    except OSError as exc:
+        log.debug("Failed to read Codex session metadata %s: %s", path, exc)
+    return path.stem
+
+
+def query_codex_today() -> dict[str, dict[str, ModelUsage]]:
+    """Read today's Codex sessions from local JSONL transcripts.
+
+    Codex ``notify`` hooks only apply to processes that started after the hook
+    was registered. Polling recent session files lets the applet recover usage
+    for already-running Codex sessions as well.
+    """
+    sessions_dir = Path.home() / ".codex" / "sessions"
+    if not sessions_dir.is_dir():
+        return {}
+
+    today_start = datetime.datetime.fromisoformat(_today_iso()).timestamp()
+    result: dict[str, dict[str, ModelUsage]] = {}
+    for jsonl in sessions_dir.rglob("*.jsonl"):
+        try:
+            if jsonl.stat().st_mtime < today_start:
+                continue
+        except OSError as exc:
+            log.debug("Failed to stat Codex transcript %s: %s", jsonl, exc)
+            continue
+
+        model_usage = parse_codex_transcript(path=jsonl)
+        if model_usage:
+            result[_codex_session_id(path=jsonl)] = model_usage
+    return result
+
+
 # ---------------------------------------------------------------------------
 # OpenCode usage (SQLite database)
 # ---------------------------------------------------------------------------

--- a/tests/applets/test_aiusage.py
+++ b/tests/applets/test_aiusage.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import datetime
 import json
 import logging
+import os
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -26,6 +28,7 @@ from docking.applets.aiusage.state import (
     parse_codex_transcript,
     prefs_from_state,
     provider_for_model,
+    query_codex_today,
     reset_today,
     set_session,
     state_from_prefs,
@@ -408,6 +411,56 @@ class TestCodexTranscript:
         )
         assert parse_codex_transcript(path=jsonl) == {}
 
+    def test_query_codex_today_reads_recent_sessions(self, tmp_path, monkeypatch):
+        sessions_dir = tmp_path / ".codex" / "sessions" / "2026" / "04" / "29"
+        sessions_dir.mkdir(parents=True)
+        jsonl = sessions_dir / "rollout-2026-04-29T08-00-00-thread-1.jsonl"
+        jsonl.write_text(
+            "\n".join(
+                [
+                    json.dumps(
+                        {
+                            "type": "session_meta",
+                            "payload": {"id": "thread-1"},
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "turn_context",
+                            "payload": {"model": "gpt-5.5"},
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "event_msg",
+                            "payload": {
+                                "type": "token_count",
+                                "info": {
+                                    "total_token_usage": {
+                                        "input_tokens": 1200,
+                                        "cached_input_tokens": 200,
+                                        "output_tokens": 50,
+                                        "total_tokens": 1250,
+                                    }
+                                },
+                            },
+                        }
+                    ),
+                ]
+            )
+        )
+        today_ts = datetime.datetime.fromisoformat("2026-04-29T12:00:00").timestamp()
+        os.utime(jsonl, (today_ts, today_ts))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "docking.applets.aiusage.state._today_iso",
+            lambda: "2026-04-29",
+        )
+
+        result = query_codex_today()
+
+        assert result["thread-1"]["gpt-5.5"].input_tokens == 1200
+
 
 # ---------------------------------------------------------------
 # Hook
@@ -645,6 +698,7 @@ class TestAiUsageApplet:
         applet = AiUsageApplet(48)
         applet.present = MagicMock()
         monkeypatch.setattr(aiusage_mod, "_read_prefs_from_disk", lambda: None)
+        monkeypatch.setattr(aiusage_mod, "query_codex_today", dict)
         monkeypatch.setattr(
             aiusage_mod,
             "query_opencode_today",
@@ -662,6 +716,31 @@ class TestAiUsageApplet:
         assert applet._tick() is True
         assert applet._opencode_poll_error is None
         assert applet._state.days[0].sessions == 1
+        assert applet.present.call_count == 1
+
+    def test_tick_merges_codex_sessions_and_updates_state(self, monkeypatch):
+        applet = AiUsageApplet(48)
+        applet.present = MagicMock()
+        monkeypatch.setattr(aiusage_mod, "_read_prefs_from_disk", lambda: None)
+        monkeypatch.setattr(aiusage_mod, "query_opencode_today", dict)
+        monkeypatch.setattr(
+            aiusage_mod,
+            "query_codex_today",
+            lambda: {
+                "thread-1": {
+                    "gpt-5.5": ModelUsage(
+                        input_tokens=1200,
+                        output_tokens=50,
+                        cache_read_tokens=200,
+                    )
+                }
+            },
+        )
+
+        assert applet._tick() is True
+        assert applet._codex_poll_error is None
+        assert applet._state.days[0].sessions == 1
+        assert applet._state.days[0].by_model[0][0] == "gpt-5.5"
         assert applet.present.call_count == 1
 
     def test_reset_today_saves_prefs_and_presents(self):
@@ -683,6 +762,7 @@ class TestAiUsageApplet:
     def test_tick_warns_once_when_opencode_poll_fails(self, monkeypatch, caplog):
         applet = AiUsageApplet(48)
         monkeypatch.setattr(aiusage_mod, "_read_prefs_from_disk", lambda: None)
+        monkeypatch.setattr(aiusage_mod, "query_codex_today", dict)
 
         def fail_query():
             raise RuntimeError("database locked")


### PR DESCRIPTION
## Summary
- poll local Codex JSONL sessions during AI Usage refresh, alongside the existing notify hook
- merge polled Codex usage by session id so updates are idempotent
- add coverage for Codex session polling and applet tick integration

## Investigation
On my machine, Codex usage was present in ~/.codex/sessions and parse_codex_transcript could read it, but ~/.config/docking/dock.json had no AI Usage entry after 2026-04-25. The Codex notify hook was installed in ~/.codex/config.toml, but the running Codex process appears to have started before that notify command was active, so no hook write happened for the current session. Polling today's local session files lets the applet recover immediately even when notify did not fire.

Verified locally that query_codex_today finds today's gpt-5.5 Codex session and the running applet updated right away after the polling path was available.