### PR TITLE
Apply applet usability updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,7 +809,9 @@ Hacker News headline viewer. It fetches HN top stories, keeps a cached list for 
 - **Open Story**
 - **Open Comments**
 - **Next Headline**
-- **Refresh Hacker News**
+- **Refresh Now**
+
+**Update interval:** 10 minutes. Additional pages load on demand when you reach the last loaded headline, up to 100 stories.
 
 **Preferences stored:** cached `stories`, `active_index`, `fetched_at`
 
@@ -856,6 +858,8 @@ Live currency pair monitor with a sparkline icon. Add the pairs you care about, 
 **Scroll:** Cycle added pairs
 **Right-click:** Refresh, swap pair, add pair, chart interval, switch/remove added pair
 
+**Update interval:** 15 minutes. Day charts use local samples collected on each successful refresh; week and month charts use remote daily history plus the current rate.
+
 **Preferences stored:** `pairs`, `active_index`, `chart_interval`, `sample_source`, `samples`
 
 ### URL Shortener
@@ -900,7 +904,9 @@ Monitor certificate expiry for a list of domains. The shield color highlights th
 - Per-domain status with days remaining
 - Add domain
 - Remove submenu
-- Refresh now
+- Refresh Now
+
+**Update interval:** 1 hour. Failed certificate checks retry after 5 minutes.
 
 **Preferences stored:** `domains` list (host, port)
 
@@ -908,7 +914,7 @@ Monitor certificate expiry for a list of domains. The shield color highlights th
 
 <img src="docking/assets/icons/applets/speedtest.png" alt="Speedtest" width="48">
 
-One-click internet speed test. The dial is painted as a classic four-band speedometer (red, orange, yellow, green from left to right); the needle points at the last download speed and takes its color from the current tier. The badge shows Mbps (e.g. `250M`, `1.2G`). Tooltip shows download, upload, ping, jitter, server, and timestamp.
+One-click internet speed test. The dial is painted as a classic four-band speedometer (red, orange, yellow, green from left to right); the needle points at the last download speed and takes its color from the current tier. The badge shows Mbps (e.g. `250Mb`, `1.2Gb`). Tooltip shows download, upload, ping, jitter, server, and timestamp.
 
 **Click:** Run one test (~20 seconds: ping + 10s download + 10s upload)
 
@@ -916,6 +922,8 @@ One-click internet speed test. The dial is painted as a classic four-band speedo
 - Summary header (Down / Up)
 - Run Test (disabled while running)
 - Copy Last Result (to clipboard)
+
+**Update interval:** Manual. Results update only when you run a test.
 
 **Preferences stored:** `last_result` (download_mbps, upload_mbps, ping_ms, jitter_ms, server, timestamp)
 
@@ -945,6 +953,8 @@ Shows NASA's Astronomy Picture of the Day as a dock thumbnail. The tooltip inclu
 - Open on apod.nasa.gov
 - Copy Explanation
 - Refresh Now
+
+**Update interval:** 1 hour. The applet fetches again when the APOD date changes and retries errors after 10 minutes.
 
 **Preferences stored:** `last_result` (date, title, explanation, media_type, image_url, page_url, copyright, cached_path)
 

--- a/docking/applets/aiusage/applet.py
+++ b/docking/applets/aiusage/applet.py
@@ -42,7 +42,7 @@ from docking.applets.aiusage.state import (
     week_tokens,
 )
 from docking.applets.base import Applet
-from docking.applets.menu import radio_menu_items
+from docking.applets.menu import menu_sections, radio_menu_items
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -151,42 +151,35 @@ class AiUsageApplet(Applet):
         self.present()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
-
-        items.extend(
-            radio_menu_items(
-                choices=(
-                    (_("Auto"), None),
-                    (_("Claude"), Provider.CLAUDE),
-                    (_("Codex"), Provider.CODEX),
-                    (_("OpenCode"), Provider.OPENCODE),
-                ),
-                active_value=self._selected_provider,
-                on_selected=lambda _widget, value: self._set_provider(provider=value),
-                gtk=Gtk,
-            )
+        provider_items = radio_menu_items(
+            choices=(
+                (_("Auto"), None),
+                (_("Claude"), Provider.CLAUDE),
+                (_("Codex"), Provider.CODEX),
+                (_("OpenCode"), Provider.OPENCODE),
+            ),
+            active_value=self._selected_provider,
+            on_selected=lambda _widget, value: self._set_provider(provider=value),
+            gtk=Gtk,
         )
 
-        items.append(Gtk.SeparatorMenuItem())
-
-        items.extend(
-            radio_menu_items(
-                choices=(
-                    (_("Show Cost"), DisplayMode.COST),
-                    (_("Show Tokens"), DisplayMode.TOKENS),
-                ),
-                active_value=self._display_mode,
-                on_selected=lambda _widget, value: self._set_display_mode(mode=value),
-                gtk=Gtk,
-            )
+        display_items = radio_menu_items(
+            choices=(
+                (_("Show Cost"), DisplayMode.COST),
+                (_("Show Tokens"), DisplayMode.TOKENS),
+            ),
+            active_value=self._display_mode,
+            on_selected=lambda _widget, value: self._set_display_mode(mode=value),
+            gtk=Gtk,
         )
-
-        items.append(Gtk.SeparatorMenuItem())
 
         mi = Gtk.MenuItem(label=_("Reset Today"))
         mi.connect("activate", lambda _w: self._reset_today())
-        items.append(mi)
-        return items
+        return menu_sections(
+            display=[*provider_items, Gtk.SeparatorMenuItem(), *display_items],
+            destructive=[mi],
+            gtk=Gtk,
+        )
 
     # ------------------------------------------------------------------
     # Internal

--- a/docking/applets/aiusage/state.py
+++ b/docking/applets/aiusage/state.py
@@ -10,6 +10,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from docking.applets.tooltip import structured_tooltip
 from docking.i18n import _
 from docking.log import get_logger
 
@@ -457,8 +458,14 @@ def tooltip_text(state: AiUsageState, provider: Provider | None = None) -> str:
         name = "AI Usage"
     sessions = today_sessions(state=state)
     if sessions == 0 and cost <= 0:
-        return _("{name}: no usage today").format(name=name)
-    return _("{name} today: {cost}").format(name=name, cost=_format_cost(cost=cost))
+        return structured_tooltip(
+            title=name,
+            primary=_("no usage today"),
+        )
+    return structured_tooltip(
+        title=name,
+        primary=_("Today: {cost}").format(cost=_format_cost(cost=cost)),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/docking/applets/ambient/applet.py
+++ b/docking/applets/ambient/applet.py
@@ -28,6 +28,7 @@ from docking.applets.ambient.state import (
     tooltip_text,
 )
 from docking.applets.base import Applet
+from docking.applets.menu import menu_sections
 from docking.i18n import _
 from docking.log import get_logger
 
@@ -135,7 +136,7 @@ class AmbientApplet(Applet):
         self.present()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        display: list[Gtk.MenuItem] = []
         for sound in ALL_SOUNDS:
             menu_item = Gtk.CheckMenuItem(label=sound.label)
             menu_item.set_active(
@@ -145,8 +146,8 @@ class AmbientApplet(Applet):
                 "toggled",
                 lambda _w, s=sound.name: self._select_sound(name=s),
             )
-            items.append(menu_item)
-        return items
+            display.append(menu_item)
+        return menu_sections(display=display, gtk=Gtk)
 
     def _select_sound(self, name: str) -> None:
         was_playing = self._state.playing

--- a/docking/applets/apod/applet.py
+++ b/docking/applets/apod/applet.py
@@ -25,6 +25,13 @@ from docking.applets.apod.state import (
     prefs_payload,
 )
 from docking.applets.base import Applet
+from docking.applets.freshness import cadence_label
+from docking.applets.live_state import (
+    live_state_error,
+    live_state_label,
+    resolve_live_status,
+)
+from docking.applets.menu import disabled_menu_item, menu_sections
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -53,6 +60,7 @@ class ApodApplet(Applet):
         self._retry_timer_id: int = 0
         self._startup_fetch_timer_id: int = 0
         self._fetch_request_id: int = 0
+        self._loading = False
         self._error: str | None = None
         self._worker = BackgroundWorker(logger=log)
 
@@ -66,41 +74,68 @@ class ApodApplet(Applet):
 
     def create_icon(self, size: int) -> GdkPixbuf.Pixbuf | None:
         cached = self._result.cached_path if self._result else ""
-        return render_icon(size=size, cached_path=cached)
+        return render_icon(size=size, cached_path=cached, warning=bool(self._error))
 
     def refresh_tooltip(self) -> None:
-        self.item.name = build_tooltip(result=self._result, error=self._error)
+        self.item.name = build_tooltip(
+            result=self._result,
+            error=self._error,
+            loading=self._loading,
+            cadence_seconds=REFRESH_CHECK_INTERVAL_S,
+        )
 
     def on_clicked(self) -> None:
         self._open_page()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        status: list[Gtk.MenuItem] = []
         if self._result is not None:
-            header = Gtk.MenuItem(
-                label=_("{date}: {title}").format(
-                    date=self._result.date,
-                    title=self._result.title or _("Untitled"),
+            status.append(
+                disabled_menu_item(
+                    _("{date}: {title}").format(
+                        date=self._result.date,
+                        title=self._result.title or _("Untitled"),
+                    ),
+                    gtk=Gtk,
                 )
             )
-            header.set_sensitive(False)
-            items.append(header)
-            items.append(Gtk.SeparatorMenuItem())
+            status.append(
+                disabled_menu_item(
+                    cadence_label(
+                        seconds=REFRESH_CHECK_INTERVAL_S,
+                        verb=_("Checks"),
+                    ),
+                    gtk=Gtk,
+                )
+            )
+        state_status = self._live_status()
+        state_label = live_state_label(state_status)
+        if state_label:
+            status.append(disabled_menu_item(state_label, gtk=Gtk))
+        error = live_state_error(status=state_status, error=self._error)
+        if error:
+            status.append(
+                disabled_menu_item(_("Error: {msg}").format(msg=error), gtk=Gtk)
+            )
 
         open_item = Gtk.MenuItem(label=_("Open on apod.nasa.gov"))
         open_item.connect("activate", lambda _w: self._open_page())
-        items.append(open_item)
+        primary = [open_item]
 
         if self._result is not None and self._result.explanation:
             copy_item = Gtk.MenuItem(label=_("Copy Explanation"))
             copy_item.connect("activate", lambda _w: self._copy_explanation())
-            items.append(copy_item)
+            primary.append(copy_item)
 
         refresh_item = Gtk.MenuItem(label=_("Refresh Now"))
         refresh_item.connect("activate", lambda _w: self._fetch_async())
-        items.append(refresh_item)
 
-        return items
+        return menu_sections(
+            status=status,
+            primary=primary,
+            refresh=[refresh_item],
+            gtk=Gtk,
+        )
 
     def start(self, notify: Callable[[], None]) -> None:
         super().start(notify=notify)
@@ -141,6 +176,9 @@ class ApodApplet(Applet):
             self._startup_fetch_timer_id = 0
         self._fetch_request_id += 1
         request_id = self._fetch_request_id
+        self._loading = True
+        self._error = None
+        self.present()
 
         self._worker.run(
             name="apod-fetch",
@@ -157,6 +195,7 @@ class ApodApplet(Applet):
     ) -> bool:
         if request_id != self._fetch_request_id:
             return False
+        self._loading = False
         if isinstance(result, ApodError):
             self._error = result.message
             self._schedule_retry()
@@ -170,6 +209,7 @@ class ApodApplet(Applet):
     def _on_fetch_error(self, *, request_id: int, exc: Exception) -> bool:
         if request_id != self._fetch_request_id:
             return False
+        self._loading = False
         self._error = str(exc) or exc.__class__.__name__
         log.bind(action="fetch_error").debug("APOD fetch crashed: %s", exc)
         self._schedule_retry()
@@ -204,3 +244,10 @@ class ApodApplet(Applet):
 
     def _save_prefs(self) -> None:
         self.save_prefs(prefs=prefs_payload(result=self._result))
+
+    def _live_status(self):
+        return resolve_live_status(
+            has_data=self._result is not None,
+            loading=self._loading,
+            error=self._error,
+        )

--- a/docking/applets/apod/render.py
+++ b/docking/applets/apod/render.py
@@ -124,6 +124,7 @@ def render_icon(
     *,
     size: int,
     cached_path: str,
+    warning: bool = False,
 ) -> GdkPixbuf.Pixbuf | None:
     """Render the thumbnail as a rounded-square icon."""
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, size, size)
@@ -135,6 +136,8 @@ def render_icon(
 
     if pixbuf is None:
         _draw_fallback(cr=cr, size=size)
+        if warning:
+            _draw_warning_badge(cr=cr, size=size)
         return Gdk.pixbuf_get_from_surface(surface, 0, 0, size, size)
 
     # Clip to a rounded square and paint the image edge-to-edge, no backdrop.
@@ -143,5 +146,21 @@ def render_icon(
     cr.clip()
     _paint_cover(cr=cr, pixbuf=pixbuf, size=size)
     cr.restore()
+    if warning:
+        _draw_warning_badge(cr=cr, size=size)
 
     return Gdk.pixbuf_get_from_surface(surface, 0, 0, size, size)
+
+
+def _draw_warning_badge(*, cr: cairo.Context, size: int) -> None:
+    cr.save()
+    radius = max(2.0, size * 0.08)
+    cx = size * 0.80
+    cy = size * 0.20
+    cr.arc(cx, cy, radius, 0, math.tau)
+    cr.set_source_rgba(0.95, 0.60, 0.22, 0.96)
+    cr.fill_preserve()
+    cr.set_line_width(max(0.8, size * 0.018))
+    cr.set_source_rgba(0, 0, 0, 0.44)
+    cr.stroke()
+    cr.restore()

--- a/docking/applets/apod/state.py
+++ b/docking/applets/apod/state.py
@@ -7,6 +7,15 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, NamedTuple
 
+from docking.applets.live_state import (
+    LiveDataStatus,
+    live_freshness_lines,
+    live_state_error,
+    live_state_label,
+    refresh_recovery_label,
+    resolve_live_status,
+)
+from docking.applets.tooltip import structured_tooltip
 from docking.i18n import _
 
 # Maximum characters per tooltip line. Chosen so the wrapped explanation
@@ -74,23 +83,50 @@ def format_explanation(
     )
 
 
-def build_tooltip(*, result: ApodResult | None, error: str | None) -> str:
-    lines = [_("Astronomy Picture of the Day")]
-    if error and result is None:
-        lines.append(_("Error: {msg}").format(msg=error))
-        return "\n".join(lines)
+def build_tooltip(
+    *,
+    result: ApodResult | None,
+    error: str | None,
+    loading: bool = False,
+    cadence_seconds: int | None = None,
+) -> str:
+    status = resolve_live_status(
+        has_data=result is not None,
+        loading=loading,
+        error=error,
+        stale_after_seconds=None,
+    )
     if result is None:
-        lines.append(_("Loading..."))
-        return "\n".join(lines)
-    lines.append(result.date)
+        return structured_tooltip(
+            title=_("Astronomy Picture of the Day"),
+            primary=live_state_label(status),
+            freshness=live_freshness_lines(
+                status=status,
+                cadence_seconds=cadence_seconds,
+                cadence_verb=_("Checks"),
+            ),
+            error=live_state_error(status=status, error=error),
+            recovery=refresh_recovery_label(status),
+        )
+    details = []
     if result.title:
-        lines.append(result.title)
+        details.append(result.title)
     if result.copyright:
-        lines.append(_("(c) {who}").format(who=result.copyright.strip()))
+        details.append(_("(c) {who}").format(who=result.copyright.strip()))
     if result.explanation:
-        lines.append("")
-        lines.append(format_explanation(result.explanation))
-    return "\n".join(lines)
+        details.append(format_explanation(result.explanation))
+    return structured_tooltip(
+        title=_("Astronomy Picture of the Day"),
+        primary=result.date,
+        details=details,
+        freshness=live_freshness_lines(
+            status=LiveDataStatus.STALE if error else LiveDataStatus.READY,
+            cadence_seconds=cadence_seconds,
+            cadence_verb=_("Checks"),
+        ),
+        error=live_state_error(status=status, error=error),
+        recovery=refresh_recovery_label(status),
+    )
 
 
 def prefs_from_mapping(prefs: Mapping[str, Any] | None) -> ApodPrefs:

--- a/docking/applets/battery/applet.py
+++ b/docking/applets/battery/applet.py
@@ -21,6 +21,7 @@ from docking.applets.battery.state import (
     read_battery,
     tooltip_text,
 )
+from docking.applets.menu import menu_sections
 from docking.i18n import _
 
 if TYPE_CHECKING:
@@ -68,18 +69,17 @@ class BatteryApplet(Applet):
         super().stop()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
         show = Gtk.CheckMenuItem(label=_("Show Percent"))
         show.set_active(self._show_percent)
         show.connect("toggled", self._on_toggle_percent)
-        items.append(show)
 
+        settings: list[Gtk.MenuItem] = []
         cmd = power_settings_command()
         if cmd is not None:
             power_settings = Gtk.MenuItem(label=_("Power Settings"))
             power_settings.connect("activate", lambda _widget: open_power_settings())
-            items.append(power_settings)
-        return items
+            settings.append(power_settings)
+        return menu_sections(display=[show], settings=settings, gtk=Gtk)
 
     def _on_toggle_percent(self, widget: Gtk.CheckMenuItem) -> None:
         self._show_percent = widget.get_active()

--- a/docking/applets/battery/state.py
+++ b/docking/applets/battery/state.py
@@ -9,10 +9,10 @@ from pathlib import Path
 from typing import NamedTuple
 
 from docking.i18n import _
-from docking.log import get_logger
+from docking.log import get_logger, with_context
 
 BAT_BASE = Path("/sys/class/power_supply")
-log = get_logger("battery.state")
+log = with_context(get_logger("battery.state"))
 
 
 class BatteryState(NamedTuple):

--- a/docking/applets/bluetooth/applet.py
+++ b/docking/applets/bluetooth/applet.py
@@ -23,7 +23,7 @@ from gi.repository import GLib, Gtk
 
 from docking.applets.base import Applet
 from docking.applets.bluetooth import meta
-from docking.applets.menu import radio_submenu
+from docking.applets.menu import disabled_menu_item, menu_sections, radio_submenu
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -165,20 +165,11 @@ class BluetoothApplet(Applet):
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         if not self._state.available:
-            placeholder = Gtk.MenuItem(label=_("Bluetooth unavailable"))
-            placeholder.set_sensitive(False)
-            return [placeholder]
+            return [disabled_menu_item(_("Bluetooth unavailable"), gtk=Gtk)]
 
-        items: list[Gtk.MenuItem] = []
         adapter = self._active_adapter()
         if adapter is None:
-            placeholder = Gtk.MenuItem(label=_("No Bluetooth adapter"))
-            placeholder.set_sensitive(False)
-            return [placeholder]
-
-        items.extend(self._build_quick_actions(adapter=adapter))
-        if items:
-            items.append(Gtk.SeparatorMenuItem())
+            return [disabled_menu_item(_("No Bluetooth adapter"), gtk=Gtk)]
 
         powered_label = _("On") if adapter.powered else _("Off")
         connected_devices = [
@@ -187,39 +178,49 @@ class BluetoothApplet(Applet):
             if d.adapter_path == adapter.path and d.connected
         ]
 
-        status = Gtk.MenuItem(
-            label=_("{alias} ({powered}) - Connected {connected}").format(
-                alias=adapter.alias,
-                powered=powered_label,
-                connected=len(connected_devices),
+        status = [
+            disabled_menu_item(
+                _("{alias} ({powered}) - Connected {connected}").format(
+                    alias=adapter.alias,
+                    powered=powered_label,
+                    connected=len(connected_devices),
+                ),
+                gtk=Gtk,
             )
-        )
-        status.set_sensitive(False)
-        items.append(status)
+        ]
+
+        primary, manage, settings = self._build_action_sections(adapter=adapter)
 
         discovery_toggle = Gtk.CheckMenuItem(label=_("Continuous Discovery"))
         discovery_toggle.set_active(self._continuous_discovery)
         discovery_toggle.connect("toggled", self._on_continuous_discovery_toggled)
-        items.append(discovery_toggle)
+        display: list[Gtk.MenuItem] = [discovery_toggle]
 
         if len(self._state.adapters) > 1:
-            items.append(self._build_adapter_submenu())
+            display.append(self._build_adapter_submenu())
 
-        items.append(Gtk.SeparatorMenuItem())
-        items.extend(self._build_devices_sections(adapter_path=adapter.path))
+        manage.extend(self._build_devices_sections(adapter_path=adapter.path))
 
         refresh_item = Gtk.MenuItem(label=_("Refresh Now"))
         refresh_item.connect("activate", lambda _w: self._refresh_now())
-        items.append(Gtk.SeparatorMenuItem())
-        items.append(refresh_item)
-        return items
+        return menu_sections(
+            status=status,
+            primary=primary,
+            refresh=[refresh_item],
+            display=display,
+            manage=manage,
+            settings=settings,
+            gtk=Gtk,
+        )
 
-    def _build_quick_actions(
+    def _build_action_sections(
         self,
         *,
         adapter: BluetoothAdapterState,
-    ) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+    ) -> tuple[list[Gtk.MenuItem], list[Gtk.MenuItem], list[Gtk.MenuItem]]:
+        primary: list[Gtk.MenuItem] = []
+        manage: list[Gtk.MenuItem] = []
+        settings: list[Gtk.MenuItem] = []
 
         power_label = (
             _("Turn Bluetooth Off") if adapter.powered else _("Turn Bluetooth On")
@@ -229,7 +230,7 @@ class BluetoothApplet(Applet):
             "activate",
             lambda _w: self._set_power_async(target=not adapter.powered),
         )
-        items.append(power_item)
+        primary.append(power_item)
 
         connected_devices = [
             d
@@ -248,35 +249,35 @@ class BluetoothApplet(Applet):
                     lambda: self._backend.disconnect_device(p)
                 ),
             )
-            items.append(disconnect_item)
+            primary.append(disconnect_item)
 
         send_cmd = send_files_command()
         if send_cmd is not None:
             send_item = Gtk.MenuItem(label=_("Send Files to Device..."))
             send_item.connect("activate", lambda _w: open_send_files())
-            items.append(send_item)
+            primary.append(send_item)
 
-        items.append(self._build_recent_connections_submenu(adapter_path=adapter.path))
+        manage.append(self._build_recent_connections_submenu(adapter_path=adapter.path))
 
         devices_cmd = devices_command()
         if devices_cmd is not None:
             devices_item = Gtk.MenuItem(label=_("Devices..."))
             devices_item.connect("activate", lambda _w: open_devices())
-            items.append(devices_item)
+            settings.append(devices_item)
 
         adapters_cmd = adapters_command()
         if adapters_cmd is not None:
             adapters_item = Gtk.MenuItem(label=_("Adapters..."))
             adapters_item.connect("activate", lambda _w: open_adapters())
-            items.append(adapters_item)
+            settings.append(adapters_item)
 
         services_cmd = local_services_command()
         if services_cmd is not None:
             services_item = Gtk.MenuItem(label=_("Local Services..."))
             services_item.connect("activate", lambda _w: open_local_services())
-            items.append(services_item)
+            settings.append(services_item)
 
-        return items
+        return primary, manage, settings
 
     def _build_recent_connections_submenu(self, *, adapter_path: str) -> Gtk.MenuItem:
         item = Gtk.MenuItem(label=_("Recent Connections"))

--- a/docking/applets/bookmarks/applet.py
+++ b/docking/applets/bookmarks/applet.py
@@ -20,6 +20,8 @@ from docking.applets.bookmarks.state import (
     tooltip_text,
     truncate_label,
 )
+from docking.applets.menu import menu_sections
+from docking.applets.popup import add_cancel_ok_buttons, prepare_dialog_content
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -31,7 +33,6 @@ log = with_context(get_logger(name="bookmarks"), applet_id=meta.id)
 ADD_DIALOG_WIDTH_PX = 350
 DIALOG_CONTENT_SPACING_PX = 8
 DIALOG_HORIZONTAL_MARGIN_PX = 12
-DIALOG_VERTICAL_MARGIN_PX = 8
 
 
 class BookmarksApplet(Applet):
@@ -60,7 +61,7 @@ class BookmarksApplet(Applet):
         self._open_url(url=self._bookmarks[0].url)
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        primary: list[Gtk.MenuItem] = []
 
         for bookmark in self._bookmarks:
             item = Gtk.MenuItem(label=truncate_label(text=bookmark.name))
@@ -68,21 +69,21 @@ class BookmarksApplet(Applet):
                 "activate",
                 lambda _w, url=bookmark.url: self._open_url(url=url),
             )
-            items.append(item)
-
-        if self._bookmarks:
-            items.append(Gtk.SeparatorMenuItem())
+            primary.append(item)
 
         add_item = Gtk.MenuItem(label=_("Add Bookmark..."))
         add_item.connect("activate", lambda _: self._show_add_dialog())
-        items.append(add_item)
 
         remove_all = Gtk.MenuItem(label=_("Remove All"))
         remove_all.connect("activate", lambda _: self._remove_all())
         remove_all.set_sensitive(bool(self._bookmarks))
-        items.append(remove_all)
 
-        return items
+        return menu_sections(
+            primary=primary,
+            manage=[add_item],
+            destructive=[remove_all],
+            gtk=Gtk,
+        )
 
     def _open_url(self, url: str) -> None:
         try:
@@ -97,31 +98,27 @@ class BookmarksApplet(Applet):
             title=_("Add Bookmark"),
             flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
         )
-        dialog.add_buttons(
-            Gtk.STOCK_CANCEL,
-            Gtk.ResponseType.CANCEL,
-            Gtk.STOCK_OK,
-            Gtk.ResponseType.OK,
+        add_cancel_ok_buttons(dialog=dialog)
+        box = prepare_dialog_content(
+            dialog=dialog,
+            width=ADD_DIALOG_WIDTH_PX,
+            spacing=DIALOG_CONTENT_SPACING_PX,
+            margin=DIALOG_HORIZONTAL_MARGIN_PX,
+            default_response=Gtk.ResponseType.OK,
         )
-        dialog.set_default_size(ADD_DIALOG_WIDTH_PX, -1)
-        dialog.set_position(Gtk.WindowPosition.MOUSE)
-
-        box = dialog.get_content_area()
-        box.set_spacing(DIALOG_CONTENT_SPACING_PX)
-        box.set_margin_start(DIALOG_HORIZONTAL_MARGIN_PX)
-        box.set_margin_end(DIALOG_HORIZONTAL_MARGIN_PX)
-        box.set_margin_top(DIALOG_VERTICAL_MARGIN_PX)
-        box.set_margin_bottom(DIALOG_VERTICAL_MARGIN_PX)
 
         name_entry = Gtk.Entry()
         name_entry.set_placeholder_text(_("Bookmark name"))
+        name_entry.set_activates_default(True)
         box.pack_start(name_entry, False, False, 0)
 
         url_entry = Gtk.Entry()
         url_entry.set_placeholder_text(_("https://..."))
+        url_entry.set_activates_default(True)
         box.pack_start(url_entry, False, False, 0)
 
         dialog.show_all()
+        name_entry.grab_focus()
 
         response = dialog.run()
         if response == Gtk.ResponseType.OK:

--- a/docking/applets/brightness/applet.py
+++ b/docking/applets/brightness/applet.py
@@ -19,6 +19,7 @@ from docking.applets.brightness.state import (
     get_brightness,
     set_brightness,
 )
+from docking.applets.menu import menu_sections
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -92,12 +93,10 @@ class BrightnessApplet(Applet):
             )
 
     def get_menu_items(self) -> list:
-        items = []
         show = Gtk.CheckMenuItem(label=_("Show Level"))
         show.set_active(self._show_level)
         show.connect("toggled", self._on_toggle_level)
-        items.append(show)
-        return items
+        return menu_sections(display=[show], gtk=Gtk)
 
     def _on_toggle_level(self, widget) -> None:
         self._show_level = widget.get_active()

--- a/docking/applets/calculator/applet.py
+++ b/docking/applets/calculator/applet.py
@@ -32,22 +32,19 @@ from typing import TYPE_CHECKING
 import gi
 
 gi.require_version("Gtk", "3.0")
-gi.require_version("Gdk", "3.0")
 gi.require_version("GdkPixbuf", "2.0")
-from gi.repository import Gdk, GdkPixbuf, Gtk
+from gi.repository import GdkPixbuf, Gtk
 
 from docking.applets.base import Applet
 from docking.applets.calculator import meta
 from docking.applets.calculator.render import create_icon
 from docking.applets.calculator.state import evaluate, prefs_payload
-from docking.applets.popup import wrap_popup
+from docking.applets.popup import create_popup_window, show_wrapped_popup
 from docking.i18n import _
-from docking.ui.display import get_pointer_position
 
 if TYPE_CHECKING:
     from docking.core.config import Config
 
-POPUP_CORNER_RADIUS_PX = 8
 POPUP_PADDING_PX = 10
 POPUP_CURSOR_GAP_PX = 20
 BUTTON_SPACING_PX = 4
@@ -99,42 +96,13 @@ class CalculatorApplet(Applet):
 
     def _show_popup(self) -> None:
         if self._popup is None:
-            self._popup = Gtk.Window(type=Gtk.WindowType.POPUP)
-            self._popup.set_decorated(False)
-            self._popup.set_skip_taskbar_hint(True)
-            self._popup.set_type_hint(Gdk.WindowTypeHint.TOOLTIP)
+            self._popup = create_popup_window()
 
-        child = self._popup.get_child()
-        if child:
-            self._popup.remove(child)
-
-        self._popup.add(wrap_popup(self._build_popup_content()))
-        self._popup.show_all()
-
-        # Position near mouse
-        display = Gdk.Display.get_default()
-        pos = get_pointer_position(display)
-        mouse_x = pos.x if pos is not None else 0
-        mouse_y = pos.y if pos is not None else 0
-
-        pref = self._popup.get_preferred_size()[1]
-        popup_w = max(pref.width, 1)
-        popup_h = max(pref.height, 1)
-
-        screen = self._popup.get_screen()
-        screen_w = screen.get_width()
-        screen_h = screen.get_height()
-
-        popup_x = max(0, min(int(mouse_x - popup_w / 2), screen_w - popup_w))
-        popup_y = max(
-            0,
-            min(
-                int(mouse_y - popup_h - POPUP_CURSOR_GAP_PX),
-                screen_h - popup_h,
-            ),
+        show_wrapped_popup(
+            window=self._popup,
+            content=self._build_popup_content(),
+            gap_px=POPUP_CURSOR_GAP_PX,
         )
-
-        self._popup.move(popup_x, popup_y)
 
     def _build_popup_content(self) -> Gtk.Box:
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=BUTTON_SPACING_PX)

--- a/docking/applets/calendar/applet.py
+++ b/docking/applets/calendar/applet.py
@@ -8,17 +8,15 @@ from typing import TYPE_CHECKING
 import gi
 
 gi.require_version("Gtk", "3.0")
-gi.require_version("Gdk", "3.0")
 gi.require_version("GdkPixbuf", "2.0")
-from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
+from gi.repository import GdkPixbuf, GLib, Gtk
 
 from docking.applets.base import Applet
 from docking.applets.calendar import meta
 from docking.applets.calendar.render import render_icon
 from docking.applets.calendar.state import snapshot_from
-from docking.applets.popup import wrap_popup
+from docking.applets.popup import create_popup_window, show_wrapped_popup
 from docking.i18n import _
-from docking.ui.display import get_pointer_position
 
 if TYPE_CHECKING:
     from docking.core.config import Config
@@ -82,45 +80,15 @@ class CalendarApplet(Applet):
 
     def _show_popup(self) -> None:
         if self._popup is None:
-            self._popup = Gtk.Window(type=Gtk.WindowType.POPUP)
-            self._popup.set_decorated(False)
-            self._popup.set_skip_taskbar_hint(True)
-            self._popup.set_type_hint(Gdk.WindowTypeHint.TOOLTIP)
-
-        child = self._popup.get_child()
-        if child:
-            self._popup.remove(child)
+            self._popup = create_popup_window()
 
         calendar = Gtk.Calendar()
         calendar.set_margin_start(CALENDAR_POPUP_PADDING_PX)
         calendar.set_margin_end(CALENDAR_POPUP_PADDING_PX)
         calendar.set_margin_top(CALENDAR_POPUP_PADDING_PX)
         calendar.set_margin_bottom(CALENDAR_POPUP_PADDING_PX)
-        self._popup.add(wrap_popup(calendar))
-
-        self._popup.show_all()
-
-        # Position near mouse
-        display = Gdk.Display.get_default()
-        pos = get_pointer_position(display)
-        mouse_x = pos.x if pos is not None else 0
-        mouse_y = pos.y if pos is not None else 0
-
-        pref = self._popup.get_preferred_size()[1]
-        popup_w = max(pref.width, 1)
-        popup_h = max(pref.height, 1)
-
-        screen = self._popup.get_screen()
-        screen_w = screen.get_width()
-        screen_h = screen.get_height()
-
-        popup_x = max(0, min(int(mouse_x - popup_w / 2), screen_w - popup_w))
-        popup_y = max(
-            0,
-            min(
-                int(mouse_y - popup_h - CALENDAR_POPUP_CURSOR_GAP_PX),
-                screen_h - popup_h,
-            ),
+        show_wrapped_popup(
+            window=self._popup,
+            content=calendar,
+            gap_px=CALENDAR_POPUP_CURSOR_GAP_PX,
         )
-
-        self._popup.move(popup_x, popup_y)

--- a/docking/applets/camshield/applet.py
+++ b/docking/applets/camshield/applet.py
@@ -26,6 +26,7 @@ from docking.applets.camshield.state import (
     holder_label,
     probe_camera_state,
 )
+from docking.applets.menu import disabled_menu_item, menu_sections
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -87,45 +88,37 @@ class CamshieldApplet(Applet):
         super().stop()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        status: list[Gtk.MenuItem] = []
         if not self._state.available:
-            placeholder = Gtk.MenuItem(label=_("No camera devices found"))
-            placeholder.set_sensitive(False)
-            items.append(placeholder)
+            status.append(disabled_menu_item(_("No camera devices found"), gtk=Gtk))
         elif not self._state.active:
-            placeholder = Gtk.MenuItem(label=_("Camera idle"))
-            placeholder.set_sensitive(False)
-            items.append(placeholder)
+            status.append(disabled_menu_item(_("Camera idle"), gtk=Gtk))
         else:
-            header = Gtk.MenuItem(label=_("Camera active"))
-            header.set_sensitive(False)
-            items.append(header)
+            status.append(disabled_menu_item(_("Camera active"), gtk=Gtk))
             for holder in self._state.holders:
-                item = Gtk.MenuItem(label=holder_label(holder))
-                item.set_sensitive(False)
-                items.append(item)
+                status.append(disabled_menu_item(holder_label(holder), gtk=Gtk))
 
-        items.append(Gtk.SeparatorMenuItem())
         lock = Gtk.MenuItem(label=_("Lock Camera"))
         lock.set_sensitive(self._helper_available())
         lock.connect("activate", lambda _w: self._run_helper_action("lock"))
-        items.append(lock)
 
         unlock = Gtk.MenuItem(label=_("Unlock Camera"))
         unlock.set_sensitive(self._helper_available())
         unlock.connect("activate", lambda _w: self._run_helper_action("unlock"))
-        items.append(unlock)
 
         if not self._helper_available():
-            unavailable = Gtk.MenuItem(label=_("Camera lock helper unavailable"))
-            unavailable.set_sensitive(False)
-            items.append(unavailable)
+            status.append(
+                disabled_menu_item(_("Camera lock helper unavailable"), gtk=Gtk)
+            )
 
-        items.append(Gtk.SeparatorMenuItem())
         refresh = Gtk.MenuItem(label=_("Refresh Now"))
         refresh.connect("activate", lambda _w: self._refresh_now())
-        items.append(refresh)
-        return items
+        return menu_sections(
+            status=status,
+            primary=[lock, unlock],
+            refresh=[refresh],
+            gtk=Gtk,
+        )
 
     def _refresh_once(self) -> bool:
         self._refresh_now()

--- a/docking/applets/capslock/applet.py
+++ b/docking/applets/capslock/applet.py
@@ -21,6 +21,7 @@ from docking.applets.capslock.state import (
     query_lock_state,
     tooltip_text,
 )
+from docking.applets.menu import disabled_menu_item, menu_sections
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -63,24 +64,26 @@ class CapslockApplet(Applet):
         self._refresh_now()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        status: list[Gtk.MenuItem] = []
         if not self._state.available:
-            unavailable = Gtk.MenuItem(label=_("Keyboard lock state unavailable"))
-            unavailable.set_sensitive(False)
-            items.append(unavailable)
+            status.append(
+                disabled_menu_item(_("Keyboard lock state unavailable"), gtk=Gtk)
+            )
         else:
-            caps = Gtk.MenuItem(label=menu_label(_("Caps Lock"), self._state.caps_lock))
-            caps.set_sensitive(False)
-            items.append(caps)
-            num = Gtk.MenuItem(label=menu_label(_("Num Lock"), self._state.num_lock))
-            num.set_sensitive(False)
-            items.append(num)
+            status.append(
+                disabled_menu_item(
+                    menu_label(_("Caps Lock"), self._state.caps_lock), gtk=Gtk
+                )
+            )
+            status.append(
+                disabled_menu_item(
+                    menu_label(_("Num Lock"), self._state.num_lock), gtk=Gtk
+                )
+            )
 
-        items.append(Gtk.SeparatorMenuItem())
         refresh = Gtk.MenuItem(label=_("Refresh Now"))
         refresh.connect("activate", lambda _w: self._refresh_now())
-        items.append(refresh)
-        return items
+        return menu_sections(status=status, refresh=[refresh], gtk=Gtk)
 
     def _refresh_now(self) -> None:
         self._state = query_lock_state()

--- a/docking/applets/capslock/state.py
+++ b/docking/applets/capslock/state.py
@@ -12,8 +12,7 @@ from docking.i18n import _
 POLL_INTERVAL_S = 1
 
 _INDICATOR_RE = re.compile(
-    r"\b(?P<index>\d+):\s*(?P<name>Caps Lock|Num Lock):\s*"
-    r"(?P<state>on|off)\b",
+    r"\b(?P<index>\d+):\s*(?P<name>Caps Lock|Num Lock):\s*(?P<state>on|off)\b",
     re.IGNORECASE,
 )
 

--- a/docking/applets/certwatch/api.py
+++ b/docking/applets/certwatch/api.py
@@ -107,7 +107,7 @@ def fetch_cert(
             not_after=None,
             subject="",
             issuer="",
-            error=f"verify failed: {exc.verify_message or exc}",
+            error=f"verify failed: {getattr(exc, 'verify_message', None) or exc}",
         )
     except TimeoutError:
         return CertInfo(

--- a/docking/applets/certwatch/applet.py
+++ b/docking/applets/certwatch/applet.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -29,6 +30,14 @@ from docking.applets.certwatch.state import (
     tooltip_line,
     worst_status,
 )
+from docking.applets.freshness import cadence_label
+from docking.applets.live_state import (
+    live_state_error,
+    live_state_label,
+    resolve_live_status,
+)
+from docking.applets.menu import disabled_menu_item, menu_sections
+from docking.applets.popup import add_cancel_ok_buttons, prepare_dialog_content
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -45,7 +54,6 @@ STARTUP_FETCH_DELAY_S = 2
 ADD_DIALOG_WIDTH_PX = 350
 DIALOG_CONTENT_SPACING_PX = 8
 DIALOG_HORIZONTAL_MARGIN_PX = 12
-DIALOG_VERTICAL_MARGIN_PX = 8
 
 
 class CertwatchApplet(Applet):
@@ -60,6 +68,9 @@ class CertwatchApplet(Applet):
         self._startup_fetch_timer_id: int = 0
         self._retry_timer_id: int = 0
         self._fetch_request_id: int = 0
+        self._last_updated: dt.datetime | None = None
+        self._loading = False
+        self._fetch_error = ""
         self._worker = BackgroundWorker(logger=log)
 
         prefs = prefs_from_mapping(
@@ -73,21 +84,29 @@ class CertwatchApplet(Applet):
 
     def create_icon(self, size: int) -> GdkPixbuf.Pixbuf | None:
         certs = self._current_certs()
-        status = worst_status(certs) if self._domains else CertStatus.UNKNOWN
-        label = icon_label(certs) if self._domains else ""
+        if self._domains and self._fetch_error and not certs:
+            status = CertStatus.ERROR
+            label = "!"
+        else:
+            status = worst_status(certs) if self._domains else CertStatus.UNKNOWN
+            label = icon_label(certs) if self._domains else ""
         return render_icon(size=size, status=status, label=label)
 
     def refresh_tooltip(self) -> None:
         self.item.name = build_tooltip(
             domains=self._domains,
             certs=self._current_certs(),
+            loading=self._loading,
+            error=self._fetch_error,
+            updated_at=self._last_updated,
+            cadence_seconds=REFRESH_INTERVAL_S if self._domains else None,
         )
 
     def on_clicked(self) -> None:
         self._show_add_dialog()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        status: list[Gtk.MenuItem] = []
 
         if self._domains:
             for pref in self._domains:
@@ -97,16 +116,36 @@ class CertwatchApplet(Applet):
                     if cert is not None
                     else _("{host}: loading...").format(host=format_host(pref))
                 )
-                row = Gtk.MenuItem(label=label)
-                row.set_sensitive(False)
-                items.append(row)
-            items.append(Gtk.SeparatorMenuItem())
+                status.append(disabled_menu_item(label, gtk=Gtk))
+            state_status = self._live_status()
+            state_label = live_state_label(state_status)
+            if state_label:
+                status.append(disabled_menu_item(state_label, gtk=Gtk))
+            error = live_state_error(status=state_status, error=self._fetch_error)
+            if error:
+                status.append(
+                    disabled_menu_item(
+                        _("Error: {msg}").format(msg=error),
+                        gtk=Gtk,
+                    )
+                )
+            status.append(
+                disabled_menu_item(
+                    cadence_label(seconds=REFRESH_INTERVAL_S, verb=_("Checks")),
+                    gtk=Gtk,
+                )
+            )
 
         add_item = Gtk.MenuItem(label=_("Add Domain..."))
         add_item.connect("activate", lambda _w: self._show_add_dialog())
-        items.append(add_item)
 
+        refresh: list[Gtk.MenuItem] = []
+        destructive: list[Gtk.MenuItem] = []
         if self._domains:
+            refresh_item = Gtk.MenuItem(label=_("Refresh Now"))
+            refresh_item.connect("activate", lambda _w: self._fetch_all())
+            refresh.append(refresh_item)
+
             remove_menu = Gtk.Menu()
             for pref in self._domains:
                 entry = Gtk.MenuItem(label=format_host(pref))
@@ -117,13 +156,15 @@ class CertwatchApplet(Applet):
                 remove_menu.append(entry)
             remove_root = Gtk.MenuItem(label=_("Remove"))
             remove_root.set_submenu(remove_menu)
-            items.append(remove_root)
+            destructive.append(remove_root)
 
-            refresh = Gtk.MenuItem(label=_("Refresh Now"))
-            refresh.connect("activate", lambda _w: self._fetch_all())
-            items.append(refresh)
-
-        return items
+        return menu_sections(
+            status=status,
+            refresh=refresh,
+            manage=[add_item],
+            destructive=destructive,
+            gtk=Gtk,
+        )
 
     def start(self, notify: Callable[[], None]) -> None:
         super().start(notify=notify)
@@ -173,6 +214,9 @@ class CertwatchApplet(Applet):
         self._fetch_request_id += 1
         request_id = self._fetch_request_id
         targets = tuple(self._domains)
+        self._loading = not self._current_certs()
+        self._fetch_error = ""
+        self.present()
 
         def fetch() -> list[CertInfo]:
             return [fetch_cert(host=d.host, port=d.port) for d in targets]
@@ -189,8 +233,11 @@ class CertwatchApplet(Applet):
     def _on_fetch_result(self, *, request_id: int, certs: list[CertInfo]) -> bool:
         if request_id != self._fetch_request_id:
             return False
+        self._loading = False
+        self._fetch_error = ""
         for cert in certs:
             self._certs[(cert.host, cert.port)] = cert
+        self._last_updated = dt.datetime.now(dt.timezone.utc)
         self._prune_stale_certs()
         self._log_critical(certs=certs)
         self._schedule_retry_if_any_error(certs=certs)
@@ -200,7 +247,15 @@ class CertwatchApplet(Applet):
     def _on_fetch_error(self, *, request_id: int, exc: Exception) -> bool:
         if request_id != self._fetch_request_id:
             return False
+        self._loading = False
+        self._fetch_error = str(exc) or exc.__class__.__name__
         log.bind(action="fetch_error").debug("Cert fetch failed: %s", exc)
+        if not self._retry_timer_id:
+            self._retry_timer_id = GLib.timeout_add_seconds(
+                RETRY_ON_ERROR_S,
+                self._run_retry,
+            )
+        self.present()
         return False
 
     def _schedule_retry_if_any_error(self, *, certs: list[CertInfo]) -> None:
@@ -238,29 +293,22 @@ class CertwatchApplet(Applet):
             title=_("Add Domain"),
             flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
         )
-        dialog.add_buttons(
-            Gtk.STOCK_CANCEL,
-            Gtk.ResponseType.CANCEL,
-            Gtk.STOCK_OK,
-            Gtk.ResponseType.OK,
+        add_cancel_ok_buttons(dialog=dialog)
+        box = prepare_dialog_content(
+            dialog=dialog,
+            width=ADD_DIALOG_WIDTH_PX,
+            spacing=DIALOG_CONTENT_SPACING_PX,
+            margin=DIALOG_HORIZONTAL_MARGIN_PX,
+            default_response=Gtk.ResponseType.OK,
         )
-        dialog.set_default_size(ADD_DIALOG_WIDTH_PX, -1)
-        dialog.set_position(Gtk.WindowPosition.MOUSE)
-
-        box = dialog.get_content_area()
-        box.set_spacing(DIALOG_CONTENT_SPACING_PX)
-        box.set_margin_start(DIALOG_HORIZONTAL_MARGIN_PX)
-        box.set_margin_end(DIALOG_HORIZONTAL_MARGIN_PX)
-        box.set_margin_top(DIALOG_VERTICAL_MARGIN_PX)
-        box.set_margin_bottom(DIALOG_VERTICAL_MARGIN_PX)
 
         entry = Gtk.Entry()
         entry.set_placeholder_text(_("example.com or example.com:8443"))
         entry.set_activates_default(True)
         box.pack_start(entry, False, False, 0)
 
-        dialog.set_default_response(Gtk.ResponseType.OK)
         dialog.show_all()
+        entry.grab_focus()
 
         response = dialog.run()
         if response == Gtk.ResponseType.OK:
@@ -289,3 +337,12 @@ class CertwatchApplet(Applet):
 
     def _save_prefs(self) -> None:
         self.save_prefs(prefs=prefs_payload(domains=self._domains))
+
+    def _live_status(self):
+        return resolve_live_status(
+            has_data=bool(self._current_certs()),
+            loading=self._loading,
+            error=self._fetch_error,
+            updated_at=self._last_updated,
+            stale_after_seconds=REFRESH_INTERVAL_S * 2,
+        )

--- a/docking/applets/certwatch/state.py
+++ b/docking/applets/certwatch/state.py
@@ -8,6 +8,14 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, NamedTuple
 
+from docking.applets.live_state import (
+    live_freshness_lines,
+    live_state_error,
+    live_state_label,
+    refresh_recovery_label,
+    resolve_live_status,
+)
+from docking.applets.tooltip import structured_tooltip
 from docking.i18n import _
 
 DEFAULT_HTTPS_PORT = 443
@@ -257,19 +265,52 @@ def build_tooltip(
     *,
     domains: Iterable[DomainPref],
     certs: Iterable[CertInfo],
+    loading: bool = False,
+    error: str | None = None,
     now: datetime | None = None,
+    updated_at: object | None = None,
+    cadence_seconds: int | None = None,
 ) -> str:
     """Full tooltip text: header + one line per domain."""
     domain_list = list(domains)
     if not domain_list:
-        return _("Cert Watch (no domains configured)")
+        return structured_tooltip(
+            title=_("Cert Watch"),
+            primary=_("No domains configured"),
+        )
 
     cert_map = {(c.host, c.port): c for c in certs}
-    lines = [_("Cert Watch")]
+    has_data = bool(cert_map)
+    status = resolve_live_status(
+        has_data=has_data,
+        loading=loading,
+        error=error,
+        updated_at=updated_at,
+        stale_after_seconds=cadence_seconds * 2 if cadence_seconds else None,
+        now=now,
+    )
+    details = []
     for pref in domain_list:
         cert = cert_map.get((pref.host, pref.port))
         if cert is None:
-            lines.append(_("{host}: loading...").format(host=format_host(pref)))
+            if error and not loading:
+                details.append(_("{host}: unavailable").format(host=format_host(pref)))
+            else:
+                details.append(_("{host}: loading...").format(host=format_host(pref)))
         else:
-            lines.append(tooltip_line(cert=cert, now=now))
-    return "\n".join(lines)
+            details.append(tooltip_line(cert=cert, now=now))
+    state_label = live_state_label(status)
+    if state_label and has_data:
+        details.append(state_label)
+    return structured_tooltip(
+        title=_("Cert Watch"),
+        details=details,
+        freshness=live_freshness_lines(
+            status=status,
+            updated_at=updated_at,
+            cadence_seconds=cadence_seconds,
+            cadence_verb=_("Checks"),
+        ),
+        error=live_state_error(status=status, error=error),
+        recovery=refresh_recovery_label(status),
+    )

--- a/docking/applets/clippy/applet.py
+++ b/docking/applets/clippy/applet.py
@@ -21,6 +21,7 @@ from docking.applets.clippy.state import (
     cycle_position,
     tooltip_text,
 )
+from docking.applets.menu import menu_sections
 from docking.i18n import _
 
 if TYPE_CHECKING:
@@ -79,7 +80,7 @@ class ClippyApplet(Applet):
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         """List all clips (newest first) + Clear button."""
-        items: list[Gtk.MenuItem] = []
+        primary: list[Gtk.MenuItem] = []
 
         for clip in reversed(self._clips):
             menu_item = Gtk.MenuItem(label=_truncate(clip))
@@ -87,15 +88,15 @@ class ClippyApplet(Applet):
                 "activate",
                 lambda _, t=clip: self._copy_to_clipboard(text=t),
             )
-            items.append(menu_item)
+            primary.append(menu_item)
 
+        destructive: list[Gtk.MenuItem] = []
         if self._clips:
-            items.append(Gtk.SeparatorMenuItem())
             clear = Gtk.MenuItem(label=_("Clear"))
             clear.connect("activate", lambda _: self._clear())
-            items.append(clear)
+            destructive.append(clear)
 
-        return items
+        return menu_sections(primary=primary, destructive=destructive, gtk=Gtk)
 
     def start(self, notify: Callable[[], None]) -> None:
         """Connect to clipboard owner-change signal."""

--- a/docking/applets/clock/applet.py
+++ b/docking/applets/clock/applet.py
@@ -22,6 +22,8 @@ from docking.applets.clock.state import (
     load_prefs,
     save_payload,
 )
+from docking.applets.menu import menu_sections
+from docking.applets.popup import add_cancel_ok_buttons, prepare_dialog_content
 from docking.i18n import _
 
 if TYPE_CHECKING:
@@ -82,46 +84,44 @@ class ClockApplet(Applet):
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         """Clock display, seconds, and one-shot alarm controls."""
-        items: list[Gtk.MenuItem] = []
-
         digital = Gtk.CheckMenuItem(label=_("Digital Clock"))
         digital.set_active(self._show_digital)
         digital.connect("toggled", self._on_toggle_digital)
-        items.append(digital)
 
         military = Gtk.CheckMenuItem(label=_("24-Hour Clock"))
         military.set_active(self._show_military)
         military.connect("toggled", self._on_toggle_military)
-        items.append(military)
 
         date = Gtk.CheckMenuItem(label=_("Show Date"))
         date.set_active(self._show_date)
         date.set_sensitive(self._show_digital)
         date.connect("toggled", self._on_toggle_date)
-        items.append(date)
 
         seconds = Gtk.CheckMenuItem(label=_("Show Seconds"))
         seconds.set_active(self._show_seconds)
         seconds.connect("toggled", self._on_toggle_seconds)
-        items.append(seconds)
-
-        items.append(Gtk.SeparatorMenuItem())
 
         set_alarm = Gtk.MenuItem(label=_("Set Alarm..."))
         set_alarm.connect("activate", lambda _w: self._show_alarm_dialog())
-        items.append(set_alarm)
+        manage = [set_alarm]
 
+        destructive: list[Gtk.MenuItem] = []
         if self._alarm_target is not None:
             clear_alarm = Gtk.MenuItem(label=_("Clear Alarm"))
             clear_alarm.connect("activate", lambda _w: self._clear_alarm())
-            items.append(clear_alarm)
+            destructive.append(clear_alarm)
 
         if self.item.is_urgent:
             acknowledge = Gtk.MenuItem(label=_("Acknowledge Alarm"))
             acknowledge.connect("activate", lambda _w: self._acknowledge_alarm())
-            items.append(acknowledge)
+            manage.append(acknowledge)
 
-        return items
+        return menu_sections(
+            display=[digital, military, date, seconds],
+            manage=manage,
+            destructive=destructive,
+            gtk=Gtk,
+        )
 
     def _on_toggle_digital(self, widget: Gtk.CheckMenuItem) -> None:
         self._show_digital = widget.get_active()
@@ -202,16 +202,13 @@ class ClockApplet(Applet):
             title=_("Set Alarm"),
             flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
         )
-        dialog.set_position(Gtk.WindowPosition.MOUSE)
-        dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
-        dialog.add_button(_("OK"), Gtk.ResponseType.OK)
-
-        content = dialog.get_content_area()
-        content.set_spacing(ALARM_DIALOG_CONTENT_SPACING_PX)
-        content.set_margin_start(ALARM_DIALOG_MARGIN_PX)
-        content.set_margin_end(ALARM_DIALOG_MARGIN_PX)
-        content.set_margin_top(ALARM_DIALOG_MARGIN_PX)
-        content.set_margin_bottom(ALARM_DIALOG_MARGIN_PX)
+        add_cancel_ok_buttons(dialog=dialog, ok_label=_("OK"), cancel_label=_("Cancel"))
+        content = prepare_dialog_content(
+            dialog=dialog,
+            spacing=ALARM_DIALOG_CONTENT_SPACING_PX,
+            margin=ALARM_DIALOG_MARGIN_PX,
+            default_response=Gtk.ResponseType.OK,
+        )
 
         current = time.localtime(self._alarm_target or (time.time() + 60))
 
@@ -257,6 +254,7 @@ class ClockApplet(Applet):
 
         dialog.connect("response", on_response)
         dialog.show_all()
+        hour_spin.grab_focus()
 
     def _set_alarm(self, *, hour: int, minute: int) -> None:
         self._alarm_target = compute_alarm_target(

--- a/docking/applets/colorpicker/applet.py
+++ b/docking/applets/colorpicker/applet.py
@@ -14,6 +14,12 @@ from docking.applets.base import Applet
 from docking.applets.colorpicker import meta
 from docking.applets.colorpicker.render import create_icon
 from docking.applets.colorpicker.state import pick_pixel, rgb_to_hex
+from docking.applets.menu import menu_sections
+from docking.applets.popup import (
+    create_capture_overlay,
+    dismiss_capture_overlay,
+    draw_transparent_capture_overlay,
+)
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -73,19 +79,18 @@ class ColorPickerApplet(Applet):
         self._start_pick()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        primary: list[Gtk.MenuItem] = []
 
         if self._hex:
             copy = Gtk.MenuItem(label=_("Copy {hex}").format(hex=self._hex))
             copy.connect("activate", lambda _: self._copy_to_clipboard())
-            items.append(copy)
+            primary.append(copy)
 
         show = Gtk.CheckMenuItem(label=_("Show Hex"))
         show.set_active(self._show_hex)
         show.connect("toggled", self._on_toggle_hex)
-        items.append(show)
 
-        return items
+        return menu_sections(primary=primary, display=[show], gtk=Gtk)
 
     def _on_toggle_hex(self, widget: Gtk.CheckMenuItem) -> None:
         self._show_hex = widget.get_active()
@@ -97,51 +102,16 @@ class ColorPickerApplet(Applet):
         if self._overlay:
             return
 
-        # POPUP bypasses WM decoration and focus stealing prevention
-        overlay = Gtk.Window(type=Gtk.WindowType.POPUP)
-        overlay.set_decorated(False)
-        overlay.set_app_paintable(True)
-
-        screen = overlay.get_screen()
-        visual = screen.get_rgba_visual()
-        if visual:
-            overlay.set_visual(visual)
-
-        overlay.set_default_size(screen.get_width(), screen.get_height())
-        overlay.move(0, 0)
-
-        # Transparent background
-        overlay.connect("draw", self._on_overlay_draw)
-        overlay.set_events(Gdk.EventMask.BUTTON_PRESS_MASK)
-        overlay.connect("button-press-event", self._on_overlay_click)
-        overlay.connect("key-press-event", self._on_overlay_key)
-
-        # Crosshair cursor
-        display = Gdk.Display.get_default()
-        crosshair = Gdk.Cursor.new_for_display(display, Gdk.CursorType.CROSSHAIR)
-
-        overlay.show_all()
-        overlay.get_window().set_cursor(crosshair)
-
-        # Grab pointer so click goes to overlay
-        seat = display.get_default_seat()
-        seat.grab(
-            overlay.get_window(),
-            Gdk.SeatCapabilities.ALL_POINTING | Gdk.SeatCapabilities.KEYBOARD,
-            True,
-            crosshair,
-            None,
-            None,
-            None,
+        self._overlay = create_capture_overlay(
+            draw_handler=self._on_overlay_draw,
+            click_handler=self._on_overlay_click,
+            key_handler=self._on_overlay_key,
+            cursor_type=Gdk.CursorType.CROSSHAIR,
         )
-
-        self._overlay = overlay
 
     @staticmethod
     def _on_overlay_draw(widget: Gtk.Window, cr) -> bool:
-        cr.set_source_rgba(0, 0, 0, 0.01)  # near-transparent
-        cr.paint()
-        return True
+        return draw_transparent_capture_overlay(widget, cr)
 
     def _on_overlay_click(self, _widget: Gtk.Window, event: Gdk.EventButton) -> bool:
         """Sample pixel at click position."""
@@ -168,10 +138,7 @@ class ColorPickerApplet(Applet):
 
     def _dismiss_overlay(self) -> None:
         if self._overlay:
-            display = Gdk.Display.get_default()
-            seat = display.get_default_seat()
-            seat.ungrab()
-            self._overlay.destroy()
+            dismiss_capture_overlay(self._overlay)
             self._overlay = None
 
     def _copy_to_clipboard(self) -> None:

--- a/docking/applets/currencyfx/applet.py
+++ b/docking/applets/currencyfx/applet.py
@@ -48,7 +48,14 @@ from docking.applets.currencyfx.state import (
     prefs_from_mapping,
     prefs_payload,
 )
-from docking.applets.menu import radio_submenu
+from docking.applets.freshness import cadence_label
+from docking.applets.live_state import (
+    live_state_error,
+    live_state_label,
+    resolve_live_status,
+)
+from docking.applets.menu import disabled_menu_item, menu_sections, radio_submenu
+from docking.applets.popup import add_cancel_ok_buttons, prepare_dialog_content
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -90,7 +97,9 @@ class CurrencyFxApplet(Applet):
         self._pulse_phase: float = 0.0
         self._fetch_request_id: int = 0
         self._snapshot: FxSnapshot | None = None
+        self._loading = False
         self._fetch_failed = False
+        self._fetch_error = ""
         self._worker = BackgroundWorker(logger=log)
 
         raw_prefs = config.applet_prefs.get(meta.id, {}) if config else None
@@ -136,7 +145,11 @@ class CurrencyFxApplet(Applet):
             base=self._base,
             quote=self._quote,
             snapshot=self._snapshot,
+            loading=self._loading,
             fetch_failed=self._fetch_failed,
+            error=self._fetch_error,
+            chart_interval=self._chart_interval,
+            cadence_seconds=REFRESH_INTERVAL_S,
         )
 
     def on_clicked(self) -> None:
@@ -152,25 +165,34 @@ class CurrencyFxApplet(Applet):
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         """Build the right-click menu for all Currency FX controls."""
-        items: list[Gtk.MenuItem] = []
+        status: list[Gtk.MenuItem] = [disabled_menu_item(self._menu_header(), gtk=Gtk)]
+        verb = _("Day samples") if self._chart_interval == ChartInterval.DAY else None
+        status.append(
+            disabled_menu_item(
+                cadence_label(seconds=REFRESH_INTERVAL_S, verb=verb),
+                gtk=Gtk,
+            )
+        )
+        state_status = self._live_status()
+        state_label = live_state_label(state_status)
+        if state_label:
+            status.append(disabled_menu_item(state_label, gtk=Gtk))
+        error = live_state_error(status=state_status, error=self._fetch_error)
+        if error:
+            status.append(
+                disabled_menu_item(_("Error: {msg}").format(msg=error), gtk=Gtk)
+            )
 
-        header = Gtk.MenuItem(label=self._menu_header())
-        header.set_sensitive(False)
-        items.append(header)
+        navigation: list[Gtk.MenuItem] = []
+        swap = Gtk.MenuItem(label=_("Swap Pair"))
+        swap.connect("activate", lambda _w: self._add_pair(self._quote, self._base))
+        navigation.append(swap)
 
         refresh = Gtk.MenuItem(label=_("Refresh Now"))
         refresh.connect("activate", lambda _w: self._fetch_async())
-        items.append(refresh)
+        refresh_items = [refresh]
 
-        swap = Gtk.MenuItem(label=_("Swap Pair"))
-        swap.connect("activate", lambda _w: self._add_pair(self._quote, self._base))
-        items.append(swap)
-
-        choose = Gtk.MenuItem(label=_("Add Pair..."))
-        choose.connect("activate", lambda _w: self._show_pair_dialog())
-        items.append(choose)
-
-        items.append(
+        display: list[Gtk.MenuItem] = [
             radio_submenu(
                 label=_("Chart Interval"),
                 choices=(
@@ -185,10 +207,11 @@ class CurrencyFxApplet(Applet):
                 ),
                 gtk=Gtk,
             )
-        )
+        ]
 
+        destructive: list[Gtk.MenuItem] = []
         if len(self._pairs) > 1:
-            items.append(
+            display.append(
                 radio_submenu(
                     label=_("Added Pairs"),
                     choices=tuple(
@@ -200,15 +223,25 @@ class CurrencyFxApplet(Applet):
                     gtk=Gtk,
                 )
             )
-
             remove = Gtk.MenuItem(label=_("Remove Current Pair"))
             remove.connect(
                 "activate",
                 lambda _w: self._remove_active_pair(),
             )
-            items.append(remove)
+            destructive.append(remove)
 
-        return items
+        choose = Gtk.MenuItem(label=_("Add Pair..."))
+        choose.connect("activate", lambda _w: self._show_pair_dialog())
+
+        return menu_sections(
+            status=status,
+            navigation=navigation,
+            refresh=refresh_items,
+            display=display,
+            manage=[choose],
+            destructive=destructive,
+            gtk=Gtk,
+        )
 
     def start(self, notify: Callable[[], None]) -> None:
         """Start periodic refresh and one delayed startup fetch."""
@@ -259,7 +292,10 @@ class CurrencyFxApplet(Applet):
         base = self._base
         quote = self._quote
         chart_interval = self._chart_interval
+        self._loading = True
         self._fetch_failed = False
+        self._fetch_error = ""
+        self.present()
 
         self._worker.run(
             name="currencyfx-fetch",
@@ -291,6 +327,7 @@ class CurrencyFxApplet(Applet):
         """
         if request_id != self._fetch_request_id:
             return False
+        self._loading = False
         self._available_codes = merge_currency_codes((*codes, *self._pair_codes()))
         if snapshot is not None:
             self._samples = append_local_sample(
@@ -303,7 +340,10 @@ class CurrencyFxApplet(Applet):
             if self._chart_interval == ChartInterval.DAY:
                 snapshot = self._snapshot_with_local_samples(snapshot=snapshot)
             self._save_prefs()
-        self._snapshot = snapshot
+            self._snapshot = snapshot
+            self._fetch_error = ""
+        else:
+            self._fetch_error = _("No rate data")
         self._fetch_failed = snapshot is None
         self._ensure_pulse_timer()
         self.present()
@@ -314,8 +354,9 @@ class CurrencyFxApplet(Applet):
         if request_id != self._fetch_request_id:
             return False
         log.bind(action="fetch_error").debug("Currency FX fetch failed: %s", exc)
-        self._snapshot = None
+        self._loading = False
         self._fetch_failed = True
+        self._fetch_error = str(exc) or exc.__class__.__name__
         self._ensure_pulse_timer()
         self.present()
         return False
@@ -360,6 +401,8 @@ class CurrencyFxApplet(Applet):
             else None
         )
         self._fetch_failed = False
+        self._fetch_error = ""
+        self._loading = False
         self._available_codes = merge_currency_codes(self._pair_codes())
         self._save_prefs()
         self._fetch_async()
@@ -388,6 +431,15 @@ class CurrencyFxApplet(Applet):
             change=format_change(self._snapshot.points),
         )
 
+    def _live_status(self):
+        return resolve_live_status(
+            has_data=self._snapshot is not None,
+            loading=self._loading,
+            error=self._fetch_error if self._fetch_failed else None,
+            updated_at=self._snapshot.fetched_at if self._snapshot else None,
+            stale_after_seconds=REFRESH_INTERVAL_S * 2,
+        )
+
     def _on_interval_selected(
         self,
         *,
@@ -406,6 +458,8 @@ class CurrencyFxApplet(Applet):
             else None
         )
         self._fetch_failed = False
+        self._fetch_error = ""
+        self._loading = False
         self._save_prefs()
         self._fetch_async()
         self._ensure_pulse_timer()
@@ -417,22 +471,14 @@ class CurrencyFxApplet(Applet):
             title=_("Add FX Pair"),
             flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
         )
-        dialog.add_buttons(
-            Gtk.STOCK_CANCEL,
-            Gtk.ResponseType.CANCEL,
-            Gtk.STOCK_OK,
-            Gtk.ResponseType.OK,
+        add_cancel_ok_buttons(dialog=dialog)
+        box = prepare_dialog_content(
+            dialog=dialog,
+            width=DIALOG_WIDTH_PX,
+            spacing=DIALOG_SPACING_PX,
+            margin=DIALOG_MARGIN_PX,
+            default_response=Gtk.ResponseType.OK,
         )
-        dialog.set_default_response(Gtk.ResponseType.OK)
-        dialog.set_default_size(DIALOG_WIDTH_PX, -1)
-        dialog.set_position(Gtk.WindowPosition.MOUSE)
-
-        box = dialog.get_content_area()
-        box.set_spacing(DIALOG_SPACING_PX)
-        box.set_margin_start(DIALOG_MARGIN_PX)
-        box.set_margin_end(DIALOG_MARGIN_PX)
-        box.set_margin_top(DIALOG_MARGIN_PX)
-        box.set_margin_bottom(DIALOG_MARGIN_PX)
 
         base_combo = self._currency_combo(active=self._base)
         quote_combo = self._currency_combo(active=self._quote)
@@ -442,6 +488,7 @@ class CurrencyFxApplet(Applet):
         box.pack_start(quote_combo, False, False, 0)
 
         dialog.show_all()
+        base_combo.grab_focus()
         response = dialog.run()
         if response == Gtk.ResponseType.OK:
             base = base_combo.get_active_text() or self._base

--- a/docking/applets/currencyfx/render.py
+++ b/docking/applets/currencyfx/render.py
@@ -68,6 +68,8 @@ def render_icon(
             points=points,
             pulse_phase=pulse_phase,
         )
+        if fetch_failed:
+            _draw_warning_badge(cr=cr, size=size)
     else:
         _draw_empty_state(cr=cr, size=size, failed=fetch_failed)
 
@@ -247,5 +249,20 @@ def _draw_empty_state(*, cr: cairo.Context, size: int, failed: bool) -> None:
     y = size * 0.48
     cr.move_to(size * 0.24, y)
     cr.line_to(size * 0.76, y)
+    cr.stroke()
+    cr.restore()
+
+
+def _draw_warning_badge(*, cr: cairo.Context, size: int) -> None:
+    """Draw a small warning marker while stale chart data is still visible."""
+    cr.save()
+    radius = max(2.0, size * 0.075)
+    cx = size * 0.79
+    cy = size * 0.22
+    cr.arc(cx, cy, radius, 0, math.tau)
+    cr.set_source_rgba(_WARN[0], _WARN[1], _WARN[2], 0.95)
+    cr.fill_preserve()
+    cr.set_line_width(max(0.8, size * 0.018))
+    cr.set_source_rgba(0, 0, 0, 0.42)
     cr.stroke()
     cr.restore()

--- a/docking/applets/currencyfx/state.py
+++ b/docking/applets/currencyfx/state.py
@@ -32,6 +32,14 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, cast
 
+from docking.applets.live_state import (
+    live_freshness_lines,
+    live_state_error,
+    live_state_label,
+    refresh_recovery_label,
+    resolve_live_status,
+)
+from docking.applets.tooltip import structured_tooltip
 from docking.applets.unitconverter.state import Unit, fetch_currency_rates
 from docking.i18n import _
 from docking.log import get_logger
@@ -706,24 +714,54 @@ def build_tooltip(
     base: str,
     quote: str,
     snapshot: FxSnapshot | None,
+    loading: bool = False,
     fetch_failed: bool,
+    error: str | None = None,
+    chart_interval: ChartInterval | str = DEFAULT_CHART_INTERVAL,
+    cadence_seconds: int | None = None,
 ) -> str:
     """Build tooltip text."""
     pair = f"{base}/{quote}"
+    verb = (
+        _("Day samples")
+        if normalize_chart_interval(chart_interval) == ChartInterval.DAY
+        else None
+    )
+    state_error = error or (_("Unavailable") if fetch_failed else None)
+    status = resolve_live_status(
+        has_data=snapshot is not None,
+        loading=loading,
+        error=state_error,
+        updated_at=snapshot.fetched_at if snapshot else None,
+    )
     if snapshot is None:
-        if fetch_failed:
-            return _("{pair}: unavailable").format(pair=pair)
-        return _("{pair}: loading...").format(pair=pair)
-    return "\n".join(
-        (
-            pair,
-            _("1 {base} = {rate} {quote}").format(
-                base=snapshot.base,
-                rate=format_rate(snapshot.rate),
-                quote=snapshot.quote,
+        return structured_tooltip(
+            title=pair,
+            primary=live_state_label(status),
+            freshness=live_freshness_lines(
+                status=status,
+                cadence_seconds=cadence_seconds,
+                cadence_verb=verb,
             ),
-            _("Change: {change}").format(change=format_change(snapshot.points)),
+            error=live_state_error(status=status, error=state_error),
+            recovery=refresh_recovery_label(status),
         )
+    return structured_tooltip(
+        title=pair,
+        primary=_("1 {base} = {rate} {quote}").format(
+            base=snapshot.base,
+            rate=format_rate(snapshot.rate),
+            quote=snapshot.quote,
+        ),
+        details=(_("Change: {change}").format(change=format_change(snapshot.points)),),
+        freshness=live_freshness_lines(
+            status=status,
+            updated_at=snapshot.fetched_at,
+            cadence_seconds=cadence_seconds,
+            cadence_verb=verb,
+        ),
+        error=live_state_error(status=status, error=state_error),
+        recovery=refresh_recovery_label(status),
     )
 
 

--- a/docking/applets/deskpresence/applet.py
+++ b/docking/applets/deskpresence/applet.py
@@ -28,7 +28,7 @@ from docking.applets.deskpresence.state import (
     prefs_payload,
     state_from_prefs,
 )
-from docking.applets.menu import radio_submenu
+from docking.applets.menu import disabled_menu_item, menu_sections, radio_submenu
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -79,36 +79,36 @@ class DeskpresenceApplet(Applet):
         self.item.name = build_tooltip(state=self._state, now_epoch=time.time())
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
-
-        header = Gtk.MenuItem(
-            label=_("{status}").format(
-                status=_presence_text(self._state.presence),
-            )
-        )
-        header.set_sensitive(False)
-        items.append(header)
-        items.append(Gtk.SeparatorMenuItem())
-
-        items.append(
-            radio_submenu(
-                label=_("Idle Threshold"),
-                choices=tuple(
-                    (_threshold_label(preset_s), preset_s)
-                    for preset_s in _IDLE_THRESHOLD_PRESETS_S
+        status = [
+            disabled_menu_item(
+                _("{status}").format(
+                    status=_presence_text(self._state.presence),
                 ),
-                active_value=self._state.idle_threshold_s,
-                is_active=lambda value: abs(self._state.idle_threshold_s - value) < 0.5,
-                on_selected=lambda _widget, value: self._set_threshold(seconds=value),
                 gtk=Gtk,
             )
+        ]
+
+        threshold = radio_submenu(
+            label=_("Idle Threshold"),
+            choices=tuple(
+                (_threshold_label(preset_s), preset_s)
+                for preset_s in _IDLE_THRESHOLD_PRESETS_S
+            ),
+            active_value=self._state.idle_threshold_s,
+            is_active=lambda value: abs(self._state.idle_threshold_s - value) < 0.5,
+            on_selected=lambda _widget, value: self._set_threshold(seconds=value),
+            gtk=Gtk,
         )
 
         reset = Gtk.MenuItem(label=_("Reset Today"))
         reset.connect("activate", lambda _w: self._reset_today())
-        items.append(reset)
 
-        return items
+        return menu_sections(
+            status=status,
+            display=[threshold],
+            destructive=[reset],
+            gtk=Gtk,
+        )
 
     def start(self, notify: Callable[[], None]) -> None:
         super().start(notify=notify)

--- a/docking/applets/dragshare/applet.py
+++ b/docking/applets/dragshare/applet.py
@@ -23,6 +23,7 @@ from docking.applets.dragshare.state import (
     first_uploadable_file,
     upload_file,
 )
+from docking.applets.tooltip import structured_tooltip
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -55,20 +56,34 @@ class DragshareApplet(Applet):
 
     def refresh_tooltip(self) -> None:
         if self._status is DragshareStatus.UPLOADING:
-            self.item.name = _("Uploading {file}...").format(file=self._file_name)
+            self.item.name = structured_tooltip(
+                title=_("Drag Share"),
+                primary=_("Uploading {file}...").format(file=self._file_name),
+            )
             return
         if self._status is DragshareStatus.DONE and self._last_url:
-            self.item.name = _("Uploaded {file}; URL copied").format(
-                file=self._file_name
+            self.item.name = structured_tooltip(
+                title=_("Drag Share"),
+                primary=_("Uploaded {file}; URL copied").format(file=self._file_name),
             )
             return
         if self._status is DragshareStatus.ERROR:
-            self.item.name = _("Upload failed: {error}").format(error=self._error)
+            self.item.name = structured_tooltip(
+                title=_("Drag Share"),
+                primary=_("Upload failed"),
+                error=self._error,
+            )
             return
         if self._last_url:
-            self.item.name = _("Drag Share - click to copy last URL")
+            self.item.name = structured_tooltip(
+                title=_("Drag Share"),
+                primary=_("Click to copy last URL"),
+            )
             return
-        self.item.name = _("Drag Share - drop a file to upload")
+        self.item.name = structured_tooltip(
+            title=_("Drag Share"),
+            primary=_("Drop a file to upload"),
+        )
 
     def accepts_drop_uris(self) -> bool:
         return True

--- a/docking/applets/freshness.py
+++ b/docking/applets/freshness.py
@@ -1,0 +1,70 @@
+"""Shared freshness and update-cadence text for applets."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from docking.i18n import _
+
+
+def format_interval(seconds: int) -> str:
+    """Return a compact human interval for menu and tooltip text."""
+    seconds = max(1, int(seconds))
+    if seconds % 3600 == 0:
+        hours = seconds // 3600
+        return _("1 hour") if hours == 1 else _("{count} hours").format(count=hours)
+    if seconds % 60 == 0:
+        minutes = seconds // 60
+        return (
+            _("1 minute")
+            if minutes == 1
+            else _("{count} minutes").format(count=minutes)
+        )
+    return _("1 second") if seconds == 1 else _("{count} seconds").format(count=seconds)
+
+
+def cadence_label(*, seconds: int, verb: str | None = None) -> str:
+    """Return "<Verb> every <interval>"."""
+    return _("{verb} every {interval}").format(
+        verb=verb or _("Updates"),
+        interval=format_interval(seconds),
+    )
+
+
+def on_demand_label(*, verb: str | None = None) -> str:
+    """Return "<Verb> on demand" for manual applets."""
+    return _("{verb} on demand").format(verb=verb or _("Updates"))
+
+
+def updated_label(timestamp: dt.datetime | str | None) -> str:
+    """Return a local-time updated label, or an empty string when unknown."""
+    parsed = parse_timestamp(timestamp)
+    if parsed is None:
+        return ""
+    return _("Updated: {time}").format(time=format_local_time(parsed))
+
+
+def parse_timestamp(timestamp: dt.datetime | str | None) -> dt.datetime | None:
+    """Parse an aware UTC/local timestamp into a timezone-aware datetime."""
+    if timestamp is None:
+        return None
+    if isinstance(timestamp, dt.datetime):
+        parsed = timestamp
+    else:
+        text = str(timestamp).strip()
+        if not text:
+            return None
+        try:
+            parsed = dt.datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed
+
+
+def format_local_time(timestamp: dt.datetime) -> str:
+    """Format a timestamp in the user's local timezone."""
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=dt.timezone.utc)
+    return timestamp.astimezone().strftime("%Y-%m-%d %H:%M")

--- a/docking/applets/hackernews/applet.py
+++ b/docking/applets/hackernews/applet.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -13,6 +14,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GdkPixbuf, Gio, GLib, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.freshness import cadence_label, parse_timestamp
 from docking.applets.hackernews import meta
 from docking.applets.hackernews.render import render_icon
 from docking.applets.hackernews.state import (
@@ -30,6 +32,12 @@ from docking.applets.hackernews.state import (
     prefs_from_mapping,
     prefs_payload,
 )
+from docking.applets.live_state import (
+    live_state_error,
+    live_state_label,
+    resolve_live_status,
+)
+from docking.applets.menu import disabled_menu_item, menu_sections
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -54,6 +62,7 @@ class HackerNewsApplet(Applet):
         self._stories: list[HackerNewsStory] = list(prefs.stories)
         self._active_index = prefs.active_index
         self._next_story_offset = prefs.next_offset
+        self._fetched_at = parse_timestamp(prefs.fetched_at)
         self._loading = False
         self._page_loading = False
         self._has_more_stories = (
@@ -96,6 +105,8 @@ class HackerNewsApplet(Applet):
             loading=self._loading,
             page_loading=self._page_loading,
             error=self._error,
+            fetched_at=self._fetched_at,
+            cadence_seconds=REFRESH_INTERVAL_S,
         )
 
     def start(self, notify: Callable[[], None]) -> None:
@@ -130,45 +141,73 @@ class HackerNewsApplet(Applet):
         self._move_story(step=step)
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
-
-        header = Gtk.MenuItem(label=HN_SOURCE_LABEL)
-        header.set_sensitive(False)
-        items.append(header)
+        status: list[Gtk.MenuItem] = [
+            disabled_menu_item(HN_SOURCE_LABEL, gtk=Gtk),
+            disabled_menu_item(
+                cadence_label(seconds=REFRESH_INTERVAL_S, verb=_("Refreshes")),
+                gtk=Gtk,
+            ),
+        ]
 
         current = self._current_story
+        primary: list[Gtk.MenuItem] = []
         if current is not None:
-            title = Gtk.MenuItem(label=current.title)
-            title.set_sensitive(False)
-            items.append(title)
-            stats = Gtk.MenuItem(
-                label=_("{score} points, {comments} comments").format(
-                    score=current.score,
-                    comments=current.comments,
-                )
+            status.extend(
+                [
+                    disabled_menu_item(current.title, gtk=Gtk),
+                    disabled_menu_item(
+                        _("{score} points, {comments} comments").format(
+                            score=current.score,
+                            comments=current.comments,
+                        ),
+                        gtk=Gtk,
+                    ),
+                ]
             )
-            stats.set_sensitive(False)
-            items.append(stats)
-            items.append(Gtk.SeparatorMenuItem())
+            state_status = self._live_status()
+            state_label = live_state_label(state_status)
+            if state_label:
+                status.append(disabled_menu_item(state_label, gtk=Gtk))
+            error = live_state_error(status=state_status, error=self._error)
+            if error:
+                status.append(
+                    disabled_menu_item(
+                        _("Error: {msg}").format(msg=error),
+                        gtk=Gtk,
+                    )
+                )
 
             open_story = Gtk.MenuItem(label=_("Open Story"))
             open_story.connect("activate", lambda _w: self._open_current_story())
-            items.append(open_story)
+            primary.append(open_story)
 
             open_comments = Gtk.MenuItem(label=_("Open Comments"))
             open_comments.connect("activate", lambda _w: self._open_current_comments())
-            items.append(open_comments)
+            primary.append(open_comments)
 
         next_item = Gtk.MenuItem(label=_("Next Headline"))
         next_item.set_sensitive(bool(self._stories))
         next_item.connect("activate", lambda _w: self._advance_story())
-        items.append(next_item)
 
         refresh = Gtk.MenuItem(label=_("Refresh Now"))
         refresh.connect("activate", lambda _w: self._fetch_async())
-        items.append(refresh)
 
-        return items
+        return menu_sections(
+            status=status,
+            primary=primary,
+            navigation=[next_item],
+            refresh=[refresh],
+            gtk=Gtk,
+        )
+
+    def _live_status(self):
+        return resolve_live_status(
+            has_data=self._current_story is not None,
+            loading=self._loading,
+            error=self._error,
+            updated_at=self._fetched_at,
+            stale_after_seconds=REFRESH_INTERVAL_S * 2,
+        )
 
     def _refresh_tick(self) -> bool:
         self._fetch_async()
@@ -269,6 +308,7 @@ class HackerNewsApplet(Applet):
             self._next_story_offset = page.next_offset
             self._has_more_stories = page.has_more and len(self._stories) < MAX_STORIES
             self._error = ""
+            self._fetched_at = dt.datetime.now(dt.timezone.utc)
             self._save_prefs()
         elif not self._stories:
             self._error = _("No Hacker News stories")
@@ -352,6 +392,7 @@ class HackerNewsApplet(Applet):
             return False
 
         self._stories = list(merged)
+        self._fetched_at = dt.datetime.now(dt.timezone.utc)
         self._save_prefs()
         self.present()
         return False
@@ -393,5 +434,6 @@ class HackerNewsApplet(Applet):
                 active_index=self._active_index,
                 next_offset=self._next_story_offset,
                 has_more_stories=self._has_more_stories,
+                fetched_at=self._fetched_at,
             )
         )

--- a/docking/applets/hackernews/state.py
+++ b/docking/applets/hackernews/state.py
@@ -18,6 +18,14 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from docking.applets.live_state import (
+    live_freshness_lines,
+    live_state_error,
+    live_state_label,
+    refresh_recovery_label,
+    resolve_live_status,
+)
+from docking.applets.tooltip import structured_tooltip
 from docking.i18n import _
 from docking.log import get_logger
 
@@ -127,14 +135,29 @@ def build_tooltip(
     loading: bool = False,
     page_loading: bool = False,
     error: str = "",
+    fetched_at: object | None = None,
+    cadence_seconds: int | None = None,
 ) -> str:
     """Build tooltip text for the current applet state."""
+    status = resolve_live_status(
+        has_data=story is not None,
+        loading=loading,
+        error=error,
+        updated_at=fetched_at,
+    )
     if story is None:
-        if loading:
-            return _("Hacker News: loading...")
-        if error:
-            return _("Hacker News: {error}").format(error=error)
-        return _("Hacker News")
+        return structured_tooltip(
+            title=_("Hacker News"),
+            primary=live_state_label(status),
+            freshness=live_freshness_lines(
+                status=status,
+                updated_at=fetched_at,
+                cadence_seconds=cadence_seconds,
+                cadence_verb=_("Refreshes"),
+            ),
+            error=live_state_error(status=status, error=error),
+            recovery=refresh_recovery_label(status),
+        )
 
     rank = story_rank(index=index, count=count)
     header = (
@@ -152,10 +175,22 @@ def build_tooltip(
     age = story_age(story=story)
     if age:
         stats = f"{stats}, {age}"
-    lines = [header, story.title, stats]
+    details = [stats]
     if page_loading:
-        lines.append(_("Loading next stories..."))
-    return "\n".join(lines)
+        details.append(_("Loading next stories..."))
+    return structured_tooltip(
+        title=header,
+        primary=story.title,
+        details=details,
+        freshness=live_freshness_lines(
+            status=status,
+            updated_at=fetched_at,
+            cadence_seconds=cadence_seconds,
+            cadence_verb=_("Refreshes"),
+        ),
+        error=live_state_error(status=status, error=error),
+        recovery=refresh_recovery_label(status),
+    )
 
 
 def parse_story_payload(data: object) -> HackerNewsStory | None:

--- a/docking/applets/hydration/applet.py
+++ b/docking/applets/hydration/applet.py
@@ -26,7 +26,7 @@ from docking.applets.hydration.state import (
     tooltip_text,
     with_fill,
 )
-from docking.applets.menu import radio_menu_items
+from docking.applets.menu import menu_sections, radio_menu_items
 from docking.i18n import _
 
 if TYPE_CHECKING:
@@ -111,27 +111,22 @@ class HydrationApplet(Applet):
         self.present()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
-
         show = Gtk.CheckMenuItem(label=_("Show Timer"))
         show.set_active(self._state.show_timer)
         show.connect("toggled", self._on_toggle_timer)
-        items.append(show)
 
-        items.append(Gtk.SeparatorMenuItem())
-
-        items.extend(
-            radio_menu_items(
-                choices=tuple(
-                    (_("{mins} min").format(mins=mins), mins)
-                    for mins in INTERVAL_PRESETS
-                ),
-                active_value=self._state.interval_min,
-                on_selected=lambda _widget, value: self._set_interval(minutes=value),
-                gtk=Gtk,
-            )
+        intervals = radio_menu_items(
+            choices=tuple(
+                (_("{mins} min").format(mins=mins), mins) for mins in INTERVAL_PRESETS
+            ),
+            active_value=self._state.interval_min,
+            on_selected=lambda _widget, value: self._set_interval(minutes=value),
+            gtk=Gtk,
         )
-        return items
+        return menu_sections(
+            display=[show, Gtk.SeparatorMenuItem(), *intervals],
+            gtk=Gtk,
+        )
 
     def _on_toggle_timer(self, widget: Gtk.CheckMenuItem) -> None:
         self._state = set_show_timer(

--- a/docking/applets/keyboardlayout/applet.py
+++ b/docking/applets/keyboardlayout/applet.py
@@ -25,6 +25,7 @@ from docking.applets.keyboardlayout.state import (
     show_current_layout,
     tooltip_text,
 )
+from docking.applets.menu import menu_sections, radio_menu_items
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -115,34 +116,37 @@ class KeyboardLayoutApplet(Applet):
         self.present()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        settings: list[Gtk.MenuItem] = []
         settings_cmd = keyboard_settings_command()
         if settings_cmd is not None:
             settings_item = Gtk.MenuItem(label=_("Keyboard Settings"))
             settings_item.connect("activate", lambda _w: open_keyboard_settings())
-            items.append(settings_item)
+            settings.append(settings_item)
 
+        primary: list[Gtk.MenuItem] = []
         if self._active and current_layout_command(self._active) is not None:
             layout_item = Gtk.MenuItem(label=_("Show Current Layout"))
             layout_item.connect(
                 "activate",
                 lambda _w: show_current_layout(self._active),
             )
-            items.append(layout_item)
+            primary.append(layout_item)
 
-        if items and self._available:
-            items.append(Gtk.SeparatorMenuItem())
-
-        for code in self._available:
-            prefix = "\u2022 " if code == self._active else "  "
-            label = f"{prefix}{layout_label(code=code)} - {code}"
-            mi = Gtk.MenuItem(label=label)
-            mi.connect(
-                "activate",
-                lambda _w, c=code: self._select_layout(code=c),
-            )
-            items.append(mi)
-        return items
+        display = radio_menu_items(
+            choices=tuple(
+                (f"{layout_label(code=code)} - {code}", code)
+                for code in self._available
+            ),
+            active_value=self._active,
+            on_selected=lambda _widget, code: self._select_layout(code=code),
+            gtk=Gtk,
+        )
+        return menu_sections(
+            primary=primary,
+            display=display,
+            settings=settings,
+            gtk=Gtk,
+        )
 
     def _select_layout(self, code: str) -> None:
         self._backend.switch(layout_code=code)

--- a/docking/applets/live_state.py
+++ b/docking/applets/live_state.py
@@ -1,0 +1,133 @@
+"""Shared loading, stale, and error state helpers for live applets."""
+
+from __future__ import annotations
+
+import datetime as dt
+from enum import Enum
+
+from docking.applets.freshness import (
+    cadence_label,
+    format_local_time,
+    parse_timestamp,
+    updated_label,
+)
+from docking.i18n import _
+
+
+class LiveDataStatus(str, Enum):
+    """Common status vocabulary for applets backed by changing data."""
+
+    EMPTY = "empty"
+    LOADING = "loading"
+    READY = "ready"
+    STALE = "stale"
+    ERROR = "error"
+
+
+def resolve_live_status(
+    *,
+    has_data: bool,
+    loading: bool = False,
+    error: str | None = None,
+    updated_at: dt.datetime | str | None = None,
+    stale_after_seconds: int | None = None,
+    now: dt.datetime | None = None,
+) -> LiveDataStatus:
+    """Classify a live applet without losing old usable data."""
+    if loading and not has_data:
+        return LiveDataStatus.LOADING
+    if _clean_error(error):
+        return LiveDataStatus.STALE if has_data else LiveDataStatus.ERROR
+    if has_data:
+        if is_stale(
+            updated_at,
+            max_age_seconds=stale_after_seconds,
+            now=now,
+        ):
+            return LiveDataStatus.STALE
+        return LiveDataStatus.READY
+    return LiveDataStatus.EMPTY
+
+
+def is_stale(
+    updated_at: dt.datetime | str | None,
+    *,
+    max_age_seconds: int | None,
+    now: dt.datetime | None = None,
+) -> bool:
+    """Return true when ``updated_at`` is older than the allowed age."""
+    if max_age_seconds is None or max_age_seconds <= 0:
+        return False
+    parsed = parse_timestamp(updated_at)
+    if parsed is None:
+        return False
+    reference = now or dt.datetime.now(dt.timezone.utc)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=dt.timezone.utc)
+    age = reference.astimezone(dt.timezone.utc) - parsed.astimezone(dt.timezone.utc)
+    return age.total_seconds() > max_age_seconds
+
+
+def live_state_label(status: LiveDataStatus) -> str:
+    """Return the compact user-facing label for a live-data state."""
+    return {
+        LiveDataStatus.EMPTY: _("No data yet"),
+        LiveDataStatus.LOADING: _("Loading..."),
+        LiveDataStatus.READY: "",
+        LiveDataStatus.STALE: _("Stale data"),
+        LiveDataStatus.ERROR: _("Unavailable"),
+    }[status]
+
+
+def live_state_error(
+    *,
+    status: LiveDataStatus,
+    error: str | None,
+) -> str | None:
+    """Expose error details only for states where they matter."""
+    if status not in (LiveDataStatus.ERROR, LiveDataStatus.STALE):
+        return None
+    return _clean_error(error) or None
+
+
+def live_freshness_lines(
+    *,
+    status: LiveDataStatus,
+    updated_at: dt.datetime | str | None = None,
+    cadence_seconds: int | None = None,
+    cadence_verb: str | None = None,
+) -> tuple[str, ...]:
+    """Build standard freshness/cadence lines for structured tooltips."""
+    lines: list[str] = []
+    if status is LiveDataStatus.STALE:
+        lines.append(stale_label(updated_at))
+    else:
+        updated = updated_label(updated_at)
+        if updated:
+            lines.append(updated)
+    if cadence_seconds:
+        lines.append(cadence_label(seconds=cadence_seconds, verb=cadence_verb))
+    return tuple(line for line in lines if line)
+
+
+def stale_label(updated_at: dt.datetime | str | None = None) -> str:
+    """Return a standard stale-data line, with last update when known."""
+    parsed = parse_timestamp(updated_at)
+    if parsed is None:
+        return _("Stale data")
+    return _("Stale: last updated {time}").format(time=format_local_time(parsed))
+
+
+def refresh_recovery_label(status: LiveDataStatus) -> str | None:
+    """Return a standard recovery hint for non-ready live-data states."""
+    if status in (
+        LiveDataStatus.EMPTY,
+        LiveDataStatus.STALE,
+        LiveDataStatus.ERROR,
+    ):
+        return _("Use Refresh Now from the menu.")
+    return None
+
+
+def _clean_error(error: str | None) -> str:
+    return str(error or "").strip()

--- a/docking/applets/menu.py
+++ b/docking/applets/menu.py
@@ -13,6 +13,51 @@ from gi.repository import Gtk
 T = TypeVar("T")
 
 
+def disabled_menu_item(label: str, *, gtk=Gtk) -> Gtk.MenuItem:
+    """Build a non-interactive status/header row."""
+    item = gtk.MenuItem(label=label)
+    item.set_sensitive(False)
+    return item
+
+
+def menu_sections(
+    *,
+    status: Iterable[Gtk.MenuItem] = (),
+    primary: Iterable[Gtk.MenuItem] = (),
+    navigation: Iterable[Gtk.MenuItem] = (),
+    refresh: Iterable[Gtk.MenuItem] = (),
+    display: Iterable[Gtk.MenuItem] = (),
+    manage: Iterable[Gtk.MenuItem] = (),
+    destructive: Iterable[Gtk.MenuItem] = (),
+    settings: Iterable[Gtk.MenuItem] = (),
+    gtk=Gtk,
+) -> list[Gtk.MenuItem]:
+    """Return menu items in the standard applet section order.
+
+    Order is status/header, primary open/run actions, navigation, refresh,
+    display controls, manage/add actions, destructive actions, then settings.
+    Separators are inserted only between non-empty sections.
+    """
+    ordered_sections = (
+        tuple(status),
+        tuple(primary),
+        tuple(navigation),
+        tuple(refresh),
+        tuple(display),
+        tuple(manage),
+        tuple(destructive),
+        tuple(settings),
+    )
+    visible_sections = [section for section in ordered_sections if section]
+    separator_menu_item = getattr(gtk, "SeparatorMenuItem", Gtk.SeparatorMenuItem)
+    items: list[Gtk.MenuItem] = []
+    for index, section in enumerate(visible_sections):
+        if index > 0:
+            items.append(separator_menu_item())
+        items.extend(section)
+    return items
+
+
 def radio_menu_items(
     *,
     choices: Iterable[tuple[str, T]],

--- a/docking/applets/micshield/applet.py
+++ b/docking/applets/micshield/applet.py
@@ -12,6 +12,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import GdkPixbuf, GLib, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.menu import disabled_menu_item, menu_sections
 from docking.applets.micshield import meta
 from docking.applets.micshield.render import render_icon
 from docking.applets.micshield.state import (
@@ -87,46 +88,41 @@ class MicShieldApplet(Applet):
         self._toggle_mute()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        status: list[Gtk.MenuItem] = []
         if not self._state.available:
-            placeholder = Gtk.MenuItem(label=_("No microphone source found"))
-            placeholder.set_sensitive(False)
-            items.append(placeholder)
+            status.append(disabled_menu_item(_("No microphone source found"), gtk=Gtk))
         else:
-            header = Gtk.MenuItem(
-                label=_("Microphone muted")
-                if self._state.muted
-                else _("Microphone unmuted")
+            status.append(
+                disabled_menu_item(
+                    _("Microphone muted")
+                    if self._state.muted
+                    else _("Microphone unmuted"),
+                    gtk=Gtk,
+                )
             )
-            header.set_sensitive(False)
-            items.append(header)
 
             if self._state.active:
-                active = Gtk.MenuItem(label=_("Microphone active"))
-                active.set_sensitive(False)
-                items.append(active)
+                status.append(disabled_menu_item(_("Microphone active"), gtk=Gtk))
                 for stream in self._state.streams:
-                    item = Gtk.MenuItem(label=stream_label(stream))
-                    item.set_sensitive(False)
-                    items.append(item)
+                    status.append(disabled_menu_item(stream_label(stream), gtk=Gtk))
             else:
-                idle = Gtk.MenuItem(label=_("Microphone idle"))
-                idle.set_sensitive(False)
-                items.append(idle)
+                status.append(disabled_menu_item(_("Microphone idle"), gtk=Gtk))
 
-        items.append(Gtk.SeparatorMenuItem())
         mute_label = (
             _("Unmute Microphone") if self._state.muted else _("Mute Microphone")
         )
         mute = Gtk.MenuItem(label=mute_label)
         mute.set_sensitive(self._state.available)
         mute.connect("activate", lambda _w: self._set_muted(not self._state.muted))
-        items.append(mute)
 
         refresh = Gtk.MenuItem(label=_("Refresh Now"))
         refresh.connect("activate", lambda _w: self._refresh_now())
-        items.append(refresh)
-        return items
+        return menu_sections(
+            status=status,
+            primary=[mute],
+            refresh=[refresh],
+            gtk=Gtk,
+        )
 
     def _refresh_once(self) -> bool:
         self._refresh_now()

--- a/docking/applets/micshield/state.py
+++ b/docking/applets/micshield/state.py
@@ -16,9 +16,9 @@ import subprocess
 from dataclasses import dataclass
 
 from docking.i18n import _
-from docking.log import get_logger
+from docking.log import get_logger, with_context
 
-log = get_logger(name="micshield.state")
+log = with_context(get_logger(name="micshield.state"))
 
 DEFAULT_POLL_INTERVAL_S = 2
 MAX_TOOLTIP_STREAMS = 6

--- a/docking/applets/moon/applet.py
+++ b/docking/applets/moon/applet.py
@@ -18,6 +18,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import GLib, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.menu import menu_sections
 from docking.applets.moon import meta
 from docking.applets.moon.render import create_icon
 from docking.applets.moon.state import MoonData, fetch_moon, phase_name
@@ -116,18 +117,14 @@ class MoonApplet(Applet):
         self._fetch_async()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
-
         show = Gtk.CheckMenuItem(label=_("Show Phase Name"))
         show.set_active(self._show_phase)
         show.connect("toggled", self._on_toggle_phase)
-        items.append(show)
 
         refresh = Gtk.MenuItem(label=_("Refresh Now"))
         refresh.connect("activate", lambda _: self._fetch_async())
-        items.append(refresh)
 
-        return items
+        return menu_sections(refresh=[refresh], display=[show], gtk=Gtk)
 
     def _on_toggle_phase(self, widget: Gtk.CheckMenuItem) -> None:
         self._show_phase = widget.get_active()

--- a/docking/applets/music/applet.py
+++ b/docking/applets/music/applet.py
@@ -14,6 +14,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.menu import disabled_menu_item, menu_sections
 from docking.applets.music import meta
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
@@ -101,9 +102,7 @@ class MusicApplet(Applet):
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         if not self._state.available:
-            placeholder = Gtk.MenuItem(label=_("No active player"))
-            placeholder.set_sensitive(False)
-            return [placeholder]
+            return [disabled_menu_item(_("No active player"), gtk=Gtk)]
 
         previous_item = Gtk.MenuItem(label=_("Previous"))
         previous_item.set_sensitive(self._state.can_go_previous)
@@ -128,14 +127,12 @@ class MusicApplet(Applet):
             "activate", lambda _w: self._action_volume(direction_up=False)
         )
 
-        return [
-            previous_item,
-            play_pause_item,
-            next_item,
-            Gtk.SeparatorMenuItem(),
-            volume_up_item,
-            volume_down_item,
-        ]
+        return menu_sections(
+            primary=[play_pause_item],
+            navigation=[previous_item, next_item],
+            display=[volume_up_item, volume_down_item],
+            gtk=Gtk,
+        )
 
     def _action_previous(self) -> None:
         if self._backend.previous_track(state=self._state):

--- a/docking/applets/music/state.py
+++ b/docking/applets/music/state.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import gi
 
+from docking.applets.tooltip import structured_tooltip
 from docking.i18n import _
 
 gi.require_version("Gio", "2.0")
@@ -124,19 +125,25 @@ def _icon_name_from_bus_name(bus_name: str) -> str:
 def tooltip_text(state: MusicState) -> str:
     """Detailed tooltip text for the music applet."""
     if not state.available:
-        return _("Music: No active player")
+        return structured_tooltip(
+            title=_("Music"),
+            primary=_("No active player"),
+        )
 
-    lines: list[str] = []
     details = " - ".join(part for part in [state.artist, state.title] if part)
+    primary = None
     if details:
-        lines.append(details)
+        primary = details
     elif state.title:
-        lines.append(state.title)
+        primary = state.title
+    secondary = []
     if state.album:
-        lines.append(f"Album: {state.album}")
-    if not lines:
-        return _("Music")
-    return "\n".join(lines)
+        secondary.append(f"Album: {state.album}")
+    return structured_tooltip(
+        title=_("Music"),
+        primary=primary,
+        details=secondary,
+    )
 
 
 def _unpack(value: Any) -> Any:

--- a/docking/applets/network/applet.py
+++ b/docking/applets/network/applet.py
@@ -15,7 +15,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import NM, GLib, Gtk
 
 from docking.applets.base import Applet
-from docking.applets.menu import radio_menu_items
+from docking.applets.menu import disabled_menu_item, menu_sections, radio_menu_items
 from docking.applets.network import meta
 from docking.applets.network.render import create_icon
 from docking.applets.network.state import (
@@ -111,59 +111,53 @@ class NetworkApplet(Applet):
 
     def get_menu_items(self) -> list:
         """Show connection info and common network actions."""
-        items = []
+        status: list[Gtk.MenuItem] = []
         if self._ssid:
-            header = Gtk.MenuItem(
-                label=_("WiFi: {ssid} ({pct}%)").format(
-                    ssid=self._ssid, pct=self._signal_strength
+            status.append(
+                disabled_menu_item(
+                    _("WiFi: {ssid} ({pct}%)").format(
+                        ssid=self._ssid, pct=self._signal_strength
+                    ),
+                    gtk=Gtk,
                 )
             )
-            header.set_sensitive(False)
-            items.append(header)
         elif self._is_connected:
-            header = Gtk.MenuItem(
-                label=_("Ethernet: {iface}").format(iface=self._iface)
+            status.append(
+                disabled_menu_item(
+                    _("Ethernet: {iface}").format(iface=self._iface),
+                    gtk=Gtk,
+                )
             )
-            header.set_sensitive(False)
-            items.append(header)
         else:
-            header = Gtk.MenuItem(label=_("Not connected"))
-            header.set_sensitive(False)
-            items.append(header)
+            status.append(disabled_menu_item(_("Not connected"), gtk=Gtk))
 
         if self._ip_address:
-            ip_item = Gtk.MenuItem(label=_("IP: {ip}").format(ip=self._ip_address))
-            ip_item.set_sensitive(False)
-            items.append(ip_item)
+            status.append(
+                disabled_menu_item(_("IP: {ip}").format(ip=self._ip_address), gtk=Gtk)
+            )
 
         if self._is_connected:
             down = format_speed(bps=self._rx_speed)
             up = format_speed(bps=self._tx_speed)
-            speed_item = Gtk.MenuItem(label=f"\u2193 {down}  \u2191 {up}")
-            speed_item.set_sensitive(False)
-            items.append(speed_item)
+            status.append(disabled_menu_item(f"\u2193 {down}  \u2191 {up}", gtk=Gtk))
 
-        if items:
-            items.append(Gtk.SeparatorMenuItem())
-
+        settings: list[Gtk.MenuItem] = []
         info_cmd = connection_info_command()
         if info_cmd is not None:
             info_item = Gtk.MenuItem(label=_("Connection Information"))
             info_item.connect("activate", lambda _widget: open_connection_info())
-            items.append(info_item)
+            settings.append(info_item)
 
         edit_cmd = edit_connections_command()
         if edit_cmd is not None:
             edit_item = Gtk.MenuItem(label=_("Edit Connections..."))
             edit_item.connect("activate", lambda _widget: open_edit_connections())
-            items.append(edit_item)
+            settings.append(edit_item)
 
+        manage: list[Gtk.MenuItem] = []
         if self._nm_client is not None:
-            if info_cmd is not None or edit_cmd is not None:
-                items.append(Gtk.SeparatorMenuItem())
-
             if self._has_wifi_device():
-                items.append(self._build_available_networks_submenu())
+                manage.append(self._build_available_networks_submenu())
 
                 hidden_item = Gtk.MenuItem(
                     label=_("Connect to Hidden Wi-Fi Network...")
@@ -171,11 +165,11 @@ class NetworkApplet(Applet):
                 hidden_item.connect(
                     "activate", lambda _widget: open_hidden_wifi_settings()
                 )
-                items.append(hidden_item)
+                manage.append(hidden_item)
 
                 new_item = Gtk.MenuItem(label=_("Create New Wi-Fi Network..."))
                 new_item.connect("activate", lambda _widget: open_new_wifi_settings())
-                items.append(new_item)
+                manage.append(new_item)
 
             networking_item = Gtk.CheckMenuItem(label=_("Enable Networking"))
             networking_item.set_active(self._nm_client.networking_get_enabled())
@@ -185,7 +179,7 @@ class NetworkApplet(Applet):
                     enabled=widget.get_active()
                 ),
             )
-            items.append(networking_item)
+            manage.append(networking_item)
 
             if self._has_wifi_device():
                 wifi_item = Gtk.CheckMenuItem(label=_("Enable Wi-Fi"))
@@ -197,28 +191,30 @@ class NetworkApplet(Applet):
                         enabled=widget.get_active()
                     ),
                 )
-                items.append(wifi_item)
+                manage.append(wifi_item)
 
             vpn_item = self._build_vpn_connections_submenu()
             if vpn_item is not None:
-                items.append(vpn_item)
+                manage.append(vpn_item)
 
-            items.append(Gtk.SeparatorMenuItem())
-
-        items.extend(
-            radio_menu_items(
-                choices=(
-                    (_("Show Download"), "download"),
-                    (_("Show Upload"), "upload"),
-                    (_("Hide Speeds"), "none"),
-                ),
-                active_value=self._speed_overlay,
-                on_selected=lambda _widget, value: self._set_speed_overlay(mode=value),
-                gtk=Gtk,
-            )
+        display = radio_menu_items(
+            choices=(
+                (_("Show Download"), "download"),
+                (_("Show Upload"), "upload"),
+                (_("Hide Speeds"), "none"),
+            ),
+            active_value=self._speed_overlay,
+            on_selected=lambda _widget, value: self._set_speed_overlay(mode=value),
+            gtk=Gtk,
         )
 
-        return items
+        return menu_sections(
+            status=status,
+            display=display,
+            manage=manage,
+            settings=settings,
+            gtk=Gtk,
+        )
 
     def _set_speed_overlay(self, mode: str) -> None:
         self._speed_overlay = mode

--- a/docking/applets/network/state.py
+++ b/docking/applets/network/state.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 from typing import NamedTuple
 
+from docking.applets.tooltip import structured_tooltip
 from docking.applets.units import format_compact_number
 from docking.i18n import _
 from docking.log import get_logger
@@ -214,18 +215,22 @@ def build_tooltip(
 ) -> str:
     """Multi-line tooltip with connection details."""
     if not is_connected:
-        return _("Network: Not connected")
-    lines = []
-    if ssid:
-        lines.append(f"WiFi: {ssid} ({signal_strength}%)")
-    else:
-        lines.append(f"Ethernet: {iface}")
+        return structured_tooltip(
+            title=_("Network"),
+            primary=_("Not connected"),
+        )
+    primary = f"WiFi: {ssid} ({signal_strength}%)" if ssid else f"Ethernet: {iface}"
+    details = []
     if ip_address:
-        lines.append(f"IP: {ip_address}")
+        details.append(f"IP: {ip_address}")
     down = format_speed(bps=rx_speed)
     up = format_speed(bps=tx_speed)
-    lines.append(f"\u2193 {down}  \u2191 {up}")
-    return "\n".join(lines)
+    details.append(f"\u2193 {down}  \u2191 {up}")
+    return structured_tooltip(
+        title=_("Network"),
+        primary=primary,
+        details=details,
+    )
 
 
 def _open_command(*, cmd: list[str] | None, action: str) -> bool:

--- a/docking/applets/notifications/applet.py
+++ b/docking/applets/notifications/applet.py
@@ -16,6 +16,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import GLib, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.menu import disabled_menu_item, menu_sections
 from docking.applets.notifications import meta
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
@@ -123,34 +124,31 @@ class NotificationsApplet(Applet):
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         if not self._state.available:
-            placeholder = Gtk.MenuItem(label=_("No notification backend available"))
-            placeholder.set_sensitive(False)
-            return [placeholder]
-
-        items: list[Gtk.MenuItem] = []
+            return [disabled_menu_item(_("No notification backend available"), gtk=Gtk)]
 
         dnd = Gtk.CheckMenuItem(label=_("Do Not Disturb"))
         dnd.set_active(self._state.paused)
         dnd.connect("toggled", self._on_toggle_dnd)
-        items.append(dnd)
 
+        status: list[Gtk.MenuItem] = []
         if self._state.pending_known:
-            pending = Gtk.MenuItem(
-                label=_("Pending: {n}").format(n=self._state.pending)
+            status.append(
+                disabled_menu_item(
+                    _("Pending: {n}").format(n=self._state.pending),
+                    gtk=Gtk,
+                )
             )
-            pending.set_sensitive(False)
-            items.append(pending)
 
         clear_history = Gtk.MenuItem(label=_("Clear History"))
         clear_history.connect("activate", lambda _w: self._on_clear_history())
-        items.append(clear_history)
+        destructive = [clear_history]
 
         if self._backend.supports_clear:
             clear = Gtk.MenuItem(label=_("Clear Notifications"))
             clear.connect("activate", lambda _w: self._on_clear())
-            items.append(clear)
+            destructive.append(clear)
 
-        return items
+        return menu_sections(status=status, display=[dnd], destructive=destructive)
 
     def _on_toggle_dnd(self, widget: Gtk.CheckMenuItem) -> None:
         target = widget.get_active()

--- a/docking/applets/pomodoro/applet.py
+++ b/docking/applets/pomodoro/applet.py
@@ -13,7 +13,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GdkPixbuf, GLib, Gtk
 
 from docking.applets.base import Applet
-from docking.applets.menu import radio_menu_items
+from docking.applets.menu import menu_sections, radio_menu_items
 from docking.applets.pomodoro import meta
 from docking.applets.pomodoro.render import render_icon
 from docking.applets.pomodoro.state import (
@@ -151,23 +151,16 @@ class PomodoroApplet(Applet):
         self.present()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
-
-        # Reset
         reset_item = Gtk.MenuItem(label=_("Reset"))
         reset_item.connect("activate", lambda _w: self._reset())
-        items.append(reset_item)
 
         show = Gtk.CheckMenuItem(label=_("Show Timer"))
         show.set_active(self._data.show_timer)
         show.connect("toggled", self._on_toggle_timer)
-        items.append(show)
 
-        items.append(Gtk.SeparatorMenuItem())
-
-        # Work duration
-        items.append(self._make_duration_header(label=_("Work")))
-        items.extend(
+        display: list[Gtk.MenuItem] = [show, Gtk.SeparatorMenuItem()]
+        display.append(self._make_duration_header(label=_("Work")))
+        display.extend(
             radio_menu_items(
                 choices=tuple(
                     (_("{mins} min").format(mins=mins), mins) for mins in WORK_PRESETS
@@ -178,11 +171,9 @@ class PomodoroApplet(Applet):
             )
         )
 
-        items.append(Gtk.SeparatorMenuItem())
-
-        # Break duration
-        items.append(self._make_duration_header(label=_("Break")))
-        items.extend(
+        display.append(Gtk.SeparatorMenuItem())
+        display.append(self._make_duration_header(label=_("Break")))
+        display.extend(
             radio_menu_items(
                 choices=tuple(
                     (_("{mins} min").format(mins=mins), mins) for mins in BREAK_PRESETS
@@ -193,11 +184,9 @@ class PomodoroApplet(Applet):
             )
         )
 
-        items.append(Gtk.SeparatorMenuItem())
-
-        # Long break duration
-        items.append(self._make_duration_header(label=_("Long Break")))
-        items.extend(
+        display.append(Gtk.SeparatorMenuItem())
+        display.append(self._make_duration_header(label=_("Long Break")))
+        display.extend(
             radio_menu_items(
                 choices=tuple(
                     (_("{mins} min").format(mins=mins), mins)
@@ -209,7 +198,7 @@ class PomodoroApplet(Applet):
             )
         )
 
-        return items
+        return menu_sections(display=display, destructive=[reset_item], gtk=Gtk)
 
     # -- Internals -----------------------------------------------------------
 

--- a/docking/applets/popup.py
+++ b/docking/applets/popup.py
@@ -1,12 +1,16 @@
-"""Shared themed popup helpers for applet-owned popup windows."""
+"""Shared GTK surface helpers for applet-owned secondary UI."""
 
 from __future__ import annotations
+
+from collections.abc import Callable
 
 import gi
 
 gi.require_version("Gdk", "3.0")
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, Gtk
+
+from docking.ui.display import clamp_to_screen, get_pointer_position
 
 _POPUP_CLASS = "applet-popup-surface"
 _POPUP_CSS = f"""
@@ -19,6 +23,10 @@ _POPUP_CSS = f"""
 """.encode()
 
 _popup_css_provider: Gtk.CssProvider | None = None
+
+DEFAULT_POPUP_CURSOR_GAP_PX = 20
+DEFAULT_DIALOG_CONTENT_SPACING_PX = 8
+DEFAULT_DIALOG_MARGIN_PX = 12
 
 
 def ensure_popup_css() -> None:
@@ -50,3 +58,160 @@ def wrap_popup(content: Gtk.Widget) -> Gtk.Frame:
     frame.get_style_context().add_class(_POPUP_CLASS)
     frame.add(content)
     return frame
+
+
+def create_popup_window() -> Gtk.Window:
+    """Create a transient, undecorated applet popup window."""
+    window = Gtk.Window(type=Gtk.WindowType.POPUP)
+    window.set_decorated(False)
+    window.set_skip_taskbar_hint(True)
+    window.set_resizable(False)
+    window.set_type_hint(Gdk.WindowTypeHint.TOOLTIP)
+    return window
+
+
+def show_wrapped_popup(
+    *,
+    window: Gtk.Window,
+    content: Gtk.Widget,
+    gap_px: int = DEFAULT_POPUP_CURSOR_GAP_PX,
+) -> None:
+    """Replace popup content, show it, and place it near the pointer."""
+    child = window.get_child()
+    if child:
+        window.remove(child)
+
+    window.add(wrap_popup(content))
+    window.show_all()
+    position_popup_near_pointer(window=window, gap_px=gap_px)
+
+
+def position_popup_near_pointer(
+    *,
+    window: Gtk.Window,
+    gap_px: int = DEFAULT_POPUP_CURSOR_GAP_PX,
+) -> None:
+    """Position a popup above the pointer, clamped to the current screen."""
+    display = Gdk.Display.get_default()
+    pos = get_pointer_position(display) if display is not None else None
+    mouse_x = pos.x if pos is not None else 0
+    mouse_y = pos.y if pos is not None else 0
+
+    pref = window.get_preferred_size()[1]
+    popup_w = max(pref.width, 1)
+    popup_h = max(pref.height, 1)
+
+    screen = window.get_screen()
+    popup_x = int(mouse_x - popup_w / 2)
+    popup_y = int(mouse_y - popup_h - gap_px)
+    popup_pos = clamp_to_screen(
+        popup_x,
+        popup_y,
+        popup_w,
+        popup_h,
+        screen.get_width(),
+        screen.get_height(),
+    )
+    window.move(popup_pos.x, popup_pos.y)
+
+
+def prepare_dialog_content(
+    *,
+    dialog: Gtk.Dialog,
+    width: int | None = None,
+    height: int = -1,
+    spacing: int = DEFAULT_DIALOG_CONTENT_SPACING_PX,
+    margin: int = DEFAULT_DIALOG_MARGIN_PX,
+    default_response: int | None = None,
+    resizable: bool | None = None,
+) -> Gtk.Box:
+    """Apply standard applet dialog sizing, placement, and content spacing."""
+    if width is not None:
+        dialog.set_default_size(width, height)
+    dialog.set_position(Gtk.WindowPosition.MOUSE)
+    if resizable is not None:
+        dialog.set_resizable(resizable)
+    if default_response is not None:
+        dialog.set_default_response(default_response)
+
+    box = dialog.get_content_area()
+    box.set_spacing(spacing)
+    box.set_margin_start(margin)
+    box.set_margin_end(margin)
+    box.set_margin_top(margin)
+    box.set_margin_bottom(margin)
+    return box
+
+
+def add_cancel_ok_buttons(
+    *,
+    dialog: Gtk.Dialog,
+    ok_label: str | None = None,
+    cancel_label: str | None = None,
+) -> None:
+    """Add cancel then OK buttons in the standard GTK response order."""
+    dialog.add_buttons(
+        cancel_label or Gtk.STOCK_CANCEL,
+        Gtk.ResponseType.CANCEL,
+        ok_label or Gtk.STOCK_OK,
+        Gtk.ResponseType.OK,
+    )
+
+
+def create_capture_overlay(
+    *,
+    draw_handler: Callable[[Gtk.Window, object], bool],
+    click_handler: Callable[[Gtk.Window, Gdk.EventButton], bool],
+    key_handler: Callable[[Gtk.Window, Gdk.EventKey], bool],
+    cursor_type: Gdk.CursorType,
+) -> Gtk.Window:
+    """Create a fullscreen pointer-capture overlay with Escape handled by caller."""
+    overlay = Gtk.Window(type=Gtk.WindowType.POPUP)
+    overlay.set_decorated(False)
+    overlay.set_app_paintable(True)
+
+    screen = overlay.get_screen()
+    visual = screen.get_rgba_visual()
+    if visual:
+        overlay.set_visual(visual)
+
+    overlay.set_default_size(screen.get_width(), screen.get_height())
+    overlay.move(0, 0)
+    overlay.connect("draw", draw_handler)
+    overlay.set_events(Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.KEY_PRESS_MASK)
+    overlay.connect("button-press-event", click_handler)
+    overlay.connect("key-press-event", key_handler)
+
+    display = Gdk.Display.get_default()
+    cursor = Gdk.Cursor.new_for_display(display, cursor_type)
+    overlay.show_all()
+    overlay.get_window().set_cursor(cursor)
+
+    seat = display.get_default_seat()
+    seat.grab(
+        overlay.get_window(),
+        Gdk.SeatCapabilities.ALL_POINTING | Gdk.SeatCapabilities.KEYBOARD,
+        True,
+        cursor,
+        None,
+        None,
+        None,
+    )
+    return overlay
+
+
+def dismiss_capture_overlay(overlay: Gtk.Window | None) -> None:
+    """Release the active grab and destroy a capture overlay."""
+    if overlay is None:
+        return
+    display = Gdk.Display.get_default()
+    seat = display.get_default_seat()
+    seat.ungrab()
+    overlay.destroy()
+
+
+def draw_transparent_capture_overlay(_widget: Gtk.Window, cr) -> bool:
+    """Paint a near-transparent surface so the overlay receives events."""
+    cr.set_source_rgba(0, 0, 0, 0.01)
+    cr.paint()
+    return True

--- a/docking/applets/powerprofiles/applet.py
+++ b/docking/applets/powerprofiles/applet.py
@@ -27,7 +27,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import GLib, Gtk
 
 from docking.applets.base import Applet
-from docking.applets.menu import radio_menu_items
+from docking.applets.menu import disabled_menu_item, menu_sections, radio_menu_items
 from docking.applets.powerprofiles import meta
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
@@ -120,17 +120,11 @@ class PowerProfilesApplet(Applet):
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         """Build context menu with radio-selector profile entries."""
         if not self._state.available:
-            item = Gtk.MenuItem(label=_("Power Profiles unavailable"))
-            item.set_sensitive(False)
-            return [item]
+            return [disabled_menu_item(_("Power Profiles unavailable"), gtk=Gtk)]
 
-        items: list[Gtk.MenuItem] = []
-        title = Gtk.MenuItem(label=_("Select Profile"))
-        title.set_sensitive(False)
-        items.append(title)
-
-        items.extend(
-            radio_menu_items(
+        display = [
+            disabled_menu_item(_("Select Profile"), gtk=Gtk),
+            *radio_menu_items(
                 choices=tuple(
                     (profile_label(profile), profile)
                     for profile in self._ordered_profiles()
@@ -141,18 +135,19 @@ class PowerProfilesApplet(Applet):
                     value,
                 ),
                 gtk=Gtk,
-            )
-        )
+            ),
+        ]
 
+        status: list[Gtk.MenuItem] = []
         if self._state.degraded_reason:
-            items.append(Gtk.SeparatorMenuItem())
-            reason = Gtk.MenuItem(
-                label=_("Limited: {reason}").format(reason=self._state.degraded_reason)
+            status.append(
+                disabled_menu_item(
+                    _("Limited: {reason}").format(reason=self._state.degraded_reason),
+                    gtk=Gtk,
+                )
             )
-            reason.set_sensitive(False)
-            items.append(reason)
 
-        return items
+        return menu_sections(status=status, display=display, gtk=Gtk)
 
     def _ordered_profiles(self) -> tuple[str, ...]:
         """Resolve safe ordered profile list for menu/cycle actions."""

--- a/docking/applets/quicknote/applet.py
+++ b/docking/applets/quicknote/applet.py
@@ -11,6 +11,8 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GdkPixbuf, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.menu import menu_sections
+from docking.applets.popup import prepare_dialog_content
 from docking.applets.quicknote import meta
 from docking.applets.quicknote.render import render_icon
 from docking.applets.quicknote.state import (
@@ -30,7 +32,6 @@ EDIT_DIALOG_WIDTH_PX = 350
 EDIT_DIALOG_HEIGHT_PX = 250
 DIALOG_CONTENT_SPACING_PX = 8
 DIALOG_HORIZONTAL_MARGIN_PX = 12
-DIALOG_VERTICAL_MARGIN_PX = 8
 
 
 class QuickNoteApplet(Applet):
@@ -56,33 +57,29 @@ class QuickNoteApplet(Applet):
         self._show_edit_dialog()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
-
         edit = Gtk.MenuItem(label=_("Edit Note"))
         edit.connect("activate", lambda _: self._show_edit_dialog())
-        items.append(edit)
 
         clear = Gtk.MenuItem(label=_("Clear Note"))
         clear.connect("activate", lambda _: self._clear_note())
-        items.append(clear)
 
-        return items
+        return menu_sections(manage=[edit], destructive=[clear], gtk=Gtk)
 
     def _show_edit_dialog(self) -> None:
         dialog = Gtk.Dialog(
             title=_("Quick Note"),
             flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
         )
-        dialog.set_default_size(EDIT_DIALOG_WIDTH_PX, EDIT_DIALOG_HEIGHT_PX)
-        dialog.set_position(Gtk.WindowPosition.MOUSE)
+        dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         dialog.add_button(_("OK"), Gtk.ResponseType.OK)
-
-        box = dialog.get_content_area()
-        box.set_spacing(DIALOG_CONTENT_SPACING_PX)
-        box.set_margin_start(DIALOG_HORIZONTAL_MARGIN_PX)
-        box.set_margin_end(DIALOG_HORIZONTAL_MARGIN_PX)
-        box.set_margin_top(DIALOG_VERTICAL_MARGIN_PX)
-        box.set_margin_bottom(DIALOG_VERTICAL_MARGIN_PX)
+        box = prepare_dialog_content(
+            dialog=dialog,
+            width=EDIT_DIALOG_WIDTH_PX,
+            height=EDIT_DIALOG_HEIGHT_PX,
+            spacing=DIALOG_CONTENT_SPACING_PX,
+            margin=DIALOG_HORIZONTAL_MARGIN_PX,
+            default_response=Gtk.ResponseType.OK,
+        )
 
         scroll = Gtk.ScrolledWindow()
         scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
@@ -95,11 +92,12 @@ class QuickNoteApplet(Applet):
         box.pack_start(scroll, True, True, 0)
 
         def on_response(_dlg: Gtk.Dialog, _response_id: int) -> None:
-            buf = text_view.get_buffer()
-            start, end = buf.get_bounds()
-            self._note = buf.get_text(start, end, include_hidden_chars=True)
-            self._save()
-            self.present()
+            if _response_id == Gtk.ResponseType.OK:
+                buf = text_view.get_buffer()
+                start, end = buf.get_bounds()
+                self._note = buf.get_text(start, end, include_hidden_chars=True)
+                self._save()
+                self.present()
             dialog.destroy()
 
         dialog.connect("response", on_response)

--- a/docking/applets/quote/applet.py
+++ b/docking/applets/quote/applet.py
@@ -14,7 +14,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
 
 from docking.applets.base import Applet
-from docking.applets.menu import radio_menu_items
+from docking.applets.menu import disabled_menu_item, menu_sections, radio_menu_items
 from docking.applets.quote import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -79,32 +79,22 @@ class QuoteApplet(Applet):
         self._fetch_async(show_first=True)
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
-
-        source_header = Gtk.MenuItem(label=SOURCE_LABELS.get(self._source, _("Quote")))
-        source_header.set_sensitive(False)
-        items.append(source_header)
+        status = [
+            disabled_menu_item(SOURCE_LABELS.get(self._source, _("Quote")), gtk=Gtk)
+        ]
 
         next_item = Gtk.MenuItem(label=_("Next Quote"))
         next_item.connect("activate", lambda _: self.on_clicked())
-        items.append(next_item)
 
         copy_item = Gtk.MenuItem(label=_("Copy Quote"))
         copy_item.connect("activate", lambda _: self._copy_current_quote())
-        items.append(copy_item)
 
         refresh_item = Gtk.MenuItem(label=_("Refresh Now"))
         refresh_item.connect("activate", lambda _: self._refresh_from_web())
-        items.append(refresh_item)
 
-        items.append(Gtk.SeparatorMenuItem())
-
-        source_title = Gtk.MenuItem(label=_("Source"))
-        source_title.set_sensitive(False)
-        items.append(source_title)
-
-        items.extend(
-            radio_menu_items(
+        display = [
+            disabled_menu_item(_("Source"), gtk=Gtk),
+            *radio_menu_items(
                 choices=tuple(
                     (label, source_id) for source_id, label in SOURCE_LABELS.items()
                 ),
@@ -114,10 +104,17 @@ class QuoteApplet(Applet):
                     value,
                 ),
                 gtk=Gtk,
-            )
-        )
+            ),
+        ]
 
-        return items
+        return menu_sections(
+            status=status,
+            primary=[copy_item],
+            navigation=[next_item],
+            refresh=[refresh_item],
+            display=display,
+            gtk=Gtk,
+        )
 
     def _on_source_toggled(self, widget: Gtk.RadioMenuItem, source_id: str) -> None:
         if not widget.get_active():

--- a/docking/applets/recentfiles/applet.py
+++ b/docking/applets/recentfiles/applet.py
@@ -14,6 +14,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GdkPixbuf, Gio, GLib, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.menu import menu_sections
 from docking.applets.recentfiles import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -70,23 +71,19 @@ class RecentFilesApplet(Applet):
             log.bind(action="open_recent").warning("Failed to open %s: %s", uri, exc)
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        primary: list[Gtk.MenuItem] = []
 
         for entry in self._entries:
             mi = Gtk.MenuItem(label=truncate_name(text=entry.name))
             uri = entry.uri
             mi.connect("activate", lambda _, u=uri: self._open_uri(uri=u))
-            items.append(mi)
-
-        if self._entries:
-            items.append(Gtk.SeparatorMenuItem())
+            primary.append(mi)
 
         clear_item = Gtk.MenuItem(label=_("Clear Recent Files"))
         clear_item.set_sensitive(bool(self._entries))
         clear_item.connect("activate", lambda _: self._clear_recent())
-        items.append(clear_item)
 
-        return items
+        return menu_sections(primary=primary, destructive=[clear_item], gtk=Gtk)
 
     def _refresh_entries(self) -> None:
         """Read from Gtk.RecentManager, sort by modified time descending."""

--- a/docking/applets/screenshot/applet.py
+++ b/docking/applets/screenshot/applet.py
@@ -13,6 +13,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, GdkPixbuf, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.menu import menu_sections
 from docking.applets.screenshot import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -61,24 +62,24 @@ class ScreenshotApplet(Applet):
         self._run_mode(mode="full")
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
         tool = self._tool
         if not tool:
-            return items
+            return []
+        primary: list[Gtk.MenuItem] = []
         for label, mode in _MODE_OPTIONS:
             mi = Gtk.MenuItem(label=label)
             mi.connect("activate", lambda _w, m=mode: self._run_mode(mode=m))
-            items.append(mi)
+            primary.append(mi)
 
-        items.append(Gtk.SeparatorMenuItem())
+        manage: list[Gtk.MenuItem] = []
         for delay_s in _TIMED_DELAYS_S:
             mi = Gtk.MenuItem(label=_("Full Screen in {delay}s").format(delay=delay_s))
             mi.connect(
                 "activate",
                 lambda _w, d=delay_s: self._run_mode(mode="full", delay_seconds=d),
             )
-            items.append(mi)
-        return items
+            manage.append(mi)
+        return menu_sections(primary=primary, manage=manage, gtk=Gtk)
 
     def _run_mode(self, *, mode: Mode, delay_seconds: int = 0) -> None:
         if not self._tool:

--- a/docking/applets/separator/applet.py
+++ b/docking/applets/separator/applet.py
@@ -10,7 +10,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 from docking.applets.base import Applet
-from docking.applets.menu import radio_submenu
+from docking.applets.menu import menu_sections, radio_submenu
 from docking.applets.separator import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -137,7 +137,11 @@ class SeparatorApplet(Applet):
             "toggled",
             lambda widget: self._set_invert_color(widget.get_active()),
         )
-        return [increase, decrease, Gtk.SeparatorMenuItem(), style, invert]
+        return menu_sections(
+            primary=[increase, decrease],
+            display=[style, invert],
+            gtk=Gtk,
+        )
 
 
 def _normalized_gap(*, value: object) -> int:

--- a/docking/applets/session/applet.py
+++ b/docking/applets/session/applet.py
@@ -10,6 +10,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
 from docking.applets.base import Applet
+from docking.applets.menu import menu_sections
 from docking.applets.session import meta
 from docking.i18n import _
 
@@ -39,7 +40,8 @@ class SessionApplet(Applet):
         lock_screen()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        primary: list[Gtk.MenuItem] = []
+        destructive: list[Gtk.MenuItem] = []
         for label, cmd in _ACTIONS:
             mi = Gtk.MenuItem(label=label)
             action = label.lower().replace(" ", "_")
@@ -50,5 +52,8 @@ class SessionApplet(Applet):
                     "activate",
                     lambda _w, c=cmd, a=action: _run(cmd=c, action=a),
                 )
-            items.append(mi)
-        return items
+            if label in (LOCK_SCREEN_LABEL, _("Suspend")):
+                primary.append(mi)
+            else:
+                destructive.append(mi)
+        return menu_sections(primary=primary, destructive=destructive, gtk=Gtk)

--- a/docking/applets/speedtest/applet.py
+++ b/docking/applets/speedtest/applet.py
@@ -13,6 +13,8 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import Gdk, GdkPixbuf, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.freshness import on_demand_label
+from docking.applets.menu import disabled_menu_item, menu_sections
 from docking.applets.speedtest import meta
 from docking.applets.speedtest.api import SpeedtestError, run_librespeed
 from docking.applets.speedtest.render import render_icon
@@ -70,27 +72,26 @@ class SpeedtestApplet(Applet):
         self._start_test()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        status: list[Gtk.MenuItem] = []
         header = self._menu_header_label()
         if header:
-            item = Gtk.MenuItem(label=header)
-            item.set_sensitive(False)
-            items.append(item)
-            items.append(Gtk.SeparatorMenuItem())
+            status.append(disabled_menu_item(header, gtk=Gtk))
+
+        status.append(disabled_menu_item(on_demand_label(verb=_("Runs")), gtk=Gtk))
 
         run_item = Gtk.MenuItem(
             label=_("Running...") if self._running else _("Run Test")
         )
         run_item.set_sensitive(not self._running)
         run_item.connect("activate", lambda _w: self._start_test())
-        items.append(run_item)
+        primary = [run_item]
 
         if self._result is not None:
             copy_item = Gtk.MenuItem(label=_("Copy Last Result"))
             copy_item.connect("activate", lambda _w: self._copy_last_result())
-            items.append(copy_item)
+            primary.append(copy_item)
 
-        return items
+        return menu_sections(status=status, primary=primary, gtk=Gtk)
 
     def start(self, notify: Callable[[], None]) -> None:
         super().start(notify=notify)

--- a/docking/applets/speedtest/state.py
+++ b/docking/applets/speedtest/state.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, NamedTuple
 
+from docking.applets.freshness import on_demand_label
+from docking.applets.tooltip import structured_tooltip
 from docking.applets.units import format_compact_number
 from docking.i18n import _
 
@@ -68,32 +70,46 @@ def build_tooltip(
     error: str | None,
 ) -> str:
     """Multi-line tooltip summarizing the last run."""
-    lines = [_("Speedtest")]
+    freshness = (on_demand_label(verb=_("Runs")),)
     if running:
-        lines.append(_("Running..."))
-        return "\n".join(lines)
-    if error:
-        lines.append(_("Error: {msg}").format(msg=error))
-        return "\n".join(lines)
-    if result is None:
-        lines.append(_("Click to run a test"))
-        return "\n".join(lines)
-    lines.append(
-        _("Down: {d:.1f} Mbps   Up: {u:.1f} Mbps").format(
-            d=result.download_mbps, u=result.upload_mbps
+        return structured_tooltip(
+            title=_("Speedtest"),
+            primary=_("Running..."),
+            freshness=freshness,
         )
+    if error:
+        return structured_tooltip(
+            title=_("Speedtest"),
+            freshness=freshness,
+            error=error,
+        )
+    if result is None:
+        return structured_tooltip(
+            title=_("Speedtest"),
+            primary=_("Click to run a test"),
+            freshness=freshness,
+        )
+    primary = _("Down: {d:.1f} Mbps   Up: {u:.1f} Mbps").format(
+        d=result.download_mbps, u=result.upload_mbps
     )
-    lines.append(
+    details = [
         _("Ping: {p:.1f} ms   Jitter: {j:.1f} ms").format(
             p=result.ping_ms, j=result.jitter_ms
-        )
-    )
+        ),
+    ]
     if result.server:
-        lines.append(_("Server: {s}").format(s=result.server))
+        details.append(_("Server: {s}").format(s=result.server))
     when = format_timestamp(result.timestamp)
+    freshness_lines = []
     if when:
-        lines.append(_("At: {t}").format(t=when))
-    return "\n".join(lines)
+        freshness_lines.append(_("At: {t}").format(t=when))
+    freshness_lines.extend(freshness)
+    return structured_tooltip(
+        title=_("Speedtest"),
+        primary=primary,
+        details=details,
+        freshness=freshness_lines,
+    )
 
 
 def prefs_from_mapping(prefs: Mapping[str, Any] | None) -> SpeedtestPrefs:

--- a/docking/applets/stretchcoach/applet.py
+++ b/docking/applets/stretchcoach/applet.py
@@ -12,7 +12,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GdkPixbuf, GLib, Gtk
 
 from docking.applets.base import Applet
-from docking.applets.menu import radio_menu_items
+from docking.applets.menu import menu_sections, radio_menu_items
 from docking.applets.stretchcoach import meta
 from docking.applets.stretchcoach.render import render_icon
 from docking.applets.stretchcoach.state import (
@@ -76,37 +76,31 @@ class StretchCoachApplet(Applet):
         self.present()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
-
         now_label = _("Acknowledge Break") if self._state.due else _("Take Break Now")
         take_break = Gtk.MenuItem(label=now_label)
         take_break.connect("activate", lambda _w: self.on_clicked())
-        items.append(take_break)
 
         preview = Gtk.MenuItem(label=_("Show Random Stretch"))
         preview.connect("activate", lambda _w: self._show_random_stretch())
-        items.append(preview)
 
         cards = Gtk.CheckMenuItem(label=_("Random Stretch Cards"))
         cards.set_active(self._state.cards_enabled)
         cards.connect("toggled", self._on_toggle_cards)
-        items.append(cards)
 
-        items.append(Gtk.SeparatorMenuItem())
-
-        items.extend(
-            radio_menu_items(
-                choices=tuple(
-                    (_("{mins} min").format(mins=mins), mins)
-                    for mins in INTERVAL_PRESETS
-                ),
-                active_value=self._state.interval_min,
-                on_selected=lambda _widget, value: self._set_interval(value),
-                gtk=Gtk,
-            )
+        intervals = radio_menu_items(
+            choices=tuple(
+                (_("{mins} min").format(mins=mins), mins) for mins in INTERVAL_PRESETS
+            ),
+            active_value=self._state.interval_min,
+            on_selected=lambda _widget, value: self._set_interval(value),
+            gtk=Gtk,
         )
 
-        return items
+        return menu_sections(
+            primary=[take_break, preview],
+            display=[cards, Gtk.SeparatorMenuItem(), *intervals],
+            gtk=Gtk,
+        )
 
     def _tick(self) -> bool:
         result = tick(self._state, cards=self._cards)

--- a/docking/applets/systemmonitor/applet.py
+++ b/docking/applets/systemmonitor/applet.py
@@ -13,7 +13,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import GdkPixbuf, GLib, Gtk
 
 from docking.applets.base import Applet
-from docking.applets.menu import radio_submenu
+from docking.applets.menu import menu_sections, radio_submenu
 from docking.applets.systemmonitor import meta
 from docking.applets.systemmonitor.render import render_icon
 from docking.applets.systemmonitor.state import (
@@ -82,28 +82,24 @@ class SystemMonitorApplet(Applet):
         )
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
         show_disk = Gtk.CheckMenuItem(label=_("Show Disk Usage"))
         show_disk.set_active(self._show_disk)
         show_disk.connect("toggled", self._on_toggle_disk)
-        items.append(show_disk)
 
-        items.append(
-            radio_submenu(
-                label=_("Temperature Unit"),
-                choices=tuple(
-                    (temperature_unit_label(unit), unit)
-                    for unit in (TemperatureUnit.CELSIUS, TemperatureUnit.FAHRENHEIT)
-                ),
-                active_value=self._temperature_unit,
-                on_selected=lambda widget, value: self._on_temperature_unit_selected(
-                    widget=widget,
-                    temperature_unit=value,
-                ),
-                gtk=Gtk,
-            )
+        temperature_unit = radio_submenu(
+            label=_("Temperature Unit"),
+            choices=tuple(
+                (temperature_unit_label(unit), unit)
+                for unit in (TemperatureUnit.CELSIUS, TemperatureUnit.FAHRENHEIT)
+            ),
+            active_value=self._temperature_unit,
+            on_selected=lambda widget, value: self._on_temperature_unit_selected(
+                widget=widget,
+                temperature_unit=value,
+            ),
+            gtk=Gtk,
         )
-        return items
+        return menu_sections(display=[show_disk, temperature_unit], gtk=Gtk)
 
     def _on_toggle_disk(self, widget: Gtk.CheckMenuItem) -> None:
         self._show_disk = widget.get_active()

--- a/docking/applets/systemmonitor/state.py
+++ b/docking/applets/systemmonitor/state.py
@@ -13,6 +13,7 @@ from docking.applets.temperature import (
     format_temperature,
     normalize_temperature_unit,
 )
+from docking.applets.tooltip import structured_tooltip
 from docking.i18n import _
 from docking.log import get_logger
 
@@ -147,19 +148,24 @@ def tooltip_text(
     temperature_unit: TemperatureUnit = TemperatureUnit.CELSIUS,
 ) -> str:
     """Build tooltip text for current cpu/memory values."""
-    text = _("CPU: {cpu}% | Mem: {mem}%").format(
+    primary = _("CPU: {cpu}% | Mem: {mem}%").format(
         cpu=f"{cpu * 100:.1f}", mem=f"{mem * 100:.1f}"
     )
     if temperature_c is not None:
-        text = _("{text} | Temp: {temp}").format(
-            text=text,
+        primary = _("{text} | Temp: {temp}").format(
+            text=primary,
             temp=format_temperature(
                 temperature_c,
                 temperature_unit=temperature_unit,
                 precision=1,
             ),
         )
+    details = []
     if disks:
         parts = [f"{mount}: {pct * 100:.0f}%" for mount, pct in disks]
-        text += "\n" + _("Disk: {usage}").format(usage="  ".join(parts))
-    return text
+        details.append(_("Disk: {usage}").format(usage="  ".join(parts)))
+    return structured_tooltip(
+        title=_("System Monitor"),
+        primary=primary,
+        details=details,
+    )

--- a/docking/applets/thermals/applet.py
+++ b/docking/applets/thermals/applet.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -12,7 +13,13 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import GdkPixbuf, GLib, Gtk
 
 from docking.applets.base import Applet
-from docking.applets.menu import radio_submenu
+from docking.applets.freshness import cadence_label
+from docking.applets.live_state import (
+    live_state_error,
+    live_state_label,
+    resolve_live_status,
+)
+from docking.applets.menu import disabled_menu_item, menu_sections, radio_submenu
 from docking.applets.thermals import meta
 from docking.applets.thermals.render import render_icon
 from docking.applets.thermals.state import (
@@ -48,7 +55,9 @@ class ThermalsApplet(Applet):
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
         self._snapshot: ThermalSnapshot | None = None
+        self._last_updated: dt.datetime | None = None
         self._loading = False
+        self._last_error = ""
         self._timer_id = 0
         self._startup_fetch_timer_id = 0
         self._request_id = 0
@@ -65,6 +74,7 @@ class ThermalsApplet(Applet):
             size=size,
             snapshot=self._snapshot,
             loading=self._loading,
+            error=bool(self._last_error),
             temperature_unit=self._temperature_unit,
         )
 
@@ -72,48 +82,69 @@ class ThermalsApplet(Applet):
         self.item.name = build_tooltip(
             snapshot=self._snapshot,
             loading=self._loading,
+            error=self._last_error,
             temperature_unit=self._temperature_unit,
+            updated_at=self._last_updated,
+            cadence_seconds=REFRESH_INTERVAL_S,
         )
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        status: list[Gtk.MenuItem] = []
         if self._snapshot is not None:
             if not self._snapshot.available:
-                header = Gtk.MenuItem(label=_("lm-sensors not installed"))
-                header.set_sensitive(False)
-                items.append(header)
+                status.append(
+                    disabled_menu_item(_("lm-sensors not installed"), gtk=Gtk)
+                )
             elif self._snapshot.error:
-                header = Gtk.MenuItem(label=self._snapshot.error)
-                header.set_sensitive(False)
-                items.append(header)
+                status.append(disabled_menu_item(self._snapshot.error, gtk=Gtk))
             else:
                 if self._snapshot.hottest is not None:
                     hot = self._snapshot.hottest
-                    item = Gtk.MenuItem(
-                        label=_("Hot: {label} {temp}").format(
-                            label=reading_label(hot),
-                            temp=format_temperature(
-                                hot.celsius,
-                                temperature_unit=self._temperature_unit,
+                    status.append(
+                        disabled_menu_item(
+                            _("Hot: {label} {temp}").format(
+                                label=reading_label(hot),
+                                temp=format_temperature(
+                                    hot.celsius,
+                                    temperature_unit=self._temperature_unit,
+                                ),
                             ),
+                            gtk=Gtk,
                         )
                     )
-                    item.set_sensitive(False)
-                    items.append(item)
                 if self._snapshot.fan is not None:
                     fan = self._snapshot.fan
-                    item = Gtk.MenuItem(
-                        label=_("Fan: {label} {rpm}").format(
-                            label=reading_label(fan),
-                            rpm=format_rpm(fan.rpm),
+                    status.append(
+                        disabled_menu_item(
+                            _("Fan: {label} {rpm}").format(
+                                label=reading_label(fan),
+                                rpm=format_rpm(fan.rpm),
+                            ),
+                            gtk=Gtk,
                         )
                     )
-                    item.set_sensitive(False)
-                    items.append(item)
-            if items:
-                items.append(Gtk.SeparatorMenuItem())
 
-        items.append(
+        state_status = self._live_status()
+        state_label = live_state_label(state_status)
+        if state_label:
+            status.append(disabled_menu_item(state_label, gtk=Gtk))
+        error = live_state_error(status=state_status, error=self._last_error)
+        if error:
+            status.append(
+                disabled_menu_item(_("Error: {msg}").format(msg=error), gtk=Gtk)
+            )
+
+        status.append(
+            disabled_menu_item(
+                cadence_label(seconds=REFRESH_INTERVAL_S, verb=_("Samples")),
+                gtk=Gtk,
+            )
+        )
+
+        refresh = Gtk.MenuItem(label=_("Refresh Now"))
+        refresh.connect("activate", lambda _w: self._fetch_async())
+
+        display = [
             radio_submenu(
                 label=_("Temperature Unit"),
                 choices=tuple(
@@ -127,12 +158,14 @@ class ThermalsApplet(Applet):
                 ),
                 gtk=Gtk,
             )
-        )
+        ]
 
-        refresh = Gtk.MenuItem(label=_("Refresh Now"))
-        refresh.connect("activate", lambda _w: self._fetch_async())
-        items.append(refresh)
-        return items
+        return menu_sections(
+            status=status,
+            refresh=[refresh],
+            display=display,
+            gtk=Gtk,
+        )
 
     def start(self, notify: Callable[[], None]) -> None:
         super().start(notify=notify)
@@ -187,6 +220,7 @@ class ThermalsApplet(Applet):
         self._request_id += 1
         request_id = self._request_id
         self._loading = self._snapshot is None
+        self._last_error = ""
         if self._loading:
             self.present()
 
@@ -212,7 +246,16 @@ class ThermalsApplet(Applet):
         if request_id != self._request_id:
             return False
         self._loading = False
-        self._snapshot = snapshot
+        if (
+            (snapshot.available and not snapshot.error)
+            or self._snapshot is None
+            or self._snapshot.error
+        ):
+            self._snapshot = snapshot
+            self._last_error = ""
+        else:
+            self._last_error = snapshot.error or _("Thermal readings unavailable")
+        self._last_updated = dt.datetime.now(dt.timezone.utc)
         self.present()
         return False
 
@@ -220,10 +263,27 @@ class ThermalsApplet(Applet):
         if request_id != self._request_id:
             return False
         self._loading = False
-        self._snapshot = ThermalSnapshot(
-            available=True,
-            error=str(exc) or exc.__class__.__name__,
-        )
+        error = str(exc) or exc.__class__.__name__
+        if self._snapshot is None or self._snapshot.error:
+            self._snapshot = ThermalSnapshot(available=True, error=error)
+            self._last_error = ""
+        else:
+            self._last_error = error
+        self._last_updated = dt.datetime.now(dt.timezone.utc)
         log.bind(action="fetch_error").debug("Thermals fetch failed: %s", exc)
         self.present()
         return False
+
+    def _live_status(self):
+        snapshot_error = self._snapshot.error if self._snapshot is not None else ""
+        return resolve_live_status(
+            has_data=(
+                self._snapshot is not None
+                and self._snapshot.available
+                and not self._snapshot.error
+            ),
+            loading=self._loading,
+            error=self._last_error or snapshot_error,
+            updated_at=self._last_updated,
+            stale_after_seconds=REFRESH_INTERVAL_S * 2,
+        )

--- a/docking/applets/thermals/render.py
+++ b/docking/applets/thermals/render.py
@@ -25,6 +25,7 @@ def render_icon(
     size: int,
     snapshot: ThermalSnapshot | None,
     loading: bool = False,
+    error: bool = False,
     temperature_unit: TemperatureUnit = TemperatureUnit.CELSIUS,
 ) -> GdkPixbuf.Pixbuf | None:
     """Render thermals icon with a shared bottom temperature label."""
@@ -32,7 +33,7 @@ def render_icon(
     cr = cairo.Context(surface)
 
     temp = snapshot.hottest.celsius if snapshot and snapshot.hottest else None
-    error = bool(snapshot and (not snapshot.available or snapshot.error))
+    error = error or bool(snapshot and (not snapshot.available or snapshot.error))
     r, g, b = thermal_color(temp)
 
     _draw_background(cr=cr, size=size, rgb=(r, g, b), error=error, loading=loading)

--- a/docking/applets/thermals/state.py
+++ b/docking/applets/thermals/state.py
@@ -10,6 +10,14 @@ from dataclasses import dataclass
 from typing import Any
 
 from docking.applets import temperature as temperature_display
+from docking.applets.live_state import (
+    live_freshness_lines,
+    live_state_error,
+    live_state_label,
+    refresh_recovery_label,
+    resolve_live_status,
+)
+from docking.applets.tooltip import structured_tooltip
 from docking.i18n import _
 from docking.log import get_logger
 
@@ -172,43 +180,93 @@ def build_tooltip(
     *,
     snapshot: ThermalSnapshot | None,
     loading: bool = False,
+    error: str | None = None,
     temperature_unit: TemperatureUnit = TemperatureUnit.CELSIUS,
+    updated_at: object | None = None,
+    cadence_seconds: int | None = None,
 ) -> str:
     """Build tooltip text for Thermals."""
-    lines = [_("Thermals")]
+    snapshot_error = snapshot.error if snapshot is not None else ""
+    state_error = error or snapshot_error
+    status = resolve_live_status(
+        has_data=snapshot is not None and snapshot.available and not snapshot.error,
+        loading=loading,
+        error=state_error,
+        updated_at=updated_at,
+    )
     if snapshot is None:
-        lines.append(_("Loading...") if loading else _("No reading yet"))
-        return "\n".join(lines)
+        return structured_tooltip(
+            title=_("Thermals"),
+            primary=live_state_label(status),
+            freshness=live_freshness_lines(
+                status=status,
+                updated_at=updated_at,
+                cadence_seconds=cadence_seconds,
+                cadence_verb=_("Samples"),
+            ),
+            error=live_state_error(status=status, error=state_error),
+            recovery=refresh_recovery_label(status),
+        )
     if not snapshot.available:
-        lines.append(snapshot.error or _("lm-sensors not installed"))
-        return "\n".join(lines)
+        return structured_tooltip(
+            title=_("Thermals"),
+            freshness=live_freshness_lines(
+                status=status,
+                updated_at=updated_at,
+                cadence_seconds=cadence_seconds,
+                cadence_verb=_("Samples"),
+            ),
+            error=snapshot.error or _("lm-sensors not installed"),
+            recovery=refresh_recovery_label(status),
+        )
     if snapshot.error:
-        lines.append(snapshot.error)
-        return "\n".join(lines)
+        return structured_tooltip(
+            title=_("Thermals"),
+            freshness=live_freshness_lines(
+                status=status,
+                updated_at=updated_at,
+                cadence_seconds=cadence_seconds,
+                cadence_verb=_("Samples"),
+            ),
+            error=snapshot.error,
+            recovery=refresh_recovery_label(status),
+        )
 
+    primary = None
+    details = []
     if snapshot.hottest is not None:
-        lines.append(
-            _("Hot: {label} {temp}").format(
-                label=reading_label(snapshot.hottest),
-                temp=format_temperature(
-                    snapshot.hottest.celsius,
-                    temperature_unit=temperature_unit,
-                ),
-            )
+        primary = _("Hot: {label} {temp}").format(
+            label=reading_label(snapshot.hottest),
+            temp=format_temperature(
+                snapshot.hottest.celsius,
+                temperature_unit=temperature_unit,
+            ),
         )
     else:
-        lines.append(_("Hot: unavailable"))
+        primary = _("Hot: unavailable")
 
     if snapshot.fan is not None:
-        lines.append(
+        details.append(
             _("Fan: {label} {rpm}").format(
                 label=reading_label(snapshot.fan),
                 rpm=format_rpm(snapshot.fan.rpm),
             )
         )
     else:
-        lines.append(_("Fan: unavailable"))
-    return "\n".join(lines)
+        details.append(_("Fan: unavailable"))
+    return structured_tooltip(
+        title=_("Thermals"),
+        primary=primary,
+        details=details,
+        freshness=live_freshness_lines(
+            status=status,
+            updated_at=updated_at,
+            cadence_seconds=cadence_seconds,
+            cadence_verb=_("Samples"),
+        ),
+        error=live_state_error(status=status, error=state_error),
+        recovery=refresh_recovery_label(status),
+    )
 
 
 def reading_label(reading: ThermalReading | FanReading) -> str:

--- a/docking/applets/todayinhistory/applet.py
+++ b/docking/applets/todayinhistory/applet.py
@@ -15,6 +15,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import GdkPixbuf, Gio, GLib, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.menu import disabled_menu_item, menu_sections
 from docking.applets.todayinhistory import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -84,26 +85,27 @@ class TodayInHistoryApplet(Applet):
         self.present()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        status = [disabled_menu_item(self._source_label(), gtk=Gtk)]
 
-        source_header = Gtk.MenuItem(label=self._source_label())
-        source_header.set_sensitive(False)
-        items.append(source_header)
-
+        primary: list[Gtk.MenuItem] = []
         if self._current is not None and self._current.article_url:
             open_item = Gtk.MenuItem(label=_("Open Article"))
             open_item.connect("activate", lambda _w: self._open_current_article())
-            items.append(open_item)
+            primary.append(open_item)
 
         next_item = Gtk.MenuItem(label=_("Next Event"))
         next_item.connect("activate", lambda _w: self.on_clicked())
-        items.append(next_item)
 
         refresh_item = Gtk.MenuItem(label=_("Refresh Now"))
         refresh_item.connect("activate", lambda _w: self._refresh_from_web())
-        items.append(refresh_item)
 
-        return items
+        return menu_sections(
+            status=status,
+            primary=primary,
+            navigation=[next_item],
+            refresh=[refresh_item],
+            gtk=Gtk,
+        )
 
     def refresh_tooltip(self) -> None:
         if self._loading and self._current is None:

--- a/docking/applets/tooltip.py
+++ b/docking/applets/tooltip.py
@@ -1,0 +1,43 @@
+"""Shared tooltip construction helpers for applets."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from docking.i18n import _
+
+
+def structured_tooltip(
+    *,
+    title: str,
+    primary: str | None = None,
+    details: Iterable[str | None] = (),
+    freshness: Iterable[str | None] = (),
+    error: str | None = None,
+    recovery: str | None = None,
+) -> str:
+    """Build a multi-line tooltip in the standard applet order.
+
+    Order is:
+    title or primary object, primary current value, secondary details,
+    freshness/timestamp, then error or recovery hints.
+    """
+    lines: list[str] = []
+    _append_line(lines=lines, text=title)
+    _append_line(lines=lines, text=primary)
+    for detail in details:
+        _append_line(lines=lines, text=detail)
+    for line in freshness:
+        _append_line(lines=lines, text=line)
+    if error:
+        _append_line(lines=lines, text=_("Error: {msg}").format(msg=error))
+    _append_line(lines=lines, text=recovery)
+    return "\n".join(lines)
+
+
+def _append_line(*, lines: list[str], text: str | None) -> None:
+    if text is None:
+        return
+    cleaned = str(text).strip()
+    if cleaned:
+        lines.append(cleaned)

--- a/docking/applets/trash/applet.py
+++ b/docking/applets/trash/applet.py
@@ -14,6 +14,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GdkPixbuf, Gio, GLib, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.menu import menu_sections
 from docking.applets.trash import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -55,18 +56,14 @@ class TrashApplet(Applet):
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         """Return 'Open Trash' and 'Empty Trash' menu items."""
-        items: list[Gtk.MenuItem] = []
-
         open_item = Gtk.MenuItem(label=_("Open Trash"))
         open_item.connect("activate", lambda _: self.on_clicked())
-        items.append(open_item)
 
         empty_item = Gtk.MenuItem(label=_("Empty Trash"))
         empty_item.set_sensitive(self._item_count > 0)
         empty_item.connect("activate", lambda _: self._empty_trash())
-        items.append(empty_item)
 
-        return items
+        return menu_sections(primary=[open_item], destructive=[empty_item], gtk=Gtk)
 
     def start(self, notify: Callable[[], None]) -> None:
         """Start Gio.FileMonitor on trash:/// for real-time icon updates."""

--- a/docking/applets/trivia/applet.py
+++ b/docking/applets/trivia/applet.py
@@ -14,6 +14,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.menu import disabled_menu_item, menu_sections
 from docking.applets.trivia import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -67,23 +68,19 @@ class TriviaApplet(Applet):
         self._fetch_async(show_first=True)
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        status: list[Gtk.MenuItem] = [disabled_menu_item("Open Trivia DB", gtk=Gtk)]
 
-        source_header = Gtk.MenuItem(label="Open Trivia DB")
-        source_header.set_sensitive(False)
-        items.append(source_header)
-
+        primary: list[Gtk.MenuItem] = []
         if self._current is not None:
-            meta = Gtk.MenuItem(
-                label=_("{category} / {difficulty}").format(
-                    category=self._current.category,
-                    difficulty=self._current.difficulty.title(),
+            status.append(
+                disabled_menu_item(
+                    _("{category} / {difficulty}").format(
+                        category=self._current.category,
+                        difficulty=self._current.difficulty.title(),
+                    ),
+                    gtk=Gtk,
                 )
             )
-            meta.set_sensitive(False)
-            items.append(meta)
-
-            items.append(Gtk.SeparatorMenuItem())
 
             if not self._current.selected_answer:
                 for answer in self._current.answers:
@@ -92,35 +89,39 @@ class TriviaApplet(Applet):
                         "activate",
                         lambda _w, a=answer: self._select_answer(a),
                     )
-                    items.append(answer_item)
+                    primary.append(answer_item)
             else:
-                result = Gtk.MenuItem(
-                    label=_("Correct answer: {answer}").format(
-                        answer=self._current.correct_answer
+                status.append(
+                    disabled_menu_item(
+                        _("Correct answer: {answer}").format(
+                            answer=self._current.correct_answer
+                        ),
+                        gtk=Gtk,
                     )
                 )
-                result.set_sensitive(False)
-                items.append(result)
                 if self._current.selected_answer != self._current.correct_answer:
-                    chosen = Gtk.MenuItem(
-                        label=_("Your answer: {answer}").format(
-                            answer=self._current.selected_answer
+                    status.append(
+                        disabled_menu_item(
+                            _("Your answer: {answer}").format(
+                                answer=self._current.selected_answer
+                            ),
+                            gtk=Gtk,
                         )
                     )
-                    chosen.set_sensitive(False)
-                    items.append(chosen)
-
-            items.append(Gtk.SeparatorMenuItem())
 
         next_item = Gtk.MenuItem(label=_("Next Trivia"))
         next_item.connect("activate", lambda _w: self.on_clicked())
-        items.append(next_item)
 
         refresh_item = Gtk.MenuItem(label=_("Refresh Now"))
         refresh_item.connect("activate", lambda _w: self._refresh_from_web())
-        items.append(refresh_item)
 
-        return items
+        return menu_sections(
+            status=status,
+            primary=primary,
+            navigation=[next_item],
+            refresh=[refresh_item],
+            gtk=Gtk,
+        )
 
     def _select_answer(self, answer: str) -> None:
         if self._current is None or self._current.selected_answer:

--- a/docking/applets/unitconverter/applet.py
+++ b/docking/applets/unitconverter/applet.py
@@ -36,12 +36,11 @@ from typing import TYPE_CHECKING
 import gi
 
 gi.require_version("Gtk", "3.0")
-gi.require_version("Gdk", "3.0")
 gi.require_version("GdkPixbuf", "2.0")
-from gi.repository import Gdk, GdkPixbuf, Gtk
+from gi.repository import GdkPixbuf, Gtk
 
 from docking.applets.base import Applet
-from docking.applets.popup import wrap_popup
+from docking.applets.popup import create_popup_window, show_wrapped_popup
 from docking.applets.unitconverter import meta
 from docking.applets.unitconverter.render import create_icon
 from docking.applets.unitconverter.state import (
@@ -57,14 +56,12 @@ from docking.applets.unitconverter.state import (
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
 from docking.log import get_logger, with_context
-from docking.ui.display import get_pointer_position
 
 if TYPE_CHECKING:
     from docking.core.config import Config
 
 log = with_context(get_logger(name="unitconverter"), applet_id=meta.id)
 
-POPUP_CORNER_RADIUS_PX = 8
 POPUP_PADDING_PX = 12
 POPUP_CURSOR_GAP_PX = 20
 POPUP_WIDTH_PX = 280
@@ -132,42 +129,13 @@ class UnitConverterApplet(Applet):
 
     def _show_popup(self) -> None:
         if self._popup is None:
-            self._popup = Gtk.Window(type=Gtk.WindowType.POPUP)
-            self._popup.set_decorated(False)
-            self._popup.set_skip_taskbar_hint(True)
-            self._popup.set_type_hint(Gdk.WindowTypeHint.TOOLTIP)
+            self._popup = create_popup_window()
 
-        child = self._popup.get_child()
-        if child:
-            self._popup.remove(child)
-
-        self._popup.add(wrap_popup(self._build_popup_content()))
-        self._popup.show_all()
-
-        # Position near mouse
-        display = Gdk.Display.get_default()
-        pos = get_pointer_position(display)
-        mouse_x = pos.x if pos is not None else 0
-        mouse_y = pos.y if pos is not None else 0
-
-        pref = self._popup.get_preferred_size()[1]
-        popup_w = max(pref.width, 1)
-        popup_h = max(pref.height, 1)
-
-        screen = self._popup.get_screen()
-        screen_w = screen.get_width()
-        screen_h = screen.get_height()
-
-        popup_x = max(0, min(int(mouse_x - popup_w / 2), screen_w - popup_w))
-        popup_y = max(
-            0,
-            min(
-                int(mouse_y - popup_h - POPUP_CURSOR_GAP_PX),
-                screen_h - popup_h,
-            ),
+        show_wrapped_popup(
+            window=self._popup,
+            content=self._build_popup_content(),
+            gap_px=POPUP_CURSOR_GAP_PX,
         )
-
-        self._popup.move(popup_x, popup_y)
 
     def _build_popup_content(self) -> Gtk.Box:
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)

--- a/docking/applets/urlshortener/applet.py
+++ b/docking/applets/urlshortener/applet.py
@@ -36,6 +36,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.popup import prepare_dialog_content
 from docking.applets.urlshortener import meta
 from docking.applets.urlshortener.render import create_icon
 from docking.applets.urlshortener.state import prefs_payload, shorten_url
@@ -47,7 +48,6 @@ if TYPE_CHECKING:
 DIALOG_WIDTH_PX = 350
 DIALOG_CONTENT_SPACING_PX = 8
 DIALOG_HORIZONTAL_MARGIN_PX = 12
-DIALOG_VERTICAL_MARGIN_PX = 8
 RESULT_LABEL_MAX_CHARS = 45
 COPY_FEEDBACK_RESET_MS = 1500
 
@@ -98,16 +98,13 @@ class UrlShortenerApplet(Applet):
             title=_("URL Shortener"),
             flags=Gtk.DialogFlags.DESTROY_WITH_PARENT,
         )
-        self._dialog.set_default_size(DIALOG_WIDTH_PX, -1)
-        self._dialog.set_position(Gtk.WindowPosition.MOUSE)
-        self._dialog.set_resizable(False)
-
-        box = self._dialog.get_content_area()
-        box.set_spacing(DIALOG_CONTENT_SPACING_PX)
-        box.set_margin_start(DIALOG_HORIZONTAL_MARGIN_PX)
-        box.set_margin_end(DIALOG_HORIZONTAL_MARGIN_PX)
-        box.set_margin_top(DIALOG_VERTICAL_MARGIN_PX)
-        box.set_margin_bottom(DIALOG_VERTICAL_MARGIN_PX)
+        box = prepare_dialog_content(
+            dialog=self._dialog,
+            width=DIALOG_WIDTH_PX,
+            spacing=DIALOG_CONTENT_SPACING_PX,
+            margin=DIALOG_HORIZONTAL_MARGIN_PX,
+            resizable=False,
+        )
 
         # URL entry
         self._url_entry = Gtk.Entry()

--- a/docking/applets/volume/applet.py
+++ b/docking/applets/volume/applet.py
@@ -12,6 +12,7 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import GdkPixbuf, GLib, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.menu import menu_sections
 from docking.applets.volume import meta
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
@@ -109,18 +110,17 @@ class VolumeApplet(Applet):
         self.present()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
         show = Gtk.CheckMenuItem(label=_("Show Level"))
         show.set_active(self._show_level)
         show.connect("toggled", self._on_toggle_level)
-        items.append(show)
 
+        settings: list[Gtk.MenuItem] = []
         cmd = volume_settings_command()
         if cmd is not None:
             volume_settings = Gtk.MenuItem(label=_("Volume Settings"))
             volume_settings.connect("activate", lambda _widget: open_volume_settings())
-            items.append(volume_settings)
-        return items
+            settings.append(volume_settings)
+        return menu_sections(display=[show], settings=settings, gtk=Gtk)
 
     def _on_toggle_level(self, widget: Gtk.CheckMenuItem) -> None:
         self._show_level = widget.get_active()

--- a/docking/applets/weather/applet.py
+++ b/docking/applets/weather/applet.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -13,7 +14,14 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
 
 from docking.applets.base import Applet
-from docking.applets.menu import radio_submenu
+from docking.applets.freshness import cadence_label, updated_label
+from docking.applets.live_state import (
+    live_state_error,
+    live_state_label,
+    resolve_live_status,
+)
+from docking.applets.menu import disabled_menu_item, menu_sections, radio_submenu
+from docking.applets.popup import prepare_dialog_content
 from docking.applets.weather import meta
 from docking.applets.weather.api import (
     REFRESH_INTERVAL,
@@ -50,7 +58,6 @@ log = with_context(get_logger(name="weather"), applet_id=meta.id)
 CITY_DIALOG_WIDTH_PX = 350
 DIALOG_CONTENT_SPACING_PX = 8
 DIALOG_HORIZONTAL_MARGIN_PX = 12
-DIALOG_VERTICAL_MARGIN_PX = 8
 CITY_SEARCH_MIN_CHARS = 2
 CITY_SEARCH_RESULT_LIMIT = 10
 STARTUP_FETCH_DELAY_S = 1
@@ -69,7 +76,10 @@ class WeatherApplet(Applet):
         self._fetch_request_id: int = 0
         self._weather: WeatherData | None = None
         self._air_quality: AirQualityData | None = None
+        self._last_updated: dt.datetime | None = None
+        self._loading = False
         self._fetch_failed = False
+        self._fetch_error = ""
         self._worker = BackgroundWorker(logger=log)
 
         prefs = prefs_from_mapping(
@@ -115,32 +125,63 @@ class WeatherApplet(Applet):
         )
         self._weather = None
         self._air_quality = None
+        self._last_updated = None
+        self._loading = False
         self._fetch_failed = False
+        self._fetch_error = ""
         self._save_prefs()
         self._fetch_async()
         self.present()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        items: list[Gtk.MenuItem] = []
+        status: list[Gtk.MenuItem] = []
         active = self._active_city
 
         if active:
-            header = Gtk.MenuItem(
-                label=menu_header_label(
-                    city_display=active.city_display,
-                    weather=self._weather,
-                    temperature_unit=self._temperature_unit,
+            status.append(
+                disabled_menu_item(
+                    menu_header_label(
+                        city_display=active.city_display,
+                        weather=self._weather,
+                        temperature_unit=self._temperature_unit,
+                    ),
+                    gtk=Gtk,
                 )
             )
-            header.set_sensitive(False)
-            items.append(header)
+            status.append(
+                disabled_menu_item(
+                    cadence_label(seconds=REFRESH_INTERVAL),
+                    gtk=Gtk,
+                )
+            )
+            state_status = self._live_status()
+            state_label = live_state_label(state_status)
+            if state_label:
+                status.append(disabled_menu_item(state_label, gtk=Gtk))
+            error = live_state_error(
+                status=state_status,
+                error=self._fetch_error,
+            )
+            if error:
+                status.append(
+                    disabled_menu_item(
+                        _("Error: {msg}").format(msg=error),
+                        gtk=Gtk,
+                    )
+                )
+
+        refresh: list[Gtk.MenuItem] = []
+        if active:
+            refresh_item = Gtk.MenuItem(label=_("Refresh Now"))
+            refresh_item.connect("activate", lambda _w: self._fetch_async())
+            refresh.append(refresh_item)
 
         show_temp = Gtk.CheckMenuItem(label=_("Show Temperature"))
         show_temp.set_active(self._show_temperature)
         show_temp.connect("toggled", self._on_toggle_temperature)
-        items.append(show_temp)
 
-        items.append(
+        display = [
+            show_temp,
             radio_submenu(
                 label=_("Temperature Unit"),
                 choices=tuple(
@@ -153,17 +194,24 @@ class WeatherApplet(Applet):
                     temperature_unit=value,
                 ),
                 gtk=Gtk,
-            )
-        )
+            ),
+        ]
 
+        destructive: list[Gtk.MenuItem] = []
         if active and len(self._cities) > 1:
             remove = Gtk.MenuItem(
                 label=_("Remove {city}").format(city=active.city_display)
             )
             remove.connect("activate", lambda _: self._remove_active_city())
-            items.append(remove)
+            destructive.append(remove)
 
-        return items
+        return menu_sections(
+            status=status,
+            refresh=refresh,
+            display=display,
+            destructive=destructive,
+            gtk=Gtk,
+        )
 
     def start(self, notify: Callable[[], None]) -> None:
         super().start(notify=notify)
@@ -207,15 +255,14 @@ class WeatherApplet(Applet):
             title=_("Search for the city"),
             flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
         )
-        dialog.set_default_size(CITY_DIALOG_WIDTH_PX, -1)
-        dialog.set_position(Gtk.WindowPosition.MOUSE)
-
-        box = dialog.get_content_area()
-        box.set_spacing(DIALOG_CONTENT_SPACING_PX)
-        box.set_margin_start(DIALOG_HORIZONTAL_MARGIN_PX)
-        box.set_margin_end(DIALOG_HORIZONTAL_MARGIN_PX)
-        box.set_margin_top(DIALOG_VERTICAL_MARGIN_PX)
-        box.set_margin_bottom(DIALOG_VERTICAL_MARGIN_PX)
+        dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
+        dialog.connect("response", lambda dlg, _response: dlg.destroy())
+        box = prepare_dialog_content(
+            dialog=dialog,
+            width=CITY_DIALOG_WIDTH_PX,
+            spacing=DIALOG_CONTENT_SPACING_PX,
+            margin=DIALOG_HORIZONTAL_MARGIN_PX,
+        )
 
         entry = Gtk.Entry()
         entry.set_placeholder_text(_("Type city name..."))
@@ -280,7 +327,10 @@ class WeatherApplet(Applet):
                 self._active_index = i
                 self._weather = None
                 self._air_quality = None
+                self._last_updated = None
+                self._loading = False
                 self._fetch_failed = False
+                self._fetch_error = ""
                 self._save_prefs()
                 self._fetch_async()
                 self.present()
@@ -289,7 +339,10 @@ class WeatherApplet(Applet):
         self._active_index = len(self._cities) - 1
         self._weather = None
         self._air_quality = None
+        self._last_updated = None
+        self._loading = False
         self._fetch_failed = False
+        self._fetch_error = ""
         self._save_prefs()
         self._fetch_async()
         self.present()
@@ -301,7 +354,10 @@ class WeatherApplet(Applet):
         self._active_index = min(self._active_index, len(self._cities) - 1)
         self._weather = None
         self._air_quality = None
+        self._last_updated = None
+        self._loading = False
         self._fetch_failed = False
+        self._fetch_error = ""
         self._save_prefs()
         self._fetch_async()
         self.present()
@@ -329,7 +385,10 @@ class WeatherApplet(Applet):
         request_id = self._fetch_request_id
         lat = active.lat
         lng = active.lng
+        self._loading = True
         self._fetch_failed = False
+        self._fetch_error = ""
+        self.present()
 
         def fetch() -> tuple[WeatherData | None, AirQualityData | None]:
             weather = fetch_weather(lat=lat, lng=lng)
@@ -355,9 +414,15 @@ class WeatherApplet(Applet):
     ) -> bool:
         if request_id != self._fetch_request_id:
             return False
-        self._weather = weather
-        self._air_quality = aqi
+        self._loading = False
         self._fetch_failed = weather is None
+        if weather is not None:
+            self._weather = weather
+            self._air_quality = aqi
+            self._fetch_error = ""
+            self._last_updated = dt.datetime.now(dt.timezone.utc)
+        else:
+            self._fetch_error = _("No weather data")
         self.present()
         return False
 
@@ -365,21 +430,33 @@ class WeatherApplet(Applet):
         if request_id != self._fetch_request_id:
             return False
         log.bind(action="fetch_error").debug("Weather fetch failed: %s", exc)
-        self._weather = None
-        self._air_quality = None
+        self._loading = False
         self._fetch_failed = True
+        self._fetch_error = str(exc) or exc.__class__.__name__
         self.present()
         return False
 
     def _build_tooltip(self) -> str:
         active = self._active_city
-        if active and self._fetch_failed and self._weather is None:
-            return _("{city}: unavailable").format(city=active.city_display)
         return build_tooltip(
             city_display=active.city_display if active else "",
             weather=self._weather,
             air_quality=self._air_quality,
+            loading=self._loading,
+            fetch_failed=self._fetch_failed,
+            error=self._fetch_error,
             temperature_unit=self._temperature_unit,
+            updated_at=self._last_updated,
+            cadence_seconds=REFRESH_INTERVAL,
+        )
+
+    def _live_status(self):
+        return resolve_live_status(
+            has_data=self._weather is not None,
+            loading=self._loading,
+            error=self._fetch_error if self._fetch_failed else None,
+            updated_at=self._last_updated,
+            stale_after_seconds=REFRESH_INTERVAL * 2,
         )
 
     def _build_tooltip_widget(self) -> Gtk.Box:
@@ -439,5 +516,27 @@ class WeatherApplet(Applet):
             row.pack_start(icon, False, False, 0)
             row.pack_start(label, False, False, 0)
             box.pack_start(row, False, False, 0)
+
+        state_status = self._live_status()
+        state_label = live_state_label(state_status)
+        error = live_state_error(status=state_status, error=self._fetch_error)
+        for text in (
+            state_label,
+            _("Error: {msg}").format(msg=error) if error else "",
+        ):
+            if not text:
+                continue
+            label = Gtk.Label(label=text)
+            label.override_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(1, 1, 1, 0.72))
+            box.pack_start(label, False, False, 0)
+
+        details = [
+            updated_label(self._last_updated),
+            cadence_label(seconds=REFRESH_INTERVAL),
+        ]
+        for text in (line for line in details if line):
+            label = Gtk.Label(label=text)
+            label.override_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(1, 1, 1, 0.62))
+            box.pack_start(label, False, False, 0)
 
         return box

--- a/docking/applets/weather/state.py
+++ b/docking/applets/weather/state.py
@@ -8,6 +8,14 @@ from functools import lru_cache
 from typing import Any, NamedTuple
 
 from docking.applets import temperature as temperature_display
+from docking.applets.live_state import (
+    live_freshness_lines,
+    live_state_error,
+    live_state_label,
+    refresh_recovery_label,
+    resolve_live_status,
+)
+from docking.applets.tooltip import structured_tooltip
 from docking.applets.weather.api import AirQualityData, WeatherData
 from docking.applets.weather.cities import CityEntry, load_cities
 from docking.i18n import _
@@ -141,37 +149,67 @@ def build_tooltip(
     city_display: str,
     weather: WeatherData | None,
     air_quality: AirQualityData | None,
+    loading: bool = False,
     fetch_failed: bool = False,
+    error: str | None = None,
     temperature_unit: TemperatureUnit = TemperatureUnit.CELSIUS,
+    updated_at: object | None = None,
+    cadence_seconds: int | None = None,
 ) -> str:
     """Build multi-line tooltip with current + daily forecast."""
     if not city_display:
-        return _("Weather (no city selected)")
+        return structured_tooltip(
+            title=_("Weather"),
+            primary=_("No city selected"),
+        )
+    state_error = error or (_("Unavailable") if fetch_failed else None)
+    status = resolve_live_status(
+        has_data=weather is not None,
+        loading=loading,
+        error=state_error,
+        updated_at=updated_at,
+    )
     if not weather:
-        if fetch_failed:
-            return _("{city}: unavailable").format(city=city_display)
-        return _("{city}: loading...").format(city=city_display)
-
-    lines = [
-        city_display,
-        _("{temp}, {desc}").format(
-            temp=format_temperature(
-                weather.temperature,
-                temperature_unit=temperature_unit,
+        return structured_tooltip(
+            title=city_display,
+            primary=live_state_label(status),
+            freshness=live_freshness_lines(
+                status=status,
+                updated_at=updated_at,
+                cadence_seconds=cadence_seconds,
             ),
-            desc=weather.description,
-        ),
-    ]
+            error=live_state_error(status=status, error=state_error),
+            recovery=refresh_recovery_label(status),
+        )
+
+    details = []
     if air_quality:
-        lines.append(_("Air: {label}").format(label=air_quality.label))
+        details.append(_("Air: {label}").format(label=air_quality.label))
     for day in weather.daily:
         temp = format_temperature_range(
             low_celsius=day.temp_min,
             high_celsius=day.temp_max,
             temperature_unit=temperature_unit,
         )
-        lines.append(f"{day.date}: {temp}, {day.description}")
-    return "\n".join(lines)
+        details.append(f"{day.date}: {temp}, {day.description}")
+    return structured_tooltip(
+        title=city_display,
+        primary=_("{temp}, {desc}").format(
+            temp=format_temperature(
+                weather.temperature,
+                temperature_unit=temperature_unit,
+            ),
+            desc=weather.description,
+        ),
+        details=details,
+        freshness=live_freshness_lines(
+            status=status,
+            updated_at=updated_at,
+            cadence_seconds=cadence_seconds,
+        ),
+        error=live_state_error(status=status, error=state_error),
+        recovery=refresh_recovery_label(status),
+    )
 
 
 @lru_cache(maxsize=1)

--- a/docking/applets/windowkiller/applet.py
+++ b/docking/applets/windowkiller/applet.py
@@ -40,6 +40,11 @@ gi.require_version("Wnck", "3.0")
 from gi.repository import Gdk, GdkPixbuf, Gtk, Wnck
 
 from docking.applets.base import Applet
+from docking.applets.popup import (
+    create_capture_overlay,
+    dismiss_capture_overlay,
+    draw_transparent_capture_overlay,
+)
 from docking.applets.windowkiller import meta
 from docking.applets.windowkiller.render import create_icon
 from docking.applets.windowkiller.state import kill_pid
@@ -83,49 +88,16 @@ class WindowKillerApplet(Applet):
         if self._overlay:
             return
 
-        overlay = Gtk.Window(type=Gtk.WindowType.POPUP)
-        overlay.set_decorated(False)
-        overlay.set_app_paintable(True)
-
-        screen = overlay.get_screen()
-        visual = screen.get_rgba_visual()
-        if visual:
-            overlay.set_visual(visual)
-
-        overlay.set_default_size(screen.get_width(), screen.get_height())
-        overlay.move(0, 0)
-
-        overlay.connect("draw", self._on_overlay_draw)
-        overlay.set_events(
-            Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.KEY_PRESS_MASK
+        self._overlay = create_capture_overlay(
+            draw_handler=self._on_overlay_draw,
+            click_handler=self._on_overlay_click,
+            key_handler=self._on_overlay_key,
+            cursor_type=Gdk.CursorType.PIRATE,
         )
-        overlay.connect("button-press-event", self._on_overlay_click)
-        overlay.connect("key-press-event", self._on_overlay_key)
-
-        display = Gdk.Display.get_default()
-        crosshair = Gdk.Cursor.new_for_display(display, Gdk.CursorType.PIRATE)
-
-        overlay.show_all()
-        overlay.get_window().set_cursor(crosshair)
-
-        seat = display.get_default_seat()
-        seat.grab(
-            overlay.get_window(),
-            Gdk.SeatCapabilities.ALL_POINTING | Gdk.SeatCapabilities.KEYBOARD,
-            True,
-            crosshair,
-            None,
-            None,
-            None,
-        )
-
-        self._overlay = overlay
 
     @staticmethod
     def _on_overlay_draw(widget: Gtk.Window, cr) -> bool:
-        cr.set_source_rgba(0, 0, 0, 0.01)
-        cr.paint()
-        return True
+        return draw_transparent_capture_overlay(widget, cr)
 
     def _on_overlay_click(self, _widget: Gtk.Window, event: Gdk.EventButton) -> bool:
         self._dismiss_overlay()
@@ -154,10 +126,7 @@ class WindowKillerApplet(Applet):
 
     def _dismiss_overlay(self) -> None:
         if self._overlay:
-            display = Gdk.Display.get_default()
-            seat = display.get_default_seat()
-            seat.ungrab()
-            self._overlay.destroy()
+            dismiss_capture_overlay(self._overlay)
             self._overlay = None
 
     @staticmethod

--- a/docking/applets/workspaces/applet.py
+++ b/docking/applets/workspaces/applet.py
@@ -15,7 +15,7 @@ gi.require_version("Wnck", "3.0")
 from gi.repository import Gdk, GdkPixbuf, Gtk, Wnck
 
 from docking.applets.base import Applet
-from docking.applets.menu import radio_menu_items
+from docking.applets.menu import menu_sections, radio_menu_items
 from docking.applets.workspaces import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -159,8 +159,8 @@ class WorkspacesApplet(Applet):
             active_number=active.get_number() if active else None
         )
 
-        return [
-            *radio_menu_items(
+        return menu_sections(
+            display=radio_menu_items(
                 choices=tuple(
                     (
                         workspace_label(name=ws.get_name(), number=ws.get_number()),
@@ -175,8 +175,9 @@ class WorkspacesApplet(Applet):
                     value,
                 ),
                 gtk=Gtk,
-            )
-        ]
+            ),
+            gtk=Gtk,
+        )
 
     def _on_workspace_activate(
         self, _widget: Gtk.RadioMenuItem, workspace: Wnck.Workspace

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-29 19:00+0200\n"
+"POT-Creation-Date: 2026-04-30 20:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,57 +22,60 @@ msgstr ""
 msgid "AI Usage"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:159
+#: docking/applets/aiusage/applet.py:156
 msgid "Auto"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:160
+#: docking/applets/aiusage/applet.py:157
 msgid "Claude"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:161
+#: docking/applets/aiusage/applet.py:158
 msgid "Codex"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:162
+#: docking/applets/aiusage/applet.py:159
 msgid "OpenCode"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:177
+#: docking/applets/aiusage/applet.py:168
 msgid "Show Cost"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:178
+#: docking/applets/aiusage/applet.py:169
 msgid "Show Tokens"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:188
-#: docking/applets/deskpresence/applet.py:108
+#: docking/applets/aiusage/applet.py:176
+#: docking/applets/deskpresence/applet.py:103
 msgid "Reset Today"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:261 docking/applets/aiusage/applet.py:276
-#: docking/applets/aiusage/state.py:460
+#: docking/applets/aiusage/applet.py:252 docking/applets/aiusage/applet.py:267
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:293
+#: docking/applets/aiusage/applet.py:284
 #, python-brace-format
 msgid "<b>{name}: {value}</b>"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:337
+#: docking/applets/aiusage/applet.py:328
 #, python-brace-format
 msgid "This week: {value}"
 msgstr ""
 
-#: docking/applets/aiusage/state.py:461
-#, python-brace-format
-msgid "{name} today: {cost}"
+#: docking/applets/aiusage/state.py:463
+msgid "no usage today"
 msgstr ""
 
-#: docking/applets/ambient/applet.py:65 docking/applets/ambient/state.py:87
+#: docking/applets/aiusage/state.py:467
+#, python-brace-format
+msgid "Today: {cost}"
+msgstr ""
+
+#: docking/applets/ambient/applet.py:66 docking/applets/ambient/state.py:87
 msgid "Ambient"
 msgstr ""
 
@@ -117,51 +120,58 @@ msgstr ""
 msgid "Playing: {sound} ({pct}%)"
 msgstr ""
 
-#: docking/applets/apod/applet.py:48 docking/applets/apod/state.py:78
+#: docking/applets/apod/applet.py:55 docking/applets/apod/state.py:101
+#: docking/applets/apod/state.py:119
 msgid "Astronomy Picture of the Day"
 msgstr ""
 
-#: docking/applets/apod/applet.py:81
+#: docking/applets/apod/applet.py:95
 #, python-brace-format
 msgid "{date}: {title}"
 msgstr ""
 
-#: docking/applets/apod/applet.py:83
+#: docking/applets/apod/applet.py:97
 msgid "Untitled"
 msgstr ""
 
-#: docking/applets/apod/applet.py:90
-msgid "Open on apod.nasa.gov"
+#: docking/applets/apod/applet.py:106 docking/applets/apod/state.py:106
+#: docking/applets/apod/state.py:125 docking/applets/certwatch/applet.py:134
+#: docking/applets/certwatch/state.py:312
+msgid "Checks"
 msgstr ""
 
-#: docking/applets/apod/applet.py:95
-msgid "Copy Explanation"
-msgstr ""
-
-#: docking/applets/apod/applet.py:99 docking/applets/bluetooth/applet.py:211
-#: docking/applets/camshield/applet.py:125
-#: docking/applets/capslock/applet.py:80
-#: docking/applets/certwatch/applet.py:122
-#: docking/applets/currencyfx/applet.py:161
-#: docking/applets/hackernews/applet.py:167
-#: docking/applets/micshield/applet.py:126 docking/applets/moon/applet.py:126
-#: docking/applets/quote/applet.py:96 docking/applets/thermals/applet.py:132
-#: docking/applets/todayinhistory/applet.py:102
-#: docking/applets/trivia/applet.py:119
-msgid "Refresh Now"
-msgstr ""
-
-#: docking/applets/apod/state.py:80 docking/applets/speedtest/applet.py:102
-#: docking/applets/speedtest/state.py:75
+#: docking/applets/apod/applet.py:118 docking/applets/certwatch/applet.py:128
+#: docking/applets/currencyfx/applet.py:183
+#: docking/applets/hackernews/applet.py:175
+#: docking/applets/speedtest/applet.py:103
+#: docking/applets/thermals/applet.py:134 docking/applets/tooltip.py:33
+#: docking/applets/weather/applet.py:168 docking/applets/weather/applet.py:525
 #, python-brace-format
 msgid "Error: {msg}"
 msgstr ""
 
-#: docking/applets/apod/state.py:83 docking/applets/thermals/state.py:180
-msgid "Loading..."
+#: docking/applets/apod/applet.py:121
+msgid "Open on apod.nasa.gov"
 msgstr ""
 
-#: docking/applets/apod/state.py:89
+#: docking/applets/apod/applet.py:126
+msgid "Copy Explanation"
+msgstr ""
+
+#: docking/applets/apod/applet.py:130 docking/applets/bluetooth/applet.py:204
+#: docking/applets/camshield/applet.py:114
+#: docking/applets/capslock/applet.py:84
+#: docking/applets/certwatch/applet.py:145
+#: docking/applets/currencyfx/applet.py:191
+#: docking/applets/hackernews/applet.py:192
+#: docking/applets/micshield/applet.py:118 docking/applets/moon/applet.py:124
+#: docking/applets/quote/applet.py:92 docking/applets/thermals/applet.py:144
+#: docking/applets/todayinhistory/applet.py:99
+#: docking/applets/trivia/applet.py:115 docking/applets/weather/applet.py:175
+msgid "Refresh Now"
+msgstr ""
+
+#: docking/applets/apod/state.py:115
 #, python-brace-format
 msgid "(c) {who}"
 msgstr ""
@@ -174,7 +184,7 @@ msgstr ""
 msgid "Search applications..."
 msgstr ""
 
-#: docking/applets/battery/applet.py:34
+#: docking/applets/battery/applet.py:35
 msgid "Battery"
 msgstr ""
 
@@ -223,103 +233,103 @@ msgstr ""
 msgid "Bluetooth unavailable"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:175
+#: docking/applets/bluetooth/applet.py:172
 msgid "No Bluetooth adapter"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:183
-#: docking/applets/bluetooth/state.py:142 docking/applets/capslock/state.py:100
+#: docking/applets/bluetooth/applet.py:174
+#: docking/applets/bluetooth/state.py:142 docking/applets/capslock/state.py:99
 msgid "On"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:183
-#: docking/applets/bluetooth/state.py:142 docking/applets/capslock/state.py:100
+#: docking/applets/bluetooth/applet.py:174
+#: docking/applets/bluetooth/state.py:142 docking/applets/capslock/state.py:99
 msgid "Off"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:191
+#: docking/applets/bluetooth/applet.py:183
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:200
+#: docking/applets/bluetooth/applet.py:194
 msgid "Continuous Discovery"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:225
+#: docking/applets/bluetooth/applet.py:226
 msgid "Turn Bluetooth Off"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:225
+#: docking/applets/bluetooth/applet.py:226
 msgid "Turn Bluetooth On"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:241
+#: docking/applets/bluetooth/applet.py:242
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:255
+#: docking/applets/bluetooth/applet.py:256
 msgid "Send Files to Device..."
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:263
+#: docking/applets/bluetooth/applet.py:264
 msgid "Devices..."
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:269
+#: docking/applets/bluetooth/applet.py:270
 msgid "Adapters..."
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:275
+#: docking/applets/bluetooth/applet.py:276
 msgid "Local Services..."
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:282
+#: docking/applets/bluetooth/applet.py:283
 msgid "Recent Connections"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:287
+#: docking/applets/bluetooth/applet.py:288
 msgid "No recent connections"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:311
+#: docking/applets/bluetooth/applet.py:312
 msgid "Adapter"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:329
+#: docking/applets/bluetooth/applet.py:330
 msgid "Connected Devices"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:330
+#: docking/applets/bluetooth/applet.py:331
 msgid "Paired Devices"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:331
+#: docking/applets/bluetooth/applet.py:332
 msgid "Discovered Devices"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:356
+#: docking/applets/bluetooth/applet.py:357
 msgid "Disconnect"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:365
+#: docking/applets/bluetooth/applet.py:366
 msgid "Connect"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:375
+#: docking/applets/bluetooth/applet.py:376
 msgid "Pair"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:389
+#: docking/applets/bluetooth/applet.py:390
 msgid "Remove Pairing"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:401
+#: docking/applets/bluetooth/applet.py:402
 msgid "Trusted"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:416
+#: docking/applets/bluetooth/applet.py:417
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr ""
@@ -367,35 +377,35 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: docking/applets/bookmarks/applet.py:41
+#: docking/applets/bookmarks/applet.py:42
 msgid "Bookmarks"
 msgstr ""
 
-#: docking/applets/bookmarks/applet.py:76
+#: docking/applets/bookmarks/applet.py:74
 msgid "Add Bookmark..."
 msgstr ""
 
-#: docking/applets/bookmarks/applet.py:80
+#: docking/applets/bookmarks/applet.py:77
 msgid "Remove All"
 msgstr ""
 
-#: docking/applets/bookmarks/applet.py:97
+#: docking/applets/bookmarks/applet.py:98
 msgid "Add Bookmark"
 msgstr ""
 
-#: docking/applets/bookmarks/applet.py:117
+#: docking/applets/bookmarks/applet.py:111
 msgid "Bookmark name"
 msgstr ""
 
-#: docking/applets/bookmarks/applet.py:121
+#: docking/applets/bookmarks/applet.py:116
 msgid "https://..."
 msgstr ""
 
-#: docking/applets/brightness/applet.py:42
+#: docking/applets/brightness/applet.py:43
 msgid "Brightness"
 msgstr ""
 
-#: docking/applets/brightness/applet.py:71
+#: docking/applets/brightness/applet.py:72
 #, python-brace-format
 msgid "Brightness: {pct}%"
 msgstr ""
@@ -404,41 +414,40 @@ msgstr ""
 msgid "Show Level"
 msgstr ""
 
-#: docking/applets/calculator/applet.py:67
-#: docking/applets/calculator/applet.py:84
+#: docking/applets/calculator/applet.py:64
+#: docking/applets/calculator/applet.py:81
 msgid "Calculator"
 msgstr ""
 
-#: docking/applets/calendar/applet.py:35 docking/applets/calendar/applet.py:41
+#: docking/applets/calendar/applet.py:33 docking/applets/calendar/applet.py:39
 msgid "Calendar"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:48 docking/applets/camshield/state.py:58
+#: docking/applets/camshield/applet.py:49 docking/applets/camshield/state.py:58
 msgid "Cam Shield"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:92 docking/applets/camshield/state.py:60
+#: docking/applets/camshield/applet.py:93 docking/applets/camshield/state.py:60
 msgid "No camera devices found"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:96 docking/applets/camshield/state.py:64
+#: docking/applets/camshield/applet.py:95 docking/applets/camshield/state.py:64
 msgid "Camera idle"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:100
-#: docking/applets/camshield/state.py:67
+#: docking/applets/camshield/applet.py:97 docking/applets/camshield/state.py:67
 msgid "Camera active"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:109
+#: docking/applets/camshield/applet.py:101
 msgid "Lock Camera"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:114
+#: docking/applets/camshield/applet.py:105
 msgid "Unlock Camera"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:120
+#: docking/applets/camshield/applet.py:111
 msgid "Camera lock helper unavailable"
 msgstr ""
 
@@ -459,122 +468,128 @@ msgstr ""
 
 #: docking/applets/camshield/state.py:179
 #: docking/applets/deskpresence/state.py:171
-#: docking/applets/micshield/state.py:180 docking/applets/music/state.py:81
+#: docking/applets/micshield/state.py:180 docking/applets/music/state.py:82
 #: docking/applets/powerprofiles/state.py:137
 msgid "Unknown"
 msgstr ""
 
-#: docking/applets/capslock/applet.py:37 docking/applets/capslock/applet.py:72
-#: docking/applets/capslock/state.py:87
+#: docking/applets/capslock/applet.py:38 docking/applets/capslock/applet.py:75
+#: docking/applets/capslock/state.py:86
 msgid "Caps Lock"
 msgstr ""
 
-#: docking/applets/capslock/applet.py:68 docking/applets/capslock/state.py:83
+#: docking/applets/capslock/applet.py:70 docking/applets/capslock/state.py:82
 msgid "Keyboard lock state unavailable"
 msgstr ""
 
-#: docking/applets/capslock/applet.py:75
+#: docking/applets/capslock/applet.py:80
 msgid "Num Lock"
 msgstr ""
 
-#: docking/applets/capslock/state.py:88
+#: docking/applets/capslock/state.py:87
 #, python-brace-format
 msgid "Caps Lock: {state}"
 msgstr ""
 
-#: docking/applets/capslock/state.py:89
+#: docking/applets/capslock/state.py:88
 #, python-brace-format
 msgid "Num Lock: {state}"
 msgstr ""
 
-#: docking/applets/capslock/state.py:96
+#: docking/applets/capslock/state.py:95
 #, python-brace-format
 msgid "{name}: {state}"
 msgstr ""
 
-#: docking/applets/certwatch/applet.py:55
-#: docking/applets/certwatch/state.py:268
+#: docking/applets/certwatch/applet.py:63
+#: docking/applets/certwatch/state.py:278
+#: docking/applets/certwatch/state.py:306
 msgid "Cert Watch"
 msgstr ""
 
-#: docking/applets/certwatch/applet.py:98
-#: docking/applets/certwatch/state.py:243
-#: docking/applets/certwatch/state.py:272
+#: docking/applets/certwatch/applet.py:117
+#: docking/applets/certwatch/state.py:251
+#: docking/applets/certwatch/state.py:299
 #, python-brace-format
 msgid "{host}: loading..."
 msgstr ""
 
-#: docking/applets/certwatch/applet.py:105
+#: docking/applets/certwatch/applet.py:139
 msgid "Add Domain..."
 msgstr ""
 
-#: docking/applets/certwatch/applet.py:118
+#: docking/applets/certwatch/applet.py:157
 msgid "Remove"
 msgstr ""
 
-#: docking/applets/certwatch/applet.py:238
+#: docking/applets/certwatch/applet.py:293
 msgid "Add Domain"
 msgstr ""
 
-#: docking/applets/certwatch/applet.py:258
+#: docking/applets/certwatch/applet.py:306
 msgid "example.com or example.com:8443"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:225 docking/applets/clock/applet.py:207
-#: docking/applets/quicknote/applet.py:78
+#: docking/applets/certwatch/state.py:233 docking/applets/clock/applet.py:205
+#: docking/applets/quicknote/applet.py:74
 msgid "OK"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:226
+#: docking/applets/certwatch/state.py:234
 msgid "Warn"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:227
+#: docking/applets/certwatch/state.py:235
 msgid "Critical"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:228
+#: docking/applets/certwatch/state.py:236
 msgid "Expired"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:229
+#: docking/applets/certwatch/state.py:237
 msgid "Error"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:230
-#: docking/applets/speedtest/applet.py:59
+#: docking/applets/certwatch/state.py:238
+#: docking/applets/speedtest/applet.py:61
 msgid "..."
 msgstr ""
 
-#: docking/applets/certwatch/state.py:239
+#: docking/applets/certwatch/state.py:247
 #, python-brace-format
 msgid "{host}: error ({reason})"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:246
+#: docking/applets/certwatch/state.py:254
 #, python-brace-format
 msgid "{host}: unknown"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:248
+#: docking/applets/certwatch/state.py:256
 #, python-brace-format
 msgid "{host}: expired {days}d ago"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:249
+#: docking/applets/certwatch/state.py:257
 #, python-brace-format
 msgid "{host}: {label}, {days}d left"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:265
-msgid "Cert Watch (no domains configured)"
+#: docking/applets/certwatch/state.py:279
+msgid "No domains configured"
 msgstr ""
 
-#: docking/applets/clippy/applet.py:34
+#: docking/applets/certwatch/state.py:297
+#, python-brace-format
+msgid "{host}: unavailable"
+msgstr ""
+
+#: docking/applets/clippy/applet.py:35
 msgid "Clippy"
 msgstr ""
 
-#: docking/applets/clippy/applet.py:94
+#: docking/applets/clippy/applet.py:95
 msgid "Clear"
 msgstr ""
 
@@ -582,7 +597,7 @@ msgstr ""
 msgid "Clippy (empty)"
 msgstr ""
 
-#: docking/applets/clock/applet.py:38
+#: docking/applets/clock/applet.py:40
 msgid "Clock"
 msgstr ""
 
@@ -590,27 +605,27 @@ msgstr ""
 msgid "Digital Clock"
 msgstr ""
 
-#: docking/applets/clock/applet.py:92
+#: docking/applets/clock/applet.py:91
 msgid "24-Hour Clock"
 msgstr ""
 
-#: docking/applets/clock/applet.py:97
+#: docking/applets/clock/applet.py:95
 msgid "Show Date"
 msgstr ""
 
-#: docking/applets/clock/applet.py:103
+#: docking/applets/clock/applet.py:100
 msgid "Show Seconds"
 msgstr ""
 
-#: docking/applets/clock/applet.py:110
+#: docking/applets/clock/applet.py:104
 msgid "Set Alarm..."
 msgstr ""
 
-#: docking/applets/clock/applet.py:115
+#: docking/applets/clock/applet.py:110
 msgid "Clear Alarm"
 msgstr ""
 
-#: docking/applets/clock/applet.py:120
+#: docking/applets/clock/applet.py:115
 msgid "Acknowledge Alarm"
 msgstr ""
 
@@ -618,103 +633,108 @@ msgstr ""
 msgid "Set Alarm"
 msgstr ""
 
-#: docking/applets/clock/applet.py:206
+#: docking/applets/clock/applet.py:205 docking/applets/quicknote/applet.py:73
+#: docking/applets/weather/applet.py:258
 msgid "Cancel"
 msgstr ""
 
-#: docking/applets/clock/applet.py:245
+#: docking/applets/clock/applet.py:242
 msgid "Hour"
 msgstr ""
 
-#: docking/applets/clock/applet.py:247
+#: docking/applets/clock/applet.py:244
 msgid "Minute"
 msgstr ""
 
-#: docking/applets/colorpicker/applet.py:38
-#: docking/applets/colorpicker/applet.py:69
+#: docking/applets/colorpicker/applet.py:44
+#: docking/applets/colorpicker/applet.py:75
 msgid "Color Picker"
 msgstr ""
 
-#: docking/applets/colorpicker/applet.py:79
+#: docking/applets/colorpicker/applet.py:85
 #, python-brace-format
 msgid "Copy {hex}"
 msgstr ""
 
-#: docking/applets/colorpicker/applet.py:83
+#: docking/applets/colorpicker/applet.py:89
 msgid "Show Hex"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:77
+#: docking/applets/currencyfx/applet.py:84
 msgid "Currency FX"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:165
+#: docking/applets/currencyfx/applet.py:169
+#: docking/applets/currencyfx/state.py:726
+msgid "Day samples"
+msgstr ""
+
+#: docking/applets/currencyfx/applet.py:187
 msgid "Swap Pair"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:169
-msgid "Add Pair..."
-msgstr ""
-
-#: docking/applets/currencyfx/applet.py:175
+#: docking/applets/currencyfx/applet.py:197
 msgid "Chart Interval"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:177
+#: docking/applets/currencyfx/applet.py:199
 msgid "Day"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:178
+#: docking/applets/currencyfx/applet.py:200
 msgid "Week"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:179
+#: docking/applets/currencyfx/applet.py:201
 msgid "Month"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:193
+#: docking/applets/currencyfx/applet.py:216
 msgid "Added Pairs"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:206
+#: docking/applets/currencyfx/applet.py:226
 msgid "Remove Current Pair"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:387
+#: docking/applets/currencyfx/applet.py:233
+msgid "Add Pair..."
+msgstr ""
+
+#: docking/applets/currencyfx/applet.py:346
+msgid "No rate data"
+msgstr ""
+
+#: docking/applets/currencyfx/applet.py:428
 #, python-brace-format
 msgid "{pair}: {rate} ({change})"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:419
+#: docking/applets/currencyfx/applet.py:471
 msgid "Add FX Pair"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:441
+#: docking/applets/currencyfx/applet.py:485
 msgid "Base"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:443 docking/applets/quote/applet.py:43
-#: docking/applets/quote/applet.py:84 docking/applets/quote/applet.py:211
-#: docking/applets/quote/applet.py:217
+#: docking/applets/currencyfx/applet.py:487 docking/applets/quote/applet.py:43
+#: docking/applets/quote/applet.py:83 docking/applets/quote/applet.py:208
+#: docking/applets/quote/applet.py:214
 msgid "Quote"
 msgstr ""
 
-#: docking/applets/currencyfx/state.py:715
-#, python-brace-format
-msgid "{pair}: unavailable"
+#: docking/applets/currencyfx/state.py:730 docking/applets/live_state.py:78
+#: docking/applets/weather/state.py:165
+msgid "Unavailable"
 msgstr ""
 
-#: docking/applets/currencyfx/state.py:716
-#, python-brace-format
-msgid "{pair}: loading..."
-msgstr ""
-
-#: docking/applets/currencyfx/state.py:720
+#: docking/applets/currencyfx/state.py:751
 #, python-brace-format
 msgid "1 {base} = {rate} {quote}"
 msgstr ""
 
-#: docking/applets/currencyfx/state.py:725
+#: docking/applets/currencyfx/state.py:756
 #, python-brace-format
 msgid "Change: {change}"
 msgstr ""
@@ -724,35 +744,35 @@ msgstr ""
 msgid "Desk Presence"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:85
+#: docking/applets/deskpresence/applet.py:84
 #, python-brace-format
 msgid "{status}"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:95
+#: docking/applets/deskpresence/applet.py:92
 msgid "Idle Threshold"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:191
+#: docking/applets/deskpresence/applet.py:190
 #: docking/applets/deskpresence/state.py:169
 msgid "At desk"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:192
+#: docking/applets/deskpresence/applet.py:191
 #: docking/applets/deskpresence/state.py:170
 msgid "Away"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:193
+#: docking/applets/deskpresence/applet.py:192
 msgid "Status unknown"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:200
+#: docking/applets/deskpresence/applet.py:199
 #, python-brace-format
 msgid "{m} min"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:201
+#: docking/applets/deskpresence/applet.py:200
 #, python-brace-format
 msgid "{s} sec"
 msgstr ""
@@ -812,110 +832,154 @@ msgstr ""
 msgid "Desktop"
 msgstr ""
 
-#: docking/applets/dragshare/applet.py:39
+#: docking/applets/dragshare/applet.py:40
+#: docking/applets/dragshare/applet.py:60
+#: docking/applets/dragshare/applet.py:66
+#: docking/applets/dragshare/applet.py:72
+#: docking/applets/dragshare/applet.py:79
+#: docking/applets/dragshare/applet.py:84
 msgid "Drag Share"
-msgstr ""
-
-#: docking/applets/dragshare/applet.py:58
-#, python-brace-format
-msgid "Uploading {file}..."
 msgstr ""
 
 #: docking/applets/dragshare/applet.py:61
 #, python-brace-format
+msgid "Uploading {file}..."
+msgstr ""
+
+#: docking/applets/dragshare/applet.py:67
+#, python-brace-format
 msgid "Uploaded {file}; URL copied"
 msgstr ""
 
-#: docking/applets/dragshare/applet.py:66
-#, python-brace-format
-msgid "Upload failed: {error}"
-msgstr ""
-
-#: docking/applets/dragshare/applet.py:69
-msgid "Drag Share - click to copy last URL"
-msgstr ""
-
-#: docking/applets/dragshare/applet.py:71
-msgid "Drag Share - drop a file to upload"
-msgstr ""
-
-#: docking/applets/dragshare/applet.py:78
-msgid "Upload already in progress"
-msgstr ""
-
-#: docking/applets/dragshare/applet.py:83
-msgid "Drop a local file to upload"
-msgstr ""
-
-#: docking/applets/dragshare/applet.py:94
-msgid "Copy Last URL"
-msgstr ""
-
-#: docking/applets/dragshare/applet.py:125
+#: docking/applets/dragshare/applet.py:73
+#: docking/applets/dragshare/applet.py:140
 msgid "Upload failed"
 msgstr ""
 
-#: docking/applets/hackernews/applet.py:47
-#: docking/applets/hackernews/state.py:137
+#: docking/applets/dragshare/applet.py:80
+msgid "Click to copy last URL"
+msgstr ""
+
+#: docking/applets/dragshare/applet.py:85
+msgid "Drop a file to upload"
+msgstr ""
+
+#: docking/applets/dragshare/applet.py:93
+msgid "Upload already in progress"
+msgstr ""
+
+#: docking/applets/dragshare/applet.py:98
+msgid "Drop a local file to upload"
+msgstr ""
+
+#: docking/applets/dragshare/applet.py:109
+msgid "Copy Last URL"
+msgstr ""
+
+#: docking/applets/freshness.py:15
+msgid "1 hour"
+msgstr ""
+
+#: docking/applets/freshness.py:15
+#, python-brace-format
+msgid "{count} hours"
+msgstr ""
+
+#: docking/applets/freshness.py:19
+msgid "1 minute"
+msgstr ""
+
+#: docking/applets/freshness.py:21
+#, python-brace-format
+msgid "{count} minutes"
+msgstr ""
+
+#: docking/applets/freshness.py:23
+msgid "1 second"
+msgstr ""
+
+#: docking/applets/freshness.py:23
+#, python-brace-format
+msgid "{count} seconds"
+msgstr ""
+
+#: docking/applets/freshness.py:28
+#, python-brace-format
+msgid "{verb} every {interval}"
+msgstr ""
+
+#: docking/applets/freshness.py:29 docking/applets/freshness.py:36
+msgid "Updates"
+msgstr ""
+
+#: docking/applets/freshness.py:36
+#, python-brace-format
+msgid "{verb} on demand"
+msgstr ""
+
+#: docking/applets/freshness.py:44
+#, python-brace-format
+msgid "Updated: {time}"
+msgstr ""
+
+#: docking/applets/hackernews/applet.py:55
+#: docking/applets/hackernews/state.py:150
 msgid "Hacker News"
 msgstr ""
 
-#: docking/applets/hackernews/applet.py:145
-#: docking/applets/hackernews/state.py:144
+#: docking/applets/hackernews/applet.py:147
+#: docking/applets/hackernews/state.py:156
+#: docking/applets/hackernews/state.py:189
+msgid "Refreshes"
+msgstr ""
+
+#: docking/applets/hackernews/applet.py:159
+#: docking/applets/hackernews/state.py:171
 #, python-brace-format
 msgid "{score} points, {comments} comments"
 msgstr ""
 
-#: docking/applets/hackernews/applet.py:154
+#: docking/applets/hackernews/applet.py:180
 msgid "Open Story"
 msgstr ""
 
-#: docking/applets/hackernews/applet.py:158
+#: docking/applets/hackernews/applet.py:184
 msgid "Open Comments"
 msgstr ""
 
-#: docking/applets/hackernews/applet.py:162
+#: docking/applets/hackernews/applet.py:188
 msgid "Next Headline"
 msgstr ""
 
-#: docking/applets/hackernews/applet.py:274
+#: docking/applets/hackernews/applet.py:314
 msgid "No Hacker News stories"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:99
+#: docking/applets/hackernews/state.py:107
 msgid "now"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:102
+#: docking/applets/hackernews/state.py:110
 #, python-brace-format
 msgid "{minutes}m ago"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:105
+#: docking/applets/hackernews/state.py:113
 #, python-brace-format
 msgid "{hours}h ago"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:107
+#: docking/applets/hackernews/state.py:115
 #, python-brace-format
 msgid "{days}d ago"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:134
-msgid "Hacker News: loading..."
-msgstr ""
-
-#: docking/applets/hackernews/state.py:136
-#, python-brace-format
-msgid "Hacker News: {error}"
-msgstr ""
-
-#: docking/applets/hackernews/state.py:140
+#: docking/applets/hackernews/state.py:164
 #, python-brace-format
 msgid "{source} {rank}"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:153
+#: docking/applets/hackernews/state.py:180
 msgid "Loading next stories..."
 msgstr ""
 
@@ -923,16 +987,16 @@ msgstr ""
 msgid "Hydration"
 msgstr ""
 
-#: docking/applets/hydration/applet.py:116
-#: docking/applets/pomodoro/applet.py:161
+#: docking/applets/hydration/applet.py:114
+#: docking/applets/pomodoro/applet.py:157
 msgid "Show Timer"
 msgstr ""
 
-#: docking/applets/hydration/applet.py:126
-#: docking/applets/pomodoro/applet.py:173
-#: docking/applets/pomodoro/applet.py:189
-#: docking/applets/pomodoro/applet.py:205
-#: docking/applets/stretchcoach/applet.py:100
+#: docking/applets/hydration/applet.py:120
+#: docking/applets/pomodoro/applet.py:166
+#: docking/applets/pomodoro/applet.py:179
+#: docking/applets/pomodoro/applet.py:192
+#: docking/applets/stretchcoach/applet.py:92
 #, python-brace-format
 msgid "{mins} min"
 msgstr ""
@@ -946,28 +1010,49 @@ msgstr ""
 msgid "Next in {time}"
 msgstr ""
 
-#: docking/applets/keyboardlayout/applet.py:46
+#: docking/applets/keyboardlayout/applet.py:47
 msgid "Keyboard Layout"
 msgstr ""
 
-#: docking/applets/keyboardlayout/applet.py:75
+#: docking/applets/keyboardlayout/applet.py:76
 msgid "No keyboard layout detected"
 msgstr ""
 
-#: docking/applets/keyboardlayout/applet.py:121
+#: docking/applets/keyboardlayout/applet.py:122
 msgid "Keyboard Settings"
 msgstr ""
 
-#: docking/applets/keyboardlayout/applet.py:126
+#: docking/applets/keyboardlayout/applet.py:128
 msgid "Show Current Layout"
 msgstr ""
 
-#: docking/applets/micshield/applet.py:43
+#: docking/applets/live_state.py:74
+msgid "No data yet"
+msgstr ""
+
+#: docking/applets/live_state.py:75
+msgid "Loading..."
+msgstr ""
+
+#: docking/applets/live_state.py:77 docking/applets/live_state.py:117
+msgid "Stale data"
+msgstr ""
+
+#: docking/applets/live_state.py:118
+#, python-brace-format
+msgid "Stale: last updated {time}"
+msgstr ""
+
+#: docking/applets/live_state.py:128
+msgid "Use Refresh Now from the menu."
+msgstr ""
+
+#: docking/applets/micshield/applet.py:44
 #: docking/applets/micshield/state.py:195
 msgid "Mic Shield"
 msgstr ""
 
-#: docking/applets/micshield/applet.py:92
+#: docking/applets/micshield/applet.py:93
 #: docking/applets/micshield/state.py:197
 msgid "No microphone source found"
 msgstr ""
@@ -987,16 +1072,16 @@ msgstr ""
 msgid "Microphone active"
 msgstr ""
 
-#: docking/applets/micshield/applet.py:113
+#: docking/applets/micshield/applet.py:109
 #: docking/applets/micshield/state.py:202
 msgid "Microphone idle"
 msgstr ""
 
-#: docking/applets/micshield/applet.py:119
+#: docking/applets/micshield/applet.py:112
 msgid "Unmute Microphone"
 msgstr ""
 
-#: docking/applets/micshield/applet.py:119
+#: docking/applets/micshield/applet.py:112
 msgid "Mute Microphone"
 msgstr ""
 
@@ -1005,20 +1090,20 @@ msgstr ""
 msgid "{command} (PID {pid})"
 msgstr ""
 
-#: docking/applets/moon/applet.py:48
+#: docking/applets/moon/applet.py:49
 msgid "Moon"
 msgstr ""
 
-#: docking/applets/moon/applet.py:91
+#: docking/applets/moon/applet.py:92
 msgid "Moon (loading...)"
 msgstr ""
 
-#: docking/applets/moon/applet.py:98
+#: docking/applets/moon/applet.py:99
 #, python-brace-format
 msgid "Illumination: {pct}%"
 msgstr ""
 
-#: docking/applets/moon/applet.py:121
+#: docking/applets/moon/applet.py:120
 msgid "Show Phase Name"
 msgstr ""
 
@@ -1088,167 +1173,161 @@ msgstr ""
 msgid "3rd Quarter"
 msgstr ""
 
-#: docking/applets/music/applet.py:44 docking/applets/music/state.py:138
+#: docking/applets/music/applet.py:45 docking/applets/music/state.py:129
+#: docking/applets/music/state.py:143
 msgid "Music"
 msgstr ""
 
-#: docking/applets/music/applet.py:104
+#: docking/applets/music/applet.py:105 docking/applets/music/state.py:130
 msgid "No active player"
 msgstr ""
 
-#: docking/applets/music/applet.py:108
+#: docking/applets/music/applet.py:107
 msgid "Previous"
 msgstr ""
 
-#: docking/applets/music/applet.py:116
+#: docking/applets/music/applet.py:115
 msgid "Next"
 msgstr ""
 
-#: docking/applets/music/applet.py:120
+#: docking/applets/music/applet.py:119
 msgid "Volume Up"
 msgstr ""
 
-#: docking/applets/music/applet.py:126
+#: docking/applets/music/applet.py:125
 msgid "Volume Down"
 msgstr ""
 
-#: docking/applets/music/state.py:68
+#: docking/applets/music/state.py:69
 msgid "Pause"
 msgstr ""
 
-#: docking/applets/music/state.py:68
+#: docking/applets/music/state.py:69
 msgid "Play"
 msgstr ""
 
-#: docking/applets/music/state.py:75
+#: docking/applets/music/state.py:76
 msgid "Playing"
 msgstr ""
 
-#: docking/applets/music/state.py:77
+#: docking/applets/music/state.py:78
 msgid "Paused"
 msgstr ""
 
-#: docking/applets/music/state.py:79
+#: docking/applets/music/state.py:80
 msgid "Stopped"
 msgstr ""
 
-#: docking/applets/music/state.py:127
-msgid "Music: No active player"
-msgstr ""
-
-#: docking/applets/network/applet.py:64
+#: docking/applets/network/applet.py:64 docking/applets/network/state.py:219
+#: docking/applets/network/state.py:230
 msgid "Network"
 msgstr ""
 
-#: docking/applets/network/applet.py:117
+#: docking/applets/network/applet.py:118
 #, python-brace-format
 msgid "WiFi: {ssid} ({pct}%)"
 msgstr ""
 
-#: docking/applets/network/applet.py:125
+#: docking/applets/network/applet.py:127
 #, python-brace-format
 msgid "Ethernet: {iface}"
 msgstr ""
 
-#: docking/applets/network/applet.py:130
+#: docking/applets/network/applet.py:132 docking/applets/network/state.py:220
 msgid "Not connected"
 msgstr ""
 
-#: docking/applets/network/applet.py:135
+#: docking/applets/network/applet.py:136
 #, python-brace-format
 msgid "IP: {ip}"
 msgstr ""
 
-#: docking/applets/network/applet.py:151
+#: docking/applets/network/applet.py:147
 msgid "Connection Information"
 msgstr ""
 
-#: docking/applets/network/applet.py:157
+#: docking/applets/network/applet.py:153
 msgid "Edit Connections..."
 msgstr ""
 
-#: docking/applets/network/applet.py:169
+#: docking/applets/network/applet.py:163
 msgid "Connect to Hidden Wi-Fi Network..."
 msgstr ""
 
-#: docking/applets/network/applet.py:176
+#: docking/applets/network/applet.py:170
 msgid "Create New Wi-Fi Network..."
 msgstr ""
 
-#: docking/applets/network/applet.py:180
+#: docking/applets/network/applet.py:174
 msgid "Enable Networking"
 msgstr ""
 
-#: docking/applets/network/applet.py:191
+#: docking/applets/network/applet.py:185
 msgid "Enable Wi-Fi"
 msgstr ""
 
-#: docking/applets/network/applet.py:211
+#: docking/applets/network/applet.py:202
 msgid "Show Download"
 msgstr ""
 
-#: docking/applets/network/applet.py:212
+#: docking/applets/network/applet.py:203
 msgid "Show Upload"
 msgstr ""
 
-#: docking/applets/network/applet.py:213
+#: docking/applets/network/applet.py:204
 msgid "Hide Speeds"
 msgstr ""
 
-#: docking/applets/network/applet.py:261
+#: docking/applets/network/applet.py:255
 msgid "Available Networks"
 msgstr ""
 
-#: docking/applets/network/applet.py:265
+#: docking/applets/network/applet.py:259
 #, python-brace-format
 msgid "{ssid} ({pct}%)"
 msgstr ""
 
-#: docking/applets/network/applet.py:267
+#: docking/applets/network/applet.py:261
 #, python-brace-format
 msgid "Connected: {label}"
 msgstr ""
 
-#: docking/applets/network/applet.py:276
+#: docking/applets/network/applet.py:270
 msgid "No networks found"
 msgstr ""
 
-#: docking/applets/network/applet.py:288
+#: docking/applets/network/applet.py:282
 msgid "VPN Connections"
 msgstr ""
 
-#: docking/applets/network/applet.py:291
+#: docking/applets/network/applet.py:285
 msgid "Unnamed VPN"
 msgstr ""
 
-#: docking/applets/network/state.py:205
-msgid "Network: Not connected"
-msgstr ""
-
-#: docking/applets/notifications/applet.py:59
+#: docking/applets/notifications/applet.py:60
 #: docking/applets/notifications/state.py:49
 msgid "Notifications"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:126
+#: docking/applets/notifications/applet.py:127
 msgid "No notification backend available"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:132
+#: docking/applets/notifications/applet.py:129
 msgid "Do Not Disturb"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:139
+#: docking/applets/notifications/applet.py:137
 #: docking/applets/notifications/state.py:47
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:144
+#: docking/applets/notifications/applet.py:142
 msgid "Clear History"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:149
+#: docking/applets/notifications/applet.py:147
 msgid "Clear Notifications"
 msgstr ""
 
@@ -1305,19 +1384,19 @@ msgstr ""
 msgid "Pomodoro"
 msgstr ""
 
-#: docking/applets/pomodoro/applet.py:157
+#: docking/applets/pomodoro/applet.py:154
 msgid "Reset"
 msgstr ""
 
-#: docking/applets/pomodoro/applet.py:169 docking/applets/pomodoro/state.py:68
+#: docking/applets/pomodoro/applet.py:162 docking/applets/pomodoro/state.py:68
 msgid "Work"
 msgstr ""
 
-#: docking/applets/pomodoro/applet.py:185 docking/applets/pomodoro/state.py:69
+#: docking/applets/pomodoro/applet.py:175 docking/applets/pomodoro/state.py:69
 msgid "Break"
 msgstr ""
 
-#: docking/applets/pomodoro/applet.py:201 docking/applets/pomodoro/state.py:70
+#: docking/applets/pomodoro/applet.py:188 docking/applets/pomodoro/state.py:70
 msgid "Long Break"
 msgstr ""
 
@@ -1341,11 +1420,11 @@ msgstr ""
 msgid "Power Profiles unavailable"
 msgstr ""
 
-#: docking/applets/powerprofiles/applet.py:128
+#: docking/applets/powerprofiles/applet.py:126
 msgid "Select Profile"
 msgstr ""
 
-#: docking/applets/powerprofiles/applet.py:150
+#: docking/applets/powerprofiles/applet.py:145
 #, python-brace-format
 msgid "Limited: {reason}"
 msgstr ""
@@ -1362,49 +1441,49 @@ msgstr ""
 msgid "Performance"
 msgstr ""
 
-#: docking/applets/quicknote/applet.py:40
-#: docking/applets/quicknote/applet.py:73
+#: docking/applets/quicknote/applet.py:41
+#: docking/applets/quicknote/applet.py:70
 msgid "Quick Note"
 msgstr ""
 
-#: docking/applets/quicknote/applet.py:61
+#: docking/applets/quicknote/applet.py:60
 msgid "Edit Note"
 msgstr ""
 
-#: docking/applets/quicknote/applet.py:65
+#: docking/applets/quicknote/applet.py:63
 msgid "Clear Note"
 msgstr ""
 
-#: docking/applets/quote/applet.py:88
+#: docking/applets/quote/applet.py:86
 msgid "Next Quote"
 msgstr ""
 
-#: docking/applets/quote/applet.py:92
+#: docking/applets/quote/applet.py:89
 msgid "Copy Quote"
 msgstr ""
 
-#: docking/applets/quote/applet.py:102
+#: docking/applets/quote/applet.py:96
 msgid "Source"
 msgstr ""
 
-#: docking/applets/quote/applet.py:210
+#: docking/applets/quote/applet.py:207
 #, python-brace-format
 msgid "{source}: loading..."
 msgstr ""
 
-#: docking/applets/recentfiles/applet.py:34
+#: docking/applets/recentfiles/applet.py:35
 msgid "Recent Files"
 msgstr ""
 
-#: docking/applets/recentfiles/applet.py:84
+#: docking/applets/recentfiles/applet.py:82
 msgid "Clear Recent Files"
 msgstr ""
 
-#: docking/applets/screenshot/applet.py:39
+#: docking/applets/screenshot/applet.py:40
 msgid "Screenshot"
 msgstr ""
 
-#: docking/applets/screenshot/applet.py:75
+#: docking/applets/screenshot/applet.py:76
 #, python-brace-format
 msgid "Full Screen in {delay}s"
 msgstr ""
@@ -1437,8 +1516,12 @@ msgstr ""
 msgid "Invert Color"
 msgstr ""
 
-#: docking/applets/session/applet.py:27
+#: docking/applets/session/applet.py:28
 msgid "Session"
+msgstr ""
+
+#: docking/applets/session/applet.py:55 docking/applets/session/state.py:28
+msgid "Suspend"
 msgstr ""
 
 #: docking/applets/session/state.py:24
@@ -1449,10 +1532,6 @@ msgstr ""
 msgid "Log Out"
 msgstr ""
 
-#: docking/applets/session/state.py:28
-msgid "Suspend"
-msgstr ""
-
 #: docking/applets/session/state.py:29
 msgid "Restart"
 msgstr ""
@@ -1461,56 +1540,62 @@ msgstr ""
 msgid "Shut Down"
 msgstr ""
 
-#: docking/applets/speedtest/applet.py:40 docking/applets/speedtest/state.py:70
+#: docking/applets/speedtest/applet.py:42 docking/applets/speedtest/state.py:76
+#: docking/applets/speedtest/state.py:82 docking/applets/speedtest/state.py:88
+#: docking/applets/speedtest/state.py:108
 msgid "Speedtest"
 msgstr ""
 
-#: docking/applets/speedtest/applet.py:82
-#: docking/applets/speedtest/applet.py:100
-#: docking/applets/speedtest/state.py:72
+#: docking/applets/speedtest/applet.py:80 docking/applets/speedtest/state.py:73
+msgid "Runs"
+msgstr ""
+
+#: docking/applets/speedtest/applet.py:83
+#: docking/applets/speedtest/applet.py:101
+#: docking/applets/speedtest/state.py:77
 msgid "Running..."
 msgstr ""
 
-#: docking/applets/speedtest/applet.py:82
+#: docking/applets/speedtest/applet.py:83
 msgid "Run Test"
 msgstr ""
 
-#: docking/applets/speedtest/applet.py:89
+#: docking/applets/speedtest/applet.py:90
 msgid "Copy Last Result"
 msgstr ""
 
-#: docking/applets/speedtest/applet.py:105
+#: docking/applets/speedtest/applet.py:106
 #, python-brace-format
 msgid "Down {d:.1f} / Up {u:.1f} Mbps"
 msgstr ""
 
-#: docking/applets/speedtest/applet.py:162
+#: docking/applets/speedtest/applet.py:163
 #, python-brace-format
 msgid ""
 "Down: {d:.2f} Mbps, Up: {u:.2f} Mbps, Ping: {p:.1f} ms, Jitter: {j:.1f} ms "
 "({when})"
 msgstr ""
 
-#: docking/applets/speedtest/state.py:78
+#: docking/applets/speedtest/state.py:89
 msgid "Click to run a test"
 msgstr ""
 
-#: docking/applets/speedtest/state.py:81
+#: docking/applets/speedtest/state.py:92
 #, python-brace-format
 msgid "Down: {d:.1f} Mbps   Up: {u:.1f} Mbps"
 msgstr ""
 
-#: docking/applets/speedtest/state.py:86
+#: docking/applets/speedtest/state.py:96
 #, python-brace-format
 msgid "Ping: {p:.1f} ms   Jitter: {j:.1f} ms"
 msgstr ""
 
-#: docking/applets/speedtest/state.py:91
+#: docking/applets/speedtest/state.py:101
 #, python-brace-format
 msgid "Server: {s}"
 msgstr ""
 
-#: docking/applets/speedtest/state.py:94
+#: docking/applets/speedtest/state.py:105
 #, python-brace-format
 msgid "At: {t}"
 msgstr ""
@@ -1519,19 +1604,19 @@ msgstr ""
 msgid "Stretch Coach"
 msgstr ""
 
-#: docking/applets/stretchcoach/applet.py:81
+#: docking/applets/stretchcoach/applet.py:79
 msgid "Acknowledge Break"
 msgstr ""
 
-#: docking/applets/stretchcoach/applet.py:81
+#: docking/applets/stretchcoach/applet.py:79
 msgid "Take Break Now"
 msgstr ""
 
-#: docking/applets/stretchcoach/applet.py:86
+#: docking/applets/stretchcoach/applet.py:83
 msgid "Show Random Stretch"
 msgstr ""
 
-#: docking/applets/stretchcoach/applet.py:90
+#: docking/applets/stretchcoach/applet.py:86
 msgid "Random Stretch Cards"
 msgstr ""
 
@@ -1545,29 +1630,30 @@ msgid "Next stretch in {time}"
 msgstr ""
 
 #: docking/applets/systemmonitor/applet.py:51
+#: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
 msgstr ""
 
-#: docking/applets/systemmonitor/applet.py:86
+#: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"
 msgstr ""
 
-#: docking/applets/systemmonitor/applet.py:93
-#: docking/applets/thermals/applet.py:118 docking/applets/weather/applet.py:145
+#: docking/applets/systemmonitor/applet.py:90
+#: docking/applets/thermals/applet.py:149 docking/applets/weather/applet.py:186
 msgid "Temperature Unit"
 msgstr ""
 
-#: docking/applets/systemmonitor/state.py:150
+#: docking/applets/systemmonitor/state.py:151
 #, python-brace-format
 msgid "CPU: {cpu}% | Mem: {mem}%"
 msgstr ""
 
-#: docking/applets/systemmonitor/state.py:154
+#: docking/applets/systemmonitor/state.py:155
 #, python-brace-format
 msgid "{text} | Temp: {temp}"
 msgstr ""
 
-#: docking/applets/systemmonitor/state.py:164
+#: docking/applets/systemmonitor/state.py:166
 #, python-brace-format
 msgid "Disk: {usage}"
 msgstr ""
@@ -1580,60 +1666,68 @@ msgstr ""
 msgid "Celsius"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:46 docking/applets/thermals/state.py:178
+#: docking/applets/thermals/applet.py:53 docking/applets/thermals/state.py:199
+#: docking/applets/thermals/state.py:212 docking/applets/thermals/state.py:224
+#: docking/applets/thermals/state.py:258
 msgid "Thermals"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:82 docking/applets/thermals/state.py:141
-#: docking/applets/thermals/state.py:183
+#: docking/applets/thermals/applet.py:96 docking/applets/thermals/state.py:149
+#: docking/applets/thermals/state.py:219
 msgid "lm-sensors not installed"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:93 docking/applets/thermals/state.py:191
+#: docking/applets/thermals/applet.py:105 docking/applets/thermals/state.py:238
 #, python-brace-format
 msgid "Hot: {label} {temp}"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:106 docking/applets/thermals/state.py:204
+#: docking/applets/thermals/applet.py:119 docking/applets/thermals/state.py:250
 #, python-brace-format
 msgid "Fan: {label} {rpm}"
 msgstr ""
 
-#: docking/applets/thermals/state.py:159
+#: docking/applets/thermals/applet.py:139 docking/applets/thermals/state.py:205
+#: docking/applets/thermals/state.py:217 docking/applets/thermals/state.py:229
+#: docking/applets/thermals/state.py:265
+msgid "Samples"
+msgstr ""
+
+#: docking/applets/thermals/applet.py:257
+msgid "Thermal readings unavailable"
+msgstr ""
+
+#: docking/applets/thermals/state.py:167
 msgid "sensors failed"
 msgstr ""
 
-#: docking/applets/thermals/state.py:166
+#: docking/applets/thermals/state.py:174
 msgid "No thermal readings"
 msgstr ""
 
-#: docking/applets/thermals/state.py:180
-msgid "No reading yet"
-msgstr ""
-
-#: docking/applets/thermals/state.py:200
+#: docking/applets/thermals/state.py:246
 msgid "Hot: unavailable"
 msgstr ""
 
-#: docking/applets/thermals/state.py:210
+#: docking/applets/thermals/state.py:256
 msgid "Fan: unavailable"
 msgstr ""
 
-#: docking/applets/todayinhistory/applet.py:46
-#: docking/applets/todayinhistory/applet.py:115
-#: docking/applets/todayinhistory/applet.py:127
+#: docking/applets/todayinhistory/applet.py:47
+#: docking/applets/todayinhistory/applet.py:117
+#: docking/applets/todayinhistory/applet.py:129
 msgid "Today in History"
 msgstr ""
 
-#: docking/applets/todayinhistory/applet.py:94
+#: docking/applets/todayinhistory/applet.py:92
 msgid "Open Article"
 msgstr ""
 
-#: docking/applets/todayinhistory/applet.py:98
+#: docking/applets/todayinhistory/applet.py:96
 msgid "Next Event"
 msgstr ""
 
-#: docking/applets/todayinhistory/applet.py:110
+#: docking/applets/todayinhistory/applet.py:112
 msgid "Today in History: loading..."
 msgstr ""
 
@@ -1646,15 +1740,15 @@ msgstr ""
 msgid "{year} - {title}"
 msgstr ""
 
-#: docking/applets/trash/applet.py:34
+#: docking/applets/trash/applet.py:35
 msgid "Trash"
 msgstr ""
 
-#: docking/applets/trash/applet.py:60
+#: docking/applets/trash/applet.py:59
 msgid "Open Trash"
 msgstr ""
 
-#: docking/applets/trash/applet.py:64
+#: docking/applets/trash/applet.py:62
 msgid "Empty Trash"
 msgstr ""
 
@@ -1669,30 +1763,30 @@ msgid_plural "{n} items in Trash"
 msgstr[0] ""
 msgstr[1] ""
 
-#: docking/applets/trivia/applet.py:41 docking/applets/trivia/applet.py:185
+#: docking/applets/trivia/applet.py:42 docking/applets/trivia/applet.py:186
 msgid "Random Trivia"
 msgstr ""
 
-#: docking/applets/trivia/applet.py:78 docking/applets/trivia/state.py:102
+#: docking/applets/trivia/applet.py:77 docking/applets/trivia/state.py:102
 #, python-brace-format
 msgid "{category} / {difficulty}"
 msgstr ""
 
-#: docking/applets/trivia/applet.py:98 docking/applets/trivia/state.py:113
+#: docking/applets/trivia/applet.py:96 docking/applets/trivia/state.py:113
 #, python-brace-format
 msgid "Correct answer: {answer}"
 msgstr ""
 
-#: docking/applets/trivia/applet.py:106 docking/applets/trivia/state.py:112
+#: docking/applets/trivia/applet.py:105 docking/applets/trivia/state.py:112
 #, python-brace-format
 msgid "Your answer: {answer}"
 msgstr ""
 
-#: docking/applets/trivia/applet.py:115
+#: docking/applets/trivia/applet.py:112
 msgid "Next Trivia"
 msgstr ""
 
-#: docking/applets/trivia/applet.py:180
+#: docking/applets/trivia/applet.py:181
 msgid "Trivia: loading..."
 msgstr ""
 
@@ -1713,16 +1807,16 @@ msgstr ""
 msgid "Correct: {answer}"
 msgstr ""
 
-#: docking/applets/unitconverter/applet.py:77
-#: docking/applets/unitconverter/applet.py:104
+#: docking/applets/unitconverter/applet.py:74
+#: docking/applets/unitconverter/applet.py:101
 msgid "Unit Converter"
 msgstr ""
 
-#: docking/applets/unitconverter/applet.py:198
+#: docking/applets/unitconverter/applet.py:166
 msgid "Swap units"
 msgstr ""
 
-#: docking/applets/unitconverter/applet.py:215
+#: docking/applets/unitconverter/applet.py:183
 msgid "Value"
 msgstr ""
 
@@ -1732,32 +1826,32 @@ msgstr ""
 msgid "URL Shortener"
 msgstr ""
 
-#: docking/applets/urlshortener/applet.py:120
+#: docking/applets/urlshortener/applet.py:117
 msgid "Shorten"
 msgstr ""
 
-#: docking/applets/urlshortener/applet.py:146
+#: docking/applets/urlshortener/applet.py:143
 msgid "Shortening..."
 msgstr ""
 
-#: docking/applets/urlshortener/applet.py:180
-#: docking/applets/urlshortener/applet.py:199
+#: docking/applets/urlshortener/applet.py:177
+#: docking/applets/urlshortener/applet.py:196
 msgid "Copy"
 msgstr ""
 
-#: docking/applets/urlshortener/applet.py:194
+#: docking/applets/urlshortener/applet.py:191
 msgid "Copied!"
 msgstr ""
 
-#: docking/applets/volume/applet.py:41
+#: docking/applets/volume/applet.py:42
 msgid "Volume"
 msgstr ""
 
-#: docking/applets/volume/applet.py:65
+#: docking/applets/volume/applet.py:66
 msgid "Muted"
 msgstr ""
 
-#: docking/applets/volume/applet.py:65
+#: docking/applets/volume/applet.py:66
 #, python-brace-format
 msgid "Volume: {pct}%"
 msgstr ""
@@ -1766,66 +1860,60 @@ msgstr ""
 msgid "Volume Settings"
 msgstr ""
 
-#: docking/applets/weather/applet.py:63
+#: docking/applets/weather/applet.py:70 docking/applets/weather/state.py:162
 msgid "Weather"
 msgstr ""
 
-#: docking/applets/weather/applet.py:138
+#: docking/applets/weather/applet.py:179
 msgid "Show Temperature"
 msgstr ""
 
-#: docking/applets/weather/applet.py:161
+#: docking/applets/weather/applet.py:203
 #, python-brace-format
 msgid "Remove {city}"
 msgstr ""
 
-#: docking/applets/weather/applet.py:207
+#: docking/applets/weather/applet.py:255
 msgid "Search for the city"
 msgstr ""
 
-#: docking/applets/weather/applet.py:221
+#: docking/applets/weather/applet.py:268
 msgid "Type city name..."
 msgstr ""
 
-#: docking/applets/weather/applet.py:377 docking/applets/weather/state.py:152
-#, python-brace-format
-msgid "{city}: unavailable"
+#: docking/applets/weather/applet.py:425
+msgid "No weather data"
 msgstr ""
 
-#: docking/applets/weather/applet.py:404 docking/applets/weather/state.py:157
+#: docking/applets/weather/applet.py:481 docking/applets/weather/state.py:197
 #, python-brace-format
 msgid "{temp}, {desc}"
 msgstr ""
 
-#: docking/applets/weather/applet.py:417 docking/applets/weather/state.py:166
+#: docking/applets/weather/applet.py:494 docking/applets/weather/state.py:187
 #, python-brace-format
 msgid "Air: {label}"
 msgstr ""
 
-#: docking/applets/weather/applet.py:429
+#: docking/applets/weather/applet.py:506
 #, python-brace-format
 msgid "{date}: {temp_range}"
 msgstr ""
 
-#: docking/applets/weather/state.py:130
+#: docking/applets/weather/state.py:138
 #, python-brace-format
 msgid "{city}: {temp}"
 msgstr ""
 
-#: docking/applets/weather/state.py:149
-msgid "Weather (no city selected)"
+#: docking/applets/weather/state.py:163
+msgid "No city selected"
 msgstr ""
 
-#: docking/applets/weather/state.py:153
-#, python-brace-format
-msgid "{city}: loading..."
-msgstr ""
-
-#: docking/applets/windowkiller/applet.py:59
+#: docking/applets/windowkiller/applet.py:64
 msgid "Window Killer"
 msgstr ""
 
-#: docking/applets/windowkiller/applet.py:71
+#: docking/applets/windowkiller/applet.py:76
 msgid "Click, then select a window to kill"
 msgstr ""
 

--- a/tests/applets/test_aiusage.py
+++ b/tests/applets/test_aiusage.py
@@ -6,6 +6,7 @@ import datetime
 import json
 import logging
 import os
+import sqlite3
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +14,7 @@ from unittest.mock import MagicMock
 
 import docking.applets.aiusage.applet as aiusage_mod
 import docking.applets.aiusage.render as aiusage_render_mod
+import docking.applets.aiusage.state as aiusage_state_mod
 from docking.applets.aiusage.applet import AiUsageApplet
 from docking.applets.aiusage.state import (
     AiUsageState,
@@ -22,17 +24,28 @@ from docking.applets.aiusage.state import (
     Provider,
     cost_for_usage,
     day_cost,
+    day_tokens,
     dominant_provider,
+    find_codex_session,
     match_model_tier,
     parse_claude_transcript,
     parse_codex_transcript,
     prefs_from_state,
+    provider_cost,
     provider_for_model,
+    provider_tokens,
     query_codex_today,
+    query_opencode_today,
     reset_today,
     set_session,
     state_from_prefs,
+    today_cost,
+    today_sessions,
+    today_tokens,
     tooltip_text,
+    total_tokens,
+    week_cost,
+    week_tokens,
 )
 from docking.core.config import Config
 
@@ -146,6 +159,70 @@ class TestState:
         )
         assert reset_today(state=state).days == ()
 
+    def test_state_from_prefs_handles_invalid_and_session_format(self):
+        assert state_from_prefs(prefs={"days": "bad"}) == AiUsageState()
+        state = state_from_prefs(
+            prefs={
+                "days": [
+                    "bad",
+                    {"by_model": {}},
+                    {
+                        "date": "2026-04-29",
+                        "by_session": {
+                            "s1": {
+                                "gpt-5": {"in": 100, "out": 20, "cr": 10},
+                            },
+                            "s2": {
+                                "gpt-5": {"in": 50, "pc": 1.25},
+                                "bad": "skip",
+                            },
+                        },
+                    },
+                ]
+            }
+        )
+
+        assert len(state.days) == 1
+        assert state.days[0].sessions == 2
+        usage = dict(state.days[0].by_model)["gpt-5"]
+        assert usage.input_tokens == 150
+        assert usage.precalculated_cost == 1.25
+
+    def test_prefs_from_state_serializes_session_and_precalculated_cost(self):
+        state = AiUsageState(
+            days=(
+                DayEntry(
+                    date="2026-04-29",
+                    sessions=1,
+                    by_model=(
+                        (
+                            "opencode:model",
+                            ModelUsage(input_tokens=10, precalculated_cost=0.25),
+                        ),
+                    ),
+                    by_session=(
+                        (
+                            "s1",
+                            (
+                                (
+                                    "opencode:model",
+                                    ModelUsage(
+                                        input_tokens=10,
+                                        precalculated_cost=0.25,
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        )
+
+        payload = prefs_from_state(state=state)
+
+        assert payload["days"][0]["by_model"]["opencode:model"]["pc"] == 0.25
+        assert "by_session" in payload["days"][0]
+
 
 # ---------------------------------------------------------------
 # Provider detection
@@ -158,6 +235,11 @@ class TestProvider:
 
     def test_codex_model(self):
         assert provider_for_model(model="gpt-5.4") == Provider.CODEX
+
+    def test_opencode_model(self):
+        assert (
+            provider_for_model(model="opencode:anthropic/claude") == Provider.OPENCODE
+        )
 
     def test_gpt_prefix(self):
         assert provider_for_model(model="gpt-4o") == Provider.CODEX
@@ -180,6 +262,18 @@ class TestProvider:
 
     def test_dominant_provider_none_when_empty(self):
         assert dominant_provider(state=AiUsageState()) is None
+
+    def test_dominant_provider_uses_highest_cost(self):
+        state = set_session(
+            session_id="test",
+            state=AiUsageState(),
+            model_usage={
+                "claude-opus-4-6": ModelUsage(input_tokens=1000),
+                "opencode:model": ModelUsage(precalculated_cost=5.0),
+            },
+        )
+
+        assert dominant_provider(state=state) == Provider.OPENCODE
 
 
 # ---------------------------------------------------------------
@@ -210,6 +304,10 @@ class TestClaudeCost:
     def test_unknown_model_zero(self):
         usage = ModelUsage(input_tokens=1_000_000)
         assert cost_for_usage(model="unknown-model", usage=usage) == 0.0
+
+    def test_opencode_cost_is_precalculated(self):
+        usage = ModelUsage(input_tokens=1_000_000, precalculated_cost=0.42)
+        assert cost_for_usage(model="opencode:model", usage=usage) == 0.42
 
 
 # ---------------------------------------------------------------
@@ -251,6 +349,40 @@ class TestCodexCost:
         )
         assert day_cost(entry=entry) == 5.0 + 2.50
 
+    def test_cached_tokens_do_not_make_negative_input_cost(self):
+        usage = ModelUsage(input_tokens=100, cache_read_tokens=200, output_tokens=100)
+        expected = (200 * 0.62 + 100 * 10.0) / 1_000_000
+        assert cost_for_usage(model="gpt-5", usage=usage) == expected
+
+
+class TestTokenAggregation:
+    def test_day_week_today_and_provider_totals(self):
+        today = datetime.date.today().isoformat()
+        today_entry = DayEntry(
+            date=today,
+            sessions=2,
+            by_model=(
+                ("gpt-5", ModelUsage(input_tokens=100, cache_read_tokens=25)),
+                ("claude-opus-4-6", ModelUsage(input_tokens=80, output_tokens=20)),
+            ),
+        )
+        old_entry = DayEntry(
+            date="2026-04-01",
+            sessions=1,
+            by_model=(("gpt-5", ModelUsage(input_tokens=10, output_tokens=5)),),
+        )
+        state = AiUsageState(days=(today_entry, old_entry))
+
+        assert total_tokens(ModelUsage(input_tokens=100, cache_read_tokens=25)) == 75
+        assert day_tokens(today_entry) == 175
+        assert provider_tokens(today_entry, Provider.CODEX) == 75
+        assert today_tokens(state) == 175
+        assert week_tokens(state) == 190
+        assert today_sessions(state) == 2
+        assert provider_cost(today_entry, Provider.CLAUDE) > 0
+        assert today_cost(state) > 0
+        assert week_cost(state) > today_cost(state)
+
 
 # ---------------------------------------------------------------
 # Tooltip
@@ -269,6 +401,20 @@ class TestTooltip:
         )
         text = tooltip_text(state=state)
         assert "$" in text
+
+    def test_provider_specific_tooltip(self):
+        state = set_session(
+            session_id="test",
+            state=AiUsageState(),
+            model_usage={
+                "claude-opus-4": ModelUsage(input_tokens=1000),
+                "gpt-5": ModelUsage(input_tokens=1000),
+            },
+        )
+
+        text = tooltip_text(state=state, provider=Provider.CODEX)
+
+        assert "Codex" in text
 
 
 # ---------------------------------------------------------------
@@ -311,6 +457,32 @@ class TestClaudeTranscript:
         jsonl.write_text(json.dumps({"type": "user", "message": {"role": "user"}}))
         assert parse_claude_transcript(path=jsonl) == {}
 
+    def test_ignores_malformed_and_zero_usage_entries(self, tmp_path):
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text(
+            "\n".join(
+                [
+                    "{",
+                    json.dumps({"type": "assistant", "message": "bad"}),
+                    json.dumps({"type": "assistant", "message": {"usage": "bad"}}),
+                    json.dumps(
+                        {
+                            "type": "assistant",
+                            "message": {"usage": {}, "model": ""},
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "assistant",
+                            "message": {"usage": {}, "model": "claude-haiku"},
+                        }
+                    ),
+                ]
+            )
+        )
+
+        assert parse_claude_transcript(path=jsonl) == {}
+
 
 # ---------------------------------------------------------------
 # Codex transcript parsing
@@ -318,6 +490,25 @@ class TestClaudeTranscript:
 
 
 class TestCodexTranscript:
+    def test_find_codex_session_missing_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        assert find_codex_session() is None
+
+    def test_find_codex_session_by_thread_or_mtime(self, tmp_path, monkeypatch):
+        sessions_dir = tmp_path / ".codex" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        older = sessions_dir / "session-old.jsonl"
+        newer = sessions_dir / "session-thread-123.jsonl"
+        older.write_text("{}", encoding="utf-8")
+        newer.write_text("{}", encoding="utf-8")
+        os.utime(older, (1000, 1000))
+        os.utime(newer, (2000, 2000))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        assert find_codex_session(thread_id="thread-123") == newer
+        assert find_codex_session() == newer
+
     def test_parses_valid_session(self, tmp_path):
         jsonl = tmp_path / "session.jsonl"
         lines = [
@@ -411,6 +602,33 @@ class TestCodexTranscript:
         )
         assert parse_codex_transcript(path=jsonl) == {}
 
+    def test_ignores_malformed_and_non_token_entries(self, tmp_path):
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text(
+            "\n".join(
+                [
+                    "{",
+                    json.dumps({"type": "turn_context", "payload": {}}),
+                    json.dumps({"type": "event_msg", "payload": {"type": "other"}}),
+                    json.dumps(
+                        {
+                            "type": "event_msg",
+                            "payload": {"type": "token_count", "info": "bad"},
+                        }
+                    ),
+                ]
+            )
+        )
+
+        assert parse_codex_transcript(path=jsonl) == {}
+
+    def test_codex_session_id_falls_back_to_stem(self, tmp_path):
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text("{\n{}\n", encoding="utf-8")
+
+        assert aiusage_state_mod._codex_session_id(jsonl) == "session"
+        assert aiusage_state_mod._codex_session_id(tmp_path / "missing") == "missing"
+
     def test_query_codex_today_reads_recent_sessions(self, tmp_path, monkeypatch):
         sessions_dir = tmp_path / ".codex" / "sessions" / "2026" / "04" / "29"
         sessions_dir.mkdir(parents=True)
@@ -460,6 +678,100 @@ class TestCodexTranscript:
         result = query_codex_today()
 
         assert result["thread-1"]["gpt-5.5"].input_tokens == 1200
+
+    def test_query_codex_today_skips_old_and_empty_sessions(
+        self, tmp_path, monkeypatch
+    ):
+        sessions_dir = tmp_path / ".codex" / "sessions"
+        sessions_dir.mkdir(parents=True)
+        old = sessions_dir / "old.jsonl"
+        old.write_text("{}", encoding="utf-8")
+        current = sessions_dir / "current.jsonl"
+        current.write_text(json.dumps({"type": "turn_context", "payload": {}}))
+        os.utime(old, (1000, 1000))
+        os.utime(current, (2000, 2000))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "docking.applets.aiusage.state._today_iso",
+            lambda: "1970-01-01",
+        )
+
+        assert query_codex_today() == {}
+
+
+class TestOpenCodeUsage:
+    def test_query_opencode_today_missing_db(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(aiusage_state_mod, "_OPENCODE_DB", tmp_path / "missing.db")
+
+        assert query_opencode_today() == {}
+
+    def test_query_opencode_today_connect_error(self, tmp_path, monkeypatch):
+        db = tmp_path / "opencode.db"
+        db.write_text("", encoding="utf-8")
+        monkeypatch.setattr(aiusage_state_mod, "_OPENCODE_DB", db)
+
+        def fail(*_args, **_kwargs):
+            raise sqlite3.OperationalError("locked")
+
+        monkeypatch.setattr(sqlite3, "connect", fail)
+
+        assert query_opencode_today() == {}
+
+    def test_query_opencode_today_no_sessions(self, tmp_path, monkeypatch):
+        db = tmp_path / "opencode.db"
+        conn = sqlite3.connect(db)
+        conn.execute("CREATE TABLE session (id TEXT, time_created INTEGER)")
+        conn.execute("CREATE TABLE message (session_id TEXT, data TEXT)")
+        conn.commit()
+        conn.close()
+        monkeypatch.setattr(aiusage_state_mod, "_OPENCODE_DB", db)
+        monkeypatch.setattr(aiusage_state_mod, "_today_iso", lambda: "2026-04-29")
+
+        assert query_opencode_today() == {}
+
+    def test_query_opencode_today_accumulates_valid_rows(self, tmp_path, monkeypatch):
+        db = tmp_path / "opencode.db"
+        today_start_ms = int(
+            datetime.datetime.fromisoformat("2026-04-29").timestamp() * 1000
+        )
+        conn = sqlite3.connect(db)
+        conn.execute("CREATE TABLE session (id TEXT, time_created INTEGER)")
+        conn.execute("CREATE TABLE message (session_id TEXT, data TEXT)")
+        conn.execute(
+            "INSERT INTO session VALUES (?, ?)",
+            ("s1", today_start_ms + 1000),
+        )
+        rows = [
+            "{",
+            json.dumps({"modelID": "", "tokens": {"input": 10}}),
+            json.dumps({"modelID": "m", "tokens": {}, "cost": 0}),
+            json.dumps(
+                {
+                    "modelID": "m",
+                    "tokens": {"input": 10, "output": 5},
+                    "cost": 0.25,
+                }
+            ),
+            json.dumps(
+                {
+                    "modelID": "m",
+                    "tokens": {"input": 2, "output": 3},
+                    "cost": 0.10,
+                }
+            ),
+        ]
+        conn.executemany("INSERT INTO message VALUES (?, ?)", [("s1", r) for r in rows])
+        conn.commit()
+        conn.close()
+        monkeypatch.setattr(aiusage_state_mod, "_OPENCODE_DB", db)
+        monkeypatch.setattr(aiusage_state_mod, "_today_iso", lambda: "2026-04-29")
+
+        result = query_opencode_today()
+
+        usage = result["s1"]["opencode:m"]
+        assert usage.input_tokens == 12
+        assert usage.output_tokens == 8
+        assert usage.precalculated_cost == 0.35
 
 
 # ---------------------------------------------------------------

--- a/tests/applets/test_apod.py
+++ b/tests/applets/test_apod.py
@@ -98,8 +98,12 @@ class TestBuildPageUrl:
 
 
 class TestBuildTooltip:
-    def test_loading_state(self):
+    def test_no_data_state(self):
         text = build_tooltip(result=None, error=None)
+        assert "No data yet" in text
+
+    def test_loading_state(self):
+        text = build_tooltip(result=None, error=None, loading=True)
         assert "Loading" in text
 
     def test_error_state(self):
@@ -107,11 +111,16 @@ class TestBuildTooltip:
         assert "network down" in text
 
     def test_full_result(self):
-        text = build_tooltip(result=_sample_result(), error=None)
+        text = build_tooltip(
+            result=_sample_result(),
+            error=None,
+            cadence_seconds=3600,
+        )
         assert "Spiral Galaxy" in text
         assert "NASA" in text
         assert "2026-04-24" in text
         assert "distant spiral" in text
+        assert "Checks every 1 hour" in text
 
 
 class TestPrefsRoundTrip:
@@ -216,16 +225,55 @@ class TestAppletLifecycle:
             applet = _make_applet(size)
             assert applet.create_icon(size) is not None
 
-    def test_tooltip_initial_loading(self):
+    def test_tooltip_initial_no_data(self):
         applet = _make_applet()
         applet.refresh_tooltip()
-        assert "Loading" in applet.item.name
+        assert "No data yet" in applet.item.name
 
     def test_tooltip_with_result(self):
         applet = _make_applet()
         applet._result = _sample_result()
         applet.refresh_tooltip()
         assert "Spiral Galaxy" in applet.item.name
+
+    def test_start_stop_and_ticks_manage_timers(self, monkeypatch):
+        applet = _make_applet()
+        add = MagicMock(side_effect=[11, 12, 13])
+        removed: list[int] = []
+        monkeypatch.setattr("docking.applets.apod.applet.GLib.timeout_add_seconds", add)
+        monkeypatch.setattr(
+            "docking.applets.apod.applet.GLib.source_remove",
+            lambda timer_id: removed.append(timer_id),
+        )
+        applet._fetch_async = MagicMock()
+
+        applet.start(lambda: None)
+        assert applet._refresh_timer_id == 11
+        assert applet._startup_fetch_timer_id == 12
+
+        assert applet._tick() is True
+        assert applet._run_startup_fetch() is False
+
+        applet._retry_timer_id = 13
+        applet.stop()
+
+        assert removed == [11, 13]
+        assert applet._refresh_timer_id == 0
+        assert applet._retry_timer_id == 0
+        assert applet._startup_fetch_timer_id == 0
+        assert applet._fetch_async.call_count == 2
+
+    def test_run_retry_only_fetches_when_needed(self, monkeypatch):
+        applet = _make_applet()
+        applet._fetch_async = MagicMock()
+        monkeypatch.setattr(applet, "_needs_fetch", lambda: False)
+
+        assert applet._run_retry() is False
+        applet._fetch_async.assert_not_called()
+
+        monkeypatch.setattr(applet, "_needs_fetch", lambda: True)
+        assert applet._run_retry() is False
+        applet._fetch_async.assert_called_once()
 
 
 class TestAppletMenu:
@@ -240,6 +288,7 @@ class TestAppletMenu:
         applet._result = _sample_result()
         labels = [mi.get_label() for mi in applet.get_menu_items()]
         assert any("Spiral Galaxy" in label for label in labels)
+        assert "Checks every 1 hour" in labels
         assert any("Copy Explanation" in label for label in labels)
 
 
@@ -264,6 +313,85 @@ class TestAppletFetch:
             applet._fetch_async()
         assert applet._result == prev
         assert applet._error == "down"
+
+    def test_fetch_result_and_error_ignore_stale_requests(self):
+        applet = _make_applet()
+        applet._fetch_request_id = 7
+        applet.present = MagicMock()
+
+        assert applet._on_fetch_result(request_id=6, result=_sample_result()) is False
+        assert applet._on_fetch_error(request_id=6, exc=RuntimeError("old")) is False
+
+        applet.present.assert_not_called()
+
+    def test_fetch_error_uses_exception_name_when_message_empty(self):
+        applet = _make_applet()
+        applet._fetch_request_id = 7
+
+        assert applet._on_fetch_error(request_id=7, exc=RuntimeError()) is False
+
+        assert applet._error == "RuntimeError"
+
+    def test_schedule_retry_is_idempotent(self, monkeypatch):
+        applet = _make_applet()
+        add = MagicMock(return_value=42)
+        monkeypatch.setattr("docking.applets.apod.applet.GLib.timeout_add_seconds", add)
+
+        applet._schedule_retry()
+        applet._schedule_retry()
+
+        assert applet._retry_timer_id == 42
+        add.assert_called_once()
+
+    def test_open_page_and_copy_explanation(self, monkeypatch):
+        applet = _make_applet()
+        applet._result = _sample_result(page_url="https://example.test/apod")
+        opened: list[str] = []
+        monkeypatch.setattr(
+            "docking.applets.apod.applet.Gio.AppInfo.launch_default_for_uri",
+            lambda url, _ctx: opened.append(url),
+        )
+
+        applet.on_clicked()
+        assert opened == ["https://example.test/apod"]
+
+        copied: list[str] = []
+
+        class _Clipboard:
+            def set_text(self, text: str, length: int) -> None:
+                copied.append(text)
+                copied.append(str(length))
+
+        monkeypatch.setattr(
+            "docking.applets.apod.applet.Gtk.Clipboard.get",
+            lambda _selection: _Clipboard(),
+        )
+
+        applet._copy_explanation()
+
+        assert copied == ["A distant spiral galaxy.", "-1"]
+
+    def test_open_page_uses_default_and_swallows_launch_error(self, monkeypatch):
+        applet = _make_applet()
+        opened: list[str] = []
+        monkeypatch.setattr(
+            "docking.applets.apod.applet.GLib.Error",
+            RuntimeError,
+            raising=False,
+        )
+
+        def launch(url, _ctx):
+            opened.append(url)
+            raise RuntimeError("no handler")
+
+        monkeypatch.setattr(
+            "docking.applets.apod.applet.Gio.AppInfo.launch_default_for_uri",
+            launch,
+        )
+
+        applet._open_page()
+
+        assert opened == ["https://apod.nasa.gov/"]
 
     def test_needs_fetch_when_date_stale(self):
         applet = _make_applet()
@@ -306,6 +434,96 @@ class TestRenderPixbuf:
 
         pb = render_icon(size=48, cached_path="")
         assert pb is not None
+
+    def test_renders_real_pixbuf_cover_path(self, monkeypatch):
+        import docking.applets.apod.render as render_mod
+
+        pixbuf = render_mod.GdkPixbuf.Pixbuf.new(
+            render_mod.GdkPixbuf.Colorspace.RGB,
+            True,
+            8,
+            48,
+            48,
+        )
+        pixbuf.fill(0x336699FF)
+        monkeypatch.setattr(render_mod, "_load_cover_pixbuf", lambda **_kwargs: pixbuf)
+
+        pb = render_mod.render_icon(
+            size=48,
+            cached_path="/tmp/image.png",
+            warning=True,
+        )
+
+        assert pb is not None
+        assert pb.get_width() == 48
+
+    def test_load_cover_pixbuf_fallback_edges(self, monkeypatch, tmp_path):
+        import docking.applets.apod.render as render_mod
+
+        path = str(tmp_path / "image.png")
+        monkeypatch.setattr(
+            render_mod.GdkPixbuf.Pixbuf,
+            "get_file_info",
+            staticmethod(lambda _path: None),
+        )
+        fallback = MagicMock(return_value="fallback")
+        monkeypatch.setattr(render_mod, "_fallback_scaled_pixbuf", fallback)
+
+        assert render_mod._load_cover_pixbuf(path=path, size=48) == "fallback"
+
+        monkeypatch.setattr(
+            render_mod.GdkPixbuf.Pixbuf,
+            "get_file_info",
+            staticmethod(lambda _path: ("fmt", 0, 10)),
+        )
+        assert render_mod._load_cover_pixbuf(path=path, size=48) == "fallback"
+
+    def test_load_cover_pixbuf_scales_and_crops(self, monkeypatch):
+        import docking.applets.apod.render as render_mod
+
+        class _Pixbuf:
+            def __init__(self, width: int, height: int) -> None:
+                self.width = width
+                self.height = height
+                self.crop: tuple[int, int, int, int] | None = None
+
+            def get_width(self) -> int:
+                return self.width
+
+            def get_height(self) -> int:
+                return self.height
+
+            def new_subpixbuf(self, x: int, y: int, w: int, h: int):
+                self.crop = (x, y, w, h)
+                return self
+
+        scaled = _Pixbuf(96, 48)
+        monkeypatch.setattr(
+            render_mod.GdkPixbuf.Pixbuf,
+            "get_file_info",
+            staticmethod(lambda _path: ("fmt", 100, 50)),
+        )
+        monkeypatch.setattr(
+            render_mod.GdkPixbuf.Pixbuf,
+            "new_from_file_at_scale",
+            staticmethod(lambda _path, _w, _h, _preserve: scaled),
+        )
+
+        assert render_mod._load_cover_pixbuf(path="/tmp/img", size=48) is scaled
+        assert scaled.crop == (24, 0, 48, 48)
+
+    def test_fallback_scaled_pixbuf_returns_none_on_error(self, monkeypatch):
+        import docking.applets.apod.render as render_mod
+
+        monkeypatch.setattr(
+            render_mod.GdkPixbuf.Pixbuf,
+            "new_from_file_at_scale",
+            staticmethod(
+                lambda *_args: (_ for _ in ()).throw(render_mod.GLib.Error("bad"))
+            ),
+        )
+
+        assert render_mod._fallback_scaled_pixbuf(path="/bad", size=48) is None
 
 
 class TestAppletResponseStream:

--- a/tests/applets/test_battery.py
+++ b/tests/applets/test_battery.py
@@ -1,5 +1,7 @@
 """Tests for the battery applet -- sysfs parsing, launchers, and icon mapping."""
 
+import subprocess
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -73,6 +75,53 @@ class TestReadBattery:
         state = read_battery("BAT0", base=tmp_path)
         assert state is not None
         assert state.icon_name == "battery-low-charging"
+
+    def test_estimates_discharge_time_from_energy_and_power(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        bat = tmp_path / "BAT0"
+        bat.mkdir()
+        (bat / "capacity").write_text("40\n")
+        (bat / "capacity_level").write_text("Low\n")
+        (bat / "status").write_text("Discharging\n")
+        (bat / "energy_now").write_text("2000000\n")
+        (bat / "power_now").write_text("1000000\n")
+        monkeypatch.setattr(
+            battery_state_mod,
+            "_upower_seconds_remaining",
+            lambda **_kwargs: None,
+        )
+
+        state = read_battery("BAT0", base=tmp_path)
+
+        assert state is not None
+        assert state.seconds_remaining == 7200
+
+    def test_estimates_charge_time_from_energy_gap_and_power(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        bat = tmp_path / "BAT0"
+        bat.mkdir()
+        (bat / "capacity").write_text("50\n")
+        (bat / "capacity_level").write_text("Normal\n")
+        (bat / "status").write_text("Charging\n")
+        (bat / "energy_now").write_text("1000000\n")
+        (bat / "energy_full").write_text("3000000\n")
+        (bat / "power_now").write_text("1000000\n")
+        monkeypatch.setattr(
+            battery_state_mod,
+            "_upower_seconds_remaining",
+            lambda **_kwargs: None,
+        )
+
+        state = read_battery("BAT0", base=tmp_path)
+
+        assert state is not None
+        assert state.seconds_remaining == 7200
 
     def test_prefers_upower_estimate_when_available(self, tmp_path, monkeypatch):
         bat = tmp_path / "BAT0"
@@ -167,6 +216,88 @@ class TestUpowerParsing:
     def test_ignores_unknown_duration(self):
         assert battery_state_mod._parse_duration_seconds(raw="unknown") is None
 
+    def test_upower_seconds_remaining_edges(self, monkeypatch):
+        monkeypatch.setattr(battery_state_mod.shutil, "which", lambda _cmd: None)
+        assert (
+            battery_state_mod._upower_seconds_remaining(
+                bat_name="BAT0",
+                status="Discharging",
+            )
+            is None
+        )
+
+        monkeypatch.setattr(
+            battery_state_mod.shutil, "which", lambda _cmd: "/bin/upower"
+        )
+        assert (
+            battery_state_mod._upower_seconds_remaining(bat_name="BAT0", status="Full")
+            is None
+        )
+
+        monkeypatch.setattr(
+            battery_state_mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                returncode=0,
+                stdout="time to full: 30 minutes\n",
+                stderr="",
+            ),
+        )
+        assert (
+            battery_state_mod._upower_seconds_remaining(
+                bat_name="BAT0",
+                status="Charging",
+            )
+            == 1800
+        )
+
+        monkeypatch.setattr(
+            battery_state_mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                returncode=1, stdout="", stderr=""
+            ),
+        )
+        assert (
+            battery_state_mod._upower_seconds_remaining(
+                bat_name="BAT0",
+                status="Charging",
+            )
+            is None
+        )
+
+        monkeypatch.setattr(
+            battery_state_mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                subprocess.TimeoutExpired(["upower"], 2)
+            ),
+        )
+        assert (
+            battery_state_mod._upower_seconds_remaining(
+                bat_name="BAT0",
+                status="Charging",
+            )
+            is None
+        )
+
+        assert (
+            battery_state_mod._parse_upower_duration_seconds(
+                text="state: charging",
+                key="time to full",
+            )
+            is None
+        )
+
+    def test_duration_helpers_cover_short_values(self):
+        assert battery_state_mod._format_duration(59) == "1m"
+        assert battery_state_mod._format_duration(0) is None
+        assert battery_state_mod._parse_duration_seconds(raw="10 seconds") == 10
+        assert battery_state_mod._parse_duration_seconds(raw="bad") is None
+        assert battery_state_mod._seconds_from_rate(remaining=0, rate=1) is None
+        assert battery_state_mod._positive_delta(full=None, now=1) is None
+        assert battery_state_mod._positive_delta(full=1, now=1) is None
+
 
 class TestTooltipText:
     def test_shows_time_left_when_estimate_is_known(self):
@@ -195,6 +326,16 @@ class TestTooltipText:
             capacity=100,
             status="Full",
             seconds_remaining=None,
+        )
+
+        assert tooltip_text(state) == "Battery: 100%"
+
+    def test_hides_estimate_for_non_charging_status(self):
+        state = BatteryState(
+            icon_name="battery-full",
+            capacity=100,
+            status="Full",
+            seconds_remaining=60,
         )
 
         assert tooltip_text(state) == "Battery: 100%"
@@ -234,6 +375,22 @@ class TestPowerSettingsLauncher:
 
         assert open_power_settings() is True
         assert launched == [["mate-power-preferences"]]
+
+    def test_open_power_settings_handles_missing_and_launch_failure(self, monkeypatch):
+        monkeypatch.setattr(battery_state_mod, "power_settings_command", lambda: None)
+        assert open_power_settings() is False
+
+        monkeypatch.setattr(
+            battery_state_mod,
+            "power_settings_command",
+            lambda: ["mate-power-preferences"],
+        )
+        monkeypatch.setattr(
+            battery_state_mod.subprocess,
+            "Popen",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("boom")),
+        )
+        assert open_power_settings() is False
 
 
 class TestBatteryAppletRendering:
@@ -275,9 +432,10 @@ class TestBatteryAppletRendering:
 
         assert [item.get_label() for item in items] == [
             "Show Percent",
+            "",
             "Power Settings",
         ]
-        callback, args = items[1]._signals["activate"][0]
+        callback, args = items[2]._signals["activate"][0]
         callback(None, *args)
         assert opened == ["opened"]
 

--- a/tests/applets/test_bookmarks.py
+++ b/tests/applets/test_bookmarks.py
@@ -161,7 +161,7 @@ class TestApplet:
 
         items[0].emit("activate")
         items[2].emit("activate")
-        items[3].emit("activate")
+        items[4].emit("activate")
 
         assert open_url == ["https://example.com"]
         assert add_calls == [True]
@@ -225,6 +225,9 @@ class TestApplet:
             def set_position(self, *_args):
                 return
 
+            def set_default_response(self, *_args):
+                return
+
             def get_content_area(self):
                 return self.content
 
@@ -242,6 +245,12 @@ class TestApplet:
                 self._text = text
 
             def set_placeholder_text(self, _text):
+                return
+
+            def set_activates_default(self, _value):
+                return
+
+            def grab_focus(self):
                 return
 
             def get_text(self):
@@ -302,6 +311,9 @@ class TestApplet:
             def set_position(self, *_args):
                 return
 
+            def set_default_response(self, *_args):
+                return
+
             def get_content_area(self):
                 return self.content
 
@@ -319,6 +331,12 @@ class TestApplet:
                 self._text = text
 
             def set_placeholder_text(self, _text):
+                return
+
+            def set_activates_default(self, _value):
+                return
+
+            def grab_focus(self):
                 return
 
             def get_text(self):

--- a/tests/applets/test_calculator.py
+++ b/tests/applets/test_calculator.py
@@ -9,7 +9,6 @@ import docking.applets.calculator.applet as calculator_applet_mod
 from docking.applets.calculator.applet import CalculatorApplet
 from docking.applets.calculator.state import evaluate, prefs_payload
 from docking.core.config import Config
-from docking.ui.display import ScreenPosition
 
 
 def _make_applet(config: Config | None = None) -> CalculatorApplet:
@@ -256,12 +255,18 @@ class TestAppletPopup:
             applet._entry.connect("activate", lambda _entry: applet._do_evaluate())
             return {"expr": applet._last_expr}
 
+        def show_wrapped_popup(*, window, content, gap_px):
+            _ = gap_px
+            window.add(content)
+            window.show_all()
+            window.move(80, 80)
+
+        monkeypatch.setattr(calculator_applet_mod, "create_popup_window", lambda: popup)
         monkeypatch.setattr(
-            calculator_applet_mod.Gtk,
-            "Window",
-            lambda **_kwargs: popup,
+            calculator_applet_mod,
+            "show_wrapped_popup",
+            show_wrapped_popup,
         )
-        monkeypatch.setattr(calculator_applet_mod, "wrap_popup", lambda child: child)
         monkeypatch.setattr(applet, "_build_popup_content", build_popup_content)
         return wrapped_children
 
@@ -296,12 +301,6 @@ class TestAppletPopup:
         applet = _make_applet()
         fake_popup = _FakePopupWindow()
         self._patch_popup(monkeypatch, applet, fake_popup)
-        monkeypatch.setattr(
-            calculator_applet_mod,
-            "get_pointer_position",
-            lambda _display: ScreenPosition(x=120, y=140),
-        )
-
         applet._show_popup()
         first_popup = applet._popup
         first_child = first_popup.get_child()
@@ -322,36 +321,29 @@ class TestAppletPopup:
     def test_show_popup_uses_themed_surface_wrapper(self, monkeypatch):
         applet = _make_applet()
         fake_popup = _FakePopupWindow()
-        wrapped = MagicMock(name="wrapped-popup")
+        show_wrapped_popup = MagicMock()
         monkeypatch.setattr(
-            calculator_applet_mod.Gtk,
-            "Window",
-            lambda **_kwargs: fake_popup,
+            calculator_applet_mod, "create_popup_window", lambda: fake_popup
         )
-        monkeypatch.setattr(
-            calculator_applet_mod, "wrap_popup", MagicMock(return_value=wrapped)
-        )
-        monkeypatch.setattr(applet, "_build_popup_content", lambda: "content")
         monkeypatch.setattr(
             calculator_applet_mod,
-            "get_pointer_position",
-            lambda _display: ScreenPosition(x=120, y=140),
+            "show_wrapped_popup",
+            show_wrapped_popup,
         )
+        monkeypatch.setattr(applet, "_build_popup_content", lambda: "content")
 
         applet._show_popup()
 
-        popup_child = applet._popup.get_child()
-        assert popup_child is wrapped
+        show_wrapped_popup.assert_called_once_with(
+            window=fake_popup,
+            content="content",
+            gap_px=calculator_applet_mod.POPUP_CURSOR_GAP_PX,
+        )
         applet.stop()
 
     def test_activate_signal_evaluates_entry(self, monkeypatch):
         applet = _make_applet()
         self._patch_popup(monkeypatch, applet, _FakePopupWindow())
-        monkeypatch.setattr(
-            calculator_applet_mod,
-            "get_pointer_position",
-            lambda _display: ScreenPosition(x=100, y=120),
-        )
         applet._show_popup()
         assert applet._entry is not None
         applet._entry.set_text("2+3")

--- a/tests/applets/test_calendar.py
+++ b/tests/applets/test_calendar.py
@@ -227,38 +227,31 @@ class _FakePopupWindow:
 
 
 class TestCalendarPopup:
-    def test_show_popup_creates_window_and_clamps_position(self, monkeypatch):
+    def test_show_popup_creates_window_and_uses_shared_surface(self, monkeypatch):
         # Given
         applet = CalendarApplet(48)
         fake_popup = _FakePopupWindow()
-        pointer = MagicMock()
-        pointer.get_position.return_value = (None, 20, 15)
-        seat = MagicMock()
-        seat.get_pointer.return_value = pointer
-        display = MagicMock()
-        display.get_default_seat.return_value = seat
-        wrapped = _FakeFrame()
+        shown: dict[str, object] = {}
+
+        def show_wrapped_popup(*, window, content, gap_px):
+            shown["window"] = window
+            shown["content"] = content
+            shown["gap_px"] = gap_px
+            window.add(content)
+            window.show_all()
 
         monkeypatch.setattr(
             calendar_applet_mod,
             "Gtk",
             SimpleNamespace(
-                Window=lambda **_kwargs: fake_popup,
-                WindowType=SimpleNamespace(POPUP=1),
                 Calendar=_FakeCalendar,
-                Frame=_FakeFrame,
-                ShadowType=SimpleNamespace(NONE=0),
             ),
         )
         monkeypatch.setattr(
-            calendar_applet_mod.Gdk.Display,
-            "get_default",
-            lambda: display,
+            calendar_applet_mod, "create_popup_window", lambda: fake_popup
         )
         monkeypatch.setattr(
-            calendar_applet_mod,
-            "wrap_popup",
-            lambda child: wrapped.add(child) or wrapped,
+            calendar_applet_mod, "show_wrapped_popup", show_wrapped_popup
         )
 
         # When
@@ -266,12 +259,11 @@ class TestCalendarPopup:
 
         # Then
         assert applet._popup is fake_popup
-        fake_popup.remove.assert_called_once()
         fake_popup.add.assert_called_once()
         fake_popup.show_all.assert_called_once()
-        fake_popup.move.assert_called_once_with(0, 0)
-        assert fake_popup.get_child() is wrapped
-        assert wrapped.child is not None
+        assert shown["window"] is fake_popup
+        assert isinstance(shown["content"], _FakeCalendar)
+        assert shown["gap_px"] == calendar_applet_mod.CALENDAR_POPUP_CURSOR_GAP_PX
 
     def test_stop_destroys_popup(self):
         # Given

--- a/tests/applets/test_camshield.py
+++ b/tests/applets/test_camshield.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import docking.applets.camshield.applet as camshield_applet_mod
+import docking.applets.camshield.state as camshield_state_mod
 from docking.applets.camshield.applet import CamshieldApplet
 from docking.applets.camshield.render import render_icon
 from docking.applets.camshield.state import (
@@ -126,8 +129,61 @@ class TestProbeCameraState:
         assert state.active is False
         assert state.holders == ()
 
+    def test_deleted_fd_target_still_matches_device(self, tmp_path):
+        dev = tmp_path / "dev"
+        proc = tmp_path / "proc"
+        dev.mkdir()
+        proc.mkdir()
+        video0 = dev / "video0"
+        video0.touch()
+
+        class _Fd:
+            def readlink(self):
+                return f"{video0} (deleted)"
+
+        assert (
+            camshield_state_mod._fd_video_device_name(
+                _Fd(),
+                {"video0": video0.resolve(strict=False)},
+            )
+            == "video0"
+        )
+
+    def test_process_command_falls_back_to_cmdline_and_unknown(self, tmp_path):
+        proc = tmp_path / "123"
+        proc.mkdir()
+        (proc / "cmdline").write_text("/usr/bin/browser\0--camera", encoding="utf-8")
+
+        assert camshield_state_mod._process_command(proc) == "browser"
+
+        empty_proc = tmp_path / "124"
+        empty_proc.mkdir()
+        assert camshield_state_mod._process_command(empty_proc) == "Unknown"
+
+    def test_probe_handles_unreadable_roots(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            Path,
+            "glob",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("bad dev")),
+        )
+
+        assert probe_camera_state(dev_root=tmp_path, proc_root=tmp_path) == (
+            CamshieldState(False, False)
+        )
+
 
 class TestLabels:
+    def test_tooltip_unavailable_idle_and_more_holders(self):
+        assert "No camera devices found" in build_tooltip(CamshieldState(False, False))
+        assert "Camera idle" in build_tooltip(CamshieldState(True, False))
+        holders = tuple(
+            CameraHolder(pid=i, command=f"app{i}", devices=("video0",))
+            for i in range(8)
+        )
+        text = build_tooltip(CamshieldState(True, True, ("video0",), holders))
+
+        assert "2 more" in text
+
     def test_tooltip_for_active_camera_lists_holders(self):
         state = CamshieldState(
             available=True,
@@ -185,6 +241,58 @@ class TestApplet:
         assert "Camera idle" in labels
         assert "Refresh Now" in labels
 
+    def test_menu_unavailable_disables_helper_actions(self, monkeypatch):
+        state = CamshieldState(available=False, active=False)
+        monkeypatch.setattr(camshield_applet_mod, "probe_camera_state", lambda: state)
+        monkeypatch.setattr(
+            camshield_applet_mod.CamshieldApplet,
+            "_helper_available",
+            lambda _self: False,
+        )
+        applet = CamshieldApplet(icon_size=48)
+
+        items = applet.get_menu_items()
+        labels = [item.get_label() for item in items]
+
+        assert "No camera devices found" in labels
+        assert "Camera lock helper unavailable" in labels
+        assert not next(
+            item for item in items if item.get_label() == "Lock Camera"
+        ).get_sensitive()
+
+    def test_start_stop_refresh_and_tick(self, monkeypatch):
+        state = CamshieldState(available=True, active=False, devices=("video0",))
+        monkeypatch.setattr(camshield_applet_mod, "probe_camera_state", lambda: state)
+        idle = MagicMock()
+        add_seconds = MagicMock(return_value=11)
+        removed: list[int] = []
+        monkeypatch.setattr(camshield_applet_mod.GLib, "idle_add", idle)
+        monkeypatch.setattr(
+            camshield_applet_mod.GLib,
+            "timeout_add_seconds",
+            add_seconds,
+        )
+        monkeypatch.setattr(
+            camshield_applet_mod.GLib,
+            "source_remove",
+            lambda timer_id: removed.append(timer_id),
+        )
+        applet = CamshieldApplet(icon_size=48)
+
+        applet.start(lambda: None)
+        assert applet._timer_id == 11
+        assert idle.call_count == 1
+
+        assert applet._refresh_once() is False
+        assert applet._tick() is True
+
+        applet._pulse_timer_id = 42
+        applet.stop()
+
+        assert removed == [11, 42]
+        assert applet._timer_id == 0
+        assert applet._pulse_timer_id == 0
+
     def test_pulse_tick_repaints_icon(self, monkeypatch):
         state = CamshieldState(
             available=True,
@@ -207,6 +315,94 @@ class TestApplet:
         assert applet.item.icon is not None
         assert notifications == 1
         applet.stop()
+
+    def test_pulse_timer_stops_when_state_becomes_idle(self, monkeypatch):
+        states = iter(
+            [
+                CamshieldState(True, True, ("video0",)),
+                CamshieldState(True, False, ("video0",)),
+            ]
+        )
+        monkeypatch.setattr(
+            camshield_applet_mod, "probe_camera_state", lambda: next(states)
+        )
+        removed: list[int] = []
+        monkeypatch.setattr(
+            camshield_applet_mod.GLib,
+            "source_remove",
+            lambda timer_id: removed.append(timer_id),
+        )
+        applet = CamshieldApplet(icon_size=48)
+        applet._pulse_timer_id = 42
+        applet._pulse_phase = 0.5
+
+        applet._refresh_now()
+
+        assert removed == [42]
+        assert applet._pulse_timer_id == 0
+        assert applet._pulse_phase == 0.0
+
+    def test_helper_available_requires_pkexec_and_helper(self, monkeypatch, tmp_path):
+        helper_path = tmp_path / "helper.py"
+        monkeypatch.setattr(camshield_applet_mod, "_SOURCE_HELPER", helper_path)
+        monkeypatch.setattr(
+            camshield_applet_mod.shutil,
+            "which",
+            lambda command: "/usr/bin/pkexec" if command == "pkexec" else None,
+        )
+        applet = CamshieldApplet(icon_size=48)
+
+        assert applet._helper_available() is False
+
+        helper_path.touch()
+        assert applet._helper_available() is True
+
+    def test_run_helper_action_and_command_paths(self, monkeypatch):
+        applet = CamshieldApplet(icon_size=48)
+        applet._run_helper_command = MagicMock()
+
+        class _Thread:
+            def __init__(self, *, target, args, daemon):
+                self.target = target
+                self.args = args
+                self.daemon = daemon
+
+            def start(self):
+                self.target(*self.args)
+
+        monkeypatch.setattr(
+            camshield_applet_mod, "_helper_command", lambda **_: ["cmd"]
+        )
+        monkeypatch.setattr(camshield_applet_mod.threading, "Thread", _Thread)
+
+        applet._run_helper_action("lock")
+        applet._run_helper_command.assert_called_once_with(["cmd"])
+
+        monkeypatch.setattr(camshield_applet_mod, "_helper_command", lambda **_: None)
+        applet._run_helper_action("lock")
+
+    def test_run_helper_command_refreshes_and_logs_failures(self, monkeypatch):
+        applet = CamshieldApplet(icon_size=48)
+        idle: list[object] = []
+        monkeypatch.setattr(
+            camshield_applet_mod.GLib, "idle_add", lambda cb: idle.append(cb)
+        )
+        monkeypatch.setattr(
+            camshield_applet_mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: SimpleNamespace(returncode=1),
+        )
+
+        applet._run_helper_command(["cmd"])
+
+        assert idle == [applet._refresh_once]
+
+        monkeypatch.setattr(
+            camshield_applet_mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("boom")),
+        )
+        applet._run_helper_command(["cmd"])
 
     def test_helper_command_prefers_installed_helper(self, monkeypatch):
         paths = {
@@ -237,3 +433,13 @@ class TestApplet:
             str(helper_path),
             "unlock",
         ]
+
+    def test_helper_command_returns_none_without_pkexec_or_helper(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(camshield_applet_mod.shutil, "which", lambda _command: None)
+        monkeypatch.setattr(
+            camshield_applet_mod, "_SOURCE_HELPER", tmp_path / "missing"
+        )
+
+        assert camshield_applet_mod._helper_command(action="lock") is None

--- a/tests/applets/test_camshield_helper.py
+++ b/tests/applets/test_camshield_helper.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import stat
+import subprocess
 
 import docking.applets.camshield.helper as helper
 
@@ -23,6 +24,19 @@ def test_discover_video_devices_filters_names(tmp_path):
     devices = helper.discover_video_devices(dev_root=dev)
 
     assert devices == (dev / "video0", dev / "video10")
+
+
+def test_discover_video_devices_missing_root_returns_empty(tmp_path):
+    assert helper.discover_video_devices(dev_root=tmp_path / "missing") == ()
+
+
+def test_lock_without_devices_reports_error(tmp_path, monkeypatch, capsys):
+    dev = tmp_path / "dev"
+    dev.mkdir()
+    monkeypatch.setattr(helper.os, "geteuid", lambda: 0)
+
+    assert helper.lock_devices(dev_root=dev, state_dir=tmp_path / "state") == 1
+    assert "No camera devices" in capsys.readouterr().err
 
 
 def test_lock_and_unlock_restore_previous_mode(tmp_path, monkeypatch):
@@ -45,6 +59,13 @@ def test_lock_and_unlock_restore_previous_mode(tmp_path, monkeypatch):
     assert not (state_dir / helper.STATE_FILE.name).exists()
 
 
+def test_unlock_without_state_reports_error(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(helper.os, "geteuid", lambda: 0)
+
+    assert helper.unlock_devices(state_dir=tmp_path / "state") == 1
+    assert "No locked camera" in capsys.readouterr().err
+
+
 def test_lock_preserves_original_snapshot_on_repeated_lock(tmp_path, monkeypatch):
     dev = tmp_path / "dev"
     state_dir = tmp_path / "state"
@@ -61,6 +82,34 @@ def test_lock_preserves_original_snapshot_on_repeated_lock(tmp_path, monkeypatch
     assert helper.lock_devices(dev_root=dev, state_dir=state_dir) == 0
     assert helper.unlock_devices(state_dir=state_dir) == 0
 
+    assert _mode(video0) == 0o660
+
+
+def test_unlock_skips_missing_and_disallowed_devices(tmp_path, monkeypatch):
+    dev = tmp_path / "dev"
+    state_dir = tmp_path / "state"
+    dev.mkdir()
+    state_dir.mkdir()
+    video0 = dev / "video0"
+    video0.touch()
+    video0.chmod(0)
+    monkeypatch.setattr(helper, "DEV_ROOT", dev)
+    monkeypatch.setattr(helper.os, "geteuid", lambda: 0)
+    (state_dir / helper.STATE_FILE.name).write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "devices": {
+                    str(video0): {"mode": 0o660, "acl_file": None},
+                    str(tmp_path / "video9"): {"mode": 0o660, "acl_file": None},
+                    str(dev / "missing"): {"mode": 0o660, "acl_file": None},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert helper.unlock_devices(state_dir=state_dir) == 0
     assert _mode(video0) == 0o660
 
 
@@ -89,8 +138,158 @@ def test_status_reports_locked_devices(tmp_path, monkeypatch, capsys):
     ]
 
 
+def test_status_marks_recorded_devices(tmp_path, monkeypatch, capsys):
+    dev = tmp_path / "dev"
+    state_dir = tmp_path / "state"
+    dev.mkdir()
+    state_dir.mkdir()
+    video0 = dev / "video0"
+    video0.touch()
+    video0.chmod(0o660)
+    monkeypatch.setattr(helper, "DEV_ROOT", dev)
+    helper._write_state(
+        state={str(video0): helper.DeviceSnapshot(path=video0, mode=0o660)},
+        state_dir=state_dir,
+    )
+
+    assert helper.status_devices(dev_root=dev, state_dir=state_dir) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["devices"][0]["recorded"] is True
+    assert payload["devices"][0]["locked"] is False
+
+
 def test_main_rejects_lock_without_root(monkeypatch, capsys):
     monkeypatch.setattr(helper.os, "geteuid", lambda: 1000)
 
     assert helper.main(["lock"]) == 77
     assert "must be run as root" in capsys.readouterr().err
+
+
+def test_acl_snapshot_save_and_restore_success(tmp_path, monkeypatch):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    device = tmp_path / "video0"
+    device.touch()
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(tuple(argv))
+        stdout = kwargs.get("stdout")
+        if stdout is not None and hasattr(stdout, "write"):
+            stdout.write("# acl\n")
+        return subprocess.CompletedProcess(args=argv, returncode=0)
+
+    monkeypatch.setattr(
+        helper.shutil,
+        "which",
+        lambda command: f"/usr/bin/{command}",
+    )
+    monkeypatch.setattr(helper.subprocess, "run", fake_run)
+
+    acl_file = helper._save_acl_snapshot(device=device, state_dir=state_dir)
+    assert acl_file is not None
+    assert acl_file.exists()
+    assert helper._restore_acl(
+        snapshot=helper.DeviceSnapshot(path=device, mode=0o660, acl_file=acl_file)
+    )
+    assert calls[0][0].endswith("getfacl")
+    assert calls[1][0].endswith("setfacl")
+
+
+def test_acl_snapshot_failures_return_false_or_none(tmp_path, monkeypatch):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    device = tmp_path / "video0"
+    device.touch()
+
+    monkeypatch.setattr(helper.shutil, "which", lambda command: f"/usr/bin/{command}")
+    monkeypatch.setattr(
+        helper.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            subprocess.CalledProcessError(1, args[0])
+        ),
+    )
+    assert helper._save_acl_snapshot(device=device, state_dir=state_dir) is None
+
+    acl_file = state_dir / "missing.acl"
+    snapshot = helper.DeviceSnapshot(path=device, mode=0o660, acl_file=acl_file)
+    assert helper._restore_acl(snapshot=snapshot) is False
+
+    acl_file.write_text("# acl\n", encoding="utf-8")
+    monkeypatch.setattr(helper.shutil, "which", lambda _command: None)
+    assert helper._restore_acl(snapshot=snapshot) is False
+
+
+def test_read_state_filters_malformed_entries(tmp_path, monkeypatch):
+    dev = tmp_path / "dev"
+    state_dir = tmp_path / "state"
+    dev.mkdir()
+    state_dir.mkdir()
+    video0 = dev / "video0"
+    monkeypatch.setattr(helper, "DEV_ROOT", dev)
+    (state_dir / helper.STATE_FILE.name).write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "devices": {
+                    str(video0): {"mode": 0o660, "acl_file": str(tmp_path / "a")},
+                    "relative": {"mode": 0o660},
+                    str(dev / "videoX"): {"mode": 0o660},
+                    str(dev / "video1"): {"mode": "bad"},
+                    str(dev / "video2"): "bad",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    state = helper._read_state(state_dir=state_dir)
+
+    assert state == {
+        str(video0): helper.DeviceSnapshot(
+            path=video0,
+            mode=0o660,
+            acl_file=tmp_path / "a",
+        )
+    }
+
+
+def test_read_state_rejects_bad_json_version_and_shape(tmp_path):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    path = state_dir / helper.STATE_FILE.name
+
+    path.write_text("{", encoding="utf-8")
+    assert helper._read_state(state_dir=state_dir) == {}
+
+    path.write_text(json.dumps({"version": 999, "devices": {}}), encoding="utf-8")
+    assert helper._read_state(state_dir=state_dir) == {}
+
+    path.write_text(json.dumps({"version": 1, "devices": []}), encoding="utf-8")
+    assert helper._read_state(state_dir=state_dir) == {}
+
+
+def test_device_locked_handles_stat_error(tmp_path):
+    assert helper._device_locked(tmp_path / "missing") is False
+
+
+def test_main_dispatches_commands_and_os_errors(monkeypatch, capsys):
+    calls: list[str] = []
+    monkeypatch.setattr(helper, "lock_devices", lambda: calls.append("lock") or 0)
+    monkeypatch.setattr(helper, "unlock_devices", lambda: calls.append("unlock") or 0)
+    monkeypatch.setattr(helper, "status_devices", lambda: calls.append("status") or 0)
+
+    assert helper.main(["lock"]) == 0
+    assert helper.main(["unlock"]) == 0
+    assert helper.main(["status"]) == 0
+    assert calls == ["lock", "unlock", "status"]
+
+    monkeypatch.setattr(
+        helper,
+        "status_devices",
+        lambda: (_ for _ in ()).throw(OSError("boom")),
+    )
+    assert helper.main(["status"]) == 1
+    assert "Camera helper failed" in capsys.readouterr().err

--- a/tests/applets/test_capslock.py
+++ b/tests/applets/test_capslock.py
@@ -56,6 +56,29 @@ class TestState:
             num_lock=False,
         )
 
+    def test_query_lock_state_handles_failures(self, monkeypatch):
+        monkeypatch.setattr(capslock_state_mod.shutil, "which", lambda _cmd: "/bin/x")
+        monkeypatch.setattr(
+            capslock_state_mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: SimpleNamespace(returncode=1, stdout=""),
+        )
+        assert query_lock_state() == LockKeyState(available=False)
+
+        monkeypatch.setattr(
+            capslock_state_mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("boom")),
+        )
+        assert query_lock_state() == LockKeyState(available=False)
+
+    def test_state_labels_cover_all_combinations(self):
+        assert capslock_state_mod.state_label(LockKeyState(False)) == "??"
+        assert capslock_state_mod.state_label(LockKeyState(True, True, True)) == "CN"
+        assert capslock_state_mod.state_label(LockKeyState(True, True, False)) == "CAP"
+        assert capslock_state_mod.state_label(LockKeyState(True, False, True)) == "NUM"
+        assert capslock_state_mod.state_label(LockKeyState(True, False, False)) == "--"
+
     def test_tooltip_text(self):
         text = tooltip_text(
             LockKeyState(available=True, caps_lock=True, num_lock=False)
@@ -66,6 +89,7 @@ class TestState:
 
     def test_menu_label(self):
         assert menu_label("Caps Lock", True) == "Caps Lock: On"
+        assert tooltip_text(LockKeyState(False)) == "Keyboard lock state unavailable"
 
 
 class TestRender:
@@ -103,6 +127,48 @@ class TestApplet:
         assert "Num Lock: On" in labels
         assert "Refresh Now" in labels
 
+    def test_menu_unavailable_and_click_refresh(self, monkeypatch):
+        states = iter(
+            [
+                LockKeyState(False),
+                LockKeyState(True, True, False),
+            ]
+        )
+        monkeypatch.setattr(
+            capslock_applet_mod,
+            "query_lock_state",
+            lambda: next(states),
+        )
+        applet = CapslockApplet(icon_size=48)
+        labels = [item.get_label() for item in applet.get_menu_items()]
+        assert "Keyboard lock state unavailable" in labels
+
+        applet.present = lambda: None
+        applet.on_clicked()
+        assert applet._state == LockKeyState(True, True, False)
+
+    def test_start_stop_manage_timer(self, monkeypatch):
+        state = LockKeyState(available=True)
+        monkeypatch.setattr(capslock_applet_mod, "query_lock_state", lambda: state)
+        monkeypatch.setattr(
+            capslock_applet_mod.GLib,
+            "timeout_add_seconds",
+            lambda interval, cb: 42,
+        )
+        removed: list[int] = []
+        monkeypatch.setattr(
+            capslock_applet_mod.GLib,
+            "source_remove",
+            lambda timer_id: removed.append(timer_id),
+        )
+        applet = CapslockApplet(icon_size=48)
+
+        applet.start(lambda: None)
+        applet.stop()
+
+        assert applet._timer_id == 0
+        assert removed == [42]
+
     def test_tick_updates_when_state_changes(self, monkeypatch):
         states = iter(
             [
@@ -124,3 +190,11 @@ class TestApplet:
 
         assert applet._tick() is True
         assert calls == 1
+
+    def test_tick_does_not_present_when_state_is_same(self, monkeypatch):
+        state = LockKeyState(available=True, caps_lock=False, num_lock=False)
+        monkeypatch.setattr(capslock_applet_mod, "query_lock_state", lambda: state)
+        applet = CapslockApplet(icon_size=48)
+        applet.present = lambda: (_ for _ in ()).throw(AssertionError("no present"))
+
+        assert applet._tick() is True

--- a/tests/applets/test_certwatch.py
+++ b/tests/applets/test_certwatch.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import socket
+import ssl
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import docking.applets.certwatch.api as certwatch_api
+import docking.applets.certwatch.applet as certwatch_applet_mod
+from docking.applets.certwatch.api import fetch_cert
 from docking.applets.certwatch.applet import CertwatchApplet
 from docking.applets.certwatch.state import (
     CRITICAL_THRESHOLD_DAYS,
@@ -246,10 +251,18 @@ class TestTooltip:
     def test_lists_each_domain(self):
         domains = [DomainPref("a.test", 443), DomainPref("b.test", 443)]
         certs = [_cert("a.test", days=60), _cert("b.test", days=5)]
-        text = build_tooltip(domains=domains, certs=certs, now=_NOW)
+        text = build_tooltip(
+            domains=domains,
+            certs=certs,
+            now=_NOW,
+            updated_at=_NOW,
+            cadence_seconds=3600,
+        )
         assert "a.test" in text
         assert "b.test" in text
         assert "5d" in text
+        assert "Updated:" in text
+        assert "Checks every 1 hour" in text
 
     def test_loading_line_when_cert_missing(self):
         domains = [DomainPref("a.test", 443)]
@@ -276,6 +289,22 @@ class TestAppletCreation:
         for size in [32, 48, 64]:
             applet = _make_applet(size)
             assert applet.create_icon(size) is not None
+
+    def test_error_icon_when_all_fetches_failed(self):
+        applet = _make_applet()
+        applet._domains = [DomainPref("a.test", 443)]
+        applet._fetch_error = "boom"
+
+        assert applet.create_icon(48) is not None
+
+    def test_click_opens_add_dialog(self, monkeypatch):
+        applet = _make_applet()
+        called = []
+        monkeypatch.setattr(applet, "_show_add_dialog", lambda: called.append(True))
+
+        applet.on_clicked()
+
+        assert called == [True]
 
 
 class TestAppletTooltip:
@@ -305,6 +334,7 @@ class TestAppletMenu:
         items = applet.get_menu_items()
         labels = [mi.get_label() for mi in items]
         assert any("a.test" in label for label in labels)
+        assert "Checks every 1 hour" in labels
         assert any("Remove" in label for label in labels)
         assert any("Refresh Now" in label for label in labels)
 
@@ -357,6 +387,163 @@ class TestAppletRetry:
         assert scheduled == []
         assert applet._retry_timer_id == 99
 
+    def test_run_retry_clears_timer_and_fetches(self, monkeypatch):
+        applet = _make_applet()
+        applet._retry_timer_id = 77
+        fetch = []
+        monkeypatch.setattr(applet, "_fetch_all", lambda: fetch.append(True))
+
+        assert applet._run_retry() is False
+        assert applet._retry_timer_id == 0
+        assert fetch == [True]
+
+
+class TestAppletLifecycleAndFetch:
+    def test_start_and_stop_timers(self, monkeypatch):
+        applet = _make_applet()
+        applet._domains = [DomainPref("a.test", 443)]
+        added = iter([11, 12])
+        removed: list[int] = []
+        monkeypatch.setattr(
+            certwatch_applet_mod.GLib,
+            "timeout_add_seconds",
+            lambda *_args: next(added),
+        )
+        monkeypatch.setattr(
+            certwatch_applet_mod.GLib,
+            "source_remove",
+            lambda timer_id: removed.append(timer_id),
+        )
+
+        applet.start(lambda: None)
+        applet._retry_timer_id = 13
+        applet.stop()
+
+        assert removed == [11, 12, 13]
+        assert applet._timer_id == 0
+        assert applet._startup_fetch_timer_id == 0
+        assert applet._retry_timer_id == 0
+
+    def test_current_certs_preserves_domain_order(self):
+        applet = _make_applet()
+        applet._domains = [DomainPref("b.test", 443), DomainPref("a.test", 443)]
+        cert_a = _cert("a.test")
+        cert_b = _cert("b.test")
+        applet._certs = {
+            ("a.test", 443): cert_a,
+            ("b.test", 443): cert_b,
+        }
+
+        assert applet._current_certs() == [cert_b, cert_a]
+
+    def test_tick_and_startup_fetch(self, monkeypatch):
+        applet = _make_applet()
+        calls: list[str] = []
+        monkeypatch.setattr(applet, "_fetch_all", lambda: calls.append("fetch"))
+
+        assert applet._tick() is True
+        applet._startup_fetch_timer_id = 99
+        assert applet._run_startup_fetch() is False
+
+        assert applet._startup_fetch_timer_id == 0
+        assert calls == ["fetch", "fetch"]
+
+    def test_fetch_all_no_domains_is_noop(self):
+        applet = _make_applet()
+        applet._worker.run = lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("worker should not run")
+        )
+
+        applet._fetch_all()
+
+    def test_fetch_all_queues_worker_and_removes_startup_timer(self, monkeypatch):
+        applet = _make_applet()
+        applet._domains = [DomainPref("a.test", 443)]
+        applet._startup_fetch_timer_id = 77
+        removed: list[int] = []
+        worker_calls: list[dict[str, object]] = []
+        monkeypatch.setattr(
+            certwatch_applet_mod.GLib,
+            "source_remove",
+            lambda timer_id: removed.append(timer_id),
+        )
+        monkeypatch.setattr(
+            certwatch_applet_mod,
+            "fetch_cert",
+            lambda host, port: _cert(host, port),
+        )
+        applet._worker.run = lambda **kwargs: worker_calls.append(kwargs)
+
+        applet._fetch_all()
+
+        assert removed == [77]
+        assert applet._loading is True
+        assert worker_calls[0]["name"] == "certwatch-fetch"
+        assert worker_calls[0]["fn"]() == [_cert("a.test")]
+
+    def test_fetch_result_ignores_stale_request(self):
+        applet = _make_applet()
+        applet._fetch_request_id = 2
+
+        assert applet._on_fetch_result(request_id=1, certs=[_cert("a.test")]) is False
+        assert applet._certs == {}
+
+    def test_fetch_result_updates_state_and_prunes_stale_certs(self):
+        applet = _make_applet()
+        applet._fetch_request_id = 7
+        applet._domains = [DomainPref("a.test", 443)]
+        applet._certs = {("old.test", 443): _cert("old.test")}
+
+        assert applet._on_fetch_result(request_id=7, certs=[_cert("a.test")]) is False
+
+        assert ("a.test", 443) in applet._certs
+        assert ("old.test", 443) not in applet._certs
+        assert applet._last_updated is not None
+
+    def test_fetch_error_ignores_stale_and_schedules_retry(self, monkeypatch):
+        applet = _make_applet()
+        applet._fetch_request_id = 7
+        scheduled: list[int] = []
+        monkeypatch.setattr(
+            certwatch_applet_mod.GLib,
+            "timeout_add_seconds",
+            lambda seconds, _fn: scheduled.append(seconds) or 42,
+        )
+
+        assert applet._on_fetch_error(request_id=6, exc=RuntimeError("old")) is False
+        assert applet._on_fetch_error(request_id=7, exc=RuntimeError("boom")) is False
+
+        assert applet._fetch_error == "boom"
+        assert applet._retry_timer_id == 42
+        assert scheduled == [300]
+
+    def test_fetch_error_does_not_double_schedule_retry(self, monkeypatch):
+        applet = _make_applet()
+        applet._fetch_request_id = 7
+        applet._retry_timer_id = 42
+        monkeypatch.setattr(
+            certwatch_applet_mod.GLib,
+            "timeout_add_seconds",
+            lambda *_args: (_ for _ in ()).throw(AssertionError("no schedule")),
+        )
+
+        applet._on_fetch_error(request_id=7, exc=RuntimeError())
+
+        assert applet._fetch_error == "RuntimeError"
+
+    def test_log_critical_and_prune_helpers(self):
+        applet = _make_applet()
+        applet._domains = [DomainPref("keep.test", 443)]
+        applet._certs = {
+            ("keep.test", 443): _cert("keep.test"),
+            ("drop.test", 443): _cert("drop.test"),
+        }
+
+        applet._log_critical(certs=[_cert("exp.test", days=-1)])
+        applet._prune_stale_certs()
+
+        assert list(applet._certs) == [("keep.test", 443)]
+
 
 class TestAppletPrefs:
     def test_loads_domains_from_config(self):
@@ -407,6 +594,108 @@ class TestAppletPrefs:
         assert applet._domains == [DomainPref("b.test", 443)]
 
 
+class _FakeDialogBox:
+    def __init__(self) -> None:
+        self.children: list[object] = []
+
+    def pack_start(self, child, *_args) -> None:
+        self.children.append(child)
+
+
+class _FakeDialog:
+    def __init__(self, *, response: int) -> None:
+        self.response = response
+        self.destroyed = False
+        self.box = _FakeDialogBox()
+
+    def show_all(self) -> None:
+        return
+
+    def run(self) -> int:
+        return self.response
+
+    def destroy(self) -> None:
+        self.destroyed = True
+
+
+class _FakeEntry:
+    text = ""
+
+    def set_placeholder_text(self, _text: str) -> None:
+        return
+
+    def set_activates_default(self, _value: bool) -> None:
+        return
+
+    def grab_focus(self) -> None:
+        return
+
+    def get_text(self) -> str:
+        return self.text
+
+
+class TestAppletDialog:
+    def test_show_add_dialog_adds_valid_domain(self, monkeypatch):
+        dialog = _FakeDialog(response=certwatch_applet_mod.Gtk.ResponseType.OK)
+        entry = _FakeEntry()
+        entry.text = "example.com:8443"
+        monkeypatch.setattr(
+            certwatch_applet_mod.Gtk, "Dialog", lambda **_kwargs: dialog
+        )
+        monkeypatch.setattr(certwatch_applet_mod.Gtk, "Entry", lambda: entry)
+        monkeypatch.setattr(
+            certwatch_applet_mod,
+            "prepare_dialog_content",
+            lambda **_kwargs: dialog.box,
+        )
+        monkeypatch.setattr(
+            certwatch_applet_mod, "add_cancel_ok_buttons", lambda **_: None
+        )
+        applet = _make_applet()
+        applet._add_domain = MagicMock()
+
+        applet._show_add_dialog()
+
+        applet._add_domain.assert_called_once_with(pref=DomainPref("example.com", 8443))
+        assert dialog.destroyed is True
+
+    def test_show_add_dialog_ignores_cancel_and_invalid_domain(self, monkeypatch):
+        for response, text in (
+            (certwatch_applet_mod.Gtk.ResponseType.CANCEL, "example.com"),
+            (certwatch_applet_mod.Gtk.ResponseType.OK, "example.com:bad"),
+        ):
+            dialog = _FakeDialog(response=response)
+            entry = _FakeEntry()
+            entry.text = text
+            monkeypatch.setattr(
+                certwatch_applet_mod.Gtk,
+                "Dialog",
+                lambda _dialog=dialog, **_kwargs: _dialog,
+            )
+            monkeypatch.setattr(
+                certwatch_applet_mod.Gtk,
+                "Entry",
+                lambda _entry=entry: _entry,
+            )
+            monkeypatch.setattr(
+                certwatch_applet_mod,
+                "prepare_dialog_content",
+                lambda _dialog=dialog, **_kwargs: _dialog.box,
+            )
+            monkeypatch.setattr(
+                certwatch_applet_mod,
+                "add_cancel_ok_buttons",
+                lambda **_: None,
+            )
+            applet = _make_applet()
+            applet._add_domain = MagicMock()
+
+            applet._show_add_dialog()
+
+            applet._add_domain.assert_not_called()
+            assert dialog.destroyed is True
+
+
 class TestStatusForCert:
     def test_uses_error_when_present(self):
         cert = _cert("a.test", error="timeout")
@@ -415,3 +704,140 @@ class TestStatusForCert:
     def test_uses_days_when_valid(self):
         cert = _cert("a.test", days=3)
         assert status_for_cert(cert=cert, now=_NOW) is CertStatus.CRITICAL
+
+
+class TestCertApiParsing:
+    def test_parse_cert_date_valid_and_invalid(self):
+        parsed = certwatch_api._parse_cert_date("Jun 24 20:14:34 2026 GMT")
+        assert parsed == datetime(2026, 6, 24, 20, 14, 34, tzinfo=timezone.utc)
+        assert certwatch_api._parse_cert_date("") is None
+        assert certwatch_api._parse_cert_date("bad") is None
+        assert certwatch_api._parse_cert_date("Nope 24 20:14:34 2026 GMT") is None
+        assert certwatch_api._parse_cert_date("Jun x 20:14:34 2026 GMT") is None
+        assert certwatch_api._parse_cert_date("Jun 31 20:14:34 2026 GMT") is None
+
+    def test_flatten_name_filters_bad_shapes(self):
+        subject = ((("commonName", "example.com"),), "bad", (("O", "Org"),))
+        assert certwatch_api._flatten_name(subject) == "commonName=example.com, O=Org"
+        assert certwatch_api._flatten_name("bad") == ""
+
+
+class _FakeRawSocket:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class _FakeTlsSocket:
+    def __init__(self, peer):
+        self._peer = peer
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def getpeercert(self):
+        return self._peer
+
+
+class _FakeSslContext:
+    def __init__(self, peer=None, error: Exception | None = None) -> None:
+        self.peer = peer
+        self.error = error
+        self.server_hostname = ""
+
+    def wrap_socket(self, _raw, *, server_hostname: str):
+        self.server_hostname = server_hostname
+        if self.error is not None:
+            raise self.error
+        return _FakeTlsSocket(self.peer)
+
+
+class TestCertApiFetch:
+    def _patch_peer(self, monkeypatch, peer, error: Exception | None = None):
+        context = _FakeSslContext(peer=peer, error=error)
+        monkeypatch.setattr(
+            certwatch_api.ssl, "create_default_context", lambda: context
+        )
+        monkeypatch.setattr(
+            certwatch_api.socket,
+            "create_connection",
+            lambda *_args, **_kwargs: _FakeRawSocket(),
+        )
+        return context
+
+    def test_fetch_cert_success(self, monkeypatch):
+        peer = {
+            "notAfter": "Jun 24 20:14:34 2026 GMT",
+            "subject": ((("commonName", "example.com"),),),
+            "issuer": ((("commonName", "Test CA"),),),
+        }
+        context = self._patch_peer(monkeypatch, peer)
+
+        info = fetch_cert(host="example.com", port=443)
+
+        assert info.not_after == datetime(
+            2026,
+            6,
+            24,
+            20,
+            14,
+            34,
+            tzinfo=timezone.utc,
+        )
+        assert info.subject == "commonName=example.com"
+        assert info.issuer == "commonName=Test CA"
+        assert info.error is None
+        assert context.server_hostname == "example.com"
+
+    def test_fetch_cert_reports_verify_failure(self, monkeypatch):
+        self._patch_peer(
+            monkeypatch,
+            peer=None,
+            error=ssl.SSLCertVerificationError("bad cert"),
+        )
+
+        info = fetch_cert(host="example.com", port=443)
+
+        assert info.error is not None
+        assert info.error.startswith("verify failed")
+
+    def test_fetch_cert_reports_timeout(self, monkeypatch):
+        monkeypatch.setattr(
+            certwatch_api.socket,
+            "create_connection",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError),
+        )
+
+        assert fetch_cert(host="example.com", port=443).error == "timeout"
+
+    def test_fetch_cert_reports_socket_errors(self, monkeypatch):
+        monkeypatch.setattr(
+            certwatch_api.socket,
+            "create_connection",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(socket.gaierror("no host")),
+        )
+
+        assert "no host" in fetch_cert(host="example.com", port=443).error
+
+    def test_fetch_cert_reports_empty_peer(self, monkeypatch):
+        self._patch_peer(monkeypatch, peer={})
+
+        assert fetch_cert(host="example.com", port=443).error == "no peer certificate"
+
+    def test_fetch_cert_reports_missing_or_bad_not_after(self, monkeypatch):
+        self._patch_peer(monkeypatch, peer={"subject": (), "issuer": ()})
+        assert fetch_cert(host="example.com", port=443).error == "missing notAfter"
+
+        self._patch_peer(monkeypatch, peer={"notAfter": "bad"})
+        assert (
+            "unparseable notAfter"
+            in fetch_cert(
+                host="example.com",
+                port=443,
+            ).error
+        )

--- a/tests/applets/test_currencyfx.py
+++ b/tests/applets/test_currencyfx.py
@@ -30,9 +30,12 @@ from docking.applets.currencyfx.state import (
     format_rate,
     local_sample_points,
     merge_currency_codes,
+    normalize_code,
+    normalize_pair,
     pair_rate_from_units,
     parse_history_payload,
     parse_live_rate_payload,
+    percent_change,
     prefs_from_mapping,
     prefs_payload,
 )
@@ -92,6 +95,11 @@ class TestCurrencyFxState:
         assert prefs.active_index == 0
         assert prefs.chart_interval == ChartInterval.WEEK
 
+    def test_normalize_code_and_pair_edges(self):
+        assert normalize_code(" usd ", fallback="EUR") == "USD"
+        assert normalize_code("bad1", fallback="EUR") == "EUR"
+        assert normalize_pair(base="usd", quote="usd") == FxPair("USD", "EUR")
+
     def test_prefs_loads_added_pairs_and_active_index(self):
         prefs = prefs_from_mapping(
             {
@@ -115,6 +123,30 @@ class TestCurrencyFxState:
             "EUR/BRL": (FxPoint("2026-04-27T10:00:00+00:00", 5.8),)
         }
 
+    def test_prefs_handles_bad_active_index_and_bad_samples(self):
+        prefs = prefs_from_mapping(
+            {
+                "pairs": [{"base": "EUR", "quote": "USD"}],
+                "active_index": "bad",
+                "sample_source": LOCAL_SAMPLE_SOURCE,
+                "samples": {
+                    1: [{"timestamp": "2026-04-27T10:00:00+00:00", "rate": 5.8}],
+                    "bad": [{"timestamp": "2026-04-27T10:00:00+00:00", "rate": 5.8}],
+                    "EUR/USD": [
+                        "bad",
+                        {"timestamp": "", "rate": 1.1},
+                        {"timestamp": "2026-04-27T10:00:00+00:00", "rate": -1},
+                        {"date": "2026-04-27T10:00:00+00:00", "rate": "1.1"},
+                    ],
+                },
+            }
+        )
+
+        assert prefs.active_index == 0
+        assert prefs.samples == {
+            "EUR/USD": (FxPoint("2026-04-27T10:00:00+00:00", 1.1),)
+        }
+
     def test_prefs_payload_saves_interval_and_samples(self):
         payload = prefs_payload(
             pairs=(FxPair("EUR", "USD"), FxPair("EUR", "BRL")),
@@ -134,6 +166,15 @@ class TestCurrencyFxState:
                 "EUR/BRL": [{"timestamp": "2026-04-27T10:00:00+00:00", "rate": 5.8}]
             },
         }
+
+    def test_samples_payload_skips_empty_and_caps(self):
+        points = tuple(FxPoint(f"t{i}", float(i + 1)) for i in range(200))
+
+        payload = fx_state.samples_payload({"EUR/USD": points, "EUR/BRL": ()})
+
+        assert list(payload) == ["EUR/USD"]
+        assert len(payload["EUR/USD"]) == fx_state.LOCAL_SAMPLE_MAX_PER_PAIR
+        assert payload["EUR/USD"][0]["timestamp"] == "t8"
 
     def test_prefs_ignore_samples_from_old_source(self):
         prefs = prefs_from_mapping(
@@ -180,6 +221,41 @@ class TestCurrencyFxState:
             FxPoint("2026-04-27T12:00:00+00:00", 5.9),
         )
 
+    def test_local_samples_drop_bad_old_and_duplicate_points(self):
+        now = dt.datetime(2026, 4, 27, 12, tzinfo=dt.timezone.utc)
+        samples = {
+            "EUR/USD": (
+                FxPoint("bad", 1.0),
+                FxPoint("2026-04-25T10:00:00+00:00", 1.1),
+                FxPoint("2026-04-27T12:00:00+00:00", 1.2),
+            )
+        }
+
+        assert local_sample_points(
+            samples=samples,
+            base="EUR",
+            quote="USD",
+            now=now,
+        ) == (FxPoint("2026-04-27T12:00:00+00:00", 1.2),)
+
+        unchanged = append_local_sample(
+            samples=samples,
+            base="EUR",
+            quote="USD",
+            rate=0,
+            now=now,
+        )
+        assert unchanged == samples
+
+        updated = append_local_sample(
+            samples={"EUR/USD": (FxPoint("2026-04-27T12:00:00+00:00", 1.2),)},
+            base="EUR",
+            quote="USD",
+            rate=1.3,
+            now=now,
+        )
+        assert updated["EUR/USD"] == (FxPoint("2026-04-27T12:00:00+00:00", 1.3),)
+
     def test_currency_codes_from_units(self):
         assert currency_codes_from_units(_units()) == ("EUR", "GBP", "USD")
 
@@ -212,6 +288,16 @@ class TestCurrencyFxState:
             FxPoint(date="2026-04-26", rate=1.09),
         )
 
+    def test_parse_history_payload_ignores_invalid_shapes(self):
+        assert parse_history_payload(data=[]) == ()
+        assert parse_history_payload(data={"rates": "bad"}) == ()
+        assert (
+            parse_history_payload(
+                data={"rates": ["bad", {"date": "2026-04-27", "rate": "bad"}]}
+            )
+            == ()
+        )
+
     def test_parse_live_rate_payload(self):
         point = parse_live_rate_payload(
             data={
@@ -226,6 +312,17 @@ class TestCurrencyFxState:
         assert point == FxPoint(
             date="2026-04-27T12:55:29.819Z",
             rate=5.84,
+        )
+
+    def test_parse_live_rate_payload_rejects_bad_shapes(self):
+        assert parse_live_rate_payload(data=[], base="EUR", quote="USD") is None
+        assert (
+            parse_live_rate_payload(
+                data={"base": "EUR", "target": "BRL", "rate": 5.8},
+                base="EUR",
+                quote="USD",
+            )
+            is None
         )
 
     def test_fetch_live_rate_parses_response(self, monkeypatch):
@@ -259,6 +356,17 @@ class TestCurrencyFxState:
 
         assert point == FxPoint("2026-04-27T12:55:29.819Z", 5.84)
         assert seen_urls == ["https://fxapi.app/api/EUR/BRL.json"]
+
+    def test_fetch_live_rate_same_pair_and_failure(self, monkeypatch):
+        urlopen = MagicMock(side_effect=OSError("down"))
+        monkeypatch.setattr(fx_state.urllib.request, "urlopen", urlopen)
+
+        same = fetch_live_rate(base="USD", quote="USD")
+        failed = fetch_live_rate(base="EUR", quote="USD")
+
+        assert same == FxPoint(same.date, 1.0)
+        assert failed is None
+        urlopen.assert_called_once()
 
     def test_fetch_history_parses_response(self, monkeypatch):
         fake_data = json.dumps(
@@ -302,6 +410,14 @@ class TestCurrencyFxState:
 
         assert fetch_history(base="EUR", quote="USD", chart_interval="day") == ()
         urlopen.assert_not_called()
+
+    def test_fetch_history_same_currency_returns_flat_point(self):
+        assert fetch_history(
+            base="USD",
+            quote="USD",
+            chart_interval=ChartInterval.WEEK,
+            today=dt.date(2026, 4, 27),
+        ) == (FxPoint("2026-04-27", 1.0),)
 
     def test_fetch_history_month_requests_30_days(self, monkeypatch):
         fake_data = json.dumps({"rates": []}).encode()
@@ -423,6 +539,40 @@ class TestCurrencyFxState:
         assert snapshot.rate == 1.07
         assert codes == ()
 
+    def test_fetch_snapshot_returns_none_when_no_rate_available(self, monkeypatch):
+        monkeypatch.setattr(fx_state, "fetch_currency_rates", lambda: ())
+        monkeypatch.setattr(fx_state, "fetch_live_rate", lambda **_kwargs: None)
+        monkeypatch.setattr(fx_state, "fetch_history", lambda **_kwargs: ())
+
+        snapshot, codes = fetch_fx_snapshot(base="EUR", quote="XXX")
+
+        assert snapshot is None
+        assert codes == ()
+
+    def test_fetch_snapshot_appends_current_point_when_history_is_old(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(fx_state, "fetch_currency_rates", lambda: _units())
+        monkeypatch.setattr(
+            fx_state,
+            "fetch_live_rate",
+            lambda **_kwargs: FxPoint("2026-04-27T12:00:00+00:00", 1.09),
+        )
+        monkeypatch.setattr(
+            fx_state,
+            "fetch_history",
+            lambda **_kwargs: (FxPoint(date="2026-04-26", rate=1.07),),
+        )
+
+        snapshot, _codes = fetch_fx_snapshot(base="EUR", quote="USD")
+
+        assert snapshot is not None
+        assert snapshot.points[-2:] == (
+            FxPoint("2026-04-26", 1.07),
+            FxPoint(dt.date.today().isoformat(), 1.09),
+        )
+
     def test_format_rate(self):
         assert format_rate(123.456) == "123.46"
         assert format_rate(1.23456) == "1.2346"
@@ -433,6 +583,7 @@ class TestCurrencyFxState:
         points = (FxPoint("a", 1.0), FxPoint("b", 1.1))
         assert format_change(points) == "+10.00%"
         assert format_change((FxPoint("a", 1.0),)) == "n/a"
+        assert percent_change((FxPoint("a", 0), FxPoint("b", 1.1))) is None
 
     def test_build_tooltip(self):
         tooltip = build_tooltip(
@@ -440,9 +591,38 @@ class TestCurrencyFxState:
             quote="USD",
             snapshot=_snapshot(),
             fetch_failed=False,
+            cadence_seconds=15 * 60,
         )
         assert "EUR/USD" in tooltip
         assert "1 EUR = 1.1 USD" in tooltip
+        assert "Updated:" in tooltip
+        assert "Updates every 15 minutes" in tooltip
+
+    def test_build_tooltip_discloses_day_sample_cadence(self):
+        tooltip = build_tooltip(
+            base="EUR",
+            quote="USD",
+            snapshot=_snapshot(),
+            fetch_failed=False,
+            chart_interval=ChartInterval.DAY,
+            cadence_seconds=15 * 60,
+        )
+
+        assert "Day samples every 15 minutes" in tooltip
+
+    def test_build_tooltip_empty_and_error_states(self):
+        text = build_tooltip(
+            base="EUR",
+            quote="USD",
+            snapshot=None,
+            loading=False,
+            fetch_failed=True,
+            error="down",
+            cadence_seconds=15 * 60,
+        )
+
+        assert "EUR/USD" in text
+        assert "down" in text
 
 
 class TestCurrencyFxRender:
@@ -494,6 +674,17 @@ class TestCurrencyFxApplet:
         assert applet.item.icon is not None
         assert "EUR/USD" in applet.item.name
 
+    def test_click_opens_pair_dialog_and_single_scroll_is_noop(self, monkeypatch):
+        applet = _make_applet()
+        called = []
+        monkeypatch.setattr(applet, "_show_pair_dialog", lambda: called.append(True))
+
+        applet.on_clicked()
+        applet.on_scroll(direction_up=False)
+
+        assert called == [True]
+        assert applet._active_index == 0
+
     def test_loads_prefs_from_config(self):
         timestamp = (
             dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=5)
@@ -540,6 +731,25 @@ class TestCurrencyFxApplet:
         assert applet._startup_fetch_timer_id == 12
         assert add.call_count == 2
         pulse_add.assert_not_called()
+
+    def test_stop_removes_all_timers(self, monkeypatch):
+        applet = _make_applet()
+        applet._timer_id = 11
+        applet._startup_fetch_timer_id = 12
+        applet._pulse_timer_id = 13
+        removed: list[int] = []
+        monkeypatch.setattr(
+            currencyfx_applet_mod.GLib,
+            "source_remove",
+            lambda timer_id: removed.append(timer_id),
+        )
+
+        applet.stop()
+
+        assert removed == [11, 12, 13]
+        assert applet._timer_id == 0
+        assert applet._startup_fetch_timer_id == 0
+        assert applet._pulse_timer_id == 0
 
     def test_pulse_timer_starts_when_chart_dot_visible(self, monkeypatch):
         add_seconds = MagicMock(side_effect=[11, 12])
@@ -597,6 +807,18 @@ class TestCurrencyFxApplet:
         assert applet._fetch_request_id == 1
         assert applet._worker.run.call_args.kwargs["name"] == "currencyfx-fetch"
 
+    def test_tick_and_startup_fetch(self, monkeypatch):
+        applet = _make_applet()
+        calls: list[str] = []
+        monkeypatch.setattr(applet, "_fetch_async", lambda: calls.append("fetch"))
+
+        assert applet._tick() is True
+        applet._startup_fetch_timer_id = 99
+        assert applet._run_startup_fetch() is False
+
+        assert applet._startup_fetch_timer_id == 0
+        assert calls == ["fetch", "fetch"]
+
     def test_fetch_result_updates_snapshot_and_codes(self):
         applet = _make_applet()
         applet._fetch_request_id = 7
@@ -614,6 +836,22 @@ class TestCurrencyFxApplet:
         assert applet._fetch_failed is False
         assert "ZAR" in applet._available_codes
         assert "EUR/USD" in applet._samples
+
+    def test_fetch_result_ignores_stale_and_handles_empty_snapshot(self):
+        applet = _make_applet()
+        applet._fetch_request_id = 7
+        applet.present = MagicMock()
+
+        assert (
+            applet._on_fetch_result(request_id=6, snapshot=_snapshot(), codes=())
+            is False
+        )
+        assert applet._snapshot is None
+        applet.present.assert_not_called()
+
+        assert applet._on_fetch_result(request_id=7, snapshot=None, codes=()) is False
+        assert applet._fetch_failed is True
+        assert applet._fetch_error == "No rate data"
 
     def test_day_fetch_result_renders_local_samples(self):
         applet = _make_applet()
@@ -641,6 +879,17 @@ class TestCurrencyFxApplet:
 
         assert applet._snapshot is None
         assert applet._fetch_failed is True
+
+    def test_fetch_error_ignores_stale_and_uses_exception_name(self):
+        applet = _make_applet()
+        applet._fetch_request_id = 7
+        applet.present = MagicMock()
+
+        assert applet._on_fetch_error(request_id=6, exc=RuntimeError("old")) is False
+        applet.present.assert_not_called()
+
+        assert applet._on_fetch_error(request_id=7, exc=RuntimeError()) is False
+        assert applet._fetch_error == "RuntimeError"
 
     def test_add_pair_appends_saves_and_fetches(self):
         applet = _make_applet()
@@ -695,6 +944,18 @@ class TestCurrencyFxApplet:
         applet.on_scroll(direction_up=True)
         assert applet._active_index == 0
 
+    def test_activate_pair_index_guards_empty_and_same_index(self):
+        applet = _make_applet()
+        applet._pairs = []
+        applet._activate_pair_index(0)
+
+        applet._pairs = [FxPair("EUR", "USD")]
+        applet._active_index = 0
+        applet._pair_changed = MagicMock()
+        applet._activate_pair_index(9)
+
+        applet._pair_changed.assert_not_called()
+
     def test_remove_active_pair_keeps_cycle_valid(self):
         applet = _make_applet()
         applet._pairs = [FxPair("EUR", "USD"), FxPair("EUR", "BRL")]
@@ -709,6 +970,14 @@ class TestCurrencyFxApplet:
         applet.save_prefs.assert_called_once()
         applet._fetch_async.assert_called_once()
 
+    def test_remove_active_pair_ignores_single_pair(self):
+        applet = _make_applet()
+        applet.save_prefs = MagicMock()
+
+        applet._remove_active_pair()
+
+        applet.save_prefs.assert_not_called()
+
     def test_interval_selection_saves_and_fetches(self):
         applet = _make_applet()
         applet.save_prefs = MagicMock()
@@ -721,6 +990,16 @@ class TestCurrencyFxApplet:
         assert applet._chart_interval == ChartInterval.MONTH
         applet.save_prefs.assert_called_once()
         applet._fetch_async.assert_called_once()
+
+    def test_interval_selection_ignores_current_interval(self):
+        applet = _make_applet()
+        applet.save_prefs = MagicMock()
+        widget = MagicMock()
+        widget.get_active.return_value = True
+
+        applet._on_interval_selected(widget=widget, interval=ChartInterval.WEEK)
+
+        applet.save_prefs.assert_not_called()
 
     def test_interval_selection_ignores_inactive_widget(self):
         applet = _make_applet()
@@ -740,3 +1019,151 @@ class TestCurrencyFxApplet:
         applet._snapshot = _snapshot()
         assert "EUR/USD" in applet._menu_header()
         assert "1.1" in applet._menu_header()
+
+    def test_menu_discloses_update_cadence(self):
+        applet = _make_applet()
+        labels = [item.get_label() for item in applet.get_menu_items()]
+
+        assert "Updates every 15 minutes" in labels
+
+    def test_menu_with_multiple_pairs_has_pair_controls(self):
+        applet = _make_applet()
+        applet._pairs = [FxPair("EUR", "USD"), FxPair("EUR", "BRL")]
+
+        labels = [item.get_label() for item in applet.get_menu_items()]
+
+        assert "Added Pairs" in labels
+        assert "Remove Current Pair" in labels
+
+    def test_pair_changed_uses_day_cache_snapshot(self):
+        applet = _make_applet()
+        applet._chart_interval = ChartInterval.DAY
+        now = dt.datetime.now(dt.timezone.utc).isoformat()
+        applet._samples = {"EUR/USD": (FxPoint(now, 1.2),)}
+        applet._fetch_async = MagicMock()
+
+        applet._pair_changed()
+
+        assert applet._snapshot is not None
+        assert applet._snapshot.rate == 1.2
+        applet._fetch_async.assert_called_once()
+
+    def test_local_snapshot_helpers(self):
+        applet = _make_applet()
+        assert applet._snapshot_from_local_samples() is None
+
+        fetched = _snapshot()
+        applet._samples = {"EUR/USD": (FxPoint(fetched.fetched_at.isoformat(), 1.10),)}
+        with_local = applet._snapshot_with_local_samples(snapshot=fetched)
+
+        assert with_local.points == (FxPoint(fetched.fetched_at.isoformat(), 1.10),)
+        assert with_local.fetched_at == fetched.fetched_at
+
+    def test_currency_combo_and_pair_codes(self, monkeypatch):
+        monkeypatch.setattr(currencyfx_applet_mod.Gtk, "ComboBoxText", _FakeCombo)
+        applet = _make_applet()
+        applet._available_codes = ("EUR", "USD")
+        combo = applet._currency_combo(active="BRL")
+
+        assert combo.get_active_text() == "EUR"
+        assert applet._pair_codes() == ("EUR", "USD")
+
+
+class _FakeBox:
+    def __init__(self) -> None:
+        self.children: list[object] = []
+
+    def pack_start(self, child, *_args) -> None:
+        self.children.append(child)
+
+
+class _FakeDialog:
+    def __init__(self, *, response: int) -> None:
+        self.response = response
+        self.box = _FakeBox()
+        self.destroyed = False
+
+    def show_all(self) -> None:
+        return
+
+    def run(self) -> int:
+        return self.response
+
+    def destroy(self) -> None:
+        self.destroyed = True
+
+
+class _FakeCombo:
+    active_text = ""
+
+    def __init__(self) -> None:
+        self.values: list[str] = []
+        self.active = 0
+
+    def append_text(self, text: str) -> None:
+        self.values.append(text)
+
+    def set_active(self, index: int) -> None:
+        self.active = index
+
+    def get_active_text(self) -> str:
+        return self.active_text or self.values[self.active]
+
+    def grab_focus(self) -> None:
+        return
+
+
+class _FakeLabel:
+    def __init__(self, label: str = "") -> None:
+        self.label = label
+
+
+class TestCurrencyFxDialog:
+    def test_show_pair_dialog_adds_selected_pair(self, monkeypatch):
+        dialog = _FakeDialog(response=currencyfx_applet_mod.Gtk.ResponseType.OK)
+        combos: list[_FakeCombo] = []
+
+        def combo_factory():
+            combo = _FakeCombo()
+            combos.append(combo)
+            return combo
+
+        monkeypatch.setattr(currencyfx_applet_mod.Gtk, "Dialog", lambda **_: dialog)
+        monkeypatch.setattr(currencyfx_applet_mod.Gtk, "ComboBoxText", combo_factory)
+        monkeypatch.setattr(currencyfx_applet_mod.Gtk, "Label", _FakeLabel)
+        monkeypatch.setattr(
+            currencyfx_applet_mod,
+            "prepare_dialog_content",
+            lambda **_: dialog.box,
+        )
+        monkeypatch.setattr(
+            currencyfx_applet_mod, "add_cancel_ok_buttons", lambda **_: None
+        )
+        applet = _make_applet()
+        applet._available_codes = ("EUR", "USD", "BRL")
+        applet._add_pair = MagicMock()
+
+        applet._show_pair_dialog()
+
+        applet._add_pair.assert_called_once_with("EUR", "USD")
+        assert dialog.destroyed is True
+
+    def test_show_pair_dialog_ignores_cancel(self, monkeypatch):
+        dialog = _FakeDialog(response=currencyfx_applet_mod.Gtk.ResponseType.CANCEL)
+        monkeypatch.setattr(currencyfx_applet_mod.Gtk, "Dialog", lambda **_: dialog)
+        monkeypatch.setattr(currencyfx_applet_mod.Gtk, "ComboBoxText", _FakeCombo)
+        monkeypatch.setattr(currencyfx_applet_mod.Gtk, "Label", _FakeLabel)
+        monkeypatch.setattr(
+            currencyfx_applet_mod,
+            "prepare_dialog_content",
+            lambda **_: dialog.box,
+        )
+        monkeypatch.setattr(
+            currencyfx_applet_mod, "add_cancel_ok_buttons", lambda **_: None
+        )
+        applet = _make_applet()
+        applet._add_pair = MagicMock()
+
+        applet._show_pair_dialog()
+
+        applet._add_pair.assert_not_called()

--- a/tests/applets/test_deskpresence.py
+++ b/tests/applets/test_deskpresence.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import builtins
+import ctypes
+import sys
+import types
 from datetime import date
 from unittest.mock import patch
 
+import docking.applets.deskpresence.idle as idle_mod
 from docking.applets.deskpresence.applet import DeskpresenceApplet
 from docking.applets.deskpresence.state import (
     DEFAULT_IDLE_THRESHOLD_S,
@@ -467,3 +472,138 @@ class TestAppletPrefs:
         )
         applet = _make_applet(config=config)
         assert applet._state.idle_threshold_s == 240.0
+
+
+def _reset_idle_module() -> None:
+    idle_mod._xlib = None
+    idle_mod._xss = None
+    idle_mod._loaded = False
+
+
+class _FakeCFunc:
+    def __init__(self, func):
+        self._func = func
+        self.restype = None
+        self.argtypes = None
+
+    def __call__(self, *args):
+        return self._func(*args)
+
+
+class _FakeXlib:
+    def __init__(self) -> None:
+        self.freed: list[object] = []
+        self.XDefaultRootWindow = _FakeCFunc(lambda _display: 99)
+        self.XFree = _FakeCFunc(lambda ptr: self.freed.append(ptr))
+
+
+class _FakeXss:
+    def __init__(self, *, idle_ms: int = 1234, query_ok: bool = True) -> None:
+        info = idle_mod._XScreenSaverInfo()
+        info.idle = idle_ms
+        self.info_ptr = ctypes.pointer(info)
+        self.query_ok = query_ok
+        self.XScreenSaverAllocInfo = _FakeCFunc(lambda: self.info_ptr)
+        self.XScreenSaverQueryInfo = _FakeCFunc(
+            lambda _display, _root, _info: int(self.query_ok)
+        )
+
+
+class TestIdleProbe:
+    def setup_method(self):
+        _reset_idle_module()
+
+    def test_load_libraries_failure_is_cached(self, monkeypatch):
+        calls: list[str] = []
+
+        def fail(name: str):
+            calls.append(name)
+            raise OSError("missing")
+
+        monkeypatch.setattr(idle_mod.ctypes.cdll, "LoadLibrary", fail)
+
+        assert idle_mod._load_libraries() is False
+        assert idle_mod._load_libraries() is False
+        assert calls == ["libX11.so.6"]
+
+    def test_load_libraries_success_configures_functions(self, monkeypatch):
+        xlib = _FakeXlib()
+        xss = _FakeXss()
+        monkeypatch.setattr(
+            idle_mod.ctypes.cdll,
+            "LoadLibrary",
+            lambda name: xlib if "X11" in name else xss,
+        )
+
+        assert idle_mod._load_libraries() is True
+        assert idle_mod._load_libraries() is True
+        assert xlib.XDefaultRootWindow.argtypes == [ctypes.c_void_p]
+        assert xss.XScreenSaverQueryInfo.restype is ctypes.c_int
+
+    def test_xdisplay_handle_import_failure(self, monkeypatch):
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "gi":
+                raise ImportError("missing gi")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        assert idle_mod._xdisplay_handle() is None
+
+    def test_xdisplay_handle_none_and_success(self, monkeypatch):
+        gi = types.ModuleType("gi")
+        gi.require_version = lambda *_args: None
+        repository = types.ModuleType("gi.repository")
+
+        class _Display:
+            def get_xdisplay(self):
+                return 123
+
+        gdk_x11 = types.SimpleNamespace(
+            X11Display=types.SimpleNamespace(get_default=lambda: None)
+        )
+        repository.GdkX11 = gdk_x11
+        monkeypatch.setitem(sys.modules, "gi", gi)
+        monkeypatch.setitem(sys.modules, "gi.repository", repository)
+
+        assert idle_mod._xdisplay_handle() is None
+
+        gdk_x11.X11Display.get_default = lambda: _Display()
+        handle = idle_mod._xdisplay_handle()
+        assert isinstance(handle, ctypes.c_void_p)
+        assert handle.value == 123
+
+    def test_get_idle_ms_success_and_failures(self, monkeypatch):
+        xlib = _FakeXlib()
+        xss = _FakeXss(idle_ms=4242)
+        monkeypatch.setattr(
+            idle_mod.ctypes.cdll,
+            "LoadLibrary",
+            lambda name: xlib if "X11" in name else xss,
+        )
+        monkeypatch.setattr(idle_mod, "_xdisplay_handle", lambda: ctypes.c_void_p(1))
+
+        assert idle_mod.get_idle_ms() == 4242
+        assert xlib.freed == [xss.info_ptr]
+
+        _reset_idle_module()
+        monkeypatch.setattr(idle_mod, "_load_libraries", lambda: False)
+        assert idle_mod.get_idle_ms() is None
+
+        monkeypatch.setattr(idle_mod, "_load_libraries", lambda: True)
+        idle_mod._xlib = xlib
+        idle_mod._xss = xss
+        monkeypatch.setattr(idle_mod, "_xdisplay_handle", lambda: None)
+        assert idle_mod.get_idle_ms() is None
+
+        monkeypatch.setattr(idle_mod, "_xdisplay_handle", lambda: ctypes.c_void_p(1))
+        null_ptr = ctypes.POINTER(idle_mod._XScreenSaverInfo)()
+        xss.XScreenSaverAllocInfo = _FakeCFunc(lambda: null_ptr)
+        assert idle_mod.get_idle_ms() is None
+
+        xss = _FakeXss(query_ok=False)
+        idle_mod._xss = xss
+        assert idle_mod.get_idle_ms() is None
+        assert xlib.freed[-1] == xss.info_ptr

--- a/tests/applets/test_freshness.py
+++ b/tests/applets/test_freshness.py
@@ -1,0 +1,31 @@
+import datetime as dt
+
+from docking.applets.freshness import (
+    cadence_label,
+    format_interval,
+    on_demand_label,
+    updated_label,
+)
+
+
+def test_format_interval_prefers_largest_clean_unit():
+    assert format_interval(5) == "5 seconds"
+    assert format_interval(300) == "5 minutes"
+    assert format_interval(3600) == "1 hour"
+
+
+def test_cadence_label_uses_default_and_custom_verbs():
+    assert cadence_label(seconds=300) == "Updates every 5 minutes"
+    assert cadence_label(seconds=5, verb="Samples") == "Samples every 5 seconds"
+
+
+def test_on_demand_label():
+    assert on_demand_label(verb="Runs") == "Runs on demand"
+
+
+def test_updated_label_formats_valid_timestamp():
+    timestamp = dt.datetime(2026, 4, 27, 12, 0, tzinfo=dt.timezone.utc)
+
+    assert "Updated:" in updated_label(timestamp)
+    assert "2026-04-27" in updated_label(timestamp)
+    assert updated_label("") == ""

--- a/tests/applets/test_hackernews.py
+++ b/tests/applets/test_hackernews.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 from unittest.mock import MagicMock, patch
 
 import docking.applets.hackernews.applet as hackernews_applet_mod
@@ -24,10 +25,14 @@ from docking.applets.hackernews.state import (
     normalize_active_index,
     normalize_text,
     parse_story_payload,
+    parse_top_story_id_page,
     parse_top_story_ids,
     prefs_from_mapping,
     prefs_payload,
     story_age,
+    story_from_pref,
+    story_rank,
+    story_to_pref,
 )
 from docking.core.config import Config
 
@@ -88,10 +93,40 @@ class TestHackerNewsState:
     def test_comments_url(self):
         assert comments_url(123) == f"{HN_WEB_URL}/item?id=123"
 
+    def test_story_rank_and_age_edges(self):
+        assert story_rank(index=0, count=0) == ""
+        assert story_age(story=_story(time=0)) == ""
+        now = dt.datetime.fromtimestamp(1000, tz=dt.timezone.utc)
+        assert story_age(story=_story(time=1000), now=now) == "now"
+        assert (
+            story_age(
+                story=_story(time=1000),
+                now=now + dt.timedelta(minutes=10),
+            )
+            == "10m ago"
+        )
+        assert (
+            story_age(
+                story=_story(time=1000),
+                now=now + dt.timedelta(days=3),
+            )
+            == "3d ago"
+        )
+
     def test_parse_top_story_ids(self):
         assert parse_top_story_ids([1, "2", "bad", 3], limit=3) == (1, 2, 3)
         assert parse_top_story_ids([1, 2, 3, 4], limit=2, offset=2) == (3, 4)
         assert parse_top_story_ids("bad", limit=3) == ()
+        assert parse_top_story_ids([1, 2], limit=0) == ()
+
+    def test_parse_top_story_id_page_edges(self):
+        assert parse_top_story_id_page("bad", limit=2, offset=-1) == ((), 0, False)
+        assert parse_top_story_id_page([1, 2], limit=0, offset=5) == ((), 5, False)
+        assert parse_top_story_id_page([0, "bad", 1, "2", 3], limit=2, offset=1) == (
+            (2, 3),
+            3,
+            False,
+        )
 
     def test_append_unique_stories(self):
         first = _story(id=1, title="First")
@@ -125,11 +160,38 @@ class TestHackerNewsState:
         assert story.comments == 7
 
     def test_parse_story_payload_rejects_dead_and_non_story_items(self):
+        assert parse_story_payload("bad") is None
+        assert parse_story_payload({"id": "bad", "type": "story", "title": "x"}) is None
+        assert parse_story_payload({"id": 0, "type": "story", "title": "x"}) is None
+        assert parse_story_payload({"id": 1, "type": "story", "title": ""}) is None
+        assert (
+            parse_story_payload(
+                {"id": 1, "type": "story", "title": "x", "deleted": True}
+            )
+            is None
+        )
         assert parse_story_payload({"id": 1, "type": "comment", "title": "x"}) is None
         assert (
             parse_story_payload({"id": 1, "type": "story", "title": "x", "dead": True})
             is None
         )
+
+    def test_parse_story_payload_bad_numeric_fields_clamp(self):
+        story = parse_story_payload(
+            {
+                "id": 123,
+                "type": "story",
+                "title": "Story",
+                "score": "bad",
+                "descendants": -3,
+                "time": "bad",
+            }
+        )
+
+        assert story is not None
+        assert story.score == 0
+        assert story.comments == 0
+        assert story.time == 0
 
     def test_story_without_url_opens_comments(self):
         story = parse_story_payload({"id": 99, "type": "story", "title": "Ask HN"})
@@ -144,11 +206,14 @@ class TestHackerNewsState:
         assert story_age(story=story, now=now) == "3h ago"
 
     def test_build_tooltip_states(self):
-        assert "loading" in build_tooltip(
-            story=None,
-            index=0,
-            count=0,
-            loading=True,
+        assert (
+            "loading"
+            in build_tooltip(
+                story=None,
+                index=0,
+                count=0,
+                loading=True,
+            ).lower()
         )
         assert "network down" in build_tooltip(
             story=None,
@@ -156,10 +221,18 @@ class TestHackerNewsState:
             count=0,
             error="network down",
         )
-        text = build_tooltip(story=_story(), index=1, count=3)
+        text = build_tooltip(
+            story=_story(),
+            index=1,
+            count=3,
+            fetched_at=dt.datetime(2026, 4, 27, tzinfo=dt.timezone.utc),
+            cadence_seconds=10 * 60,
+        )
         assert "Hacker News 2/3" in text
         assert "SQLite on the Edge" in text
         assert "456 points" in text
+        assert "Updated:" in text
+        assert "Refreshes every 10 minutes" in text
         assert "Loading next stories" in build_tooltip(
             story=_story(),
             index=2,
@@ -183,6 +256,26 @@ class TestHackerNewsState:
         assert prefs.has_more_stories is True
         assert prefs.fetched_at
 
+    def test_story_pref_edges(self):
+        story = _story(id=42, title="Story")
+        payload = story_to_pref(story)
+
+        assert story_from_pref(payload) == story
+        assert story_from_pref("bad") is None
+        assert story_from_pref({"id": "bad", "title": "Story"}) is None
+        assert story_from_pref({"id": 0, "title": "Story"}) is None
+        assert story_from_pref({"id": 42, "title": ""}) is None
+        assert story_from_pref({"id": 42, "title": "Story"}) == _story(
+            id=42,
+            title="Story",
+            url=f"{HN_WEB_URL}/item?id=42",
+            hn_url=f"{HN_WEB_URL}/item?id=42",
+            score=0,
+            comments=0,
+            by="",
+            time=0,
+        )
+
     def test_prefs_without_cursor_fields_are_ignored(self):
         prefs = prefs_from_mapping(
             {
@@ -204,6 +297,14 @@ class TestHackerNewsState:
     def test_bad_prefs_return_empty(self):
         assert prefs_from_mapping(None) == HackerNewsPrefs()
         assert prefs_from_mapping({"stories": [{"id": "bad"}]}).stories == ()
+        assert prefs_from_mapping(
+            {
+                "stories": "bad",
+                "active_index": "bad",
+                "next_offset": "bad",
+                "has_more_stories": False,
+            }
+        ) == HackerNewsPrefs(has_more_stories=False)
 
     def test_normalize_active_index(self):
         assert normalize_active_index(index=5, count=2) == 1
@@ -264,6 +365,30 @@ class TestFetchHnStories:
             == ()
         )
 
+    def test_get_json_uses_request_headers(self, monkeypatch):
+        import docking.applets.hackernews.state as hn_state
+
+        seen = []
+
+        class _Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return None
+
+            def read(self):
+                return json.dumps([1, 2]).encode()
+
+        monkeypatch.setattr(
+            hn_state.urllib.request,
+            "urlopen",
+            lambda req, timeout: seen.append((req.full_url, timeout)) or _Response(),
+        )
+
+        assert hn_state._get_json("https://example.test") == [1, 2]
+        assert seen == [("https://example.test", 5)]
+
 
 class TestHackerNewsRender:
     def test_render_icon_states(self):
@@ -307,6 +432,13 @@ class TestHackerNewsApplet:
 
         assert applet._current_story is not None
         assert applet._current_story.title == "Second"
+
+    def test_scroll_without_stories_is_noop(self):
+        applet = _make_applet()
+
+        applet.on_scroll(direction_up=False)
+
+        assert applet._active_index == 0
 
     def test_backward_scroll_at_first_story_stays_at_first(self):
         applet = _make_applet()
@@ -378,6 +510,20 @@ class TestHackerNewsApplet:
         assert [story.id for story in applet._stories] == [1, 2]
         assert applet._next_story_offset == 20
 
+    def test_next_page_fetch_ignores_stale_request(self):
+        applet = _make_applet()
+        applet._fetch_request_id = 7
+        applet.present = MagicMock()
+
+        assert (
+            applet._on_page_fetch_result(
+                request_id=6,
+                page=HackerNewsPage(stories=(_story(),), next_offset=20, has_more=True),
+            )
+            is False
+        )
+        applet.present.assert_not_called()
+
     def test_next_page_fetch_stops_when_empty(self):
         applet = _make_applet()
         applet._stories = [_story()]
@@ -392,6 +538,23 @@ class TestHackerNewsApplet:
         assert result is False
         assert applet._page_loading is False
         assert applet._has_more_stories is False
+
+    def test_next_page_fetch_duplicate_only_presents_without_save(self):
+        applet = _make_applet()
+        applet._stories = [_story(id=1)]
+        applet._fetch_request_id = 7
+        applet._save_prefs = MagicMock()
+
+        applet._on_page_fetch_result(
+            request_id=7,
+            page=HackerNewsPage(
+                stories=(_story(id=1),),
+                next_offset=20,
+                has_more=True,
+            ),
+        )
+
+        applet._save_prefs.assert_not_called()
 
     def test_next_page_can_continue_after_short_visible_page(self):
         applet = _make_applet()
@@ -438,6 +601,42 @@ class TestHackerNewsApplet:
 
         applet._open_url.assert_called_once_with("https://example.test/story")
 
+    def test_open_current_story_and_comments_noop_without_story(self):
+        applet = _make_applet()
+        applet._open_url = MagicMock()
+
+        applet._open_current_story()
+        applet._open_current_comments()
+
+        applet._open_url.assert_not_called()
+
+    def test_open_current_comments_and_url_error(self, monkeypatch):
+        applet = _make_applet()
+        applet._stories = [_story(hn_url="https://news.ycombinator.com/item?id=1")]
+        opened: list[str] = []
+        monkeypatch.setattr(
+            hackernews_applet_mod.Gio.AppInfo,
+            "launch_default_for_uri",
+            lambda url, _ctx: opened.append(url),
+        )
+
+        applet._open_current_comments()
+
+        assert opened == ["https://news.ycombinator.com/item?id=1"]
+
+        monkeypatch.setattr(
+            hackernews_applet_mod.GLib,
+            "Error",
+            RuntimeError,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            hackernews_applet_mod.Gio.AppInfo,
+            "launch_default_for_uri",
+            lambda *_args: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        applet._open_url("https://example.test")
+
     def test_menu_contains_hn_actions(self):
         applet = _make_applet()
         applet._stories = [_story()]
@@ -450,7 +649,16 @@ class TestHackerNewsApplet:
         assert "Open Story" in labels
         assert "Open Comments" in labels
         assert "Next Headline" in labels
+        assert "Refreshes every 10 minutes" in labels
         assert "Refresh Now" in labels
+
+    def test_menu_without_story_disables_navigation(self):
+        applet = _make_applet()
+
+        items = applet.get_menu_items()
+        next_item = next(item for item in items if item.get_label() == "Next Headline")
+
+        assert not next_item.get_sensitive()
 
     def test_start_schedules_timers(self, monkeypatch):
         add = MagicMock(side_effect=[11, 12])
@@ -466,6 +674,52 @@ class TestHackerNewsApplet:
         assert applet._refresh_timer_id == 11
         assert applet._startup_fetch_timer_id == 12
         assert add.call_count == 2
+
+    def test_stop_removes_timers(self, monkeypatch):
+        applet = _make_applet()
+        applet._refresh_timer_id = 11
+        applet._startup_fetch_timer_id = 12
+        removed: list[int] = []
+        monkeypatch.setattr(
+            hackernews_applet_mod.GLib,
+            "source_remove",
+            lambda timer_id: removed.append(timer_id),
+        )
+
+        applet.stop()
+
+        assert removed == [11, 12]
+        assert applet._refresh_timer_id == 0
+        assert applet._startup_fetch_timer_id == 0
+
+    def test_refresh_and_startup_ticks_fetch(self, monkeypatch):
+        applet = _make_applet()
+        calls: list[str] = []
+        monkeypatch.setattr(applet, "_fetch_async", lambda: calls.append("fetch"))
+
+        assert applet._refresh_tick() is True
+        applet._startup_fetch_timer_id = 99
+        assert applet._run_startup_fetch() is False
+
+        assert applet._startup_fetch_timer_id == 0
+        assert calls == ["fetch", "fetch"]
+
+    def test_advance_and_move_story_edge_cases(self):
+        applet = _make_applet()
+        applet._advance_story()
+        applet._move_story(step=1)
+
+        applet._stories = [_story(id=1), _story(id=2)]
+        applet._active_index = 1
+        applet._has_more_stories = False
+        applet.present = MagicMock()
+        applet._move_story(step=1)
+        applet.present.assert_called_once()
+
+        applet._active_index = 0
+        applet.present.reset_mock()
+        applet._move_story(step=-1)
+        applet.present.assert_called_once()
 
     def test_fetch_result_replaces_cache_and_saves(self):
         saved = []
@@ -487,6 +741,116 @@ class TestHackerNewsApplet:
         assert applet._current_story.title == "SQLite on the Edge"
         assert applet._next_story_offset == 20
         assert saved == [True]
+
+    def test_set_active_index_saves_and_presents(self):
+        applet = _make_applet()
+        applet._stories = [_story(id=1), _story(id=2)]
+        applet._save_prefs = MagicMock()
+        applet.present = MagicMock()
+
+        applet._set_active_index(9)
+
+        assert applet._active_index == 1
+        applet._save_prefs.assert_called_once()
+        applet.present.assert_called_once()
+
+    def test_fetch_async_removes_startup_timer_and_queues_worker(
+        self,
+        monkeypatch,
+    ):
+        applet = _make_applet()
+        worker = _PendingWorker()
+        applet._worker = worker
+        applet._startup_fetch_timer_id = 77
+        removed: list[int] = []
+        monkeypatch.setattr(
+            hackernews_applet_mod.GLib,
+            "source_remove",
+            lambda timer_id: removed.append(timer_id),
+        )
+
+        applet._fetch_async()
+
+        assert removed == [77]
+        assert applet._startup_fetch_timer_id == 0
+        assert applet._loading is True
+        assert worker.calls[0]["name"] == "hackernews-fetch"
+
+    def test_fetch_result_empty_page_sets_error_only_without_cache(self):
+        applet = _make_applet()
+        applet._fetch_request_id = 7
+
+        applet._on_fetch_result(
+            request_id=7,
+            page=HackerNewsPage(stories=(), next_offset=0, has_more=False),
+        )
+
+        assert "No Hacker News stories" in applet._error
+
+    def test_fetch_error_stale_and_empty_exception(self):
+        applet = _make_applet()
+        applet._fetch_request_id = 7
+        applet.present = MagicMock()
+
+        assert applet._on_fetch_error(request_id=6, exc=RuntimeError("old")) is False
+        applet.present.assert_not_called()
+
+        assert applet._on_fetch_error(request_id=7, exc=RuntimeError()) is False
+        assert applet._error == "RuntimeError"
+
+    def test_refreshed_active_index_edge_cases(self):
+        applet = _make_applet()
+        assert (
+            applet._refreshed_active_index(current_story=_story(), previous_index=99)
+            == 0
+        )
+
+        applet._stories = [_story(id=1), _story(id=2)]
+        assert (
+            applet._refreshed_active_index(
+                current_story=_story(id=3),
+                previous_index=99,
+            )
+            == 1
+        )
+
+    def test_fetch_next_page_guards_and_max_cap(self):
+        applet = _make_applet()
+        applet._stories = [_story(id=i) for i in range(MAX_STORIES)]
+        applet._has_more_stories = True
+        applet.present = MagicMock()
+
+        applet._fetch_next_page_async()
+
+        assert applet._has_more_stories is False
+        applet.present.assert_called_once()
+
+        applet._stories = [_story(id=1)]
+        for loading, page_loading, has_more in (
+            (True, False, True),
+            (False, True, True),
+            (False, False, False),
+        ):
+            applet._loading = loading
+            applet._page_loading = page_loading
+            applet._has_more_stories = has_more
+            applet._worker = _PendingWorker()
+            applet._fetch_next_page_async()
+            assert applet._worker.calls == []
+
+    def test_fetch_next_page_queues_worker(self):
+        applet = _make_applet()
+        worker = _PendingWorker()
+        applet._worker = worker
+        applet._stories = [_story(id=1)]
+        applet._next_story_offset = 20
+        applet._has_more_stories = True
+
+        applet._fetch_next_page_async()
+
+        assert applet._page_loading is True
+        assert applet._fetch_request_id == 1
+        assert worker.calls[0]["name"] == "hackernews-page-fetch"
 
     def test_refresh_fetches_loaded_range_not_only_first_page(self):
         applet = _make_applet()

--- a/tests/applets/test_keyboardlayout.py
+++ b/tests/applets/test_keyboardlayout.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from unittest.mock import MagicMock
 
@@ -23,10 +24,13 @@ from docking.applets.keyboardlayout.state import (
     MateBackend,
     XkbBackend,
     _fcitx5_layout_code,
+    _first_available_command,
     _ibus_layout_code,
+    _open_command,
     _parse_gsettings_string,
     _parse_gsettings_string_list,
     _parse_input_sources,
+    _source_layout_code,
     current_layout_command,
     cycle_layout,
     detect_backend,
@@ -152,6 +156,35 @@ class TestIBusBackend:
         state = IBusBackend().query()
         assert state.active == "br"
 
+    def test_query_unavailable_and_fallback_to_active_engine(self, monkeypatch):
+        monkeypatch.setattr(kbl_state, "_run", lambda cmd: None)
+        assert IBusBackend().query().available == []
+
+        def mock_run(cmd):
+            if cmd == ["ibus", "engine"]:
+                return "xkb:us::eng"
+            if cmd[:2] == ["dconf", "read"]:
+                return ""
+            return None
+
+        monkeypatch.setattr(kbl_state, "_run", mock_run)
+        assert IBusBackend().query().available == ["us"]
+
+    def test_switch_falls_back_to_synthetic_engine(self, monkeypatch):
+        commands = []
+
+        def mock_run(cmd):
+            commands.append(cmd)
+            if cmd[:2] == ["dconf", "read"]:
+                return ""
+            return None
+
+        monkeypatch.setattr(kbl_state, "_run", mock_run)
+
+        IBusBackend().switch(layout_code="de")
+
+        assert ["ibus", "engine", "xkb:de::eng"] in commands
+
 
 # ---------------------------------------------------------------------------
 # Fcitx5Backend
@@ -217,6 +250,28 @@ class TestFcitx5Backend:
         assert state.active == "us"
         assert state.available == ["us"]
 
+    def test_query_unavailable_and_switch_fallback(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(kbl_state, "_run", lambda cmd: None)
+        monkeypatch.setattr(kbl_state.Path, "home", lambda: tmp_path)
+        assert Fcitx5Backend().query().available == []
+
+        commands = []
+        monkeypatch.setattr(
+            kbl_state,
+            "_run",
+            lambda cmd: commands.append(cmd) or None,
+        )
+        Fcitx5Backend().switch(layout_code="de")
+        assert ["fcitx5-remote", "-s", "keyboard-de"] in commands
+
+    def test_profile_parser_stops_at_next_group(self, monkeypatch, tmp_path):
+        profile = tmp_path / ".config" / "fcitx5" / "profile"
+        profile.parent.mkdir(parents=True)
+        profile.write_text(FCITX5_PROFILE + "\n[Other]\nName=keyboard-de\n")
+        monkeypatch.setattr(kbl_state.Path, "home", lambda: tmp_path)
+
+        assert Fcitx5Backend()._get_ims() == ["keyboard-us", "keyboard-br"]
+
 
 # ---------------------------------------------------------------------------
 # MATE backend
@@ -227,10 +282,15 @@ class TestMateBackend:
     def test_parse_gsettings_string_list(self):
         assert _parse_gsettings_string_list("['gb', 'br', 'us']") == ["gb", "br", "us"]
         assert _parse_gsettings_string_list("@as []") == []
+        assert _parse_gsettings_string_list("bad [") == []
+        assert _parse_gsettings_string_list("'not-list'") == []
+        assert _parse_gsettings_string_list("[1, 'us', '']") == ["us"]
 
     def test_parse_gsettings_string(self):
         assert _parse_gsettings_string("'pc101'") == "pc101"
         assert _parse_gsettings_string("") == ""
+        assert _parse_gsettings_string("pc105") == "pc105"
+        assert _parse_gsettings_string("123") == ""
 
     def test_query_returns_mate_layouts(self, monkeypatch):
         _set_desktop(monkeypatch, Desktop.MATE)
@@ -302,11 +362,55 @@ class TestMateBackend:
 
         assert not MateBackend().is_available()
 
+    def test_is_available_true_and_query_falls_back_to_first_layout(self, monkeypatch):
+        _set_desktop(monkeypatch, Desktop.MATE)
+
+        def mock_run(cmd):
+            if cmd == [
+                "gsettings",
+                "get",
+                "org.mate.peripherals-keyboard-xkb.kbd",
+                "layouts",
+            ]:
+                return "['gb', 'br']"
+            return None
+
+        monkeypatch.setattr(kbl_state, "_run", mock_run)
+
+        assert MateBackend().is_available()
+        assert MateBackend().query() == kbl_state.LayoutState("gb", ["gb", "br"])
+
+    def test_switch_unknown_layout_without_model_or_options(self, monkeypatch):
+        commands = []
+
+        def mock_run(cmd):
+            commands.append(cmd)
+            if cmd == [
+                "gsettings",
+                "get",
+                "org.mate.peripherals-keyboard-xkb.kbd",
+                "layouts",
+            ]:
+                return "['gb', 'br']"
+            return None
+
+        monkeypatch.setattr(kbl_state, "_run", mock_run)
+
+        MateBackend().switch(layout_code="de")
+
+        assert ["setxkbmap", "-layout", "de"] in commands
+
 
 class TestGnomeBackend:
     def test_parse_input_sources(self):
         assert _parse_input_sources(GNOME_SOURCES) == [("xkb", "us"), ("xkb", "br")]
         assert _parse_input_sources("@a(ss) []") == []
+        assert _parse_input_sources("bad [") == []
+        assert _parse_input_sources("'not-list'") == []
+        assert _parse_input_sources("[('bad',), ('xkb', 'us'), (1, 'bad')]") == [
+            ("xkb", "us")
+        ]
+        assert _source_layout_code("br+abnt2") == "br"
 
     def test_query_returns_gnome_sources(self, monkeypatch):
         _set_desktop(monkeypatch, Desktop.UBUNTU | Desktop.GNOME)
@@ -389,6 +493,69 @@ class TestGnomeBackend:
         )
         assert GnomeBackend().is_available()
 
+    def test_is_available_false_outside_gnome(self, monkeypatch):
+        _set_desktop(monkeypatch, Desktop.UNKNOWN)
+        monkeypatch.setattr(kbl_state, "_run", lambda cmd: GNOME_SOURCES)
+        assert not GnomeBackend().is_available()
+
+    def test_active_source_falls_back_to_mru_and_first_xkb(self, monkeypatch):
+        backend = GnomeBackend()
+
+        def mock_run_mru(cmd):
+            if cmd[-1] == "current":
+                return "uint32 99"
+            if cmd[-1] == "mru-sources":
+                return GNOME_MRU_SOURCES
+            return GNOME_SOURCES
+
+        monkeypatch.setattr(kbl_state, "_run", mock_run_mru)
+        assert (
+            backend._active_source_code(sources=[("xkb", "us"), ("xkb", "br")]) == "br"
+        )
+
+        def mock_run_first(cmd):
+            if cmd[-1] == "current":
+                return "none"
+            if cmd[-1] == "mru-sources":
+                return "[('ibus', 'anthy')]"
+            return GNOME_SOURCES
+
+        monkeypatch.setattr(kbl_state, "_run", mock_run_first)
+        assert (
+            backend._active_source_code(sources=[("ibus", "anthy"), ("xkb", "us")])
+            == "us"
+        )
+        assert backend._current_index() == -1
+
+    def test_query_without_active_uses_available_first(self, monkeypatch):
+        monkeypatch.setattr(GnomeBackend, "_sources", lambda self: [("xkb", "us")])
+        monkeypatch.setattr(
+            GnomeBackend, "_active_source_code", lambda self, sources: ""
+        )
+
+        assert GnomeBackend().query() == kbl_state.LayoutState("us", ["us"])
+
+    def test_switch_without_gdbus_and_no_match(self, monkeypatch):
+        commands = []
+        monkeypatch.setattr(
+            GnomeBackend,
+            "_sources",
+            lambda self: [("ibus", "anthy"), ("xkb", "br")],
+        )
+        monkeypatch.setattr(kbl_state.shutil, "which", lambda cmd: None)
+        monkeypatch.setattr(kbl_state, "_run", lambda cmd: commands.append(cmd) or None)
+
+        GnomeBackend().switch(layout_code="br")
+        GnomeBackend().switch(layout_code="de")
+
+        assert [
+            "gsettings",
+            "set",
+            "org.gnome.desktop.input-sources",
+            "current",
+            "1",
+        ] in commands
+
 
 # ---------------------------------------------------------------------------
 # XkbBackend
@@ -415,6 +582,13 @@ class TestXkbBackend:
         )
         XkbBackend().switch(layout_code="es")
         assert ["setxkbmap", "-layout", "es"] in commands
+
+    def test_query_empty_and_missing_layout(self, monkeypatch):
+        monkeypatch.setattr(kbl_state, "_run", lambda cmd: None)
+        assert XkbBackend().query() == kbl_state.LayoutState("", [])
+
+        monkeypatch.setattr(kbl_state, "_run", lambda cmd: "rules: evdev")
+        assert XkbBackend().query() == kbl_state.LayoutState("", [])
 
 
 # ---------------------------------------------------------------------------
@@ -641,6 +815,13 @@ class TestCommandHelpers:
         assert current_layout_command("br") == ["gkbd-keyboard-display", "-l", "br"]
         assert current_layout_command("") is None
 
+        monkeypatch.setattr(
+            kbl_state.shutil,
+            "which",
+            lambda cmd: "/usr/bin/tecla" if cmd == "tecla" else None,
+        )
+        assert current_layout_command("") == ["tecla"]
+
     def test_open_commands(self, monkeypatch):
         launched: list[list[str]] = []
         monkeypatch.setattr(
@@ -664,6 +845,50 @@ class TestCommandHelpers:
             ["mate-keyboard-properties"],
             ["gkbd-keyboard-display", "-l", "us"],
         ]
+
+    def test_first_available_and_open_command_failures(self, monkeypatch):
+        monkeypatch.setattr(kbl_state.shutil, "which", lambda cmd: None)
+        assert _first_available_command((("missing",),)) is None
+        assert _open_command(cmd=None, action="missing") is False
+
+        monkeypatch.setattr(
+            kbl_state.subprocess,
+            "Popen",
+            MagicMock(side_effect=OSError("boom")),
+        )
+        assert _open_command(cmd=["missing"], action="missing") is False
+
+    def test_run_helper_success_failure_and_timeout(self, monkeypatch):
+        monkeypatch.setattr(
+            kbl_state.subprocess,
+            "run",
+            lambda *_args, **_kwargs: subprocess.CompletedProcess(
+                args=["cmd"],
+                returncode=0,
+                stdout=" ok \n",
+            ),
+        )
+        assert kbl_state._run(["cmd"]) == "ok"
+
+        monkeypatch.setattr(
+            kbl_state.subprocess,
+            "run",
+            lambda *_args, **_kwargs: subprocess.CompletedProcess(
+                args=["cmd"],
+                returncode=1,
+                stdout="bad",
+            ),
+        )
+        assert kbl_state._run(["cmd"]) is None
+
+        monkeypatch.setattr(
+            kbl_state.subprocess,
+            "run",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                subprocess.TimeoutExpired("cmd", 1)
+            ),
+        )
+        assert kbl_state._run(["cmd"]) is None
 
 
 # ---------------------------------------------------------------------------
@@ -762,10 +987,16 @@ class TestKeyboardLayoutApplet:
         )
         applet = KeyboardLayoutApplet(icon_size=48)
         labels = [item.get_label() for item in applet.get_menu_items()]
-        assert labels[0] == "Keyboard Settings"
-        assert labels[1] == "Show Current Layout"
-        assert any("EN - us" in label for label in labels)
-        assert any("BR - br" in label for label in labels)
+        assert labels[0] == "Show Current Layout"
+        assert labels[-1] == "Keyboard Settings"
+        assert "EN - us" in labels
+        assert "BR - br" in labels
+        active_items = [
+            item
+            for item in applet.get_menu_items()
+            if hasattr(item, "get_active") and item.get_active()
+        ]
+        assert [item.get_label() for item in active_items] == ["EN - us"]
 
     def test_no_layout_detected(self, monkeypatch):
         monkeypatch.setattr(kbl_state, "_run", lambda cmd: None)

--- a/tests/applets/test_live_state.py
+++ b/tests/applets/test_live_state.py
@@ -1,0 +1,72 @@
+import datetime as dt
+
+from docking.applets.live_state import (
+    LiveDataStatus,
+    is_stale,
+    live_freshness_lines,
+    live_state_error,
+    live_state_label,
+    refresh_recovery_label,
+    resolve_live_status,
+    stale_label,
+)
+
+
+def test_resolve_live_status_distinguishes_empty_loading_and_error():
+    assert resolve_live_status(has_data=False) is LiveDataStatus.EMPTY
+    assert resolve_live_status(has_data=False, loading=True) is LiveDataStatus.LOADING
+    assert resolve_live_status(has_data=False, error="down") is LiveDataStatus.ERROR
+
+
+def test_resolve_live_status_keeps_old_data_as_stale_on_error():
+    assert resolve_live_status(has_data=True, error="down") is LiveDataStatus.STALE
+
+
+def test_resolve_live_status_uses_age_when_configured():
+    updated = dt.datetime(2026, 4, 30, 10, 0, tzinfo=dt.timezone.utc)
+    now = dt.datetime(2026, 4, 30, 10, 10, tzinfo=dt.timezone.utc)
+
+    assert is_stale(updated, max_age_seconds=60, now=now)
+    assert (
+        resolve_live_status(
+            has_data=True,
+            updated_at=updated,
+            stale_after_seconds=60,
+            now=now,
+        )
+        is LiveDataStatus.STALE
+    )
+
+
+def test_live_state_label_and_error_detail():
+    assert live_state_label(LiveDataStatus.EMPTY) == "No data yet"
+    assert live_state_label(LiveDataStatus.LOADING) == "Loading..."
+    assert live_state_label(LiveDataStatus.READY) == ""
+    assert live_state_label(LiveDataStatus.STALE) == "Stale data"
+    assert live_state_label(LiveDataStatus.ERROR) == "Unavailable"
+    assert (
+        live_state_error(status=LiveDataStatus.STALE, error="network down")
+        == "network down"
+    )
+    assert live_state_error(status=LiveDataStatus.READY, error="network down") is None
+
+
+def test_live_freshness_uses_stale_label_before_cadence():
+    updated = dt.datetime(2026, 4, 30, 10, 0, tzinfo=dt.timezone.utc)
+
+    lines = live_freshness_lines(
+        status=LiveDataStatus.STALE,
+        updated_at=updated,
+        cadence_seconds=300,
+    )
+
+    assert lines[0].startswith("Stale: last updated")
+    assert lines[1] == "Updates every 5 minutes"
+    assert stale_label(None) == "Stale data"
+
+
+def test_refresh_recovery_label_only_for_non_ready_states():
+    assert (
+        refresh_recovery_label(LiveDataStatus.ERROR) == "Use Refresh Now from the menu."
+    )
+    assert refresh_recovery_label(LiveDataStatus.READY) is None

--- a/tests/applets/test_menu.py
+++ b/tests/applets/test_menu.py
@@ -1,6 +1,11 @@
 """Tests for shared applet menu helpers."""
 
-from docking.applets.menu import radio_menu_items, radio_submenu
+from docking.applets.menu import (
+    disabled_menu_item,
+    menu_sections,
+    radio_menu_items,
+    radio_submenu,
+)
 
 
 def test_radio_menu_items_keep_active_choice_and_ignore_inactive_toggles():
@@ -37,3 +42,35 @@ def test_radio_submenu_builds_exclusive_children():
     assert root.get_label() == "Mode"
     assert [item.get_label() for item in submenu.children] == ["Cost", "Tokens"]
     assert [item.get_active() for item in submenu.children] == [True, False]
+
+
+def test_disabled_menu_item_builds_insensitive_status_row():
+    item = disabled_menu_item("Status")
+
+    assert item.get_label() == "Status"
+    assert item.get_sensitive() is False
+
+
+def test_menu_sections_orders_groups_and_separates_non_empty_sections():
+    items = menu_sections(
+        status=[disabled_menu_item("Status")],
+        primary=[disabled_menu_item("Open")],
+        refresh=[disabled_menu_item("Refresh")],
+        display=[disabled_menu_item("Display")],
+        destructive=[disabled_menu_item("Clear")],
+    )
+
+    labels = [item.get_label() for item in items if item.get_label()]
+    separators = [item for item in items if not item.get_label()]
+
+    assert labels == ["Status", "Open", "Refresh", "Display", "Clear"]
+    assert len(separators) == 4
+
+
+def test_menu_sections_skips_empty_groups_without_edge_separators():
+    items = menu_sections(
+        primary=[disabled_menu_item("Open")],
+        settings=[disabled_menu_item("Settings")],
+    )
+
+    assert [item.get_label() for item in items] == ["Open", "", "Settings"]

--- a/tests/applets/test_micshield.py
+++ b/tests/applets/test_micshield.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import docking.applets.micshield.applet as micshield_applet_mod
@@ -116,6 +118,24 @@ Source Output #7
             MicStream(stream_id=7, command="arecord"),
         )
 
+    def test_parse_source_outputs_fallbacks_and_invalid_pid(self):
+        output = """
+Source Output #8
+    Corked: no
+    Properties:
+        media.name = "Raw capture"
+        application.process.id = "bad"
+Source Output #9
+    Corked: maybe
+    Properties:
+        application.process.id = "9"
+""".strip()
+
+        assert parse_source_outputs(output=output) == (
+            MicStream(stream_id=8, command="Raw capture", name="Raw capture"),
+            MicStream(stream_id=9, command="Unknown", pid=9),
+        )
+
     def test_probe_unavailable_without_pactl(self, monkeypatch):
         monkeypatch.setattr(micshield_state_mod.shutil, "which", lambda _cmd: None)
 
@@ -143,6 +163,53 @@ Source Output #7
         monkeypatch.setattr(micshield_state_mod, "_run", run)
 
         assert probe_mic_state() == _active_state()
+
+    def test_probe_without_mute_states_is_unavailable(self, monkeypatch):
+        monkeypatch.setattr(
+            micshield_state_mod.shutil,
+            "which",
+            lambda _cmd: "/usr/bin/pactl",
+        )
+        monkeypatch.setattr(micshield_state_mod, "input_source_names", lambda: ("mic",))
+        monkeypatch.setattr(
+            micshield_state_mod,
+            "_source_mute_states",
+            lambda **_kwargs: (),
+        )
+
+        assert probe_mic_state() == MicShieldState(False, False, False)
+
+    def test_toggle_returns_false_when_unavailable(self, monkeypatch):
+        monkeypatch.setattr(
+            micshield_state_mod,
+            "probe_mic_state",
+            lambda: MicShieldState(False, False, False),
+        )
+
+        assert toggle_mic_mute() is False
+
+    def test_set_mic_muted_returns_false_without_pactl(self, monkeypatch):
+        monkeypatch.setattr(micshield_state_mod.shutil, "which", lambda _cmd: None)
+
+        assert set_mic_muted(muted=True) is False
+
+    def test_set_mic_muted_uses_default_source_when_sources_missing(self, monkeypatch):
+        seen: list[list[str]] = []
+        monkeypatch.setattr(
+            micshield_state_mod.shutil,
+            "which",
+            lambda _cmd: "/usr/bin/pactl",
+        )
+        monkeypatch.setattr(micshield_state_mod, "input_source_names", lambda: ())
+        monkeypatch.setattr(micshield_state_mod, "active_source_outputs", lambda: ())
+        monkeypatch.setattr(
+            micshield_state_mod,
+            "_run",
+            lambda *, cmd, action: seen.append(cmd) or None,
+        )
+
+        assert set_mic_muted(muted=False) is False
+        assert seen == [["pactl", "set-source-mute", "@DEFAULT_SOURCE@", "0"]]
 
     def test_toggle_mic_mute_calls_pactl(self, monkeypatch):
         seen: list[list[str]] = []
@@ -204,6 +271,61 @@ Source Output #7
         assert "Microphone active" in tooltip
         assert stream_label(_active_state().streams[0]) == "Firefox (PID 1234)"
 
+    def test_tooltip_unavailable_idle_and_more_streams(self):
+        assert "No microphone source found" in build_tooltip(
+            MicShieldState(False, False, False)
+        )
+        assert "Microphone idle" in build_tooltip(MicShieldState(True, True, False))
+        streams = tuple(MicStream(i, f"app{i}") for i in range(8))
+        tooltip = build_tooltip(MicShieldState(True, False, True, streams))
+
+        assert "2 more" in tooltip
+        assert stream_label(MicStream(1, "arecord")) == "arecord"
+
+    def test_source_mute_states_and_command_helpers(self, monkeypatch):
+        outputs = iter(["Mute: yes", "bad", "Mute: no"])
+        monkeypatch.setattr(
+            micshield_state_mod,
+            "_run",
+            lambda **_kwargs: next(outputs),
+        )
+
+        assert micshield_state_mod._source_mute_states(
+            source_names=("mic1", "mic2", "mic3")
+        ) == (True, False)
+
+    def test_run_handles_success_failure_and_exceptions(self, monkeypatch):
+        monkeypatch.setattr(
+            micshield_state_mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                returncode=0,
+                stdout="ok",
+                stderr="",
+            ),
+        )
+        assert micshield_state_mod._run(cmd=["pactl"], action="test") == "ok"
+
+        monkeypatch.setattr(
+            micshield_state_mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="bad",
+            ),
+        )
+        assert micshield_state_mod._run(cmd=["pactl"], action="test") is None
+
+        monkeypatch.setattr(
+            micshield_state_mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                subprocess.TimeoutExpired(["pactl"], timeout=2)
+            ),
+        )
+        assert micshield_state_mod._run(cmd=["pactl"], action="test") is None
+
 
 class TestMicShieldRender:
     def test_renders_states(self):
@@ -247,6 +369,37 @@ class TestMicShieldApplet:
         assert applet._timer_id == 11
         assert applet._pulse_timer_id == 42
 
+    def test_stop_removes_poll_and_pulse_timers(self, monkeypatch):
+        applet = _make_applet(_active_state())
+        applet._timer_id = 11
+        applet._pulse_timer_id = 42
+        removed: list[int] = []
+        monkeypatch.setattr(
+            micshield_applet_mod.GLib,
+            "source_remove",
+            lambda timer_id: removed.append(timer_id),
+        )
+
+        applet.stop()
+
+        assert removed == [11, 42]
+        assert applet._timer_id == 0
+        assert applet._pulse_timer_id == 0
+
+    def test_refresh_once_tick_and_refresh_now_use_worker(self, monkeypatch):
+        applet = _make_applet()
+        applet._refresh_now = MagicMock()
+
+        assert applet._refresh_once() is False
+        assert applet._tick() is True
+        assert applet._refresh_now.call_count == 2
+
+        applet = _make_applet()
+        applet._worker = MagicMock()
+        applet._refresh_now()
+
+        assert applet._worker.run.call_args.kwargs["name"] == "micshield-poll"
+
     def test_on_clicked_toggles_and_refreshes(self, monkeypatch):
         calls: list[str] = []
         monkeypatch.setattr(
@@ -262,6 +415,30 @@ class TestMicShieldApplet:
         assert calls == ["toggle"]
         applet._refresh_now.assert_called_once()
 
+    def test_toggle_and_set_muted_ignore_unavailable_state(self):
+        applet = _make_applet(MicShieldState(False, False, False))
+        applet._worker = MagicMock()
+
+        applet.on_clicked()
+        applet._set_muted(True)
+
+        applet._worker.run.assert_not_called()
+
+    def test_set_muted_runs_worker_and_refreshes(self, monkeypatch):
+        calls: list[bool] = []
+        monkeypatch.setattr(
+            micshield_applet_mod,
+            "set_mic_muted",
+            lambda *, muted: calls.append(muted) or True,
+        )
+        applet = _make_applet(_active_state())
+        applet._refresh_now = MagicMock()
+
+        applet._set_muted(True)
+
+        assert calls == [True]
+        applet._refresh_now.assert_called_once()
+
     def test_probe_result_updates_state(self):
         applet = _make_applet()
 
@@ -269,6 +446,37 @@ class TestMicShieldApplet:
 
         assert applet._state == _active_state()
         assert applet.item.icon is not None
+
+    def test_ensure_pulse_timer_stops_when_idle(self, monkeypatch):
+        applet = _make_applet(MicShieldState(True, False, False))
+        applet._notify = lambda: None
+        applet._pulse_timer_id = 42
+        applet._pulse_phase = 0.5
+        removed: list[int] = []
+        monkeypatch.setattr(
+            micshield_applet_mod.GLib,
+            "source_remove",
+            lambda timer_id: removed.append(timer_id),
+        )
+
+        applet._ensure_pulse_timer()
+
+        assert removed == [42]
+        assert applet._pulse_timer_id == 0
+        assert applet._pulse_phase == 0.0
+
+    def test_menu_labels_for_unavailable_idle_and_muted_states(self):
+        unavailable = _make_applet(MicShieldState(False, False, False))
+        assert "No microphone source found" in [
+            item.get_label() for item in unavailable.get_menu_items()
+        ]
+
+        muted = _make_applet(MicShieldState(True, True, False))
+        labels = [item.get_label() for item in muted.get_menu_items()]
+
+        assert "Microphone muted" in labels
+        assert "Microphone idle" in labels
+        assert "Unmute Microphone" in labels
 
     def test_pulse_tick_advances_phase_and_notifies(self):
         applet = _make_applet(_active_state())

--- a/tests/applets/test_music.py
+++ b/tests/applets/test_music.py
@@ -165,7 +165,7 @@ class TestMusicStateHelpers:
         assert clamp_percent(42) == 42
 
     def test_unavailable_tooltip(self):
-        assert tooltip_text(unavailable_state()) == "Music: No active player"
+        assert tooltip_text(unavailable_state()) == "Music\nNo active player"
 
     def test_detailed_tooltip(self):
         text = tooltip_text(_state())
@@ -242,7 +242,7 @@ class TestMusicStateHelpers:
 
     def test_tooltip_with_title_only(self):
         text = tooltip_text(_state(artist="", album="", title="Only Title"))
-        assert text == "Only Title"
+        assert text == "Music\nOnly Title"
 
 
 class TestMprisBackendInternals:

--- a/tests/applets/test_network.py
+++ b/tests/applets/test_network.py
@@ -29,6 +29,7 @@ from docking.applets.network.state import (
     parse_proc_net_dev,
     signal_to_icon,
 )
+from docking.core.config import Config
 
 SAMPLE_PROC_NET_DEV = """\
 Inter-|   Receive                                                |  Transmit
@@ -261,6 +262,37 @@ class TestNetworkApplet:
         items = applet.get_menu_items()
         assert len(items) >= 1
 
+    def test_loads_speed_overlay_pref(self):
+        applet = NetworkApplet(
+            48,
+            config=Config(applet_prefs={"network": {"speed_overlay": "upload"}}),
+        )
+
+        assert applet._speed_overlay == "upload"
+
+    def test_menu_status_rows_for_wifi_and_ethernet(self, monkeypatch):
+        self._fake_gtk(monkeypatch)
+        applet = NetworkApplet(48)
+        applet._is_connected = True
+        applet._is_wifi = True
+        applet._ssid = "DockNet"
+        applet._signal_strength = 77
+        applet._ip_address = "10.0.0.2"
+        applet._rx_speed = 2048
+        applet._tx_speed = 1024
+
+        labels = [item.get_label() for item in applet.get_menu_items()]
+
+        assert "WiFi: DockNet (77%)" in labels
+        assert "IP: 10.0.0.2" in labels
+        assert any("KB/s" in label for label in labels)
+
+        applet._ssid = ""
+        applet._is_wifi = False
+        applet._iface = "eth0"
+        labels = [item.get_label() for item in applet.get_menu_items()]
+        assert "Ethernet: eth0" in labels
+
     def test_menu_includes_tray_style_actions(self, monkeypatch):
         self._fake_gtk(monkeypatch)
         monkeypatch.setattr(
@@ -371,6 +403,49 @@ class TestNetworkApplet:
         applet._available_networks()
 
         assert wifi_device.request_scan.call_count == 2
+
+    def test_available_networks_handles_empty_and_non_wifi(self, monkeypatch):
+        self._fake_gtk(monkeypatch)
+        monkeypatch.setattr(
+            network_applet_mod.NM,
+            "DeviceType",
+            SimpleNamespace(WIFI=2, ETHERNET=1),
+            raising=False,
+        )
+        applet = NetworkApplet(48)
+        assert applet._available_networks() == []
+
+        ethernet = MagicMock()
+        ethernet.get_device_type.return_value = 1
+        hidden_ap = MagicMock()
+        hidden_ap.get_ssid.return_value = b""
+        wifi = MagicMock()
+        wifi.get_device_type.return_value = 2
+        wifi.get_active_access_point.return_value = None
+        wifi.get_access_points.return_value = [hidden_ap]
+        wifi.request_scan.return_value = False
+        applet._nm_client = MagicMock()
+        applet._nm_client.get_devices.return_value = [ethernet, wifi]
+
+        assert applet._available_networks() == []
+        wifi.request_scan.assert_called_once_with(None)
+
+    def test_request_wifi_scan_handles_glib_error(self, monkeypatch):
+        monkeypatch.setattr(
+            network_applet_mod.GLib,
+            "Error",
+            RuntimeError,
+            raising=False,
+        )
+        monkeypatch.setattr(network_applet_mod.time, "monotonic", lambda: 100.0)
+        device = MagicMock()
+        device.request_scan.side_effect = RuntimeError("scan failed")
+        device.get_iface.return_value = "wlan0"
+        applet = NetworkApplet(48)
+
+        applet._request_wifi_scan(device=device)
+
+        assert applet._last_wifi_scan_request_time == 0.0
 
     def test_menu_includes_vpn_connections_submenu(self, monkeypatch):
         self._fake_gtk(monkeypatch)
@@ -611,6 +686,62 @@ class TestNetworkAppletInternals:
             None,
         )
 
+    def test_connect_available_network_no_client_no_match_and_error(self, monkeypatch):
+        applet = NetworkApplet(48)
+        network = AvailableNetwork("DockNet", 70, "/ap/known", False)
+        applet._connect_available_network(network=network)
+
+        applet._nm_client = MagicMock()
+        monkeypatch.setattr(applet, "_find_wifi_access_point", lambda network: None)
+        applet._connect_available_network(network=network)
+        applet._nm_client.activate_connection_async.assert_not_called()
+
+        monkeypatch.setattr(
+            network_applet_mod.GLib,
+            "Error",
+            RuntimeError,
+            raising=False,
+        )
+        device = MagicMock()
+        access_point = MagicMock()
+        access_point.get_path.return_value = "/ap/known"
+        monkeypatch.setattr(
+            applet,
+            "_find_wifi_access_point",
+            lambda network: (device, access_point),
+        )
+        monkeypatch.setattr(applet, "_find_saved_wifi_connection", lambda ssid: None)
+        applet._nm_client.add_and_activate_connection_async.side_effect = RuntimeError(
+            "boom"
+        )
+        applet._connect_available_network(network=network)
+
+    def test_toggle_vpn_connection_no_client_and_error(self, monkeypatch):
+        applet = NetworkApplet(48)
+        connection = MagicMock()
+        applet._toggle_vpn_connection(
+            connection=connection,
+            is_active=False,
+            active_connection=None,
+        )
+
+        monkeypatch.setattr(
+            network_applet_mod.GLib,
+            "Error",
+            RuntimeError,
+            raising=False,
+        )
+        applet._nm_client = MagicMock()
+        applet._nm_client.activate_connection_async.side_effect = RuntimeError("boom")
+        connection.get_id.return_value = ""
+        connection.get_uuid.return_value = "vpn-1"
+
+        applet._toggle_vpn_connection(
+            connection=connection,
+            is_active=False,
+            active_connection=None,
+        )
+
     def test_set_networking_enabled_updates_client_and_refreshes(self, monkeypatch):
         applet = NetworkApplet(48)
         applet._nm_client = MagicMock()
@@ -625,6 +756,28 @@ class TestNetworkAppletInternals:
         update.assert_called_once()
         refresh.assert_called_once()
 
+    def test_set_networking_enabled_no_client_and_error(self, monkeypatch):
+        applet = NetworkApplet(48)
+        applet._set_networking_enabled(enabled=True)
+
+        monkeypatch.setattr(
+            network_applet_mod.GLib,
+            "Error",
+            RuntimeError,
+            raising=False,
+        )
+        applet._nm_client = MagicMock()
+        applet._nm_client.networking_set_enabled.side_effect = RuntimeError("boom")
+        update = MagicMock()
+        present = MagicMock()
+        monkeypatch.setattr(applet, "_update_nm_state", update)
+        monkeypatch.setattr(applet, "present", present)
+
+        applet._set_networking_enabled(enabled=True)
+
+        update.assert_not_called()
+        present.assert_not_called()
+
     def test_set_wireless_enabled_updates_client_and_refreshes(self, monkeypatch):
         applet = NetworkApplet(48)
         applet._nm_client = MagicMock()
@@ -638,6 +791,28 @@ class TestNetworkAppletInternals:
         applet._nm_client.wireless_set_enabled.assert_called_once_with(False)
         update.assert_called_once()
         refresh.assert_called_once()
+
+    def test_set_wireless_enabled_no_client_and_error(self, monkeypatch):
+        applet = NetworkApplet(48)
+        applet._set_wireless_enabled(enabled=True)
+
+        monkeypatch.setattr(
+            network_applet_mod.GLib,
+            "Error",
+            RuntimeError,
+            raising=False,
+        )
+        applet._nm_client = MagicMock()
+        applet._nm_client.wireless_set_enabled.side_effect = RuntimeError("boom")
+        update = MagicMock()
+        present = MagicMock()
+        monkeypatch.setattr(applet, "_update_nm_state", update)
+        monkeypatch.setattr(applet, "present", present)
+
+        applet._set_wireless_enabled(enabled=True)
+
+        update.assert_not_called()
+        present.assert_not_called()
 
     def test_start_connects_nm_and_timer(self, monkeypatch):
         # Given
@@ -917,7 +1092,11 @@ class TestNetworkAppletInternals:
         # Given
         applet = NetworkApplet(48)
         applet._iface = "eth0"
-        monkeypatch.setattr("builtins.open", MagicMock(side_effect=OSError("boom")))
+        monkeypatch.setattr(
+            type(network_applet_mod._PROC_NET_DEV),
+            "open",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("boom")),
+        )
         # When / Then
         applet._update_traffic()
 
@@ -980,6 +1159,59 @@ class TestNetworkAppletInternals:
         applet._update_wifi_signal()
         # Then
         assert applet._signal_strength == 81
+
+    def test_update_wifi_signal_ignores_unavailable_states(self, monkeypatch):
+        applet = NetworkApplet(48)
+        applet._update_wifi_signal()
+
+        applet._nm_client = MagicMock()
+        applet._is_wifi = False
+        applet._update_wifi_signal()
+
+        applet._is_wifi = True
+        monkeypatch.setattr(
+            network_applet_mod.NM,
+            "ActiveConnectionState",
+            SimpleNamespace(ACTIVATED=9),
+            raising=False,
+        )
+        conn = MagicMock()
+        conn.get_state.return_value = 0
+        applet._nm_client.get_active_connections.return_value = [conn]
+
+        applet._update_wifi_signal()
+
+        assert applet._signal_strength == 0
+
+    def test_update_wifi_signal_handles_wifi_without_ap(self, monkeypatch):
+        applet = NetworkApplet(48)
+        applet._nm_client = MagicMock()
+        applet._is_wifi = True
+        monkeypatch.setattr(
+            network_applet_mod.NM,
+            "ActiveConnectionState",
+            SimpleNamespace(ACTIVATED=9),
+            raising=False,
+        )
+
+        class FakeWifiDevice:
+            def get_active_access_point(self):
+                return None
+
+        monkeypatch.setattr(
+            network_applet_mod.NM,
+            "DeviceWifi",
+            FakeWifiDevice,
+            raising=False,
+        )
+        conn = MagicMock()
+        conn.get_state.return_value = 9
+        conn.get_devices.return_value = [FakeWifiDevice()]
+        applet._nm_client.get_active_connections.return_value = [conn]
+
+        applet._update_wifi_signal()
+
+        assert applet._signal_strength == 0
 
     def test_update_wifi_signal_skips_non_wifi_active_connection_first(
         self, monkeypatch
@@ -1061,7 +1293,7 @@ class TestNetworkAppletInternals:
         # Given
         applet = NetworkApplet(48)
         # When / Then
-        assert applet._build_tooltip() == "Network: Not connected"
+        assert applet._build_tooltip() == "Network\nNot connected"
 
         # Given
         applet._is_connected = True
@@ -1073,9 +1305,135 @@ class TestNetworkAppletInternals:
         # When
         tooltip = applet._build_tooltip()
         # Then
+        assert tooltip.splitlines()[0] == "Network"
         assert "Ethernet: eth0" in tooltip
         assert "IP: 10.0.0.2" in tooltip
         assert "\u2193" in tooltip and "\u2191" in tooltip
+
+    def test_find_wifi_access_point(self, monkeypatch):
+        monkeypatch.setattr(
+            network_applet_mod.NM,
+            "DeviceType",
+            SimpleNamespace(WIFI=2, ETHERNET=1),
+            raising=False,
+        )
+        applet = NetworkApplet(48)
+        network = AvailableNetwork("DockNet", 70, "/ap/known", False)
+
+        assert applet._find_wifi_access_point(network=network) is None
+
+        ethernet = MagicMock()
+        ethernet.get_device_type.return_value = 1
+        access_point = MagicMock()
+        access_point.get_path.return_value = "/ap/known"
+        wifi = MagicMock()
+        wifi.get_device_type.return_value = 2
+        wifi.get_access_points.return_value = [access_point]
+        applet._nm_client = MagicMock()
+        applet._nm_client.get_devices.return_value = [ethernet, wifi]
+
+        assert applet._find_wifi_access_point(network=network) == (wifi, access_point)
+        assert (
+            applet._find_wifi_access_point(
+                network=AvailableNetwork("Other", 20, "/ap/missing", False)
+            )
+            is None
+        )
+
+    def test_find_saved_wifi_connection(self):
+        applet = NetworkApplet(48)
+        assert applet._find_saved_wifi_connection(ssid="DockNet") is None
+
+        no_wifi = MagicMock()
+        no_wifi.get_setting_wireless.return_value = None
+        setting = MagicMock()
+        setting.get_ssid.return_value = b"DockNet"
+        match = MagicMock()
+        match.get_setting_wireless.return_value = setting
+        applet._nm_client = MagicMock()
+        applet._nm_client.get_connections.return_value = [no_wifi, match]
+
+        assert applet._find_saved_wifi_connection(ssid="DockNet") is match
+        assert applet._find_saved_wifi_connection(ssid="Other") is None
+
+    def test_vpn_connections_filters_and_sorts_active_first(self):
+        applet = NetworkApplet(48)
+        assert applet._vpn_connections() == []
+
+        plain = MagicMock()
+        plain.get_setting_vpn.return_value = None
+        inactive = MagicMock()
+        inactive.get_setting_vpn.return_value = object()
+        inactive.get_uuid.return_value = "vpn-2"
+        inactive.get_id.return_value = "Zeta"
+        active = MagicMock()
+        active.get_setting_vpn.return_value = object()
+        active.get_uuid.return_value = "vpn-1"
+        active.get_id.return_value = "Alpha"
+        active_connection = MagicMock()
+        active_connection.get_uuid.return_value = "vpn-1"
+        active_connection.get_vpn.return_value = True
+        applet._nm_client = MagicMock()
+        applet._nm_client.get_connections.return_value = [plain, inactive, active]
+        applet._nm_client.get_active_connections.return_value = [active_connection]
+
+        assert applet._vpn_connections() == [
+            (active, True, active_connection),
+            (inactive, False, None),
+        ]
+
+    def test_finish_callbacks_handle_success_and_errors(self, monkeypatch):
+        monkeypatch.setattr(
+            network_applet_mod.GLib,
+            "Error",
+            RuntimeError,
+            raising=False,
+        )
+        applet = NetworkApplet(48)
+        client = MagicMock()
+        applet._on_activate_connection_finished(client, "result", None)
+        client.activate_connection_finish.assert_called_once_with("result")
+        client.activate_connection_finish.side_effect = RuntimeError("boom")
+        applet._on_activate_connection_finished(client, "result", None)
+
+        client = MagicMock()
+        applet._on_add_and_activate_connection_finished(client, "result", None)
+        client.add_and_activate_connection_finish.assert_called_once_with("result")
+        client.add_and_activate_connection_finish.side_effect = RuntimeError("boom")
+        applet._on_add_and_activate_connection_finished(client, "result", None)
+
+        client = MagicMock()
+        applet._on_deactivate_connection_finished(client, "result", None)
+        client.deactivate_connection_finish.assert_called_once_with("result")
+        client.deactivate_connection_finish.side_effect = RuntimeError("boom")
+        applet._on_deactivate_connection_finished(client, "result", None)
+
+    def test_has_wifi_device_and_device_priority(self, monkeypatch):
+        monkeypatch.setattr(
+            network_applet_mod.NM,
+            "DeviceType",
+            SimpleNamespace(WIFI=2, ETHERNET=1, TUN=3, BRIDGE=4, LOOPBACK=5),
+            raising=False,
+        )
+        applet = NetworkApplet(48)
+        assert applet._has_wifi_device() is False
+
+        wifi = MagicMock()
+        wifi.get_device_type.return_value = 2
+        eth = MagicMock()
+        eth.get_device_type.return_value = 1
+        other = MagicMock()
+        other.get_device_type.return_value = 99
+        tun = MagicMock()
+        tun.get_device_type.return_value = 3
+        applet._nm_client = MagicMock()
+        applet._nm_client.get_devices.return_value = [eth, wifi]
+
+        assert applet._has_wifi_device() is True
+        assert NetworkApplet._device_priority(device=wifi) == 2
+        assert NetworkApplet._device_priority(device=eth) == 1
+        assert NetworkApplet._device_priority(device=other) == 0
+        assert NetworkApplet._device_priority(device=tun) == -1
 
 
 class TestNetworkRender:

--- a/tests/applets/test_popup.py
+++ b/tests/applets/test_popup.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import docking.applets.popup as popup
+from docking.ui.display import ScreenPosition
 
 
 class _FakeCssProvider:
@@ -35,6 +36,175 @@ class _FakeFrame:
 
     def add(self, child) -> None:
         self.child = child
+
+
+class _FakePopupWindow:
+    def __init__(self) -> None:
+        self.child = "old"
+        self.removed = None
+        self.added = None
+        self.shown = False
+        self.moved_to = None
+        self.decorated = None
+        self.skip_taskbar = None
+        self.resizable = None
+        self.type_hint = None
+
+    def set_decorated(self, value: bool) -> None:
+        self.decorated = value
+
+    def set_skip_taskbar_hint(self, value: bool) -> None:
+        self.skip_taskbar = value
+
+    def set_resizable(self, value: bool) -> None:
+        self.resizable = value
+
+    def set_type_hint(self, hint) -> None:
+        self.type_hint = hint
+
+    def get_child(self):
+        return self.child
+
+    def remove(self, child) -> None:
+        self.removed = child
+        self.child = None
+
+    def add(self, child) -> None:
+        self.added = child
+        self.child = child
+
+    def show_all(self) -> None:
+        self.shown = True
+
+    def get_preferred_size(self):
+        size = type("Size", (), {"width": 80, "height": 40})()
+        return None, size
+
+    def get_screen(self):
+        return type(
+            "Screen",
+            (),
+            {"get_width": lambda _self: 100, "get_height": lambda _self: 80},
+        )()
+
+    def move(self, x: int, y: int) -> None:
+        self.moved_to = (x, y)
+
+
+class _FakeDialogBox:
+    def __init__(self) -> None:
+        self.spacing = None
+        self.margins: list[tuple[str, int]] = []
+
+    def set_spacing(self, value: int) -> None:
+        self.spacing = value
+
+    def set_margin_start(self, value: int) -> None:
+        self.margins.append(("start", value))
+
+    def set_margin_end(self, value: int) -> None:
+        self.margins.append(("end", value))
+
+    def set_margin_top(self, value: int) -> None:
+        self.margins.append(("top", value))
+
+    def set_margin_bottom(self, value: int) -> None:
+        self.margins.append(("bottom", value))
+
+
+class _FakeDialog:
+    def __init__(self) -> None:
+        self.box = _FakeDialogBox()
+        self.size = None
+        self.position = None
+        self.resizable = None
+        self.default_response = None
+        self.buttons: list[object] = []
+
+    def set_default_size(self, width: int, height: int) -> None:
+        self.size = (width, height)
+
+    def set_position(self, position) -> None:
+        self.position = position
+
+    def set_resizable(self, value: bool) -> None:
+        self.resizable = value
+
+    def set_default_response(self, response) -> None:
+        self.default_response = response
+
+    def get_content_area(self):
+        return self.box
+
+    def add_buttons(self, *args) -> None:
+        self.buttons.extend(args)
+
+
+class _FakeCaptureScreen:
+    def get_rgba_visual(self):
+        return "rgba"
+
+    def get_width(self) -> int:
+        return 800
+
+    def get_height(self) -> int:
+        return 600
+
+
+class _FakeCaptureGdkWindow:
+    def __init__(self) -> None:
+        self.cursor = None
+
+    def set_cursor(self, cursor) -> None:
+        self.cursor = cursor
+
+
+class _FakeCaptureOverlay:
+    def __init__(self, **_kwargs) -> None:
+        self.screen = _FakeCaptureScreen()
+        self.gdk_window = _FakeCaptureGdkWindow()
+        self.decorated = None
+        self.paintable = None
+        self.visual = None
+        self.size = None
+        self.moved_to = None
+        self.connections: list[str] = []
+        self.events = None
+        self.shown = False
+        self.destroyed = False
+
+    def set_decorated(self, value: bool) -> None:
+        self.decorated = value
+
+    def set_app_paintable(self, value: bool) -> None:
+        self.paintable = value
+
+    def get_screen(self):
+        return self.screen
+
+    def set_visual(self, visual) -> None:
+        self.visual = visual
+
+    def set_default_size(self, width: int, height: int) -> None:
+        self.size = (width, height)
+
+    def move(self, x: int, y: int) -> None:
+        self.moved_to = (x, y)
+
+    def connect(self, signal: str, _handler) -> None:
+        self.connections.append(signal)
+
+    def set_events(self, events) -> None:
+        self.events = events
+
+    def show_all(self) -> None:
+        self.shown = True
+
+    def get_window(self):
+        return self.gdk_window
+
+    def destroy(self) -> None:
+        self.destroyed = True
 
 
 def test_ensure_popup_css_returns_without_screen(monkeypatch):
@@ -84,3 +254,137 @@ def test_wrap_popup_applies_theme_class_and_adds_child(monkeypatch):
     assert frame.style_context.classes == [popup._POPUP_CLASS]
     assert frame.child is content
     ensure_popup_css.assert_called_once_with()
+
+
+def test_create_popup_window_configures_transient_surface(monkeypatch):
+    window = _FakePopupWindow()
+    monkeypatch.setattr(popup.Gtk, "Window", lambda **_kwargs: window)
+
+    created = popup.create_popup_window()
+
+    assert created is window
+    assert window.decorated is False
+    assert window.skip_taskbar is True
+    assert window.resizable is False
+    assert window.type_hint == popup.Gdk.WindowTypeHint.TOOLTIP
+
+
+def test_show_wrapped_popup_replaces_content_and_positions(monkeypatch):
+    window = _FakePopupWindow()
+    wrapped = object()
+    position = MagicMock()
+    monkeypatch.setattr(popup, "wrap_popup", lambda _content: wrapped)
+    monkeypatch.setattr(popup, "position_popup_near_pointer", position)
+
+    popup.show_wrapped_popup(window=window, content="content", gap_px=24)
+
+    assert window.removed == "old"
+    assert window.added is wrapped
+    assert window.shown is True
+    position.assert_called_once_with(window=window, gap_px=24)
+
+
+def test_position_popup_near_pointer_clamps_to_screen(monkeypatch):
+    window = _FakePopupWindow()
+    monkeypatch.setattr(popup.Gdk.Display, "get_default", lambda: object())
+    monkeypatch.setattr(
+        popup,
+        "get_pointer_position",
+        lambda _display: ScreenPosition(x=20, y=15),
+    )
+
+    popup.position_popup_near_pointer(window=window, gap_px=20)
+
+    assert window.moved_to == (0, 0)
+
+
+def test_prepare_dialog_content_applies_standard_layout():
+    dialog = _FakeDialog()
+
+    box = popup.prepare_dialog_content(
+        dialog=dialog,
+        width=320,
+        height=120,
+        spacing=9,
+        margin=14,
+        default_response=popup.Gtk.ResponseType.OK,
+        resizable=False,
+    )
+
+    assert box is dialog.box
+    assert dialog.size == (320, 120)
+    assert dialog.position == popup.Gtk.WindowPosition.MOUSE
+    assert dialog.resizable is False
+    assert dialog.default_response == popup.Gtk.ResponseType.OK
+    assert dialog.box.spacing == 9
+    assert dialog.box.margins == [
+        ("start", 14),
+        ("end", 14),
+        ("top", 14),
+        ("bottom", 14),
+    ]
+
+
+def test_add_cancel_ok_buttons_uses_cancel_then_ok_order():
+    dialog = _FakeDialog()
+
+    popup.add_cancel_ok_buttons(dialog=dialog)
+
+    assert dialog.buttons == [
+        popup.Gtk.STOCK_CANCEL,
+        popup.Gtk.ResponseType.CANCEL,
+        popup.Gtk.STOCK_OK,
+        popup.Gtk.ResponseType.OK,
+    ]
+
+
+def test_draw_transparent_capture_overlay():
+    cr = MagicMock()
+
+    assert popup.draw_transparent_capture_overlay(MagicMock(), cr) is True
+    cr.set_source_rgba.assert_called_once_with(0, 0, 0, 0.01)
+    cr.paint.assert_called_once_with()
+
+
+def test_create_capture_overlay_configures_fullscreen_grab(monkeypatch):
+    overlay = _FakeCaptureOverlay()
+    seat = MagicMock()
+    display = MagicMock()
+    display.get_default_seat.return_value = seat
+    monkeypatch.setattr(popup.Gtk, "Window", lambda **_kwargs: overlay)
+    monkeypatch.setattr(popup.Gdk.Display, "get_default", lambda: display)
+    monkeypatch.setattr(popup.Gdk.Cursor, "new_for_display", lambda *_args: "cursor")
+
+    created = popup.create_capture_overlay(
+        draw_handler=MagicMock(),
+        click_handler=MagicMock(),
+        key_handler=MagicMock(),
+        cursor_type=popup.Gdk.CursorType.CROSSHAIR,
+    )
+
+    assert created is overlay
+    assert overlay.decorated is False
+    assert overlay.paintable is True
+    assert overlay.visual == "rgba"
+    assert overlay.size == (800, 600)
+    assert overlay.moved_to == (0, 0)
+    assert overlay.connections == [
+        "draw",
+        "button-press-event",
+        "key-press-event",
+    ]
+    assert overlay.gdk_window.cursor == "cursor"
+    seat.grab.assert_called_once()
+
+
+def test_dismiss_capture_overlay_ungrabs_and_destroys(monkeypatch):
+    overlay = _FakeCaptureOverlay()
+    seat = MagicMock()
+    display = MagicMock()
+    display.get_default_seat.return_value = seat
+    monkeypatch.setattr(popup.Gdk.Display, "get_default", lambda: display)
+
+    popup.dismiss_capture_overlay(overlay)
+
+    seat.ungrab.assert_called_once_with()
+    assert overlay.destroyed is True

--- a/tests/applets/test_quicknote.py
+++ b/tests/applets/test_quicknote.py
@@ -138,7 +138,7 @@ class TestApplet:
 
         applet = QuickNoteApplet(48)
         items = applet.get_menu_items()
-        assert len(items) == 2
+        assert [item.get_label() for item in items] == ["Edit Note", "", "Clear Note"]
 
     def test_on_clicked_opens_edit_dialog(self, monkeypatch):
         from docking.applets.quicknote.applet import QuickNoteApplet
@@ -174,7 +174,7 @@ class TestApplet:
 
         items = applet.get_menu_items()
         items[0].emit("activate")
-        items[1].emit("activate")
+        items[2].emit("activate")
 
         show.assert_called_once_with()
         clear.assert_called_once_with()
@@ -250,6 +250,9 @@ class TestApplet:
             def set_position(self, *_args):
                 return
 
+            def set_default_response(self, *_args):
+                return
+
             def add_button(self, *_args):
                 return
 
@@ -279,10 +282,17 @@ class TestApplet:
 
         applet._show_edit_dialog()
         text_view = created["text_view"]
+        text_view.get_buffer().set_text("cancelled")
+        dialog.response_cb(dialog, quicknote_applet_mod.Gtk.ResponseType.CANCEL)
+        assert applet._note == "old"
+        config.save.assert_not_called()
+
+        applet._show_edit_dialog()
+        text_view = created["text_view"]
         text_view.get_buffer().set_text("updated note")
         dialog.response_cb(dialog, quicknote_applet_mod.Gtk.ResponseType.OK)
 
         assert applet._note == "updated note"
         assert config.applet_prefs[applet.id]["note"] == "updated note"
         config.save.assert_called_once_with()
-        assert destroyed == [True]
+        assert destroyed == [True, True]

--- a/tests/applets/test_screenshot.py
+++ b/tests/applets/test_screenshot.py
@@ -1,6 +1,7 @@
 """Tests for the screenshot applet."""
 
-from unittest.mock import patch
+import subprocess
+from unittest.mock import MagicMock, patch
 
 import docking.applets.screenshot.state as screenshot_state
 from docking.applets.screenshot.applet import ScreenshotApplet
@@ -62,6 +63,60 @@ class TestDetectTool:
             patch("docking.applets.screenshot.state.shutil.which", return_value=None),
         ):
             assert _detect_tool() is None
+
+    def test_falls_back_to_portal_when_cli_tools_missing(self):
+        with (
+            patch.object(screenshot_state, "is_wayland_session", return_value=False),
+            patch.object(screenshot_state, "_portal_available", side_effect=[True]),
+            patch("docking.applets.screenshot.state.shutil.which", return_value=None),
+        ):
+            assert _detect_tool() == screenshot_state._PORTAL_TOOL
+
+
+class TestPortal:
+    def test_portal_available_requires_gdbus_and_ping(self):
+        with patch("docking.applets.screenshot.state.shutil.which", return_value=None):
+            assert screenshot_state._portal_available() is False
+
+        with (
+            patch(
+                "docking.applets.screenshot.state.shutil.which", return_value="gdbus"
+            ),
+            patch(
+                "docking.applets.screenshot.state.subprocess.run",
+                return_value=subprocess.CompletedProcess(args=["gdbus"], returncode=0),
+            ),
+        ):
+            assert screenshot_state._portal_available() is True
+
+        with (
+            patch(
+                "docking.applets.screenshot.state.shutil.which", return_value="gdbus"
+            ),
+            patch(
+                "docking.applets.screenshot.state.subprocess.run",
+                return_value=subprocess.CompletedProcess(args=["gdbus"], returncode=1),
+            ),
+        ):
+            assert screenshot_state._portal_available() is False
+
+        with (
+            patch(
+                "docking.applets.screenshot.state.shutil.which", return_value="gdbus"
+            ),
+            patch(
+                "docking.applets.screenshot.state.subprocess.run",
+                MagicMock(side_effect=subprocess.TimeoutExpired("gdbus", 1)),
+            ),
+        ):
+            assert screenshot_state._portal_available() is False
+
+    def test_portal_args_full_and_interactive(self):
+        full = screenshot_state._portal_args(mode="full")
+        region = screenshot_state._portal_args(mode="region")
+
+        assert "interactive': <false>" in full[-1]
+        assert "interactive': <true>" in region[-1]
 
 
 class TestRun:
@@ -178,6 +233,53 @@ class TestRun:
         cmd = p.call_args[0][0]
         assert cmd[0:4] == ["scrot", "-s", "-d", "7"]
         assert cmd[-1].endswith(".png")
+
+    def test_delay_args_for_other_tools_and_zero(self):
+        assert screenshot_state._delay_args(tool=_MATE, delay_seconds=0) == []
+        assert screenshot_state._delay_args(tool=_XFCE, delay_seconds=3) == ["-d", "3"]
+        assert screenshot_state._delay_args(tool=_SPECTACLE, delay_seconds=3) == [
+            "--delay",
+            "3",
+        ]
+        assert (
+            screenshot_state._delay_args(
+                tool=Tool("custom", [], [], []),
+                delay_seconds=3,
+            )
+            == []
+        )
+
+    def test_portal_run_and_delayed_launch(self, monkeypatch):
+        launched: list[list[str]] = []
+        monkeypatch.setattr(
+            screenshot_state.subprocess,
+            "Popen",
+            lambda cmd, start_new_session=True: launched.append(list(cmd)),
+        )
+
+        cmd = _run(tool=screenshot_state._PORTAL_TOOL, mode="window")
+
+        assert cmd[:2] == ["gdbus", "call"]
+        assert launched == [cmd]
+
+        timers = []
+
+        class _Timer:
+            def __init__(self, delay, fn, args, kwargs):
+                self.delay = delay
+                self.fn = fn
+                self.args = args
+                self.kwargs = kwargs
+                self.daemon = False
+
+            def start(self):
+                timers.append(self)
+
+        monkeypatch.setattr(screenshot_state.threading, "Timer", _Timer)
+        screenshot_state._launch(cmd=["tool"], delay_seconds=2)
+
+        assert timers[0].delay == 2
+        assert timers[0].daemon is True
 
 
 class TestScreenshotApplet:

--- a/tests/applets/test_separator.py
+++ b/tests/applets/test_separator.py
@@ -210,3 +210,66 @@ class TestSeparatorApplet:
         applet.apply_prefs()
 
         assert applet._style == STYLE_SPACE
+
+    def test_prefs_key_load_and_save_use_instance_id(self):
+        class _Config:
+            def __init__(self) -> None:
+                self.applet_prefs = {"separator#2": {"gap": 20}}
+                self.saved = 0
+
+            def save(self) -> None:
+                self.saved += 1
+
+        config = _Config()
+        applet = SeparatorApplet(48, config=config)
+        applet.item.desktop_id = "applet://separator#2"
+
+        assert applet._prefs_key() == "separator#2"
+        assert applet.load_instance_prefs() == {"gap": 20}
+
+        applet.save_instance_prefs({"gap": 30})
+
+        assert config.applet_prefs["separator#2"] == {"gap": 30}
+        assert config.saved == 1
+
+    def test_set_style_and_invert_ignore_same_value(self):
+        applet = SeparatorApplet(48)
+        applet._save_current_prefs = lambda: (_ for _ in ()).throw(
+            AssertionError("no save")
+        )
+
+        applet._set_style(STYLE_SPACE)
+        applet._set_invert_color(False)
+
+    def test_set_style_and_invert_save_changed_values(self):
+        applet = SeparatorApplet(48)
+        saved: list[str] = []
+        applet._save_current_prefs = lambda: saved.append("save")
+        applet.present = lambda: saved.append("present")
+
+        applet._set_style(STYLE_LINE)
+        applet._set_invert_color(True)
+
+        assert applet._style == STYLE_LINE
+        assert applet._invert_color is True
+        assert saved == ["save", "present", "save", "present"]
+
+    def test_menu_callbacks_update_gap_style_and_invert(self, monkeypatch):
+        self._fake_gtk(monkeypatch)
+        applet = SeparatorApplet(48)
+        applet._save_current_prefs = lambda: None
+        items = applet.get_menu_items()
+
+        items[0]._signals["activate"][0](None)
+        assert applet._gap == DEFAULT_SIZE + STEP
+
+        style_item = next(item for item in items if item.get_label() == "Style")
+        line_item = style_item.get_submenu().get_children()[0]
+        line_item.set_active(True)
+        line_item._signals["toggled"][0](line_item)
+        assert applet._style == STYLE_LINE
+
+        invert = next(item for item in items if item.get_label() == "Invert Color")
+        invert.set_active(True)
+        invert._signals["toggled"][0](invert)
+        assert applet._invert_color is True

--- a/tests/applets/test_session.py
+++ b/tests/applets/test_session.py
@@ -25,7 +25,14 @@ class TestSessionApplet:
         applet = SessionApplet(48)
         items = applet.get_menu_items()
         labels = [mi.get_label() for mi in items]
-        assert labels == [label for label, _cmd in _ACTIONS]
+        assert labels == [
+            "Lock Screen",
+            "Suspend",
+            "",
+            "Log Out",
+            "Restart",
+            "Shut Down",
+        ]
 
     def test_actions_list_has_expected_entries(self):
         labels = [label for label, _cmd in _ACTIONS]
@@ -131,3 +138,58 @@ class TestSessionState:
 
         assert lock_screen() is True
         assert seen == [["mate-screensaver-command", "-l"]]
+
+    def test_lock_screen_returns_false_when_commands_missing_or_fail(self, monkeypatch):
+        monkeypatch.delenv("XDG_SESSION_ID", raising=False)
+        monkeypatch.setattr(session_state_mod.shutil, "which", lambda _cmd: None)
+
+        assert lock_screen() is False
+
+        monkeypatch.setattr(session_state_mod.shutil, "which", lambda _cmd: "/bin/x")
+
+        def fail_run(cmd, capture_output, text, timeout, check):
+            _ = (cmd, capture_output, text, timeout, check)
+            return SimpleNamespace(returncode=1, stderr="no")
+
+        monkeypatch.setattr(session_state_mod.subprocess, "run", fail_run)
+        assert lock_screen() is False
+
+    def test_lock_screen_continues_after_oserror(self, monkeypatch):
+        monkeypatch.delenv("XDG_SESSION_ID", raising=False)
+        monkeypatch.setattr(
+            session_state_mod.shutil,
+            "which",
+            lambda cmd: (
+                f"/usr/bin/{cmd}" if cmd in {"loginctl", "xdg-screensaver"} else None
+            ),
+        )
+        seen: list[list[str]] = []
+
+        def fake_run(cmd, capture_output, text, timeout, check):
+            _ = (capture_output, text, timeout, check)
+            seen.append(list(cmd))
+            if cmd[0] == "xdg-screensaver":
+                raise OSError("missing display")
+            return SimpleNamespace(returncode=0, stderr="")
+
+        monkeypatch.setattr(session_state_mod.subprocess, "run", fake_run)
+
+        assert lock_screen() is True
+        assert seen == [["xdg-screensaver", "lock"], ["loginctl", "lock-session"]]
+
+    def test_run_logs_popen_failure(self, monkeypatch):
+        launched: list[list[str]] = []
+        monkeypatch.setattr(
+            session_state_mod.subprocess,
+            "Popen",
+            lambda cmd, start_new_session=True: launched.append(list(cmd)),
+        )
+        session_state_mod._run(cmd=["systemctl", "suspend"], action="suspend")
+        assert launched == [["systemctl", "suspend"]]
+
+        monkeypatch.setattr(
+            session_state_mod.subprocess,
+            "Popen",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("boom")),
+        )
+        session_state_mod._run(cmd=["systemctl", "suspend"], action="suspend")

--- a/tests/applets/test_speedtest.py
+++ b/tests/applets/test_speedtest.py
@@ -5,12 +5,28 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+import pytest
+
+import docking.applets.speedtest.librespeed as librespeed
 from docking.applets.speedtest.api import SpeedtestError, run_librespeed
 from docking.applets.speedtest.applet import SpeedtestApplet
 from docking.applets.speedtest.librespeed import (
     LibrespeedError,
     Server,
+    _Counter,
+    _download_worker,
+    _http_get_drain,
+    _http_get_text,
+    _open_connection,
+    _run_test,
+    _upload_worker,
+    fetch_server_list,
     parse_server_list,
+    ping_jitter,
+    run_download,
+    run_speedtest,
+    run_upload,
+    select_fastest,
 )
 from docking.applets.speedtest.state import (
     SpeedtestPrefs,
@@ -133,6 +149,370 @@ class TestParseServerList:
         assert len(servers) == 1
         assert servers[0].name == "ok"
 
+    def test_rejects_non_list_shape(self):
+        with pytest.raises(LibrespeedError, match="unexpected"):
+            parse_server_list(text='{"not": "a list"}')
+
+    def test_skips_bad_id(self):
+        raw = """[
+            {"id": "bad", "name": "broken", "server": "//bad.test"},
+            {"id": 2, "name": "ok", "server": "//ok.test"}
+        ]"""
+
+        servers = parse_server_list(text=raw)
+
+        assert [server.name for server in servers] == ["ok"]
+
+
+class TestLibrespeedNetworkHelpers:
+    def test_fetch_server_list_primary_success(self, monkeypatch):
+        monkeypatch.setattr(
+            librespeed,
+            "_http_get_text",
+            lambda **_kwargs: '[{"id": 1, "name": "A", "server": "//a.test"}]',
+        )
+
+        servers = fetch_server_list(url="https://servers.test", timeout=1.0)
+
+        assert servers[0].name == "A"
+
+    def test_fetch_server_list_uses_well_known_fallback(self, monkeypatch):
+        calls: list[str] = []
+
+        def fake_get_text(*, url, timeout):
+            calls.append(url)
+            if len(calls) == 1:
+                raise OSError("down")
+            return '[{"id": 1, "name": "Fallback", "server": "//b.test"}]'
+
+        monkeypatch.setattr(librespeed, "_http_get_text", fake_get_text)
+
+        servers = fetch_server_list(url="https://servers.test", timeout=1.0)
+
+        assert calls == [
+            "https://servers.test",
+            "https://servers.test/.well-known/librespeed",
+        ]
+        assert servers[0].name == "Fallback"
+
+    def test_http_get_text_and_drain_use_user_agent(self, monkeypatch):
+        seen = []
+
+        class _Response:
+            def __init__(self, payload: bytes) -> None:
+                self.payload = payload
+                self.read_args = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return None
+
+            def read(self, *args):
+                self.read_args.append(args)
+                return self.payload
+
+        response = _Response(b"hello")
+
+        def fake_urlopen(req, timeout):
+            seen.append((req.full_url, req.headers["User-agent"], timeout))
+            return response
+
+        monkeypatch.setattr(librespeed.urllib.request, "urlopen", fake_urlopen)
+
+        assert _http_get_text(url="https://x.test", timeout=3.0) == "hello"
+        _http_get_drain(url="https://x.test/ping", timeout=4.0)
+
+        assert seen == [
+            ("https://x.test", librespeed.USER_AGENT, 3.0),
+            ("https://x.test/ping", librespeed.USER_AGENT, 4.0),
+        ]
+        assert response.read_args[-1] == (1,)
+
+    def test_open_connection_variants(self, monkeypatch):
+        made = []
+
+        class _Http:
+            def __init__(self, host, port=None, timeout=None, **kwargs):
+                made.append(("http", host, port, timeout, kwargs))
+
+        class _Https:
+            def __init__(self, host, port=None, timeout=None, **kwargs):
+                made.append(("https", host, port, timeout, kwargs))
+
+        monkeypatch.setattr(librespeed.http.client, "HTTPConnection", _Http)
+        monkeypatch.setattr(librespeed.http.client, "HTTPSConnection", _Https)
+        monkeypatch.setattr(librespeed.ssl, "create_default_context", lambda: "ctx")
+
+        assert (
+            _open_connection(
+                parsed=librespeed.urllib.parse.urlsplit("http://a.test:8080/x"),
+                timeout=1.0,
+            )
+            is not None
+        )
+        assert (
+            _open_connection(
+                parsed=librespeed.urllib.parse.urlsplit("https://b.test/y"),
+                timeout=2.0,
+            )
+            is not None
+        )
+        assert (
+            _open_connection(
+                parsed=librespeed.urllib.parse.urlsplit("https:///broken"),
+                timeout=2.0,
+            )
+            is None
+        )
+
+        assert made[0][:4] == ("http", "a.test", 8080, 1.0)
+        assert made[1][:4] == ("https", "b.test", None, 2.0)
+        assert made[1][4]["context"] == "ctx"
+
+
+class TestLibrespeedPingAndSelection:
+    def test_ping_jitter_discards_first_sample_and_smooths_jitter(self, monkeypatch):
+        times = iter([0.00, 0.10, 0.20, 0.35, 0.40, 0.70, 0.80, 1.15])
+        drained: list[str] = []
+        server = Server(1, "A", "https://a.test", "dl", "ul", "ping")
+
+        monkeypatch.setattr(librespeed.time, "monotonic", lambda: next(times))
+        monkeypatch.setattr(
+            librespeed,
+            "_http_get_drain",
+            lambda *, url, timeout: drained.append(url),
+        )
+
+        avg, jitter = ping_jitter(server=server, count=4, timeout=1.0)
+
+        assert drained == ["https://a.test/ping"] * 4
+        assert avg == pytest.approx((150 + 300 + 350) / 3)
+        assert jitter > 0
+
+    def test_ping_jitter_raises_when_all_samples_fail(self, monkeypatch):
+        server = Server(1, "A", "https://a.test", "dl", "ul", "ping")
+        monkeypatch.setattr(
+            librespeed,
+            "_http_get_drain",
+            lambda **_kwargs: (_ for _ in ()).throw(OSError("down")),
+        )
+
+        with pytest.raises(LibrespeedError, match="no successful"):
+            ping_jitter(server=server, count=2)
+
+    def test_select_fastest_picks_lowest_ping_and_skips_failures(self, monkeypatch):
+        servers = [
+            Server(1, "slow", "https://slow.test", "dl", "ul", "ping"),
+            Server(2, "bad", "https://bad.test", "dl", "ul", "ping"),
+            Server(3, "fast", "https://fast.test", "dl", "ul", "ping"),
+        ]
+
+        def fake_ping(*, server, count, timeout):
+            if server.name == "bad":
+                raise OSError("down")
+            return (20.0 if server.name == "slow" else 5.0, 1.0)
+
+        monkeypatch.setattr(librespeed, "ping_jitter", fake_ping)
+
+        selected, ping, jitter = select_fastest(servers, pool=3)
+
+        assert selected.name == "fast"
+        assert ping == 5.0
+        assert jitter == 1.0
+
+    def test_select_fastest_errors(self, monkeypatch):
+        with pytest.raises(LibrespeedError, match="no servers"):
+            select_fastest([])
+
+        monkeypatch.setattr(
+            librespeed,
+            "ping_jitter",
+            lambda **_kwargs: (_ for _ in ()).throw(OSError("down")),
+        )
+        with pytest.raises(LibrespeedError, match="no server responded"):
+            select_fastest([Server(1, "bad", "https://b.test", "dl", "ul", "ping")])
+
+
+class TestLibrespeedTransfers:
+    def test_run_test_counts_bytes(self, monkeypatch):
+        now = iter([0.0, 0.2])
+        monkeypatch.setattr(librespeed.time, "monotonic", lambda: next(now))
+        monkeypatch.setattr(librespeed.time, "sleep", lambda _seconds: None)
+
+        def worker(counter, stop):
+            counter.add(250_000)
+            stop.set()
+
+        assert _run_test(worker=worker, duration=0.01, concurrency=1) == pytest.approx(
+            10.0
+        )
+
+    def test_run_download_and_upload_build_expected_workers(self, monkeypatch):
+        server = Server(
+            1,
+            "A",
+            "https://a.test",
+            "backend/garbage.php?x=1",
+            "backend/empty.php",
+            "ping",
+        )
+        captured = []
+
+        def fake_run_test(*, worker, duration, concurrency):
+            captured.append((worker, duration, concurrency))
+            return 123.0
+
+        monkeypatch.setattr(librespeed, "_run_test", fake_run_test)
+        monkeypatch.setattr(librespeed.os, "urandom", lambda size: b"x" * size)
+
+        assert run_download(server=server, duration=2.0, concurrency=4) == 123.0
+        assert run_upload(server=server, duration=3.0, concurrency=5) == 123.0
+
+        assert captured[0][1:] == (2.0, 4)
+        assert captured[1][1:] == (3.0, 5)
+
+    def test_download_worker_reads_until_response_ends(self, monkeypatch):
+        stop = librespeed.threading.Event()
+        counter = _Counter()
+
+        class _Response:
+            def __init__(self) -> None:
+                self.chunks = [b"abc", b"de", b""]
+
+            def read(self, _size):
+                chunk = self.chunks.pop(0)
+                if not chunk:
+                    stop.set()
+                return chunk
+
+            def close(self):
+                self.closed = True
+
+        class _Conn:
+            def __init__(self) -> None:
+                self.response = _Response()
+                self.closed = False
+                self.requests = []
+
+            def request(self, method, path, headers):
+                self.requests.append((method, path, headers))
+
+            def getresponse(self):
+                return self.response
+
+            def close(self):
+                self.closed = True
+
+        conn = _Conn()
+        monkeypatch.setattr(librespeed, "_open_connection", lambda **_kwargs: conn)
+
+        _download_worker(
+            url="https://a.test/backend/garbage.php?ckSize=100",
+            counter=counter,
+            stop=stop,
+            timeout=1.0,
+        )
+
+        assert counter.total == 5
+        assert conn.requests[0][0] == "GET"
+        assert conn.requests[0][1] == "/backend/garbage.php?ckSize=100"
+        assert conn.closed
+
+    def test_download_worker_returns_when_connection_missing(self, monkeypatch):
+        stop = librespeed.threading.Event()
+        counter = _Counter()
+        monkeypatch.setattr(librespeed, "_open_connection", lambda **_kwargs: None)
+
+        _download_worker(
+            url="https://a.test/backend/garbage.php",
+            counter=counter,
+            stop=stop,
+            timeout=1.0,
+        )
+
+        assert counter.total == 0
+
+    def test_upload_worker_sends_payload_and_counts_bytes(self, monkeypatch):
+        stop = librespeed.threading.Event()
+        counter = _Counter()
+
+        class _Response:
+            def read(self):
+                stop.set()
+                return b"ok"
+
+            def close(self):
+                self.closed = True
+
+        class _Conn:
+            def __init__(self) -> None:
+                self.headers = []
+                self.sent = []
+                self.closed = False
+
+            def putrequest(self, *args, **kwargs):
+                self.request = (args, kwargs)
+
+            def putheader(self, *args):
+                self.headers.append(args)
+
+            def endheaders(self):
+                self.ended = True
+
+            def send(self, payload):
+                self.sent.append(payload)
+
+            def getresponse(self):
+                return _Response()
+
+            def close(self):
+                self.closed = True
+
+        conn = _Conn()
+        monkeypatch.setattr(librespeed, "_open_connection", lambda **_kwargs: conn)
+
+        _upload_worker(
+            url="https://a.test/backend/empty.php?x=1",
+            counter=counter,
+            stop=stop,
+            timeout=1.0,
+            payload=b"abcdef",
+        )
+
+        assert counter.total == 6
+        assert conn.request[0] == ("POST", "/backend/empty.php?x=1")
+        assert ("Content-Length", "6") in conn.headers
+        assert b"".join(conn.sent) == b"abcdef"
+        assert conn.closed
+
+
+class TestRunSpeedtest:
+    def test_orchestrates_speedtest(self, monkeypatch):
+        server = Server(7, "Node", "https://n.test", "dl", "ul", "ping")
+        monkeypatch.setattr(librespeed, "fetch_server_list", lambda **_k: [server])
+        monkeypatch.setattr(
+            librespeed,
+            "select_fastest",
+            lambda servers, timeout: (servers[0], 8.0, 1.5),
+        )
+        monkeypatch.setattr(librespeed, "run_download", lambda **_k: 100.0)
+        monkeypatch.setattr(librespeed, "run_upload", lambda **_k: 20.0)
+
+        result = run_speedtest(duration=0.1, concurrency=1, timeout=2.0)
+
+        assert result.download_mbps == 100.0
+        assert result.upload_mbps == 20.0
+        assert result.ping_ms == 8.0
+        assert result.server_name == "Node"
+
+    def test_errors_when_server_list_empty(self, monkeypatch):
+        monkeypatch.setattr(librespeed, "fetch_server_list", lambda **_k: [])
+
+        with pytest.raises(LibrespeedError, match="server list is empty"):
+            run_speedtest()
+
 
 class TestRunLibrespeedFailure:
     def test_wraps_librespeed_error(self):
@@ -223,6 +603,7 @@ class TestBuildTooltip:
     def test_idle_without_result(self):
         text = build_tooltip(result=None, running=False, error=None)
         assert "Click" in text
+        assert "Runs on demand" in text
 
     def test_running_state(self):
         text = build_tooltip(result=_result(), running=True, error=None)
@@ -239,6 +620,7 @@ class TestBuildTooltip:
         assert "Ping" in text
         assert "Jitter" in text
         assert "Test Node" in text
+        assert "Runs on demand" in text
 
 
 class TestAppletCreation:
@@ -276,6 +658,7 @@ class TestAppletMenu:
     def test_empty_menu_has_run(self):
         applet = _make_applet()
         labels = [mi.get_label() for mi in applet.get_menu_items()]
+        assert "Runs on demand" in labels
         assert any("Run Test" in label or "Running" in label for label in labels)
 
     def test_menu_with_result_shows_summary_and_copy(self):

--- a/tests/applets/test_systemmonitor.py
+++ b/tests/applets/test_systemmonitor.py
@@ -1,8 +1,11 @@
 """Tests for the System Monitor applet -- parsing, temperature, and rendering."""
 
+import subprocess
+
 import pytest
 
 import docking.applets.systemmonitor.applet as systemmonitor_mod
+import docking.applets.systemmonitor.temperature as temperature_mod
 from docking.applets.systemmonitor.applet import SystemMonitorApplet
 from docking.applets.systemmonitor.state import (
     CpuSample,
@@ -17,11 +20,16 @@ from docking.applets.systemmonitor.state import (
     tooltip_text,
 )
 from docking.applets.systemmonitor.temperature import (
+    CommandBackend,
     TemperatureReader,
+    discover_available_commands,
+    discover_sysfs_temperature_path,
     parse_acpi_output,
     parse_sensors_output,
     parse_sysfs_temperature,
     parse_vcgencmd_output,
+    read_command_temperature,
+    read_temperature_file,
 )
 
 
@@ -110,6 +118,15 @@ class TestTemperatureParsing:
         text = "Thermal 0: ok, 51.0 degrees C\nThermal 1: ok, 57.5 degrees C\n"
         assert parse_acpi_output(text) == pytest.approx(57.5)
 
+    def test_parse_sensors_output_handles_no_matches_and_tiebreak(self):
+        assert parse_sensors_output("Adapter: ISA adapter\n") is None
+        text = "coretemp-isa-0000\nCore 0: +51.0°C\nCore 1: +59.0°C\n"
+        assert parse_sensors_output(text) == pytest.approx(59.0)
+
+    def test_parse_command_outputs_ignore_bad_shapes(self):
+        assert parse_vcgencmd_output("temp=bad") is None
+        assert parse_acpi_output("Thermal 0: ok") is None
+
 
 class TestTemperatureReader:
     def test_prefers_sysfs_over_command_backends(self, tmp_path):
@@ -162,15 +179,183 @@ class TestTemperatureReader:
         assert reader.read() == pytest.approx(49.5)
         assert calls == [("sensors",), ("acpi", "-t")]
 
+    def test_invalid_cached_sysfs_path_is_reprobed(self, tmp_path):
+        thermal_root = tmp_path / "thermal"
+        hwmon_root = tmp_path / "hwmon"
+        zone = thermal_root / "thermal_zone0"
+        zone.mkdir(parents=True)
+        hwmon_root.mkdir()
+        (zone / "type").write_text("cpu\n", encoding="utf-8")
+        temp = zone / "temp"
+        temp.write_text("42000\n", encoding="utf-8")
+
+        reader = TemperatureReader(
+            thermal_root=thermal_root,
+            hwmon_root=hwmon_root,
+            which=lambda _cmd: None,
+        )
+        assert reader.read() == pytest.approx(42.0)
+
+        temp.write_text("bad\n", encoding="utf-8")
+        assert reader.read() is None
+        assert reader._sysfs_path is None
+        assert reader._sysfs_probed is False
+
+    def test_command_probe_is_cached_when_no_commands(self, tmp_path):
+        calls: list[str] = []
+        reader = TemperatureReader(
+            thermal_root=tmp_path / "thermal",
+            hwmon_root=tmp_path / "hwmon",
+            which=lambda command: calls.append(command) or None,
+        )
+
+        assert reader.read() is None
+        assert reader.read() is None
+        assert calls == ["sensors", "vcgencmd", "acpi"]
+
+
+class TestTemperatureDiscovery:
+    def test_discovers_best_hwmon_temperature(self, tmp_path):
+        thermal_root = tmp_path / "thermal"
+        hwmon_root = tmp_path / "hwmon"
+        thermal_root.mkdir()
+        hwmon = hwmon_root / "hwmon0"
+        hwmon.mkdir(parents=True)
+        (hwmon / "name").write_text("coretemp\n", encoding="utf-8")
+        (hwmon / "temp1_input").write_text("48000\n", encoding="utf-8")
+        (hwmon / "temp2_label").write_text("Package id 0\n", encoding="utf-8")
+        (hwmon / "temp2_input").write_text("62000\n", encoding="utf-8")
+
+        path = discover_sysfs_temperature_path(
+            thermal_root=thermal_root,
+            hwmon_root=hwmon_root,
+        )
+
+        assert path == hwmon / "temp2_input"
+
+    def test_discovers_nothing_without_cpu_hints(self, tmp_path):
+        thermal_root = tmp_path / "thermal"
+        hwmon_root = tmp_path / "hwmon"
+        zone = thermal_root / "thermal_zone0"
+        zone.mkdir(parents=True)
+        hwmon = hwmon_root / "hwmon0"
+        hwmon.mkdir(parents=True)
+        (zone / "type").write_text("battery\n", encoding="utf-8")
+        (zone / "temp").write_text("45000\n", encoding="utf-8")
+        (hwmon / "name").write_text("random\n", encoding="utf-8")
+        (hwmon / "temp1_input").write_text("47000\n", encoding="utf-8")
+
+        assert (
+            discover_sysfs_temperature_path(
+                thermal_root=thermal_root,
+                hwmon_root=hwmon_root,
+            )
+            is None
+        )
+
+    def test_available_commands_keep_preference_order(self):
+        commands = discover_available_commands(
+            which=lambda command: f"/bin/{command}" if command != "vcgencmd" else None
+        )
+
+        assert [backend.command for backend in commands] == ["sensors", "acpi"]
+
+    def test_read_command_temperature_dispatches_and_ignores_unknown(self):
+        assert read_command_temperature(
+            backend=CommandBackend("vcgencmd", ("vcgencmd", "measure_temp")),
+            run_command=lambda _cmd, _timeout: "temp=47.0'C",
+        ) == pytest.approx(47.0)
+        assert (
+            read_command_temperature(
+                backend=CommandBackend("unknown", ("unknown",)),
+                run_command=lambda _cmd, _timeout: "47",
+            )
+            is None
+        )
+        assert (
+            read_command_temperature(
+                backend=CommandBackend("sensors", ("sensors",)),
+                run_command=lambda _cmd, _timeout: None,
+            )
+            is None
+        )
+
+    def test_read_temperature_file_handles_decode_errors(self, tmp_path):
+        path = tmp_path / "temp"
+        path.write_bytes(b"\xff")
+        assert read_temperature_file(path) is None
+        assert read_temperature_file(tmp_path / "missing") is None
+
+    def test_run_command_success_error_and_exception(self, monkeypatch):
+        monkeypatch.setattr(
+            temperature_mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: subprocess.CompletedProcess(
+                args=["sensors"],
+                returncode=0,
+                stdout="ok",
+            ),
+        )
+        assert temperature_mod._run_command(["sensors"], 0.1) == "ok"
+
+        monkeypatch.setattr(
+            temperature_mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: subprocess.CompletedProcess(
+                args=["sensors"],
+                returncode=1,
+                stdout="bad",
+            ),
+        )
+        assert temperature_mod._run_command(["sensors"], 0.1) is None
+
+        def fail(*_args, **_kwargs):
+            raise OSError("nope")
+
+        monkeypatch.setattr(temperature_mod.subprocess, "run", fail)
+        assert temperature_mod._run_command(["sensors"], 0.1) is None
+
+    def test_score_and_pick_best_helpers(self, tmp_path):
+        assert temperature_mod._score_text("CPU package", (("cpu", 10),)) == 10
+        low = temperature_mod._pick_best(
+            None,
+            score=10,
+            temperature=40.0,
+            path=tmp_path / "low",
+        )
+        high_score = temperature_mod._pick_best(
+            low,
+            score=20,
+            temperature=35.0,
+            path=tmp_path / "score",
+        )
+        high_temp = temperature_mod._pick_best(
+            low,
+            score=10,
+            temperature=45.0,
+            path=tmp_path / "temp",
+        )
+        assert high_score[2] == tmp_path / "score"
+        assert high_temp[2] == tmp_path / "temp"
+        assert (
+            temperature_mod._pick_best(
+                high_score,
+                score=10,
+                temperature=99.0,
+                path=tmp_path / "ignored",
+            )
+            == high_score
+        )
+
 
 class TestTooltipText:
     def test_without_temperature(self):
         text = tooltip_text(cpu=0.423, mem=0.671)
-        assert text == "CPU: 42.3% | Mem: 67.1%"
+        assert text == "System Monitor\nCPU: 42.3% | Mem: 67.1%"
 
     def test_with_temperature(self):
         text = tooltip_text(cpu=0.423, mem=0.671, temperature_c=58.4)
-        assert text == "CPU: 42.3% | Mem: 67.1% | Temp: 58.4°C"
+        assert text == "System Monitor\nCPU: 42.3% | Mem: 67.1% | Temp: 58.4°C"
 
     def test_with_temperature_in_fahrenheit(self):
         text = tooltip_text(
@@ -180,7 +365,7 @@ class TestTooltipText:
             temperature_unit=TemperatureUnit.FAHRENHEIT,
         )
 
-        assert text == "CPU: 42.3% | Mem: 67.1% | Temp: 137.1°F"
+        assert text == "System Monitor\nCPU: 42.3% | Mem: 67.1% | Temp: 137.1°F"
 
     def test_with_disks(self):
         disks = [("/", 0.45), ("/home", 0.72)]

--- a/tests/applets/test_thermals.py
+++ b/tests/applets/test_thermals.py
@@ -176,11 +176,12 @@ class TestThermalsState:
         }
 
     def test_build_tooltip(self):
-        text = build_tooltip(snapshot=_snapshot())
+        text = build_tooltip(snapshot=_snapshot(), cadence_seconds=5)
 
         assert "Thermals" in text
         assert "Hot: coretemp-isa-0000 Package id 0 74.2\N{DEGREE SIGN}C" in text
         assert "Fan: thinkpad-isa-0000 fan1 2987 RPM" in text
+        assert "Samples every 5 seconds" in text
         assert "Loading" in build_tooltip(snapshot=None, loading=True)
         assert "lm-sensors" in build_tooltip(
             snapshot=ThermalSnapshot(available=False, error="lm-sensors not installed")
@@ -227,6 +228,7 @@ class TestThermalsApplet:
 
         assert any(label.startswith("Hot:") for label in labels)
         assert any(label.startswith("Fan:") for label in labels)
+        assert "Samples every 5 seconds" in labels
         assert "Temperature Unit" in labels
         assert "Refresh Now" in labels
 

--- a/tests/applets/test_todayinhistory.py
+++ b/tests/applets/test_todayinhistory.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import json
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -24,6 +25,7 @@ HistoryEvent = today_state_mod.HistoryEvent
 fallback_today_in_history = today_state_mod.fallback_today_in_history
 fetch_today_in_history = today_state_mod.fetch_today_in_history
 format_history_event = today_state_mod.format_history_event
+normalize_text = today_state_mod.normalize_text
 
 ENTRY = HistoryEvent(
     year=1969,
@@ -35,6 +37,10 @@ ENTRY = HistoryEvent(
 
 
 class TestHistoryHelpers:
+    def test_normalize_text_and_header_only_format(self):
+        assert normalize_text(" Tom &amp;\nJerry ") == "Tom & Jerry"
+        assert format_history_event(HistoryEvent(1, "Title", "")) == "1 - Title"
+
     def test_format_history_event_includes_year_and_content(self):
         text = format_history_event(ENTRY)
 
@@ -84,6 +90,115 @@ class TestHistoryHelpers:
         assert entries
         assert all(isinstance(entry, HistoryEvent) for entry in entries)
 
+    def test_low_level_state_parsing_edges(self):
+        assert today_state_mod._date_key(month=0, day=0) == "01-01"
+        assert today_state_mod._coerce_year(True) is None
+        assert today_state_mod._coerce_year(1.9) == 1
+        assert today_state_mod._coerce_year(" 44 ") == 44
+        assert today_state_mod._coerce_year("bad") is None
+        assert today_state_mod._coerce_year(object()) is None
+        assert today_state_mod._extract_article("bad") == ("", "")
+
+        title, url = today_state_mod._extract_article(
+            {
+                "normalizedtitle": "Fallback title",
+                "content_urls": {"mobile": {"page": " https://m.example.test "}},
+            }
+        )
+        assert title == "Fallback title"
+        assert url == "https://m.example.test"
+
+    def test_event_from_mapping_filters_invalid_and_normalizes(self):
+        assert today_state_mod._event_from_mapping({}, default_source="Offline") is None
+        assert (
+            today_state_mod._event_from_mapping(
+                {"year": 1, "title": "", "summary": "x"},
+                default_source="Offline",
+            )
+            is None
+        )
+
+        event = today_state_mod._event_from_mapping(
+            {
+                "year": "1969",
+                "title": " Apollo &amp; 11 ",
+                "summary": " Moon landing ",
+                "article_title": 123,
+                "article_url": 123,
+                "source_label": 123,
+            },
+            default_source="Offline",
+        )
+
+        assert event == HistoryEvent(
+            year=1969,
+            title="Apollo & 11",
+            summary="Moon landing",
+            source_label="Offline",
+        )
+
+    def test_parse_wikipedia_events_filters_and_limits(self):
+        events = today_state_mod._parse_wikipedia_events(
+            data={
+                "events": [
+                    "bad",
+                    {"year": True, "text": "bad"},
+                    {"year": 1, "text": ""},
+                    {"year": 2, "text": "Only summary title."},
+                    {
+                        "year": 3,
+                        "text": "Page title event.",
+                        "pages": [{"title": "Page title"}],
+                    },
+                ]
+            },
+            limit=1,
+        )
+
+        assert events == [
+            HistoryEvent(
+                year=2,
+                title="Only summary title",
+                summary="Only summary title.",
+                article_title="Only summary title",
+            )
+        ]
+        assert today_state_mod._parse_wikipedia_events(data=[], limit=3) == []
+        assert today_state_mod._parse_wikipedia_events(data={}, limit=3) == []
+
+    def test_http_get_json_uses_urlopen(self, monkeypatch):
+        class _Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return json.dumps({"ok": True}).encode()
+
+        seen = []
+        monkeypatch.setattr(
+            today_state_mod,
+            "urlopen",
+            lambda request, timeout: (
+                seen.append((request.full_url, timeout)) or _Response()
+            ),
+        )
+
+        assert today_state_mod._http_get_json("https://example.test") == {"ok": True}
+        assert seen == [("https://example.test", 8.0)]
+
+    def test_fallback_catalog_exact_pool_and_empty(self):
+        catalog = {
+            "03-14": [ENTRY],
+            "03-15": [HistoryEvent(1900, "Other", "Other summary")],
+        }
+
+        assert fallback_today_in_history(month=3, day=14, catalog=catalog) == [ENTRY]
+        assert fallback_today_in_history(month=1, day=1, catalog={"01-01": []}) == []
+        assert len(fallback_today_in_history(month=3, day=16, catalog=catalog)) == 2
+
 
 class TestTodayInHistoryApplet:
     def test_creates_with_icon_and_initial_event(self):
@@ -91,6 +206,40 @@ class TestTodayInHistoryApplet:
 
         assert applet.item.icon is not None
         assert applet._current is not None
+
+    def test_start_and_stop_timer(self, monkeypatch):
+        applet = TodayInHistoryApplet(48)
+        fetch = MagicMock()
+        removed: list[int] = []
+        monkeypatch.setattr(applet, "_fetch_async", fetch)
+        monkeypatch.setattr(
+            today_applet_mod.GLib,
+            "timeout_add_seconds",
+            lambda *_args: 42,
+        )
+        monkeypatch.setattr(
+            today_applet_mod.GLib,
+            "source_remove",
+            lambda timer_id: removed.append(timer_id),
+        )
+
+        applet.start(lambda: None)
+        applet.stop()
+
+        fetch.assert_called_once_with(show_first=False)
+        assert removed == [42]
+        assert applet._timer_id == 0
+
+    def test_click_without_events_fetches(self, monkeypatch):
+        applet = TodayInHistoryApplet(48)
+        applet._events = []
+        fetch = MagicMock()
+        monkeypatch.setattr(applet, "_fetch_async", fetch)
+
+        applet.on_clicked()
+
+        assert applet._current is None
+        fetch.assert_called_once_with(show_first=True)
 
     def test_click_advances_and_wraps_events(self):
         applet = TodayInHistoryApplet(48)
@@ -142,6 +291,15 @@ class TestTodayInHistoryApplet:
         ]
 
         assert "Open Article" not in labels
+
+    def test_source_label_date_and_tooltip_defaults(self):
+        applet = TodayInHistoryApplet(48)
+        applet._current = None
+        assert applet._date_key(month=3, day=4) == "03-04"
+        assert applet._source_label() == "Today in History"
+
+        applet.refresh_tooltip()
+        assert applet.item.name == "Today in History"
 
     def test_on_fetch_result_uses_fallback_when_api_returns_empty(self, monkeypatch):
         applet = TodayInHistoryApplet(48)
@@ -198,6 +356,38 @@ class TestTodayInHistoryApplet:
         assert applet._loading is True
         assert applet._loading_key == "03-15"
 
+    def test_on_fetch_result_entries_keep_current_when_not_show_first(self):
+        applet = TodayInHistoryApplet(48)
+        applet._current_month = 7
+        applet._current_day = 20
+        current = HistoryEvent(1, "Current", "Current summary")
+        new = HistoryEvent(2, "New", "New summary")
+        applet._current = current
+        applet._loading = True
+        applet._loading_key = "07-20"
+
+        applet._on_fetch_result(month=7, day=20, entries=[new], show_first=False)
+
+        assert applet._events == [new]
+        assert applet._current == current
+        assert applet._loading is False
+
+    def test_on_fetch_result_empty_keeps_existing_current(self, monkeypatch):
+        applet = TodayInHistoryApplet(48)
+        applet._current_month = 7
+        applet._current_day = 20
+        current = HistoryEvent(1, "Current", "Current summary")
+        applet._current = current
+        monkeypatch.setattr(
+            today_applet_mod,
+            "fallback_today_in_history",
+            lambda month, day: [ENTRY],
+        )
+
+        applet._on_fetch_result(month=7, day=20, entries=[], show_first=False)
+
+        assert applet._current == current
+
     def test_refresh_from_web_syncs_to_new_local_day_immediately(self, monkeypatch):
         applet = TodayInHistoryApplet(48)
         old_entry = HistoryEvent(
@@ -247,6 +437,82 @@ class TestTodayInHistoryApplet:
         assert "1901" in applet.item.name
         assert started
 
+    def test_sync_to_local_day_no_change_and_poll_day_change(self, monkeypatch):
+        applet = TodayInHistoryApplet(48)
+        applet._current_month = 3
+        applet._current_day = 14
+        monkeypatch.setattr(applet, "_current_date", lambda: (3, 14))
+        assert applet._sync_to_local_day() is False
+        assert applet._poll_day_change() is True
+
+        monkeypatch.setattr(applet, "_current_date", lambda: (3, 15))
+        monkeypatch.setattr(
+            today_applet_mod,
+            "fallback_today_in_history",
+            lambda month, day: [ENTRY],
+        )
+        applet._fetch_async = MagicMock()
+        applet.present = MagicMock()
+
+        assert applet._poll_day_change() is True
+        applet.present.assert_called_once()
+        applet._fetch_async.assert_called_once_with(show_first=False)
+
+    def test_advance_event_without_events(self):
+        applet = TodayInHistoryApplet(48)
+        applet._events = []
+        applet._advance_event()
+
+        assert applet._index == -1
+        assert applet._current is None
+
+    def test_fetch_async_dedupes_same_loading_request(self, monkeypatch):
+        applet = TodayInHistoryApplet(48)
+        applet._current_month = 7
+        applet._current_day = 20
+        applet._loading = True
+        applet._loading_key = "07-20"
+        monkeypatch.setattr(applet, "_current_date", lambda: (7, 20))
+        monkeypatch.setattr(
+            today_applet_mod.threading,
+            "Thread",
+            MagicMock(side_effect=AssertionError("no new thread")),
+        )
+
+        applet._fetch_async(show_first=True)
+
+    def test_fetch_async_worker_posts_idle_result(self, monkeypatch):
+        applet = TodayInHistoryApplet(48)
+        applet._current_month = 7
+        applet._current_day = 20
+        idle_calls = []
+        monkeypatch.setattr(applet, "_current_date", lambda: (7, 20))
+        monkeypatch.setattr(
+            today_applet_mod,
+            "fetch_today_in_history",
+            lambda **_kwargs: [ENTRY],
+        )
+        monkeypatch.setattr(
+            today_applet_mod.GLib,
+            "idle_add",
+            lambda *args: idle_calls.append(args),
+        )
+
+        class _Thread:
+            def __init__(self, *, target, daemon):
+                self.target = target
+                self.daemon = daemon
+
+            def start(self) -> None:
+                self.target()
+
+        monkeypatch.setattr(today_applet_mod.threading, "Thread", _Thread)
+
+        applet._fetch_async(show_first=True)
+
+        assert idle_calls[0][0] == applet._on_fetch_result
+        assert idle_calls[0][1:4] == (7, 20, [ENTRY])
+
     def test_refresh_tooltip_loading_state(self):
         applet = TodayInHistoryApplet(48)
         applet._loading = True
@@ -255,3 +521,28 @@ class TestTodayInHistoryApplet:
         applet.refresh_tooltip()
 
         assert "loading" in applet.item.name.lower()
+
+    def test_open_current_article_noop_success_and_error(self, monkeypatch):
+        applet = TodayInHistoryApplet(48)
+        applet._current = None
+        applet._open_current_article()
+
+        applet._current = HistoryEvent(1, "No URL", "Summary")
+        applet._open_current_article()
+
+        opened: list[str] = []
+        applet._current = ENTRY
+        monkeypatch.setattr(
+            today_applet_mod.Gio.AppInfo,
+            "launch_default_for_uri",
+            lambda url, _ctx: opened.append(url),
+        )
+        applet._open_current_article()
+        assert opened == [ENTRY.article_url]
+
+        monkeypatch.setattr(
+            today_applet_mod.Gio.AppInfo,
+            "launch_default_for_uri",
+            lambda *_args: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        applet._open_current_article()

--- a/tests/applets/test_tooltip.py
+++ b/tests/applets/test_tooltip.py
@@ -1,0 +1,25 @@
+from docking.applets.tooltip import structured_tooltip
+
+
+def test_structured_tooltip_orders_sections():
+    text = structured_tooltip(
+        title="Title",
+        primary="Primary",
+        details=("Detail",),
+        freshness=("Updated: now",),
+        error="failed",
+        recovery="Retry from menu",
+    )
+
+    assert text.splitlines() == [
+        "Title",
+        "Primary",
+        "Detail",
+        "Updated: now",
+        "Error: failed",
+        "Retry from menu",
+    ]
+
+
+def test_structured_tooltip_skips_empty_lines():
+    assert structured_tooltip(title="Title", details=("", None)) == "Title"

--- a/tests/applets/test_trash.py
+++ b/tests/applets/test_trash.py
@@ -73,20 +73,24 @@ class TestTrashAppletMenu:
         with patch("docking.applets.trash.applet._count_trash_items", return_value=0):
             applet = TrashApplet(48)
         items = applet.get_menu_items()
-        assert len(items) == 2
+        assert [item.get_label() for item in items] == [
+            "Open Trash",
+            "",
+            "Empty Trash",
+        ]
 
     def test_empty_trash_insensitive_when_empty(self):
         with patch("docking.applets.trash.applet._count_trash_items", return_value=0):
             applet = TrashApplet(48)
         items = applet.get_menu_items()
-        empty_item = items[1]
+        empty_item = items[2]
         assert not empty_item.get_sensitive()
 
     def test_empty_trash_sensitive_when_full(self):
         with patch("docking.applets.trash.applet._count_trash_items", return_value=3):
             applet = TrashApplet(48)
         items = applet.get_menu_items()
-        empty_item = items[1]
+        empty_item = items[2]
         assert empty_item.get_sensitive()
 
 

--- a/tests/applets/test_unitconverter.py
+++ b/tests/applets/test_unitconverter.py
@@ -21,7 +21,6 @@ from docking.applets.unitconverter.state import (
     set_currency_units,
 )
 from docking.core.config import Config
-from docking.ui.display import ScreenPosition
 
 
 class _ImmediateWorker:
@@ -529,12 +528,20 @@ class TestAppletPrefs:
 class TestAppletPopup:
     @staticmethod
     def _patch_popup(monkeypatch, applet: UnitConverterApplet, popup: _FakePopupWindow):
+        def show_wrapped_popup(*, window, content, gap_px):
+            _ = gap_px
+            window.add(content)
+            window.show_all()
+            window.move(100, 140)
+
         monkeypatch.setattr(
-            unitconverter_applet_mod.Gtk,
-            "Window",
-            lambda **_kwargs: popup,
+            unitconverter_applet_mod, "create_popup_window", lambda: popup
         )
-        monkeypatch.setattr(unitconverter_applet_mod, "wrap_popup", lambda child: child)
+        monkeypatch.setattr(
+            unitconverter_applet_mod,
+            "show_wrapped_popup",
+            show_wrapped_popup,
+        )
         monkeypatch.setattr(
             applet, "_build_popup_content", lambda: _seed_popup_widgets(applet)
         )
@@ -590,12 +597,6 @@ class TestAppletPopup:
         applet = _make_applet()
         fake_popup = _FakePopupWindow()
         self._patch_popup(monkeypatch, applet, fake_popup)
-        monkeypatch.setattr(
-            unitconverter_applet_mod,
-            "get_pointer_position",
-            lambda _display: ScreenPosition(x=150, y=220),
-        )
-
         applet._show_popup()
         first_popup = applet._popup
         first_child = first_popup.get_child()
@@ -613,26 +614,24 @@ class TestAppletPopup:
     def test_show_popup_uses_themed_surface_wrapper(self, monkeypatch):
         applet = _make_applet()
         fake_popup = _FakePopupWindow()
-        wrapped = MagicMock(name="wrapped-popup")
+        show_wrapped_popup = MagicMock()
         monkeypatch.setattr(
-            unitconverter_applet_mod.Gtk,
-            "Window",
-            lambda **_kwargs: fake_popup,
+            unitconverter_applet_mod, "create_popup_window", lambda: fake_popup
         )
-        monkeypatch.setattr(
-            unitconverter_applet_mod, "wrap_popup", MagicMock(return_value=wrapped)
-        )
-        monkeypatch.setattr(applet, "_build_popup_content", lambda: "content")
         monkeypatch.setattr(
             unitconverter_applet_mod,
-            "get_pointer_position",
-            lambda _display: ScreenPosition(x=150, y=220),
+            "show_wrapped_popup",
+            show_wrapped_popup,
         )
+        monkeypatch.setattr(applet, "_build_popup_content", lambda: "content")
 
         applet._show_popup()
 
-        popup_child = applet._popup.get_child()
-        assert popup_child is wrapped
+        show_wrapped_popup.assert_called_once_with(
+            window=fake_popup,
+            content="content",
+            gap_px=unitconverter_applet_mod.POPUP_CURSOR_GAP_PX,
+        )
         applet.stop()
 
     def test_build_popup_content_creates_real_controls_with_fakes(self, monkeypatch):

--- a/tests/applets/test_volume.py
+++ b/tests/applets/test_volume.py
@@ -263,9 +263,10 @@ class TestVolumeApplet:
 
         assert [item.get_label() for item in items] == [
             "Show Level",
+            "",
             "Volume Settings",
         ]
-        callback, args = items[1]._signals["activate"][0]
+        callback, args = items[2]._signals["activate"][0]
         callback(None, *args)
         assert opened == ["opened"]
 

--- a/tests/applets/test_weather.py
+++ b/tests/applets/test_weather.py
@@ -208,6 +208,15 @@ class TestWeatherTooltip:
         assert "Berlin" in applet.item.name
         assert "22" in applet.item.name
 
+    def test_tooltip_discloses_update_cadence(self):
+        applet = _make_applet()
+        applet._cities = [_BERLIN]
+        applet._active_index = 0
+        applet._weather = _SAMPLE_WEATHER
+        applet.refresh_tooltip()
+
+        assert "Updates every 5 minutes" in applet.item.name
+
     def test_tooltip_uses_selected_temperature_unit(self):
         config = Config(applet_prefs={"weather": {"temperature_unit": "fahrenheit"}})
         applet = _make_applet(config=config)
@@ -231,8 +240,17 @@ class TestWeatherTooltip:
         applet._cities = [_BERLIN]
         applet._active_index = 0
         applet._weather = None
+        applet._loading = True
         applet.refresh_tooltip()
         assert "loading" in applet.item.name.lower()
+
+    def test_tooltip_no_data_state(self):
+        applet = _make_applet()
+        applet._cities = [_BERLIN]
+        applet._active_index = 0
+        applet._weather = None
+        applet.refresh_tooltip()
+        assert "no data yet" in applet.item.name.lower()
 
     def test_tooltip_unavailable_state_after_failed_fetch(self):
         applet = _make_applet()
@@ -284,6 +302,7 @@ class TestWeatherMenu:
         items = applet.get_menu_items()
         assert "Tokyo" in items[0].get_label()
         assert not items[0].get_sensitive()
+        assert any(item.get_label() == "Updates every 5 minutes" for item in items)
 
     def test_menu_no_city_header_when_unset(self):
         applet = _make_applet()
@@ -500,7 +519,20 @@ class TestWeatherAsyncFetch:
         assert applet._weather is None
         assert applet._air_quality is None
         assert applet._fetch_failed is True
+        assert applet._fetch_error == "boom"
         refresh.assert_called_once()
+
+    def test_fetch_error_keeps_previous_weather(self):
+        applet = _make_applet()
+        applet._fetch_request_id = 5
+        applet._weather = _SAMPLE_WEATHER
+        applet._air_quality = _SAMPLE_AQI
+
+        assert applet._on_fetch_error(request_id=5, exc=RuntimeError("boom")) is False
+
+        assert applet._weather == _SAMPLE_WEATHER
+        assert applet._air_quality == _SAMPLE_AQI
+        assert applet._fetch_failed is True
 
     def test_fetch_async_uses_active_city_coords(self, monkeypatch):
         applet = _make_applet()
@@ -831,12 +863,20 @@ class _FakeWeatherDialog:
     def __init__(self, **_kwargs):
         self.destroy = MagicMock()
         self._content = _FakeWeatherBox()
+        self.buttons: list[tuple[object, object]] = []
+        self.callbacks: dict[str, object] = {}
 
     def set_default_size(self, *_args) -> None:
         return
 
     def set_position(self, *_args) -> None:
         return
+
+    def add_button(self, label, response) -> None:
+        self.buttons.append((label, response))
+
+    def connect(self, signal: str, callback) -> None:
+        self.callbacks[signal] = callback
 
     def get_content_area(self):
         return self._content
@@ -863,6 +903,7 @@ class TestWeatherDialogAndWidget:
             SimpleNamespace(
                 Dialog=lambda **_kwargs: created_dialog,
                 DialogFlags=SimpleNamespace(MODAL=1, DESTROY_WITH_PARENT=2),
+                ResponseType=SimpleNamespace(CANCEL=0),
                 WindowPosition=SimpleNamespace(MOUSE=1),
                 Entry=lambda: created_entry,
                 EntryCompletion=lambda: created_completion,

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -3,12 +3,16 @@
 import json
 from pathlib import Path
 
+import pytest
+
+import docking.core.config as config_mod
 from docking.core.config import (
     APP_KIND,
     APPLET_KIND,
     FILE_KIND,
     FOLDER_KIND,
     Config,
+    HideMode,
     PinnedEntry,
 )
 from docking.core.position import Position
@@ -51,6 +55,43 @@ class TestConfigDefaults:
     def test_pos_property_returns_position_enum(self):
         c = Config(position="left")
         assert c.pos is Position.LEFT
+
+    def test_scaled_icon_and_hide_mode_properties(self):
+        c = Config(icon_size=40, zoom_percent=1.25, hide_mode="intelligent")
+
+        assert c.scaled_icon_size == 50
+        assert c.hide_mode_enum is HideMode.INTELLIGENT
+
+    def test_post_init_normalizes_invalid_runtime_values(self):
+        c = Config(
+            icon_size="bad",
+            zoom_percent="bad",
+            zoom_range="bad",
+            position=object(),
+            monitor_index="bad",
+            hide_delay_ms="bad",
+            transparency="bad",
+            previews_enabled="off",
+            lock_icons="on",
+            current_workspace_only=0,
+            anchor_applets=1,
+            active_display="no",
+            theme="",
+        )
+
+        assert c.icon_size == 48
+        assert c.zoom_percent == 1.5
+        assert c.zoom_range == 3
+        assert c.position == "bottom"
+        assert c.monitor_index == -1
+        assert c.hide_delay_ms == 0
+        assert c.transparency == 1.0
+        assert c.previews_enabled is False
+        assert c.lock_icons is True
+        assert c.current_workspace_only is False
+        assert c.anchor_applets is True
+        assert c.active_display is False
+        assert c.theme == "default"
 
 
 class TestConfigLoad:
@@ -354,6 +395,32 @@ class TestConfigLoad:
 
         assert config.pinned == [PinnedEntry(kind=APP_KIND, target="existing.desktop")]
 
+    def test_load_invalid_primary_and_backup_falls_back_to_default(self, tmp_path):
+        path = tmp_path / "dock.json"
+        backup = tmp_path / "dock.json.bak"
+        path.write_text("{", encoding="utf-8")
+        backup.write_text("{", encoding="utf-8")
+
+        config = Config.load(path)
+
+        assert config.icon_size == 48
+        assert config._path == path
+
+    def test_load_valid_primary_ignores_backup_creation_failure(
+        self, tmp_path, monkeypatch
+    ):
+        path = tmp_path / "dock.json"
+        path.write_text(json.dumps({"icon_size": 72}), encoding="utf-8")
+        monkeypatch.setattr(
+            config_mod,
+            "_write_backup_copy",
+            lambda **_kwargs: (_ for _ in ()).throw(OSError("boom")),
+        )
+
+        config = Config.load(path)
+
+        assert config.icon_size == 72
+
 
 class TestConfigSave:
     def test_save_creates_parent_dirs(self, tmp_path):
@@ -491,6 +558,30 @@ class TestConfigSave:
         assert json.loads(path.read_text())["icon_size"] == 96
         assert json.loads(backup.read_text())["icon_size"] == 48
 
+    def test_save_skips_backup_refresh_when_current_file_invalid(self, tmp_path):
+        path = tmp_path / "dock.json"
+        path.write_text("{", encoding="utf-8")
+        config = Config(icon_size=96)
+
+        config.save(path)
+
+        assert json.loads(path.read_text())["icon_size"] == 96
+        assert not (tmp_path / "dock.json.bak").exists()
+
+    def test_save_cleans_temp_file_when_write_fails(self, tmp_path, monkeypatch):
+        path = tmp_path / "dock.json"
+        config = Config(icon_size=96)
+        monkeypatch.setattr(
+            config_mod,
+            "_write_json_atomic_candidate",
+            lambda **_kwargs: (_ for _ in ()).throw(OSError("boom")),
+        )
+
+        with pytest.raises(OSError):
+            config.save(path)
+
+        assert list(tmp_path.iterdir()) == []
+
     def test_save_fsyncs_directory_after_replace(self, monkeypatch, tmp_path):
         path = tmp_path / "dock.json"
         config = Config(icon_size=96)
@@ -509,3 +600,81 @@ class TestConfigSave:
         config.save(path)
 
         assert len(fsynced) >= 2
+
+
+class TestConfigHelpers:
+    def test_pinned_entry_equality_and_raw_shapes(self, tmp_path):
+        folder_uri = tmp_path.as_uri()
+        applet_id = "applet://clock"
+        entry = PinnedEntry(kind=APP_KIND, target="firefox.desktop")
+
+        assert entry == "firefox.desktop"
+        assert entry == {"kind": APP_KIND, "target": "firefox.desktop"}
+        assert entry != 1
+        assert PinnedEntry.from_raw(entry) is entry
+        assert PinnedEntry.from_raw("") is None
+        assert PinnedEntry.from_raw(applet_id) == PinnedEntry(
+            kind=APPLET_KIND,
+            target=applet_id,
+        )
+        assert PinnedEntry.from_raw(folder_uri) == PinnedEntry(
+            kind=FOLDER_KIND,
+            target=folder_uri,
+        )
+        assert PinnedEntry.from_raw({"kind": APP_KIND, "target": ""}) is None
+        assert PinnedEntry.from_raw({"kind": "bad", "target": "x"}) is None
+        assert PinnedEntry.from_raw(["bad"]) is None
+
+    def test_resolve_initial_desktop_id_uses_candidates_and_fallbacks(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            config_mod,
+            "_desktop_id_exists",
+            lambda desktop_id: desktop_id == "good.desktop",
+        )
+        assert (
+            config_mod._resolve_initial_desktop_id(
+                candidates=("bad.desktop", "good.desktop"),
+                fallback_content_types=(),
+            )
+            == "good.desktop"
+        )
+
+        monkeypatch.setattr(config_mod, "_desktop_id_exists", lambda _desktop_id: True)
+        monkeypatch.setattr(
+            config_mod,
+            "_default_desktop_id_for",
+            lambda content_type: (
+                "fallback.desktop" if content_type == "text/plain" else None
+            ),
+        )
+        assert (
+            config_mod._resolve_initial_desktop_id(
+                candidates=(),
+                fallback_content_types=("text/plain",),
+            )
+            == "fallback.desktop"
+        )
+
+    def test_read_config_data_rejects_non_object(self, tmp_path):
+        path = tmp_path / "dock.json"
+        path.write_text("[]", encoding="utf-8")
+
+        with pytest.raises(ValueError):
+            config_mod._read_config_data(path=path)
+
+        assert config_mod._is_valid_config_file(path=path) is False
+
+    def test_write_backup_copy_cleans_temp_on_failure(self, tmp_path, monkeypatch):
+        source = tmp_path / "source.json"
+        backup = tmp_path / "backup.json"
+        source.write_text("{}", encoding="utf-8")
+        monkeypatch.setattr(
+            Path, "read_bytes", lambda _self: (_ for _ in ()).throw(OSError("boom"))
+        )
+
+        with pytest.raises(OSError):
+            config_mod._write_backup_copy(source=source, backup_path=backup)
+
+        assert not backup.exists()

--- a/tests/ui/test_new_year.py
+++ b/tests/ui/test_new_year.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+import docking.ui.new_year as new_year_mod
+from docking.core.position import Position
+from docking.ui.new_year import NewYearGreetingController
+
+
+class _FakeGLib:
+    def __init__(self) -> None:
+        self.next_id = 10
+        self.scheduled: list[tuple[int, object]] = []
+        self.removed: list[int] = []
+
+    def timeout_add_seconds(self, seconds, callback):
+        self.next_id += 1
+        self.scheduled.append((seconds, callback))
+        return self.next_id
+
+    def source_remove(self, source_id):
+        self.removed.append(source_id)
+
+
+class _FakeScreen:
+    def __init__(self) -> None:
+        self.visual = object()
+
+    def get_rgba_visual(self):
+        return self.visual
+
+    def get_width(self):
+        return 800
+
+    def get_height(self):
+        return 600
+
+
+class _FakePopup:
+    def __init__(self, *args, **kwargs) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.child = None
+        self.destroyed = False
+        self.hidden = False
+        self.shown = False
+        self.moved_to = None
+        self.screen = _FakeScreen()
+        self.connections: dict[str, object] = {}
+        self.visual = None
+
+    def set_decorated(self, value):
+        self.decorated = value
+
+    def set_skip_taskbar_hint(self, value):
+        self.skip_taskbar = value
+
+    def set_resizable(self, value):
+        self.resizable = value
+
+    def set_type_hint(self, value):
+        self.type_hint = value
+
+    def set_app_paintable(self, value):
+        self.app_paintable = value
+
+    def set_transient_for(self, window):
+        self.transient_for = window
+
+    def connect(self, signal, callback):
+        self.connections[signal] = callback
+
+    def get_screen(self):
+        return self.screen
+
+    def set_visual(self, visual):
+        self.visual = visual
+
+    def get_child(self):
+        return self.child
+
+    def remove(self, child):
+        if self.child is child:
+            self.child = None
+
+    def add(self, child):
+        self.child = child
+
+    def show_all(self):
+        self.shown = True
+
+    def get_preferred_size(self):
+        return (None, SimpleNamespace(width=180, height=64))
+
+    def move(self, x, y):
+        self.moved_to = (x, y)
+
+    def destroy(self):
+        self.destroyed = True
+
+    def hide(self):
+        self.hidden = True
+
+
+class _FakeBox:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.margins: dict[str, int] = {}
+        self.children: list[object] = []
+
+    def set_margin_start(self, value):
+        self.margins["start"] = value
+
+    def set_margin_end(self, value):
+        self.margins["end"] = value
+
+    def set_margin_top(self, value):
+        self.margins["top"] = value
+
+    def set_margin_bottom(self, value):
+        self.margins["bottom"] = value
+
+    def pack_start(self, child, *args):
+        self.children.append((child, args))
+
+
+class _FakeImage:
+    @classmethod
+    def new_from_icon_name(cls, name, size):
+        obj = cls()
+        obj.name = name
+        obj.size = size
+        return obj
+
+    def set_valign(self, value):
+        self.valign = value
+
+
+class _FakeLabel:
+    def __init__(self, *, label="") -> None:
+        self.label = label
+
+    def set_xalign(self, value):
+        self.xalign = value
+
+    def set_yalign(self, value):
+        self.yalign = value
+
+    def override_color(self, *args):
+        self.color = args
+
+
+class _FakeWindow:
+    def __init__(self, *, pos=Position.BOTTOM, realized=True) -> None:
+        self.config = SimpleNamespace(pos=pos)
+        self.realized = realized
+
+    def get_realized(self):
+        return self.realized
+
+    def get_position(self):
+        return (100, 200)
+
+    def get_size(self):
+        return (300, 48)
+
+
+class _FakeCr:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple]] = []
+
+    def __getattr__(self, name):
+        def method(*args):
+            self.calls.append((name, args))
+
+        return method
+
+
+@pytest.fixture
+def fake_gtk(monkeypatch):
+    glib = _FakeGLib()
+    monkeypatch.setattr(new_year_mod, "GLib", glib)
+    monkeypatch.setattr(
+        new_year_mod,
+        "Gtk",
+        SimpleNamespace(
+            Window=_FakePopup,
+            WindowType=SimpleNamespace(POPUP="popup"),
+            Box=_FakeBox,
+            Orientation=SimpleNamespace(HORIZONTAL="horizontal"),
+            Image=_FakeImage,
+            IconSize=SimpleNamespace(DIALOG="dialog"),
+            Label=_FakeLabel,
+            Align=SimpleNamespace(CENTER="center"),
+            StateFlags=SimpleNamespace(NORMAL="normal"),
+        ),
+    )
+    monkeypatch.setattr(
+        new_year_mod,
+        "Gdk",
+        SimpleNamespace(
+            WindowTypeHint=SimpleNamespace(NOTIFICATION="notification"),
+            RGBA=lambda *args: args,
+        ),
+    )
+    return glib
+
+
+def test_start_is_idempotent_and_stop_cleans_sources(fake_gtk):
+    controller = NewYearGreetingController(window=_FakeWindow())
+    controller._popup = _FakePopup()
+
+    controller.start()
+    controller.start()
+
+    assert len(fake_gtk.scheduled) == 1
+    assert controller._start_source_id
+
+    controller._hide_source_id = 77
+    controller.stop()
+
+    assert fake_gtk.removed == [controller._start_source_id or 11, 77]
+    assert controller._start_source_id == 0
+    assert controller._hide_source_id == 0
+    assert controller._popup is None
+
+
+def test_startup_complete_consumes_greeting_and_shows_popup(monkeypatch):
+    controller = NewYearGreetingController(
+        window=_FakeWindow(),
+        state_path="/tmp/state.json",
+        now_fn=lambda: datetime(2026, 1, 2),
+    )
+    shown: list[int] = []
+
+    monkeypatch.setattr(
+        new_year_mod,
+        "consume_new_year_greeting",
+        lambda **kwargs: 2026,
+    )
+    monkeypatch.setattr(controller, "_show_popup", lambda *, year: shown.append(year))
+
+    controller._start_source_id = 42
+    assert controller._on_startup_complete() is False
+    assert controller._start_source_id == 0
+    assert shown == [2026]
+
+
+def test_startup_complete_noops_when_not_due(monkeypatch):
+    controller = NewYearGreetingController(window=_FakeWindow())
+    monkeypatch.setattr(new_year_mod, "consume_new_year_greeting", lambda **_k: None)
+    monkeypatch.setattr(
+        controller,
+        "_show_popup",
+        lambda **_k: (_ for _ in ()).throw(AssertionError("unexpected")),
+    )
+
+    assert controller._on_startup_complete() is False
+
+
+def test_show_popup_skips_unrealized_window(fake_gtk):
+    controller = NewYearGreetingController(window=_FakeWindow(realized=False))
+
+    controller._show_popup(year=2026)
+
+    assert controller._popup is None
+    assert fake_gtk.scheduled == []
+
+
+def test_show_popup_builds_positions_and_reuses_popup(fake_gtk):
+    controller = NewYearGreetingController(window=_FakeWindow(pos=Position.BOTTOM))
+
+    controller._show_popup(year=2026)
+    popup = controller._popup
+
+    assert isinstance(popup, _FakePopup)
+    assert popup.shown
+    assert popup.moved_to is not None
+    assert popup.child is not None
+    assert fake_gtk.scheduled[-1][0] == new_year_mod.NEW_YEAR_GREETING_DURATION_S
+
+    first_child = popup.child
+    controller._hide_source_id = 88
+    controller._show_popup(year=2027)
+
+    assert popup.child is not first_child
+    assert fake_gtk.removed[-1] == 88
+
+
+@pytest.mark.parametrize(
+    ("pos", "margin_key"),
+    [
+        (Position.BOTTOM, "bottom"),
+        (Position.TOP, "top"),
+        (Position.LEFT, "start"),
+        (Position.RIGHT, "end"),
+    ],
+)
+def test_build_popup_content_margins_by_position(fake_gtk, pos, margin_key):
+    controller = NewYearGreetingController(window=_FakeWindow(pos=pos))
+
+    box = controller._build_popup_content(year=2026)
+
+    assert isinstance(box, _FakeBox)
+    assert box.margins[margin_key] == (
+        new_year_mod.GREETING_MARGIN_PX + new_year_mod.GREETING_TIP_HEIGHT_PX
+    )
+    assert len(box.children) == 2
+
+
+@pytest.mark.parametrize("pos", list(Position))
+def test_position_popup_handles_all_edges(fake_gtk, pos):
+    controller = NewYearGreetingController(window=_FakeWindow(pos=pos))
+    controller._popup = _FakePopup()
+
+    controller._position_popup()
+
+    assert controller._popup.moved_to is not None
+
+
+def test_position_popup_noops_without_popup(fake_gtk):
+    controller = NewYearGreetingController(window=_FakeWindow())
+
+    controller._position_popup()
+
+    assert controller._popup is None
+
+
+@pytest.mark.parametrize("pos", list(Position))
+def test_draw_popup_handles_all_tips(fake_gtk, pos):
+    controller = NewYearGreetingController(window=_FakeWindow(pos=pos))
+    cr = _FakeCr()
+    widget = SimpleNamespace(
+        get_allocation=lambda: SimpleNamespace(width=180, height=64)
+    )
+
+    assert controller._on_popup_draw(widget, cr) is False
+
+    called = [name for name, _args in cr.calls]
+    assert "fill_preserve" in called
+    assert "stroke" in called
+
+
+def test_hide_and_button_press_remove_timer(fake_gtk):
+    controller = NewYearGreetingController(window=_FakeWindow())
+    controller._popup = _FakePopup()
+    controller._hide_source_id = 99
+
+    assert controller._on_popup_button_press(None, None) is True
+
+    assert fake_gtk.removed == [99]
+    assert controller._hide_source_id == 0
+    assert controller._popup.hidden
+
+    controller._hide_source_id = 100
+    assert controller._hide_popup() is False
+    assert controller._hide_source_id == 0

--- a/tests/ui/test_overlays.py
+++ b/tests/ui/test_overlays.py
@@ -1,0 +1,83 @@
+"""Tests for shared Cairo overlay helpers."""
+
+from __future__ import annotations
+
+import cairo
+
+from docking.ui.overlays import draw_circle_badge, draw_count_badge, draw_progress_bar
+
+
+def _context(size: int = 64) -> tuple[cairo.ImageSurface, cairo.Context]:
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, size, size)
+    return surface, cairo.Context(surface)
+
+
+def _non_empty(surface: cairo.ImageSurface) -> bool:
+    surface.flush()
+    return any(surface.get_data())
+
+
+def test_draw_circle_badge_with_and_without_outline():
+    surface, cr = _context()
+    draw_circle_badge(
+        cr=cr,
+        cx=16,
+        cy=16,
+        radius=8,
+        background_rgba=(1, 0, 0, 1),
+    )
+    draw_circle_badge(
+        cr=cr,
+        cx=40,
+        cy=16,
+        radius=8,
+        background_rgba=(0, 1, 0, 1),
+        outline_rgba=(1, 1, 1, 1),
+        outline_width=2,
+    )
+
+    assert _non_empty(surface)
+
+
+def test_draw_count_badge_supports_all_label_lengths():
+    surface, cr = _context()
+
+    draw_count_badge(cr=cr, x=2, y=4, width=18, height=16, badge_count=7)
+    draw_count_badge(cr=cr, x=22, y=4, width=20, height=16, badge_count=42)
+    draw_count_badge(cr=cr, x=2, y=28, width=28, height=16, badge_count=120)
+
+    assert _non_empty(surface)
+
+
+def test_draw_progress_bar_clamps_and_switches_dark_fill():
+    surface, cr = _context()
+
+    draw_progress_bar(
+        cr=cr,
+        x=4,
+        y=8,
+        width=40,
+        height=8,
+        progress=0,
+        color=(0.8, 0.8, 0.8),
+    )
+    draw_progress_bar(
+        cr=cr,
+        x=4,
+        y=24,
+        width=40,
+        height=8,
+        progress=0.5,
+        color=(0.1, 0.1, 0.1),
+    )
+    draw_progress_bar(
+        cr=cr,
+        x=4,
+        y=40,
+        width=40,
+        height=8,
+        progress=2,
+        color=(0.8, 0.2, 0.2, 1.0),
+    )
+
+    assert _non_empty(surface)


### PR DESCRIPTION
## Summary
- Add shared applet helpers for freshness/cadence text, live-data state handling, structured tooltips, and GTK popup surfaces.
- Update existing applets to use the shared menu, tooltip, refresh, and status patterns from the applied patch.
- Add broad applet and UI coverage for the new shared helpers and updated applet behavior.
- Refresh `docking.pot` only; translation catalogs are intentionally left unchanged for a translation-only PR.