### PR TITLE
Fit applet icon labels within badge bounds

### DIFF
--- a/docking/applets/base.py
+++ b/docking/applets/base.py
@@ -196,31 +196,106 @@ def load_catalog_icon(*, applet_id: str, size: int) -> GdkPixbuf.Pixbuf | None:
         return None
 
 
-def draw_icon_label(cr: cairo.Context, text: str, size: int) -> None:
+RGBA = tuple[float, float, float, float]
+
+_ICON_LABEL_FONT_SCALE = 0.22
+_ICON_LABEL_MIN_FONT_SCALE = 0.12
+_ICON_LABEL_MAX_WIDTH_SCALE = 0.92
+_ICON_LABEL_OUTLINE_SCALE = 0.22
+
+
+def draw_icon_label(
+    cr: cairo.Context,
+    text: str,
+    size: int,
+    *,
+    max_width: float | None = None,
+    fill_rgba: RGBA = (1, 1, 1, 1),
+    outline_rgba: RGBA = (0, 0, 0, 0.8),
+) -> None:
     """Draw outlined text at the bottom center of a size x size icon.
 
     Shared by weather (temperature), pomodoro (countdown), and hydration
     (countdown) for a uniform appearance.
     """
-    font_size = max(1, int(size * 0.22))
-    layout = PangoCairo.create_layout(cr)
-    layout.set_font_description(Pango.FontDescription(f"Sans Bold {font_size}px"))
-    layout.set_text(text, -1)
-    _, logical = layout.get_pixel_extents()
+    if not text:
+        return
 
-    tx = (size - logical.width) / 2 - logical.x
-    ty = size - logical.height - max(1, size * 0.02) - logical.y
+    target_width = max(1.0, float(max_width or size * _ICON_LABEL_MAX_WIDTH_SCALE))
+    initial_font_size = max(1, int(size * _ICON_LABEL_FONT_SCALE))
+    min_font_size = max(
+        1, min(initial_font_size, int(size * _ICON_LABEL_MIN_FONT_SCALE))
+    )
+    layout, logical, final_font_size = _fit_icon_label_layout(
+        cr=cr,
+        text=text,
+        max_width=target_width,
+        initial_font_size=initial_font_size,
+        min_font_size=min_font_size,
+    )
+
+    tx, ty = _icon_label_origin(
+        size=size,
+        logical=logical,
+        bottom_padding=max(1, size * 0.02),
+    )
 
     cr.save()
     cr.move_to(tx, ty)
     PangoCairo.layout_path(cr, layout)
-    cr.set_source_rgba(0, 0, 0, 0.8)
-    cr.set_line_width(max(2.0, size * 0.05))
+    cr.set_source_rgba(*outline_rgba)
+    cr.set_line_width(_icon_label_outline_width(font_size=final_font_size))
     cr.set_line_join(cairo.LINE_JOIN_ROUND)
     cr.stroke_preserve()
-    cr.set_source_rgba(1, 1, 1, 1)
+    cr.set_source_rgba(*fill_rgba)
     cr.fill()
     cr.restore()
+
+
+def _fit_icon_label_layout(
+    *,
+    cr: cairo.Context,
+    text: str,
+    max_width: float,
+    initial_font_size: int,
+    min_font_size: int,
+) -> tuple[Pango.Layout, Pango.Rectangle, int]:
+    """Build a Pango layout, shrinking the font until it fits max_width."""
+    for font_size in range(initial_font_size, min_font_size - 1, -1):
+        layout = _icon_label_layout(cr=cr, text=text, font_size=font_size)
+        _, logical = layout.get_pixel_extents()
+        if logical.width <= max_width or font_size == min_font_size:
+            return layout, logical, font_size
+    layout = _icon_label_layout(cr=cr, text=text, font_size=min_font_size)
+    _, logical = layout.get_pixel_extents()
+    return layout, logical, min_font_size
+
+
+def _icon_label_layout(
+    *,
+    cr: cairo.Context,
+    text: str,
+    font_size: int,
+) -> Pango.Layout:
+    layout = PangoCairo.create_layout(cr)
+    layout.set_font_description(Pango.FontDescription(f"Sans Bold {font_size}px"))
+    layout.set_text(text, -1)
+    return layout
+
+
+def _icon_label_origin(
+    *,
+    size: int,
+    logical: Pango.Rectangle,
+    bottom_padding: float,
+) -> tuple[float, float]:
+    tx = (size - logical.width) / 2 - logical.x
+    ty = size - logical.height - bottom_padding - logical.y
+    return tx, ty
+
+
+def _icon_label_outline_width(*, font_size: int) -> float:
+    return max(1.0, font_size * _ICON_LABEL_OUTLINE_SCALE)
 
 
 class Applet(ABC):

--- a/docking/applets/currencyfx/render.py
+++ b/docking/applets/currencyfx/render.py
@@ -234,10 +234,7 @@ def _draw_currency_label(
 
 def _draw_target_label(*, cr: cairo.Context, size: int, text: str) -> None:
     """Draw the quote code with the same prominence as other applet labels."""
-    if len(text) <= 4:
-        draw_icon_label(cr=cr, text=text, size=size)
-        return
-    _draw_currency_label(cr=cr, size=size, text=text, y=size * 0.87)
+    draw_icon_label(cr=cr, text=text, size=size, max_width=size * 0.78)
 
 
 def _draw_empty_state(*, cr: cairo.Context, size: int, failed: bool) -> None:

--- a/tests/applets/test_base.py
+++ b/tests/applets/test_base.py
@@ -1,8 +1,17 @@
 """Tests for the base applet lifecycle contract."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from docking.applets.base import Applet
+import cairo
+
+from docking.applets.base import (
+    Applet,
+    _fit_icon_label_layout,
+    _icon_label_origin,
+    _icon_label_outline_width,
+    draw_icon_label,
+)
 
 
 class _DeferredInitApplet(Applet):
@@ -91,3 +100,70 @@ class TestAppletBaseHelpers:
         assert applet.item.name == "Rendered 1"
         assert applet.item.icon is not None
         notify.assert_called_once_with()
+
+
+class TestDrawIconLabel:
+    def test_long_label_shrinks_to_fit_max_width(self):
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 48, 48)
+        cr = cairo.Context(surface)
+
+        _layout, logical, font_size = _fit_icon_label_layout(
+            cr=cr,
+            text="1234567890MB",
+            max_width=34.0,
+            initial_font_size=12,
+            min_font_size=4,
+        )
+
+        assert font_size < 12
+        assert logical.width <= 34.0 or font_size == 4
+
+    def test_short_label_keeps_initial_font_size(self):
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 48, 48)
+        cr = cairo.Context(surface)
+
+        _layout, logical, font_size = _fit_icon_label_layout(
+            cr=cr,
+            text="42",
+            max_width=44.0,
+            initial_font_size=12,
+            min_font_size=4,
+        )
+
+        assert font_size == 12
+        assert logical.width <= 44.0
+
+    def test_origin_keeps_bottom_edge_stable_for_different_heights(self):
+        first = SimpleNamespace(x=0, y=1, width=24, height=9)
+        second = SimpleNamespace(x=0, y=3, width=32, height=6)
+
+        _first_x, first_y = _icon_label_origin(
+            size=48,
+            logical=first,
+            bottom_padding=2.0,
+        )
+        _second_x, second_y = _icon_label_origin(
+            size=48,
+            logical=second,
+            bottom_padding=2.0,
+        )
+
+        assert first_y + first.y + first.height == 46.0
+        assert second_y + second.y + second.height == 46.0
+
+    def test_outline_width_tracks_final_font_size(self):
+        assert _icon_label_outline_width(font_size=12) == 2.64
+        assert _icon_label_outline_width(font_size=4) == 1.0
+
+    def test_draw_icon_label_accepts_optional_width_and_tones(self):
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 48, 48)
+        cr = cairo.Context(surface)
+
+        draw_icon_label(
+            cr=cr,
+            text="1234567890MB",
+            size=48,
+            max_width=34.0,
+            fill_rgba=(0.9, 1.0, 0.9, 1.0),
+            outline_rgba=(0.0, 0.0, 0.0, 0.75),
+        )

--- a/tests/applets/test_currencyfx.py
+++ b/tests/applets/test_currencyfx.py
@@ -8,6 +8,7 @@ import urllib.parse
 from unittest.mock import MagicMock, patch
 
 import docking.applets.currencyfx.applet as currencyfx_applet_mod
+import docking.applets.currencyfx.render as currencyfx_render_mod
 import docking.applets.currencyfx.state as fx_state
 from docking.applets.currencyfx.applet import CurrencyFxApplet
 from docking.applets.currencyfx.render import render_icon
@@ -467,6 +468,24 @@ class TestCurrencyFxRender:
             fetch_failed=True,
         )
         assert pixbuf is not None
+
+    def test_quote_label_uses_shared_icon_label_for_long_codes(self, monkeypatch):
+        labels: list[tuple[str, float | None]] = []
+
+        def draw_label(*, cr, text: str, size: int, max_width=None) -> None:
+            labels.append((text, max_width))
+
+        monkeypatch.setattr(currencyfx_render_mod, "draw_icon_label", draw_label)
+
+        pixbuf = render_icon(
+            size=48,
+            snapshot=None,
+            base="EUR",
+            quote="LONGCODE",
+        )
+
+        assert pixbuf is not None
+        assert labels == [("LONGCODE", 48 * 0.78)]
 
 
 class TestCurrencyFxApplet:


### PR DESCRIPTION
## Summary

- Update the shared `draw_icon_label` helper to shrink long labels to a max width before drawing.
- Keep bottom alignment stable as label height changes.
- Scale outline thickness from the final fitted font size instead of the icon size.
- Add optional max-width and tone parameters for applets that need tighter badge control.
- Move the CurrencyFX quote-code fallback onto the shared helper, including long quote codes.
- Cover the fitting, alignment, outline, optional-style, and CurrencyFX long-label behavior in tests.

Validated locally with the focused base/CurrencyFX tests, broader label-rendering applet tests, lint/type checks, and the full commit hook suite.