### PR TITLE
Add update release checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Config is stored at `~/.config/docking/dock.json` (auto-created on first run). N
 | `anchor_files` | false | Keep file and folder entries anchored at the end independently |
 | `tooltips_enabled` | true | Show hover tooltips for dock items |
 | `active_display` | false | Follow the active monitor instead of staying on one display |
+| `update_check_enabled` | true | Check GitHub for newer Docking releases |
+| `update_check_interval_hours` | 24 | Minimum hours between automatic update checks |
 | `left_click_action` | toggle | Running-app left click: `toggle`, `cycle`, or `most-recent` |
 | `middle_click_action` | new-window | Application middle click: `new-window`, `minimize`, or `close-focused` |
 | `theme` | default | Theme name (loads from `assets/themes/{name}.json`) |
@@ -210,7 +212,12 @@ Config is stored at `~/.config/docking/dock.json` (auto-created on first run). N
 - `window-dodge`: Dock hides when any window on the current workspace overlaps the dock.
 - `dodge-maximized`: Dock hides when the focused window is maximized or a dialog overlaps the dock.
 
-All settings are also configurable via the dock's right-click menu. On multi-monitor setups, use **Display** to move the dock to another monitor. The preferences window also exposes **Mouse** actions so left click can toggle, cycle, or focus the most recently used window of the running app, and middle click can open a new window, minimize the app windows, or close the app's focused window. Pick the left-click mode under right-click -> **Preferences** -> **Behavior** -> **Mouse**.
+All settings are also configurable via the dock's right-click menu. On multi-monitor setups, use **Display** to move the dock to another monitor. The preferences window also exposes **Mouse** actions so left click can toggle, cycle, or focus the most recently used window of the running app, and middle click can open a new window, minimize the app windows, or close the app's focused window. Pick the left-click mode under right-click -> **Preferences** -> **Behavior** -> **Mouse**. Update checks live under right-click -> **Preferences** -> **Updates**, where you can disable automatic checks, choose daily or weekly checks, check immediately, or open the releases page.
+
+Docking stores update-check preferences in `dock.json`. Runtime update state,
+such as the last checked timestamp, ignored release version, and remind-later
+timestamp, is stored separately under XDG state storage in
+`~/.local/state/docking/updates.json`.
 
 ## Managing Dock Items
 

--- a/docking/app.py
+++ b/docking/app.py
@@ -107,10 +107,12 @@ def main() -> None:
         unity.start()
         window.show_all()
         new_year.start()
+        window.start_update_checks()
         GLib.idle_add(_start_runtime, items_service, model)
         Gtk.main()
     finally:
         items_service.stop()
+        window.stop_update_checks()
         new_year.stop()
         unity.stop()
         model.stop_applets()

--- a/docking/core/config.py
+++ b/docking/core/config.py
@@ -251,6 +251,8 @@ DEFAULT_ANCHOR_APPLETS = False
 DEFAULT_ANCHOR_FILES = False
 DEFAULT_TOOLTIPS_ENABLED = True
 DEFAULT_ACTIVE_DISPLAY = False
+DEFAULT_UPDATE_CHECK_ENABLED = True
+DEFAULT_UPDATE_CHECK_INTERVAL_HOURS = 24
 DEFAULT_THEME = "default"
 DEFAULT_TRANSPARENCY = 1.0
 MIN_ICON_SIZE = 32
@@ -693,6 +695,10 @@ class Config:
     tooltips_enabled: bool = DEFAULT_TOOLTIPS_ENABLED
     # Whether the dock follows the cursor across monitors
     active_display: bool = DEFAULT_ACTIVE_DISPLAY
+    # Whether Docking checks GitHub for newer releases
+    update_check_enabled: bool = DEFAULT_UPDATE_CHECK_ENABLED
+    # Minimum hours between automatic update checks
+    update_check_interval_hours: int = DEFAULT_UPDATE_CHECK_INTERVAL_HOURS
     # Left-click behavior for running apps
     left_click_action: str = DEFAULT_LEFT_CLICK_ACTION
     # Middle-click behavior for app items
@@ -800,6 +806,15 @@ class Config:
         self.active_display = _normalize_bool(
             self.active_display,
             default=DEFAULT_ACTIVE_DISPLAY,
+        )
+        self.update_check_enabled = _normalize_bool(
+            self.update_check_enabled,
+            default=DEFAULT_UPDATE_CHECK_ENABLED,
+        )
+        self.update_check_interval_hours = _normalize_int(
+            self.update_check_interval_hours,
+            default=DEFAULT_UPDATE_CHECK_INTERVAL_HOURS,
+            minimum=1,
         )
         self.left_click_action = _normalize_left_click_action(
             self.left_click_action,

--- a/docking/core/updates.py
+++ b/docking/core/updates.py
@@ -1,0 +1,276 @@
+"""Release update checks and persistent update notification state.
+
+User intent lives in ``Config``: whether update checks are enabled and how often
+they should run. Runtime bookkeeping lives here, under XDG state storage:
+last check time, ignored versions, and reminder suppression.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import cast
+
+from docking.log import get_logger
+
+logger = get_logger("updates")
+
+GITHUB_LATEST_RELEASE_URL = (
+    "https://api.github.com/repos/edumucelli/docking/releases/latest"
+)
+PROJECT_RELEASES_URL = "https://github.com/edumucelli/docking/releases"
+DEFAULT_STATE_DIR = (
+    Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state")) / "docking"
+)
+DEFAULT_STATE_FILE = DEFAULT_STATE_DIR / "updates.json"
+DEFAULT_UPDATE_TIMEOUT_S = 6
+UPDATE_USER_AGENT = "Docking update checker"
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseInfo:
+    """GitHub release metadata needed by the update UI."""
+
+    version: str
+    url: str
+    name: str
+    published_at: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateState:
+    """Persistent runtime state for update checks and popup responses."""
+
+    last_checked_at: str = ""
+    last_seen_version: str = ""
+    ignored_version: str = ""
+    remind_after: str = ""
+    last_result: str = ""
+    last_error: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateDecision:
+    """Result of deciding whether to show the update popup."""
+
+    should_show: bool
+    reason: str
+    release: ReleaseInfo | None = None
+
+
+def load_state(path: Path | str | None = None) -> UpdateState:
+    """Load update state, falling back to defaults on missing/corrupt data."""
+    state_path = Path(path) if path is not None else DEFAULT_STATE_FILE
+    if not state_path.exists():
+        return UpdateState()
+    try:
+        with state_path.open(encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except Exception as exc:
+        logger.warning("Failed to load update state %s: %s", state_path, exc)
+        return UpdateState()
+    if not isinstance(raw, dict):
+        logger.warning("Invalid update state payload in %s; using defaults", state_path)
+        return UpdateState()
+    return UpdateState(
+        last_checked_at=_coerce_str(raw.get("last_checked_at")),
+        last_seen_version=_coerce_str(raw.get("last_seen_version")),
+        ignored_version=_coerce_str(raw.get("ignored_version")),
+        remind_after=_coerce_str(raw.get("remind_after")),
+        last_result=_coerce_str(raw.get("last_result")),
+        last_error=_coerce_str(raw.get("last_error")),
+    )
+
+
+def save_state(state: UpdateState, *, path: Path | str | None = None) -> None:
+    """Persist update state atomically."""
+    state_path = Path(path) if path is not None else DEFAULT_STATE_FILE
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=state_path.parent,
+        prefix=f".{state_path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        tmp_path = Path(handle.name)
+        json.dump(
+            {
+                "ignored_version": state.ignored_version,
+                "last_checked_at": state.last_checked_at,
+                "last_error": state.last_error,
+                "last_result": state.last_result,
+                "last_seen_version": state.last_seen_version,
+                "remind_after": state.remind_after,
+            },
+            handle,
+            indent=2,
+            sort_keys=True,
+        )
+        handle.write("\n")
+    tmp_path.replace(state_path)
+
+
+def should_check_for_updates(
+    *,
+    enabled: bool,
+    interval_hours: int,
+    state: UpdateState,
+    now: datetime | None = None,
+) -> bool:
+    """Return true when an automatic update check is due."""
+    if not enabled:
+        return False
+    checked_at = parse_timestamp(state.last_checked_at)
+    if checked_at is None:
+        return True
+    reference = _aware_utc(now)
+    return reference - checked_at >= timedelta(hours=max(1, interval_hours))
+
+
+def decide_update_popup(
+    *,
+    current_version: str,
+    release: ReleaseInfo | None,
+    state: UpdateState,
+    now: datetime | None = None,
+) -> UpdateDecision:
+    """Decide whether a fetched release should be shown to the user."""
+    if release is None:
+        return UpdateDecision(False, "no-release")
+    if not is_newer_version(release.version, current_version):
+        return UpdateDecision(False, "not-newer", release)
+    if normalize_version(release.version) == normalize_version(state.ignored_version):
+        return UpdateDecision(False, "ignored", release)
+    remind_after = parse_timestamp(state.remind_after)
+    if remind_after is not None and _aware_utc(now) < remind_after:
+        return UpdateDecision(False, "remind-later", release)
+    return UpdateDecision(True, "newer", release)
+
+
+def fetch_latest_release(
+    *,
+    url: str = GITHUB_LATEST_RELEASE_URL,
+    timeout: int = DEFAULT_UPDATE_TIMEOUT_S,
+) -> ReleaseInfo:
+    """Fetch latest GitHub release metadata."""
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": UPDATE_USER_AGENT,
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = response.read()
+    except urllib.error.URLError:
+        raise
+    data = json.loads(payload.decode("utf-8"))
+    return parse_github_release(data)
+
+
+def parse_github_release(data: object) -> ReleaseInfo:
+    """Parse a GitHub release payload into ``ReleaseInfo``."""
+    if not isinstance(data, dict):
+        raise ValueError("GitHub release payload is not an object")
+    payload = cast("dict[str, object]", data)
+    tag = _coerce_str(payload.get("tag_name"))
+    if not tag:
+        raise ValueError("GitHub release payload is missing tag_name")
+    html_url = _coerce_str(payload.get("html_url"))
+    if not html_url:
+        html_url = PROJECT_RELEASES_URL
+    name = _coerce_str(payload.get("name"))
+    if not name:
+        name = tag
+    published_at = _coerce_str(payload.get("published_at"))
+    return ReleaseInfo(
+        version=normalize_version(tag),
+        url=html_url,
+        name=name,
+        published_at=published_at if published_at else None,
+    )
+
+
+def is_newer_version(candidate: str, current: str) -> bool:
+    """Return true when candidate is newer than current."""
+    return compare_versions(candidate, current) > 0
+
+
+def compare_versions(left: str, right: str) -> int:
+    """Compare two simple release versions.
+
+    Supports normal Docking tags such as ``1.16.0`` and ``v1.16.0``. Suffixes
+    are treated as prerelease/build details and ignored for ordering.
+    """
+    left_parts = _version_parts(left)
+    right_parts = _version_parts(right)
+    width = max(len(left_parts), len(right_parts), 3)
+    left_parts = left_parts + (0,) * (width - len(left_parts))
+    right_parts = right_parts + (0,) * (width - len(right_parts))
+    if left_parts > right_parts:
+        return 1
+    if left_parts < right_parts:
+        return -1
+    return 0
+
+
+def normalize_version(version: str) -> str:
+    """Normalize release tags for storage and comparison."""
+    value = str(version).strip()
+    if value.startswith(("v", "V")):
+        value = value[1:]
+    match = re.match(r"^([0-9]+(?:\.[0-9]+)*)", value)
+    return match.group(1) if match else value
+
+
+def parse_timestamp(value: str | None) -> datetime | None:
+    """Parse an ISO timestamp into an aware UTC datetime."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return _aware_utc(parsed)
+
+
+def utc_now_iso(now: datetime | None = None) -> str:
+    """Return a UTC ISO timestamp suitable for update state."""
+    return _aware_utc(now).isoformat()
+
+
+def _version_parts(version: str) -> tuple[int, ...]:
+    normalized = normalize_version(version)
+    if not normalized:
+        return ()
+    parts: list[int] = []
+    for piece in normalized.split("."):
+        try:
+            parts.append(int(piece))
+        except ValueError:
+            break
+    return tuple(parts)
+
+
+def _aware_utc(value: datetime | None) -> datetime:
+    timestamp = datetime.now(timezone.utc) if value is None else value
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc)
+
+
+def _coerce_str(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-04-30 20:33+0200\n"
+"POT-Creation-Date: 2026-05-01 21:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -909,6 +909,7 @@ msgid "{verb} every {interval}"
 msgstr ""
 
 #: docking/applets/freshness.py:29 docking/applets/freshness.py:36
+#: docking/ui/settings.py:194
 msgid "Updates"
 msgstr ""
 
@@ -1925,7 +1926,7 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: docking/ui/dock_window.py:377
+#: docking/ui/dock_window.py:379
 msgid "Docking"
 msgstr ""
 
@@ -2021,7 +2022,7 @@ msgstr ""
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:1710 docking/ui/settings.py:163
+#: docking/ui/menu.py:1710 docking/ui/settings.py:167
 msgid "Preferences"
 msgstr ""
 
@@ -2051,192 +2052,263 @@ msgstr ""
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-#: docking/ui/settings.py:187
+#: docking/ui/settings.py:191
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:188 docking/ui/settings.py:362
+#: docking/ui/settings.py:192 docking/ui/settings.py:379
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:189
+#: docking/ui/settings.py:193
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:207
+#: docking/ui/settings.py:212
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:208
+#: docking/ui/settings.py:213
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:209
+#: docking/ui/settings.py:214
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:210
+#: docking/ui/settings.py:215
 msgid "Dodge Active Window"
 msgstr ""
 
-#: docking/ui/settings.py:211
+#: docking/ui/settings.py:216
 msgid "Dodge All Windows"
 msgstr ""
 
-#: docking/ui/settings.py:212
+#: docking/ui/settings.py:217
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:229
+#: docking/ui/settings.py:234
 msgid "Toggle Focus"
 msgstr ""
 
-#: docking/ui/settings.py:230
+#: docking/ui/settings.py:235
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:231
+#: docking/ui/settings.py:236
 msgid "Most Recent Window"
 msgstr ""
 
-#: docking/ui/settings.py:238
+#: docking/ui/settings.py:243
 msgid "New Window"
 msgstr ""
 
-#: docking/ui/settings.py:239
+#: docking/ui/settings.py:244
 msgid "Minimize Windows"
 msgstr ""
 
-#: docking/ui/settings.py:240
+#: docking/ui/settings.py:245
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:247
+#: docking/ui/settings.py:252
 msgid "Click"
 msgstr ""
 
-#: docking/ui/settings.py:248
+#: docking/ui/settings.py:253
 msgid "Hover"
 msgstr ""
 
-#: docking/ui/settings.py:306
-msgid "Look"
+#: docking/ui/settings.py:269
+msgid "Daily"
 msgstr ""
 
-#: docking/ui/settings.py:308
-msgid "Theme"
-msgstr ""
-
-#: docking/ui/settings.py:309
-msgid "Icon Size"
-msgstr ""
-
-#: docking/ui/settings.py:310
-msgid "Transparency"
-msgstr ""
-
-#: docking/ui/settings.py:311
-msgid "Zoom"
-msgstr ""
-
-#: docking/ui/settings.py:312
-msgid "Zoom Percent"
-msgstr ""
-
-#: docking/ui/settings.py:313
-msgid "Show Tooltips"
-msgstr ""
-
-#: docking/ui/settings.py:314
-msgid "Window Previews"
-msgstr ""
-
-#: docking/ui/settings.py:319
-msgid "Placement"
-msgstr ""
-
-#: docking/ui/settings.py:321
-msgid "Position"
-msgstr ""
-
-#: docking/ui/settings.py:322
-msgid "Follow Cursor"
+#: docking/ui/settings.py:270
+msgid "Weekly"
 msgstr ""
 
 #: docking/ui/settings.py:323
-msgid "Current Workspace Only"
+msgid "Look"
+msgstr ""
+
+#: docking/ui/settings.py:325
+msgid "Theme"
+msgstr ""
+
+#: docking/ui/settings.py:326
+msgid "Icon Size"
+msgstr ""
+
+#: docking/ui/settings.py:327
+msgid "Transparency"
 msgstr ""
 
 #: docking/ui/settings.py:328
-msgid "Layout"
+msgid "Zoom"
+msgstr ""
+
+#: docking/ui/settings.py:329
+msgid "Zoom Percent"
 msgstr ""
 
 #: docking/ui/settings.py:330
-msgid "Lock Positions"
+msgid "Show Tooltips"
 msgstr ""
 
 #: docking/ui/settings.py:331
+msgid "Window Previews"
+msgstr ""
+
+#: docking/ui/settings.py:336
+msgid "Placement"
+msgstr ""
+
+#: docking/ui/settings.py:338
+msgid "Position"
+msgstr ""
+
+#: docking/ui/settings.py:339
+msgid "Follow Cursor"
+msgstr ""
+
+#: docking/ui/settings.py:340
+msgid "Current Workspace Only"
+msgstr ""
+
+#: docking/ui/settings.py:345
+msgid "Layout"
+msgstr ""
+
+#: docking/ui/settings.py:347
+msgid "Lock Positions"
+msgstr ""
+
+#: docking/ui/settings.py:348
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:332
+#: docking/ui/settings.py:349
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:371
 msgid "Mouse"
 msgstr ""
 
-#: docking/ui/settings.py:356
+#: docking/ui/settings.py:373
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:357
+#: docking/ui/settings.py:374
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:364
+#: docking/ui/settings.py:381
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:365
+#: docking/ui/settings.py:382
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:366
+#: docking/ui/settings.py:383
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:371
+#: docking/ui/settings.py:388
 msgid "Folder Stacks"
 msgstr ""
 
-#: docking/ui/settings.py:373
+#: docking/ui/settings.py:390
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:792
+#: docking/ui/settings.py:415
+msgid "Check Now"
+msgstr ""
+
+#: docking/ui/settings.py:417
+msgid "View Releases"
+msgstr ""
+
+#: docking/ui/settings.py:429
+msgid "Update Checks"
+msgstr ""
+
+#: docking/ui/settings.py:431
+msgid "Check Automatically"
+msgstr ""
+
+#: docking/ui/settings.py:432
+msgid "Frequency"
+msgstr ""
+
+#: docking/ui/settings.py:433
+msgid "Status"
+msgstr ""
+
+#: docking/ui/settings.py:434
+msgid "Actions"
+msgstr ""
+
+#: docking/ui/settings.py:840
+#, python-brace-format
+msgid "Last seen version: {version}"
+msgstr ""
+
+#: docking/ui/settings.py:844
+msgid "No update found yet"
+msgstr ""
+
+#: docking/ui/settings.py:846
+msgid "Not checked yet"
+msgstr ""
+
+#: docking/ui/settings.py:880
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:793
+#: docking/ui/settings.py:881
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:795
+#: docking/ui/settings.py:883
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:797
+#: docking/ui/settings.py:885
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:799
+#: docking/ui/settings.py:887
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:802
+#: docking/ui/settings.py:890
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
+msgstr ""
+
+#: docking/ui/update_popup.py:183
+#, python-brace-format
+msgid "Docking {version} is available"
+msgstr ""
+
+#: docking/ui/update_popup.py:189
+#, python-brace-format
+msgid "You are using {version}."
+msgstr ""
+
+#: docking/ui/update_popup.py:198
+msgid "View Release"
+msgstr ""
+
+#: docking/ui/update_popup.py:199
+msgid "Later"
+msgstr ""
+
+#: docking/ui/update_popup.py:200
+msgid "Ignore"
 msgstr ""

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -217,6 +217,7 @@ from docking.ui.preview import PreviewPopup
 from docking.ui.runtime import DockRuntime
 from docking.ui.settings import SettingsWindowController
 from docking.ui.tooltip import TooltipManager
+from docking.ui.update_popup import UpdateCheckController
 
 log = get_logger(name="dock_window")
 
@@ -342,6 +343,7 @@ class DockWindow(Gtk.Window):
         self._menu: MenuHandler
         self.preview: PreviewPopup
         self._menu_popup_visible: bool = False
+        self._update_checker: UpdateCheckController
         self.tooltip = TooltipManager(self, config, model, theme)
         self.geometry = DockGeometryBuilder(self)
 
@@ -445,9 +447,18 @@ class DockWindow(Gtk.Window):
         """Release model subscriptions owned by the dock shell."""
         self._disconnect_model()
 
+    def start_update_checks(self) -> None:
+        """Start update-check scheduling owned by the dock shell."""
+        self._update_checker.start()
+
+    def stop_update_checks(self) -> None:
+        """Stop update-check scheduling owned by the dock shell."""
+        self._update_checker.stop()
+
     def _build_components(self, *, launcher: Launcher) -> None:
         """Build long-lived UI collaborators that depend on the live window."""
-        runtime = DockRuntime(self)
+        self._update_checker = UpdateCheckController(window=self, config=self.config)
+        runtime = DockRuntime(self, update_checker=self._update_checker)
         about = AboutDialogController(parent=self)
         settings = SettingsWindowController(
             parent=self,

--- a/docking/ui/runtime.py
+++ b/docking/ui/runtime.py
@@ -7,13 +7,20 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from docking.core.theme import Theme
     from docking.ui.dock_window import DockWindow
+    from docking.ui.update_popup import UpdateCheckController
 
 
 class DockRuntime:
     """Narrow imperative API for subsystems that should not own DockWindow."""
 
-    def __init__(self, window: DockWindow) -> None:
+    def __init__(
+        self,
+        window: DockWindow,
+        *,
+        update_checker: UpdateCheckController,
+    ) -> None:
         self._window = window
+        self._update_checker = update_checker
 
     def menu_popup_opened(self) -> None:
         self._window.interaction.menu_popup_opened()
@@ -57,3 +64,9 @@ class DockRuntime:
 
     def set_theme(self, theme: Theme) -> None:
         self._window.theme = theme
+
+    def check_for_updates_now(self) -> None:
+        self._update_checker.check_now()
+
+    def open_releases_page(self) -> None:
+        self._update_checker.open_releases_page()

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -55,6 +55,7 @@ from docking.core.config import (
 )
 from docking.core.position import Position
 from docking.core.theme import _BUILTIN_THEMES_DIR, Theme
+from docking.core.updates import load_state
 from docking.i18n import _
 from docking.log import get_logger
 
@@ -145,6 +146,9 @@ class SettingsWindowController:
         self._zoom_percent_spin: Any = None
         self._hide_delay_spin: Any = None
         self._unhide_delay_spin: Any = None
+        self._update_check_switch: Any = None
+        self._update_interval_combo: Any = None
+        self._update_status_label: Any = None
         self._applets_box: Any = None
         self._applet_checks: dict[str, Gtk.CheckButton] = {}
         self._bindings: list[_ScalarBinding] = []
@@ -187,6 +191,7 @@ class SettingsWindowController:
         stack.add_titled(self._build_appearance_tab(), "appearance", _("Appearance"))
         stack.add_titled(self._build_behavior_tab(), "behavior", _("Behavior"))
         stack.add_titled(self._build_applets_tab(), "applets", _("Applets"))
+        stack.add_titled(self._build_updates_tab(), "updates", _("Updates"))
 
         outer.pack_start(switcher, False, False, 0)
         outer.pack_start(stack, True, True, 0)
@@ -257,6 +262,18 @@ class SettingsWindowController:
         self._anchor_applets_switch = self._new_switch()
         self._anchor_files_switch = self._new_switch()
         self._zoom_enabled_switch = self._new_switch()
+        self._update_check_switch = self._new_switch()
+
+        self._update_interval_combo = Gtk.ComboBoxText()
+        for value, label in [
+            ("24", _("Daily")),
+            ("168", _("Weekly")),
+        ]:
+            self._update_interval_combo.append(value, label)
+
+        self._update_status_label = Gtk.Label()
+        self._update_status_label.set_xalign(0.0)
+        self._update_status_label.set_line_wrap(True)
 
         self._theme_combo = Gtk.ComboBoxText()
         for theme_name in sorted(p.stem for p in _BUILTIN_THEMES_DIR.glob("*.json")):
@@ -388,6 +405,37 @@ class SettingsWindowController:
         self._rebuild_applet_tab()
         return scroller
 
+    def _build_updates_tab(self) -> Gtk.Widget:
+        outer = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=APPEARANCE_TAB_SPACING_PX,
+        )
+        outer.set_border_width(APPEARANCE_TAB_BORDER_PX)
+
+        check_now = Gtk.Button(label=_("Check Now"))
+        check_now.connect("clicked", self._on_check_updates_now)
+        view_releases = Gtk.Button(label=_("View Releases"))
+        view_releases.connect("clicked", self._on_view_releases)
+
+        actions = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=ROW_SPACING_PX,
+        )
+        actions.pack_start(check_now, False, False, 0)
+        actions.pack_start(view_releases, False, False, 0)
+
+        self._append_section(
+            outer=outer,
+            title=_("Update Checks"),
+            rows=[
+                (_("Check Automatically"), self._update_check_switch),
+                (_("Frequency"), self._update_interval_combo),
+                (_("Status"), self._update_status_label),
+                (_("Actions"), actions),
+            ],
+        )
+        return outer
+
     def _build_row(self, *, label: str, widget: Gtk.Widget) -> Gtk.Box:
         row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=ROW_SPACING_PX)
         row.set_size_request(APPEARANCE_ROW_WIDTH_PX, -1)
@@ -513,6 +561,19 @@ class SettingsWindowController:
                 config_attr="zoom_enabled",
                 widget=self._zoom_enabled_switch,
                 on_change=lambda _value: self._runtime.queue_draw(),
+            ),
+            self._register_switch_binding(
+                config_attr="update_check_enabled",
+                widget=self._update_check_switch,
+            ),
+            self._register_numeric_binding(
+                config_attr="update_check_interval_hours",
+                widget=self._update_interval_combo,
+                read_widget=self._read_update_interval_hours,
+                write_widget=lambda value: self._update_interval_combo.set_active_id(
+                    str(value)
+                ),
+                signal="changed",
             ),
             self._register_choice_binding(
                 config_attr="theme",
@@ -646,6 +707,7 @@ class SettingsWindowController:
             }
             for desktop_id, check in self._applet_checks.items():
                 check.set_active(desktop_id in active_ids)
+            self._update_updates_status()
         finally:
             self._syncing_widgets = False
         self._update_dependent_sensitivity()
@@ -763,6 +825,32 @@ class SettingsWindowController:
         if binding.on_change is not None:
             binding.on_change(value)
         self._update_dependent_sensitivity()
+
+    def _read_update_interval_hours(self) -> int | None:
+        active_id = self._update_interval_combo.get_active_id()
+        if active_id is None:
+            return None
+        return int(active_id)
+
+    def _update_updates_status(self) -> None:
+        if self._update_status_label is None:
+            return
+        state = load_state()
+        if state.last_seen_version:
+            text = _("Last seen version: {version}").format(
+                version=state.last_seen_version
+            )
+        elif state.last_checked_at:
+            text = _("No update found yet")
+        else:
+            text = _("Not checked yet")
+        self._update_status_label.set_label(text)
+
+    def _on_check_updates_now(self, _button: Gtk.Button) -> None:
+        self._runtime.check_for_updates_now()
+
+    def _on_view_releases(self, _button: Gtk.Button) -> None:
+        self._runtime.open_releases_page()
 
     def _apply_runtime_theme(self) -> None:
         theme = Theme.load(self._config.theme, self._config.icon_size).with_opacity(

--- a/docking/ui/update_popup.py
+++ b/docking/ui/update_popup.py
@@ -1,0 +1,283 @@
+"""Release update checker and popup UI."""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+import gi
+
+gi.require_version("Gdk", "3.0")
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk, Gio, GLib, Gtk
+
+from docking import __version__
+from docking.core.position import is_horizontal
+from docking.core.updates import (
+    PROJECT_RELEASES_URL,
+    ReleaseInfo,
+    UpdateState,
+    decide_update_popup,
+    fetch_latest_release,
+    load_state,
+    save_state,
+    should_check_for_updates,
+    utc_now_iso,
+)
+from docking.i18n import _
+from docking.log import get_logger
+from docking.ui.display import clamp_to_screen
+from docking.ui.tooltip import compute_tooltip_position
+
+if TYPE_CHECKING:
+    from docking.core.config import Config
+
+log = get_logger("updates")
+
+UPDATE_CHECK_DELAY_S = 8
+UPDATE_POPUP_GAP_PX = 16
+UPDATE_POPUP_SPACING_PX = 10
+UPDATE_POPUP_MARGIN_PX = 12
+REMIND_LATER_HOURS = 24
+
+
+class UpdateCheckController:
+    """Schedules release checks and presents update notifications."""
+
+    def __init__(
+        self,
+        *,
+        window: Gtk.Window,
+        config: Config,
+    ) -> None:
+        self._window = window
+        self._config = config
+        self._start_source_id: int = 0
+        self._popup: Gtk.Window | None = None
+        self._latest_release: ReleaseInfo | None = None
+
+    def start(self) -> None:
+        """Schedule an automatic update check if user preferences allow it."""
+        if self._start_source_id or not self._config.update_check_enabled:
+            return
+        state = load_state()
+        if not should_check_for_updates(
+            enabled=self._config.update_check_enabled,
+            interval_hours=self._config.update_check_interval_hours,
+            state=state,
+            now=datetime.now(timezone.utc),
+        ):
+            return
+        self._start_source_id = GLib.timeout_add_seconds(
+            UPDATE_CHECK_DELAY_S,
+            self._on_startup_delay_elapsed,
+        )
+
+    def stop(self) -> None:
+        """Cancel scheduled work and close any visible popup."""
+        if self._start_source_id:
+            GLib.source_remove(self._start_source_id)
+            self._start_source_id = 0
+        if self._popup is not None:
+            self._popup.destroy()
+            self._popup = None
+
+    def check_now(self) -> None:
+        """Run a manual update check immediately."""
+        self._run_check_in_thread()
+
+    def open_releases_page(self) -> None:
+        """Open the project releases page."""
+        self._open_url(PROJECT_RELEASES_URL)
+
+    def _on_startup_delay_elapsed(self) -> bool:
+        self._start_source_id = 0
+        self._run_check_in_thread()
+        return False
+
+    def _run_check_in_thread(self) -> None:
+        thread = threading.Thread(target=self._check_worker, daemon=True)
+        thread.start()
+
+    def _check_worker(self) -> None:
+        release: ReleaseInfo | None = None
+        error = ""
+        try:
+            release = fetch_latest_release()
+        except Exception as exc:
+            error = str(exc)
+            log.debug("Update check failed: %s", exc)
+        GLib.idle_add(self._on_check_finished, release, error)
+
+    def _on_check_finished(
+        self,
+        release: ReleaseInfo | None,
+        error: str,
+    ) -> bool:
+        now = datetime.now(timezone.utc)
+        current_state = load_state()
+        state = UpdateState(
+            ignored_version=current_state.ignored_version,
+            last_checked_at=utc_now_iso(now),
+            last_error=error,
+            last_result="error" if error else "ok",
+            last_seen_version=release.version
+            if release
+            else current_state.last_seen_version,
+            remind_after=current_state.remind_after,
+        )
+        decision = decide_update_popup(
+            current_version=__version__,
+            release=release,
+            state=state,
+            now=now,
+        )
+        save_state(state)
+        if decision.should_show and decision.release is not None:
+            self._show_popup(release=decision.release)
+        return False
+
+    def _show_popup(self, *, release: ReleaseInfo) -> None:
+        if not self._window.get_realized():
+            log.debug("Skipping update popup because dock window is not realized")
+            return
+        self._latest_release = release
+        if self._popup is None:
+            popup = Gtk.Window(type=Gtk.WindowType.POPUP)
+            popup.set_decorated(False)
+            popup.set_skip_taskbar_hint(True)
+            popup.set_resizable(False)
+            popup.set_type_hint(Gdk.WindowTypeHint.NOTIFICATION)
+            popup.set_transient_for(self._window)
+            self._popup = popup
+        else:
+            child = self._popup.get_child()
+            if child is not None:
+                self._popup.remove(child)
+
+        self._popup.add(self._build_popup_content(release=release))
+        self._popup.show_all()
+        self._position_popup()
+
+    def _build_popup_content(self, *, release: ReleaseInfo) -> Gtk.Widget:
+        frame = Gtk.Frame()
+        frame.set_shadow_type(Gtk.ShadowType.OUT)
+        box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=UPDATE_POPUP_SPACING_PX,
+        )
+        box.set_border_width(UPDATE_POPUP_MARGIN_PX)
+
+        title = Gtk.Label(
+            label=_("Docking {version} is available").format(version=release.version)
+        )
+        title.set_xalign(0.0)
+        box.pack_start(title, False, False, 0)
+
+        detail = Gtk.Label(
+            label=_("You are using {version}.").format(version=__version__)
+        )
+        detail.set_xalign(0.0)
+        box.pack_start(detail, False, False, 0)
+
+        buttons = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=UPDATE_POPUP_SPACING_PX,
+        )
+        view = Gtk.Button(label=_("View Release"))
+        later = Gtk.Button(label=_("Later"))
+        ignore = Gtk.Button(label=_("Ignore"))
+        view.connect("clicked", self._on_view_release)
+        later.connect("clicked", self._on_later)
+        ignore.connect("clicked", self._on_ignore)
+        buttons.pack_start(view, False, False, 0)
+        buttons.pack_start(later, False, False, 0)
+        buttons.pack_start(ignore, False, False, 0)
+        box.pack_start(buttons, False, False, 0)
+        frame.add(box)
+        return frame
+
+    def _position_popup(self) -> None:
+        if self._popup is None:
+            return
+        win_x, win_y = self._window.get_position()
+        win_w, win_h = self._window.get_size()
+        pref = self._popup.get_preferred_size()[1]
+        popup_w = max(pref.width, 1)
+        popup_h = max(pref.height, 1)
+        pos = self._window.config.pos
+        if is_horizontal(pos):
+            anchor_x = win_x + win_w / 2
+            anchor_y = win_y if pos.value == "bottom" else win_y + win_h
+        else:
+            anchor_x = win_x + win_w if pos.value == "left" else win_x
+            anchor_y = win_y + win_h / 2
+        popup_x, popup_y = compute_tooltip_position(
+            pos=pos,
+            anchor_x=anchor_x,
+            anchor_y=anchor_y,
+            tooltip_w=popup_w,
+            tooltip_h=popup_h,
+            gap=UPDATE_POPUP_GAP_PX,
+        )
+        screen = self._popup.get_screen()
+        clamped = clamp_to_screen(
+            popup_x,
+            popup_y,
+            popup_w,
+            popup_h,
+            screen.get_width(),
+            screen.get_height(),
+        )
+        self._popup.move(clamped.x, clamped.y)
+
+    def _on_view_release(self, _button: Gtk.Button) -> None:
+        if self._latest_release is not None:
+            self._open_url(self._latest_release.url)
+        self._hide_popup()
+
+    def _on_later(self, _button: Gtk.Button) -> None:
+        release = self._latest_release
+        state = load_state()
+        remind_after = datetime.now(timezone.utc) + timedelta(hours=REMIND_LATER_HOURS)
+        save_state(
+            UpdateState(
+                ignored_version=state.ignored_version,
+                last_checked_at=state.last_checked_at,
+                last_error=state.last_error,
+                last_result=state.last_result,
+                last_seen_version=release.version
+                if release
+                else state.last_seen_version,
+                remind_after=utc_now_iso(remind_after),
+            ),
+        )
+        self._hide_popup()
+
+    def _on_ignore(self, _button: Gtk.Button) -> None:
+        release = self._latest_release
+        state = load_state()
+        save_state(
+            UpdateState(
+                ignored_version=release.version if release else state.ignored_version,
+                last_checked_at=state.last_checked_at,
+                last_error=state.last_error,
+                last_result=state.last_result,
+                last_seen_version=release.version
+                if release
+                else state.last_seen_version,
+                remind_after="",
+            ),
+        )
+        self._hide_popup()
+
+    def _hide_popup(self) -> None:
+        if self._popup is not None:
+            self._popup.hide()
+
+    def _open_url(self, url: str) -> None:
+        try:
+            Gio.AppInfo.launch_default_for_uri(url, None)
+        except Exception as exc:
+            log.warning("Failed to open release URL: %s", exc)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -33,6 +33,8 @@ class TestConfigDefaults:
         assert c.hide_delay_ms == 0
         assert c.previews_enabled is True
         assert c.tooltips_enabled is True
+        assert c.update_check_enabled is True
+        assert c.update_check_interval_hours == 24
         assert c.left_click_action == "toggle"
         assert c.middle_click_action == "new-window"
         assert c.folder_stack_unfold == "click"
@@ -76,6 +78,8 @@ class TestConfigDefaults:
             current_workspace_only=0,
             anchor_applets=1,
             active_display="no",
+            update_check_enabled="off",
+            update_check_interval_hours="bad",
             theme="",
         )
 
@@ -91,6 +95,8 @@ class TestConfigDefaults:
         assert c.current_workspace_only is False
         assert c.anchor_applets is True
         assert c.active_display is False
+        assert c.update_check_enabled is False
+        assert c.update_check_interval_hours == 24
         assert c.theme == "default"
 
 
@@ -492,6 +498,16 @@ class TestConfigSave:
 
         saved = json.loads(path.read_text())
         assert saved["transparency"] == 0.65
+
+    def test_save_persists_update_check_preferences(self, tmp_path):
+        path = tmp_path / "dock.json"
+        config = Config(update_check_enabled=False, update_check_interval_hours=168)
+
+        config.save(path)
+
+        saved = json.loads(path.read_text())
+        assert saved["update_check_enabled"] is False
+        assert saved["update_check_interval_hours"] == 168
 
     def test_save_persists_typed_pinned_entries(self, tmp_path):
         path = tmp_path / "dock.json"

--- a/tests/core/test_updates.py
+++ b/tests/core/test_updates.py
@@ -1,0 +1,175 @@
+"""Tests for update check state and release decisions."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from docking.core.updates import (
+    ReleaseInfo,
+    UpdateState,
+    compare_versions,
+    decide_update_popup,
+    fetch_latest_release,
+    is_newer_version,
+    load_state,
+    parse_github_release,
+    save_state,
+    should_check_for_updates,
+)
+
+
+class TestVersionComparison:
+    def test_newer_versions_compare_greater(self):
+        assert is_newer_version("1.16.0", "1.15.0") is True
+        assert is_newer_version("v1.16.0", "1.15.0") is True
+        assert is_newer_version("1.16.0", "1.16.0") is False
+        assert compare_versions("1.15.0", "1.16.0") == -1
+
+
+class TestUpdateState:
+    def test_load_missing_state_returns_defaults(self, tmp_path):
+        state = load_state(path=tmp_path / "updates.json")
+
+        assert state == UpdateState()
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        path = tmp_path / "updates.json"
+        expected = UpdateState(
+            last_checked_at="2026-05-01T10:00:00+00:00",
+            last_seen_version="1.16.0",
+            ignored_version="1.15.0",
+            remind_after="2026-05-02T10:00:00+00:00",
+            last_result="ok",
+            last_error="",
+        )
+
+        save_state(expected, path=path)
+
+        assert load_state(path=path) == expected
+        assert json.loads(path.read_text())["last_seen_version"] == "1.16.0"
+
+
+class TestCheckCadence:
+    def test_disabled_checks_never_run(self):
+        assert (
+            should_check_for_updates(
+                enabled=False,
+                interval_hours=24,
+                state=UpdateState(),
+                now=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            )
+            is False
+        )
+
+    def test_check_runs_when_never_checked(self):
+        assert should_check_for_updates(
+            enabled=True,
+            interval_hours=24,
+            state=UpdateState(),
+            now=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+
+    def test_check_waits_for_interval(self):
+        now = datetime(2026, 5, 1, 12, tzinfo=timezone.utc)
+        state = UpdateState(last_checked_at=(now - timedelta(hours=2)).isoformat())
+
+        assert (
+            should_check_for_updates(
+                enabled=True,
+                interval_hours=24,
+                state=state,
+                now=now,
+            )
+            is False
+        )
+
+        old_state = UpdateState(last_checked_at=(now - timedelta(hours=25)).isoformat())
+        assert should_check_for_updates(
+            enabled=True,
+            interval_hours=24,
+            state=old_state,
+            now=now,
+        )
+
+
+class TestReleaseParsing:
+    def test_parse_github_release(self):
+        release = parse_github_release(
+            {
+                "tag_name": "v1.16.0",
+                "html_url": "https://example.test/release",
+                "name": "Docking 1.16.0",
+                "published_at": "2026-05-01T10:00:00Z",
+            }
+        )
+
+        assert release == ReleaseInfo(
+            version="1.16.0",
+            url="https://example.test/release",
+            name="Docking 1.16.0",
+            published_at="2026-05-01T10:00:00Z",
+        )
+
+    def test_fetch_latest_release_reads_github_response(self, monkeypatch):
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return None
+
+            def read(self):
+                return b'{"tag_name":"v1.16.0","html_url":"https://example.test"}'
+
+        calls = []
+
+        def urlopen(request, *, timeout):
+            calls.append((request, timeout))
+            return Response()
+
+        monkeypatch.setattr("urllib.request.urlopen", urlopen)
+
+        release = fetch_latest_release(timeout=2)
+
+        assert release.version == "1.16.0"
+        assert release.url == "https://example.test"
+        assert calls[0][1] == 2
+        assert calls[0][0].headers["User-agent"] == "Docking update checker"
+
+
+class TestUpdateDecision:
+    def test_newer_release_shows(self):
+        release = ReleaseInfo(version="1.16.0", url="https://example.test", name="")
+
+        decision = decide_update_popup(
+            current_version="1.15.0",
+            release=release,
+            state=UpdateState(),
+            now=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+
+        assert decision.should_show is True
+        assert decision.reason == "newer"
+
+    def test_ignored_and_remind_later_do_not_show(self):
+        release = ReleaseInfo(version="1.16.0", url="https://example.test", name="")
+        now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+        ignored = decide_update_popup(
+            current_version="1.15.0",
+            release=release,
+            state=UpdateState(ignored_version="v1.16.0"),
+            now=now,
+        )
+        later = decide_update_popup(
+            current_version="1.15.0",
+            release=release,
+            state=UpdateState(remind_after=(now + timedelta(hours=1)).isoformat()),
+            now=now,
+        )
+
+        assert ignored.should_show is False
+        assert ignored.reason == "ignored"
+        assert later.should_show is False
+        assert later.reason == "remind-later"

--- a/tests/smoke/test_python314_smoke.py
+++ b/tests/smoke/test_python314_smoke.py
@@ -270,6 +270,8 @@ def test_app_main_smoke(monkeypatch):
 
     new_year.start.assert_called_once()
     new_year.stop.assert_called_once()
+    window.start_update_checks.assert_called_once()
+    window.stop_update_checks.assert_called_once()
 
     fake_gtk.main.assert_called_once()
     assert fake_glib.unix_signal_add.call_count == 2

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -118,6 +118,9 @@ class TestAppMain:
         call_order: list[str] = []
 
         window.show_all.side_effect = lambda: call_order.append("show_all")
+        window.start_update_checks.side_effect = lambda: call_order.append(
+            "updates_start"
+        )
         unity.start.side_effect = lambda: call_order.append("unity_start")
         new_year.start.side_effect = lambda: call_order.append("new_year_start")
         items_service.start.side_effect = lambda: call_order.append("items_start")
@@ -179,6 +182,8 @@ class TestAppMain:
         unity.stop.assert_called_once()
         new_year.start.assert_called_once()
         new_year.stop.assert_called_once()
+        window.start_update_checks.assert_called_once()
+        window.stop_update_checks.assert_called_once()
         fake_glib.idle_add.assert_called_once_with(
             app_mod._start_runtime,
             items_service,
@@ -189,6 +194,7 @@ class TestAppMain:
             "unity_start",
             "show_all",
             "new_year_start",
+            "updates_start",
             "idle_add",
             "items_start",
             "applets_start",
@@ -220,6 +226,9 @@ class TestAppMain:
         call_order: list[str] = []
 
         window.show_all.side_effect = lambda: call_order.append("show_all")
+        window.start_update_checks.side_effect = lambda: call_order.append(
+            "updates_start"
+        )
         unity.start.side_effect = lambda: call_order.append("unity_start")
         new_year.start.side_effect = lambda: call_order.append("new_year_start")
         items_service.start.side_effect = lambda: call_order.append("items_start")
@@ -289,10 +298,13 @@ class TestAppMain:
         unity.stop.assert_called_once()
         new_year.start.assert_called_once()
         new_year.stop.assert_called_once()
+        window.start_update_checks.assert_called_once()
+        window.stop_update_checks.assert_called_once()
         assert call_order == [
             "unity_start",
             "show_all",
             "new_year_start",
+            "updates_start",
             "idle_add",
             "items_start",
             "applets_start",

--- a/tests/ui/test_pointer_scenarios.py
+++ b/tests/ui/test_pointer_scenarios.py
@@ -408,7 +408,10 @@ class TestMenuLifecycleScenarios:
                     insertion_index_for_main=lambda *_args, **_kwargs: 0,
                 )
 
-        runtime = DockRuntime(cast(Any, harness))
+        runtime = DockRuntime(
+            cast(Any, harness),
+            update_checker=MagicMock(),
+        )
         handler = MenuHandler(
             about=MagicMock(),
             settings=MagicMock(),

--- a/tests/ui/test_runtime.py
+++ b/tests/ui/test_runtime.py
@@ -58,10 +58,17 @@ def _make_window():
     )
 
 
+def _make_update_checker():
+    return SimpleNamespace(
+        check_now=MagicMock(),
+        open_releases_page=MagicMock(),
+    )
+
+
 class TestDockRuntime:
     def test_menu_popup_hooks_delegate_to_interaction(self):
         window = _make_window()
-        runtime = DockRuntime(window)
+        runtime = DockRuntime(window, update_checker=_make_update_checker())
 
         runtime.menu_popup_opened()
         runtime.menu_popup_closed()
@@ -71,7 +78,7 @@ class TestDockRuntime:
 
     def test_placement_commands_delegate_to_placement(self):
         window = _make_window()
-        runtime = DockRuntime(window)
+        runtime = DockRuntime(window, update_checker=_make_update_checker())
 
         assert runtime.get_monitor_menu_choices() == [("Display 1", 0)]
         assert runtime.current_monitor_choice() == 1
@@ -89,7 +96,8 @@ class TestDockRuntime:
 
     def test_ui_commands_delegate_to_window_subsystems(self):
         window = _make_window()
-        runtime = DockRuntime(window)
+        update_checker = _make_update_checker()
+        runtime = DockRuntime(window, update_checker=update_checker)
 
         runtime.on_hide_mode_changed()
         runtime.set_icons_locked(True)
@@ -97,10 +105,14 @@ class TestDockRuntime:
         runtime.hide_tooltip()
         runtime.hide_hover_ui()
         runtime.set_theme(cast(Theme, "new-theme"))
+        runtime.check_for_updates_now()
+        runtime.open_releases_page()
 
         window.on_hide_mode_changed.assert_called_once()
         window.dnd.set_locked.assert_called_once_with(True)
         window.queue_redraw.assert_called_once()
         assert window.tooltip.hide.call_count == 2
         window.preview.hide.assert_called_once()
+        update_checker.check_now.assert_called_once()
+        update_checker.open_releases_page.assert_called_once()
         assert window.theme == "new-theme"

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -340,6 +340,20 @@ class FakeCheckButton(FakeSwitch):
         self.size_request = (width, height)
 
 
+class FakeButton:
+    def __init__(self, label: str = "") -> None:
+        self.label = label
+        self.callbacks: dict[str, object] = {}
+
+    def connect(self, signal: str, callback) -> None:
+        self.callbacks[signal] = callback
+
+    def click(self) -> None:
+        callback = self.callbacks.get("clicked")
+        if callback is not None:
+            callback(self)
+
+
 class FakeImage:
     def __init__(self, source: object) -> None:
         self.source = source
@@ -445,6 +459,7 @@ class FakeGtk:
     Scale = FakeScale
     Switch = FakeSwitch
     CheckButton = FakeCheckButton
+    Button = FakeButton
     Image = FakeImage
     ScrolledWindow = FakeScrolledWindow
     Orientation = FakeOrientation
@@ -475,12 +490,14 @@ def _config():
         zoom_percent=1.5,
         hide_delay_ms=0,
         unhide_delay_ms=0,
+        update_check_enabled=True,
+        update_check_interval_hours=24,
         save=MagicMock(),
     )
 
 
 class TestSettingsWindowController:
-    def test_show_reuses_single_window_and_builds_three_tabs(self, monkeypatch):
+    def test_show_reuses_single_window_and_builds_four_tabs(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
         monkeypatch.setattr(
             settings_mod, "load_catalog_icon", lambda applet_id, size: None
@@ -510,6 +527,7 @@ class TestSettingsWindowController:
             "Appearance",
             "Behavior",
             "Applets",
+            "Updates",
         ]
         appearance_box = stack.pages[0][0]
         section_labels = [
@@ -533,6 +551,13 @@ class TestSettingsWindowController:
             "<b>Behavior</b>",
             "<b>Folder Stacks</b>",
         ]
+        updates_box = stack.pages[3][0]
+        updates_labels = [
+            child.get_children()[0].markup
+            for child in updates_box.get_children()
+            if isinstance(child, FakeBox) and child.get_children()
+        ]
+        assert updates_labels == ["<b>Update Checks</b>"]
 
     def test_numeric_spin_buttons_use_simple_im_context(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
@@ -789,6 +814,47 @@ class TestSettingsWindowController:
         assert config.save.call_count == save_before + 1
         runtime.queue_draw.assert_called_once()
         assert controller._zoom_percent_spin.sensitive is False
+
+    def test_updates_tab_controls_preferences_and_runtime_actions(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        monkeypatch.setattr(
+            settings_mod,
+            "load_state",
+            lambda: SimpleNamespace(last_seen_version="", last_checked_at=""),
+        )
+        runtime = MagicMock()
+        config = _config()
+        controller = settings_mod.SettingsWindowController(
+            parent=object(),
+            runtime=runtime,
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=config,
+        )
+
+        controller.show()
+        controller._update_check_switch.set_active(False)
+        controller._update_check_switch.emit_notify_active()
+        controller._update_interval_combo.set_active_id("168")
+        controller._update_interval_combo.emit_changed()
+
+        assert config.update_check_enabled is False
+        assert config.update_check_interval_hours == 168
+        assert config.save.call_count == 2
+        assert controller._update_status_label.get_label() == "Not checked yet"
+
+        updates_box = controller._window.child.children[1].pages[3][0]
+        actions_row = updates_box.children[0].children[1].children[3]
+        actions_box = actions_row.children[1]
+        check_now, view_releases = actions_box.children
+        check_now.click()
+        view_releases.click()
+
+        runtime.check_for_updates_now.assert_called_once()
+        runtime.open_releases_page.assert_called_once()
 
     def test_applet_toggle_adds_and_removes_items(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)


### PR DESCRIPTION
## Summary
- Add a GitHub latest-release check with persisted runtime state for last check, ignored versions, and remind-later choices.
- Wire startup update notifications plus manual check and releases-page actions into the Preferences Updates tab.
- Add config options for automatic checks and check frequency, with README coverage and focused tests