### PR TITLE
Improve applet selector autocomplete

### DIFF
--- a/docking/applets/currencyfx/applet.py
+++ b/docking/applets/currencyfx/applet.py
@@ -55,7 +55,11 @@ from docking.applets.live_state import (
     resolve_live_status,
 )
 from docking.applets.menu import disabled_menu_item, menu_sections, radio_submenu
-from docking.applets.popup import add_cancel_ok_buttons, prepare_dialog_content
+from docking.applets.popup import (
+    add_cancel_ok_buttons,
+    entry_completion_combo,
+    prepare_dialog_content,
+)
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -491,14 +495,14 @@ class CurrencyFxApplet(Applet):
         base_combo.grab_focus()
         response = dialog.run()
         if response == Gtk.ResponseType.OK:
-            base = base_combo.get_active_text() or self._base
-            quote = quote_combo.get_active_text() or self._quote
+            base = self._currency_combo_text(combo=base_combo, fallback=self._base)
+            quote = self._currency_combo_text(combo=quote_combo, fallback=self._quote)
             self._add_pair(base, quote)
         dialog.destroy()
 
     def _currency_combo(self, *, active: str) -> Gtk.ComboBoxText:
         """Build a currency-code combo box with a selected active code."""
-        combo = Gtk.ComboBoxText()
+        combo = entry_completion_combo()
         active_index = 0
         for index, code in enumerate(self._available_codes):
             combo.append_text(code)
@@ -506,6 +510,13 @@ class CurrencyFxApplet(Applet):
                 active_index = index
         combo.set_active(active_index)
         return combo
+
+    def _currency_combo_text(self, *, combo: Gtk.ComboBoxText, fallback: str) -> str:
+        """Return typed or selected currency code from an editable combo."""
+        text = combo.get_child().get_text().strip()
+        if text:
+            return text
+        return combo.get_active_text() or fallback
 
     def _pair_codes(self) -> tuple[str, ...]:
         """Return all codes currently referenced by added pairs."""

--- a/docking/applets/popup.py
+++ b/docking/applets/popup.py
@@ -29,6 +29,50 @@ DEFAULT_DIALOG_CONTENT_SPACING_PX = 8
 DEFAULT_DIALOG_MARGIN_PX = 12
 
 
+def entry_completion_combo(
+    *,
+    matches: Callable[[str, str], bool] | None = None,
+) -> Gtk.ComboBoxText:
+    """Create an entry-backed text combo with inline/popup completion."""
+    combo = Gtk.ComboBoxText.new_with_entry()
+    combo.set_entry_text_column(0)
+
+    completion = Gtk.EntryCompletion()
+    completion.set_model(combo.get_model())
+    completion.set_text_column(0)
+    completion.set_inline_completion(True)
+    completion.set_popup_completion(True)
+    completion.set_match_func(_completion_matches, matches or _prefix_matches)
+    entry = combo.get_child()
+    entry.set_completion(completion)
+    entry.connect("focus-in-event", _select_combo_entry_text)
+    entry.connect("button-release-event", _select_combo_entry_text)
+    return combo
+
+
+def _prefix_matches(text: str, label: str) -> bool:
+    """Return true when typed text starts the visible label."""
+    needle = text.strip().casefold()
+    return not needle or label.strip().casefold().startswith(needle)
+
+
+def _completion_matches(
+    completion: Gtk.EntryCompletion,
+    key: str,
+    tree_iter,
+    matches: Callable[[str, str], bool],
+) -> bool:
+    model = completion.get_model()
+    if model is None:
+        return False
+    return matches(key, str(model.get_value(tree_iter, 0)))
+
+
+def _select_combo_entry_text(entry: Gtk.Entry, *_args) -> bool:
+    entry.select_region(0, -1)
+    return False
+
+
 def ensure_popup_css() -> None:
     """Install the shared popup CSS once per screen."""
     global _popup_css_provider
@@ -66,7 +110,9 @@ def create_popup_window() -> Gtk.Window:
     window.set_decorated(False)
     window.set_skip_taskbar_hint(True)
     window.set_resizable(False)
-    window.set_type_hint(Gdk.WindowTypeHint.TOOLTIP)
+    window.set_accept_focus(True)
+    window.set_focus_on_map(True)
+    window.set_type_hint(Gdk.WindowTypeHint.UTILITY)
     return window
 
 

--- a/docking/applets/unitconverter/applet.py
+++ b/docking/applets/unitconverter/applet.py
@@ -40,7 +40,10 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GdkPixbuf, Gtk
 
 from docking.applets.base import Applet
-from docking.applets.popup import create_popup_window, show_wrapped_popup
+from docking.applets.popup import (
+    entry_completion_combo,
+    prepare_dialog_content,
+)
 from docking.applets.unitconverter import meta
 from docking.applets.unitconverter.render import create_icon
 from docking.applets.unitconverter.state import (
@@ -67,6 +70,31 @@ POPUP_CURSOR_GAP_PX = 20
 POPUP_WIDTH_PX = 280
 
 
+def _unit_label(unit: Unit) -> str:
+    return f"{unit.name} ({unit.symbol})"
+
+
+def _unit_label_matches(text: str, label: str) -> bool:
+    """Match "Unit Name (sym)" by visible label, unit name, or symbol prefix."""
+    needle = text.strip().casefold()
+    if not needle:
+        return True
+    normalized_label = label.strip().casefold()
+    if normalized_label.startswith(needle):
+        return True
+    name, symbol = _split_unit_label(label=label)
+    return name.casefold().startswith(needle) or symbol.casefold().startswith(needle)
+
+
+def _split_unit_label(*, label: str) -> tuple[str, str]:
+    """Split "Unit Name (sym)" into name and symbol."""
+    text = label.strip()
+    if text.endswith(")") and "(" in text:
+        name, symbol = text.rsplit("(", 1)
+        return name.strip(), symbol[:-1].strip()
+    return text, ""
+
+
 class UnitConverterApplet(Applet):
     """Instant unit conversion via a click-to-open popup."""
 
@@ -75,7 +103,7 @@ class UnitConverterApplet(Applet):
     icon_name = "emblem-synchronizing-symbolic"
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        self._popup: Gtk.Window | None = None
+        self._popup: Gtk.Dialog | None = None
         self._result_label: Gtk.Label | None = None
         self._from_combo: Gtk.ComboBoxText | None = None
         self._to_combo: Gtk.ComboBoxText | None = None
@@ -125,17 +153,33 @@ class UnitConverterApplet(Applet):
             set_currency_units(units)
         return False
 
-    # -- Popup ----------------------------------------------------------------
+    # -- Dialog ---------------------------------------------------------------
 
     def _show_popup(self) -> None:
         if self._popup is None:
-            self._popup = create_popup_window()
+            self._popup = Gtk.Dialog(
+                title=_("Unit Converter"),
+                flags=Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            )
+            self._popup.connect("delete-event", self._on_popup_delete)
 
-        show_wrapped_popup(
-            window=self._popup,
-            content=self._build_popup_content(),
-            gap_px=POPUP_CURSOR_GAP_PX,
+        content = prepare_dialog_content(
+            dialog=self._popup,
+            width=POPUP_WIDTH_PX,
+            spacing=0,
+            margin=0,
+            resizable=False,
         )
+        for child in content.get_children():
+            content.remove(child)
+        content.add(self._build_popup_content())
+        self._popup.show_all()
+        self._popup.present()
+
+    def _on_popup_delete(self, _dialog: Gtk.Dialog, _event) -> bool:
+        if self._popup:
+            self._popup.hide()
+        return True
 
     def _build_popup_content(self) -> Gtk.Box:
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
@@ -158,7 +202,7 @@ class UnitConverterApplet(Applet):
         # From / Swap / To row
         row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
 
-        self._from_combo = Gtk.ComboBoxText()
+        self._from_combo = entry_completion_combo(matches=_unit_label_matches)
         self._from_combo.set_hexpand(True)
         row.pack_start(self._from_combo, True, True, 0)
 
@@ -167,7 +211,7 @@ class UnitConverterApplet(Applet):
         swap_btn.connect("clicked", self._on_swap)
         row.pack_start(swap_btn, False, False, 0)
 
-        self._to_combo = Gtk.ComboBoxText()
+        self._to_combo = entry_completion_combo(matches=_unit_label_matches)
         self._to_combo.set_hexpand(True)
         row.pack_start(self._to_combo, True, True, 0)
 
@@ -201,14 +245,14 @@ class UnitConverterApplet(Applet):
         if self._from_combo:
             self._from_combo.remove_all()
             for u in units:
-                self._from_combo.append_text(f"{u.name} ({u.symbol})")
+                self._from_combo.append_text(_unit_label(u))
             idx = max(0, min(self._from_idx, len(units) - 1))
             self._from_combo.set_active(idx)
 
         if self._to_combo:
             self._to_combo.remove_all()
             for u in units:
-                self._to_combo.append_text(f"{u.name} ({u.symbol})")
+                self._to_combo.append_text(_unit_label(u))
             idx = max(0, min(self._to_idx, len(units) - 1))
             self._to_combo.set_active(idx)
 
@@ -234,11 +278,26 @@ class UnitConverterApplet(Applet):
 
     def _on_unit_changed(self, _combo: Gtk.ComboBoxText) -> None:
         if self._from_combo:
-            self._from_idx = max(0, self._from_combo.get_active())
+            self._from_idx = self._unit_index_from_combo(
+                combo=self._from_combo,
+                fallback=self._from_idx,
+            )
         if self._to_combo:
-            self._to_idx = max(0, self._to_combo.get_active())
+            self._to_idx = self._unit_index_from_combo(
+                combo=self._to_combo,
+                fallback=self._to_idx,
+            )
         self._update_result()
         self._save_prefs()
+
+    def _unit_index_from_combo(self, *, combo: Gtk.ComboBoxText, fallback: int) -> int:
+        """Resolve either selected or typed unit text into the current unit index."""
+        typed = combo.get_child().get_text().strip()
+        units = get_units(get_categories()[self._cat_idx])
+        for index, unit in enumerate(units):
+            if _unit_label_matches(typed, _unit_label(unit)):
+                return index
+        return max(0, combo.get_active(), fallback)
 
     def _on_input_changed(self, _entry: Gtk.Entry) -> None:
         self._update_result()

--- a/tests/applets/test_currencyfx.py
+++ b/tests/applets/test_currencyfx.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import datetime as dt
 import json
 import urllib.parse
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import docking.applets.currencyfx.applet as currencyfx_applet_mod
 import docking.applets.currencyfx.render as currencyfx_render_mod
 import docking.applets.currencyfx.state as fx_state
+import docking.applets.popup as applet_popup_mod
 from docking.applets.currencyfx.applet import CurrencyFxApplet
 from docking.applets.currencyfx.render import render_icon
 from docking.applets.currencyfx.state import (
@@ -1060,7 +1062,11 @@ class TestCurrencyFxApplet:
         assert with_local.fetched_at == fetched.fetched_at
 
     def test_currency_combo_and_pair_codes(self, monkeypatch):
-        monkeypatch.setattr(currencyfx_applet_mod.Gtk, "ComboBoxText", _FakeCombo)
+        monkeypatch.setattr(
+            currencyfx_applet_mod,
+            "entry_completion_combo",
+            lambda **_: _FakeCombo(),
+        )
         applet = _make_applet()
         applet._available_codes = ("EUR", "USD")
         combo = applet._currency_combo(active="BRL")
@@ -1105,12 +1111,93 @@ class _FakeCombo:
 
     def set_active(self, index: int) -> None:
         self.active = index
+        if hasattr(self, "entry") and 0 <= index < len(self.values):
+            self.entry.text = self.values[index]
 
     def get_active_text(self) -> str:
         return self.active_text or self.values[self.active]
 
     def grab_focus(self) -> None:
         return
+
+
+class _FakeEntry:
+    def __init__(self) -> None:
+        self.text = ""
+        self.completion = None
+        self._callbacks: dict[str, object] = {}
+
+    def get_text(self) -> str:
+        return self.text
+
+    def set_completion(self, completion) -> None:
+        self.completion = completion
+
+    def connect(self, signal: str, callback) -> None:
+        self._callbacks[signal] = callback
+
+    def select_region(self, _start: int, _end: int) -> None:
+        return
+
+
+class _FakeComboModel:
+    def __init__(self, values: list[str]) -> None:
+        self.values = values
+
+    def get_value(self, tree_iter: int, _column: int) -> str:
+        return self.values[tree_iter]
+
+
+class _FakeEntryCombo(_FakeCombo):
+    def __init__(self) -> None:
+        super().__init__()
+        self.entry = _FakeEntry()
+        self.entry_text_column = None
+
+    @classmethod
+    def new_with_entry(cls):
+        return cls()
+
+    def set_entry_text_column(self, column: int) -> None:
+        self.entry_text_column = column
+
+    def get_child(self) -> _FakeEntry:
+        return self.entry
+
+    def get_model(self) -> _FakeComboModel:
+        return _FakeComboModel(self.values)
+
+
+class _FakeEntryCompletion:
+    def __init__(self) -> None:
+        self.model = None
+        self.text_column = None
+        self.inline_completion = False
+        self.popup_completion = False
+        self.match_func = None
+
+    def set_model(self, model) -> None:
+        self.model = model
+
+    def get_model(self):
+        return self.model
+
+    def set_text_column(self, column: int) -> None:
+        self.text_column = column
+
+    def set_inline_completion(self, value: bool) -> None:
+        self.inline_completion = value
+
+    def set_popup_completion(self, value: bool) -> None:
+        self.popup_completion = value
+
+    def set_match_func(self, func, user_data) -> None:
+        self.match_func = lambda completion, key, tree_iter, _data: func(
+            completion,
+            key,
+            tree_iter,
+            user_data,
+        )
 
 
 class _FakeLabel:
@@ -1124,12 +1211,16 @@ class TestCurrencyFxDialog:
         combos: list[_FakeCombo] = []
 
         def combo_factory():
-            combo = _FakeCombo()
+            combo = _FakeEntryCombo()
             combos.append(combo)
             return combo
 
         monkeypatch.setattr(currencyfx_applet_mod.Gtk, "Dialog", lambda **_: dialog)
-        monkeypatch.setattr(currencyfx_applet_mod.Gtk, "ComboBoxText", combo_factory)
+        monkeypatch.setattr(
+            currencyfx_applet_mod,
+            "entry_completion_combo",
+            lambda **_: combo_factory(),
+        )
         monkeypatch.setattr(currencyfx_applet_mod.Gtk, "Label", _FakeLabel)
         monkeypatch.setattr(
             currencyfx_applet_mod,
@@ -1151,7 +1242,11 @@ class TestCurrencyFxDialog:
     def test_show_pair_dialog_ignores_cancel(self, monkeypatch):
         dialog = _FakeDialog(response=currencyfx_applet_mod.Gtk.ResponseType.CANCEL)
         monkeypatch.setattr(currencyfx_applet_mod.Gtk, "Dialog", lambda **_: dialog)
-        monkeypatch.setattr(currencyfx_applet_mod.Gtk, "ComboBoxText", _FakeCombo)
+        monkeypatch.setattr(
+            currencyfx_applet_mod,
+            "entry_completion_combo",
+            lambda **_: _FakeEntryCombo(),
+        )
         monkeypatch.setattr(currencyfx_applet_mod.Gtk, "Label", _FakeLabel)
         monkeypatch.setattr(
             currencyfx_applet_mod,
@@ -1167,3 +1262,28 @@ class TestCurrencyFxDialog:
         applet._show_pair_dialog()
 
         applet._add_pair.assert_not_called()
+
+    def test_currency_combo_autocompletes_typed_code_prefix(self, monkeypatch):
+        monkeypatch.setattr(
+            applet_popup_mod,
+            "Gtk",
+            SimpleNamespace(
+                ComboBoxText=_FakeEntryCombo,
+                EntryCompletion=_FakeEntryCompletion,
+            ),
+        )
+        applet = _make_applet()
+        applet._available_codes = ("EUR", "USD", "BRL")
+
+        combo = applet._currency_combo(active="USD")
+        completion = combo.entry.completion
+
+        assert combo.entry_text_column == 0
+        assert completion.text_column == 0
+        assert completion.inline_completion is True
+        assert completion.popup_completion is True
+        assert completion.match_func(completion, "br", 2, None) is True
+        assert completion.match_func(completion, "gb", 2, None) is False
+
+        combo.entry.text = "brl"
+        assert applet._currency_combo_text(combo=combo, fallback="EUR") == "brl"

--- a/tests/applets/test_popup.py
+++ b/tests/applets/test_popup.py
@@ -49,6 +49,8 @@ class _FakePopupWindow:
         self.skip_taskbar = None
         self.resizable = None
         self.type_hint = None
+        self.accept_focus = None
+        self.focus_on_map = None
 
     def set_decorated(self, value: bool) -> None:
         self.decorated = value
@@ -58,6 +60,12 @@ class _FakePopupWindow:
 
     def set_resizable(self, value: bool) -> None:
         self.resizable = value
+
+    def set_accept_focus(self, value: bool) -> None:
+        self.accept_focus = value
+
+    def set_focus_on_map(self, value: bool) -> None:
+        self.focus_on_map = value
 
     def set_type_hint(self, hint) -> None:
         self.type_hint = hint
@@ -266,7 +274,9 @@ def test_create_popup_window_configures_transient_surface(monkeypatch):
     assert window.decorated is False
     assert window.skip_taskbar is True
     assert window.resizable is False
-    assert window.type_hint == popup.Gdk.WindowTypeHint.TOOLTIP
+    assert window.accept_focus is True
+    assert window.focus_on_map is True
+    assert window.type_hint == popup.Gdk.WindowTypeHint.UTILITY
 
 
 def test_show_wrapped_popup_replaces_content_and_positions(monkeypatch):

--- a/tests/applets/test_unitconverter.py
+++ b/tests/applets/test_unitconverter.py
@@ -6,6 +6,7 @@ import re
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import docking.applets.popup as applet_popup_mod
 import docking.applets.unitconverter.applet as unitconverter_applet_mod
 import docking.applets.unitconverter.state as uc_state
 from docking.applets.unitconverter.applet import UnitConverterApplet
@@ -55,17 +56,26 @@ def _unit(cat: Category, symbol: str) -> Unit:
 class _FakePopupWindow:
     def __init__(self) -> None:
         self.child = None
-        self.moved_to = None
         self.destroyed = False
+        self.visible = False
+        self.presented = False
+        self.connected = None
+        self.size = None
+        self.position = None
+        self.resizable = None
+        self.content = _FakeDialogContent()
 
-    def set_decorated(self, _value: bool) -> None:
-        return
+    def connect(self, signal: str, callback) -> None:
+        self.connected = (signal, callback)
 
-    def set_skip_taskbar_hint(self, _value: bool) -> None:
-        return
+    def set_default_size(self, width: int, height: int) -> None:
+        self.size = (width, height)
 
-    def set_type_hint(self, _hint) -> None:
-        return
+    def set_position(self, position) -> None:
+        self.position = position
+
+    def set_resizable(self, value: bool) -> None:
+        self.resizable = value
 
     def get_child(self):
         return self.child
@@ -77,7 +87,19 @@ class _FakePopupWindow:
         self.child = child
 
     def show_all(self) -> None:
-        return
+        self.visible = True
+
+    def present(self) -> None:
+        self.presented = True
+
+    def hide(self) -> None:
+        self.visible = False
+
+    def get_visible(self) -> bool:
+        return self.visible
+
+    def get_content_area(self):
+        return self.content
 
     def get_preferred_size(self):
         return None, SimpleNamespace(width=100, height=60)
@@ -92,10 +114,47 @@ class _FakePopupWindow:
         self.destroyed = True
 
 
+class _FakeDialogContent:
+    def __init__(self) -> None:
+        self.children: list[object] = []
+        self.spacing = None
+        self.margins: list[tuple[str, int]] = []
+
+    def set_spacing(self, value: int) -> None:
+        self.spacing = value
+
+    def set_margin_start(self, value: int) -> None:
+        self.margins.append(("start", value))
+
+    def set_margin_end(self, value: int) -> None:
+        self.margins.append(("end", value))
+
+    def set_margin_top(self, value: int) -> None:
+        self.margins.append(("top", value))
+
+    def set_margin_bottom(self, value: int) -> None:
+        self.margins.append(("bottom", value))
+
+    def get_children(self):
+        return list(self.children)
+
+    def remove(self, child) -> None:
+        self.children.remove(child)
+
+    def add(self, child) -> None:
+        self.children.append(child)
+
+
 class _FakeComboBoxText:
     def __init__(self) -> None:
         self.items: list[str] = []
         self.active = -1
+        self.entry = _FakeEntry()
+        self.entry_text_column = None
+
+    @classmethod
+    def new_with_entry(cls):
+        return cls()
 
     def append_text(self, text: str) -> None:
         self.items.append(text)
@@ -103,12 +162,26 @@ class _FakeComboBoxText:
     def remove_all(self) -> None:
         self.items.clear()
         self.active = -1
+        self.entry.set_text("")
 
     def set_active(self, idx: int) -> None:
         self.active = idx
+        if 0 <= idx < len(self.items):
+            self.entry.set_text(self.items[idx])
+        elif idx < 0:
+            self.entry.set_text("")
 
     def get_active(self) -> int:
         return self.active
+
+    def get_child(self) -> _FakeEntry:
+        return self.entry
+
+    def get_model(self) -> _FakeComboModel:
+        return _FakeComboModel(self.items)
+
+    def set_entry_text_column(self, column: int) -> None:
+        self.entry_text_column = column
 
     def set_hexpand(self, _value: bool) -> None:
         return
@@ -122,6 +195,7 @@ class _FakeEntry:
         self.text = text
         self.placeholder = ""
         self._callbacks: dict[str, object] = {}
+        self.selected_region = None
 
     def set_text(self, text: str) -> None:
         self.text = text
@@ -134,6 +208,52 @@ class _FakeEntry:
 
     def connect(self, signal: str, callback) -> None:
         self._callbacks[signal] = callback
+
+    def set_completion(self, completion) -> None:
+        self.completion = completion
+
+    def select_region(self, start: int, end: int) -> None:
+        self.selected_region = (start, end)
+
+
+class _FakeComboModel:
+    def __init__(self, items: list[str]) -> None:
+        self.items = items
+
+    def get_value(self, tree_iter: int, _column: int) -> str:
+        return self.items[tree_iter]
+
+
+class _FakeEntryCompletion:
+    def __init__(self) -> None:
+        self.model = None
+        self.text_column = None
+        self.inline_completion = False
+        self.popup_completion = False
+        self.match_func = None
+
+    def set_model(self, model) -> None:
+        self.model = model
+
+    def get_model(self):
+        return self.model
+
+    def set_text_column(self, column: int) -> None:
+        self.text_column = column
+
+    def set_inline_completion(self, value: bool) -> None:
+        self.inline_completion = value
+
+    def set_popup_completion(self, value: bool) -> None:
+        self.popup_completion = value
+
+    def set_match_func(self, func, user_data) -> None:
+        self.match_func = lambda completion, key, tree_iter, _data: func(
+            completion,
+            key,
+            tree_iter,
+            user_data,
+        )
 
 
 class _FakeLabel:
@@ -528,19 +648,10 @@ class TestAppletPrefs:
 class TestAppletPopup:
     @staticmethod
     def _patch_popup(monkeypatch, applet: UnitConverterApplet, popup: _FakePopupWindow):
-        def show_wrapped_popup(*, window, content, gap_px):
-            _ = gap_px
-            window.add(content)
-            window.show_all()
-            window.move(100, 140)
-
         monkeypatch.setattr(
-            unitconverter_applet_mod, "create_popup_window", lambda: popup
-        )
-        monkeypatch.setattr(
-            unitconverter_applet_mod,
-            "show_wrapped_popup",
-            show_wrapped_popup,
+            unitconverter_applet_mod.Gtk,
+            "Dialog",
+            lambda **_: popup,
         )
         monkeypatch.setattr(
             applet, "_build_popup_content", lambda: _seed_popup_widgets(applet)
@@ -599,7 +710,7 @@ class TestAppletPopup:
         self._patch_popup(monkeypatch, applet, fake_popup)
         applet._show_popup()
         first_popup = applet._popup
-        first_child = first_popup.get_child()
+        first_child = first_popup.get_content_area().get_children()[0]
         assert applet._entry is not None
         assert applet._from_combo is not None
         assert applet._to_combo is not None
@@ -607,31 +718,28 @@ class TestAppletPopup:
         applet._show_popup()
 
         assert applet._popup is first_popup
-        assert applet._popup.get_child() is not first_child
-        assert fake_popup.moved_to == (100, 140)
+        assert applet._popup.get_content_area().get_children()[0] is not first_child
+        assert fake_popup.presented is True
+        assert fake_popup.resizable is False
         applet.stop()
 
-    def test_show_popup_uses_themed_surface_wrapper(self, monkeypatch):
+    def test_show_popup_uses_real_dialog(self, monkeypatch):
         applet = _make_applet()
-        fake_popup = _FakePopupWindow()
-        show_wrapped_popup = MagicMock()
+        dialog = _FakePopupWindow()
         monkeypatch.setattr(
-            unitconverter_applet_mod, "create_popup_window", lambda: fake_popup
-        )
-        monkeypatch.setattr(
-            unitconverter_applet_mod,
-            "show_wrapped_popup",
-            show_wrapped_popup,
+            unitconverter_applet_mod.Gtk,
+            "Dialog",
+            lambda **_: dialog,
         )
         monkeypatch.setattr(applet, "_build_popup_content", lambda: "content")
 
         applet._show_popup()
 
-        show_wrapped_popup.assert_called_once_with(
-            window=fake_popup,
-            content="content",
-            gap_px=unitconverter_applet_mod.POPUP_CURSOR_GAP_PX,
-        )
+        assert applet._popup is dialog
+        assert dialog.connected[0] == "delete-event"
+        assert dialog.content.get_children() == ["content"]
+        assert dialog.size == (unitconverter_applet_mod.POPUP_WIDTH_PX, -1)
+        assert dialog.presented is True
         applet.stop()
 
     def test_build_popup_content_creates_real_controls_with_fakes(self, monkeypatch):
@@ -648,6 +756,11 @@ class TestAppletPopup:
                 Orientation=SimpleNamespace(VERTICAL=1, HORIZONTAL=2),
             ),
         )
+        monkeypatch.setattr(
+            unitconverter_applet_mod,
+            "entry_completion_combo",
+            lambda **_: _FakeComboBoxText(),
+        )
 
         box = unitconverter_applet_mod.UnitConverterApplet._build_popup_content(applet)
 
@@ -663,6 +776,50 @@ class TestAppletPopup:
         assert applet._result_label is not None
         assert applet._result_label.selectable is True
         assert applet._result_label.xalign == 0.5
+
+    def test_unit_combos_autocomplete_by_name_or_symbol(self, monkeypatch):
+        monkeypatch.setattr(
+            applet_popup_mod,
+            "Gtk",
+            SimpleNamespace(
+                ComboBoxText=_FakeComboBoxText,
+                EntryCompletion=_FakeEntryCompletion,
+            ),
+        )
+
+        combo = applet_popup_mod.entry_completion_combo(
+            matches=unitconverter_applet_mod._unit_label_matches
+        )
+        for unit in get_units(Category.LENGTH):
+            combo.append_text(unitconverter_applet_mod._unit_label(unit))
+
+        completion = combo.entry.completion
+        km_index = [unit.symbol for unit in get_units(Category.LENGTH)].index("km")
+
+        assert combo.entry_text_column == 0
+        assert completion.text_column == 0
+        assert completion.inline_completion is True
+        assert completion.popup_completion is True
+        assert completion.match_func(completion, "kilo", km_index, None) is True
+        assert completion.match_func(completion, "km", km_index, None) is True
+        assert completion.match_func(completion, "mile", km_index, None) is False
+        combo.entry._callbacks["focus-in-event"](combo.entry, None)
+        assert combo.entry.selected_region == (0, -1)
+
+    def test_typed_unit_text_updates_selected_index(self):
+        applet = _make_applet()
+        _seed_popup_widgets(applet)
+        applet.save_prefs = MagicMock()
+        applet._cat_idx = get_categories().index(Category.LENGTH)
+        applet._populate_unit_combos()
+        assert applet._from_combo is not None
+        km_index = [unit.symbol for unit in get_units(Category.LENGTH)].index("km")
+
+        applet._from_combo.entry.set_text("km")
+        applet._on_unit_changed(applet._from_combo)
+
+        assert applet._from_idx == km_index
+        applet.save_prefs.assert_called_once()
 
     def test_category_change_repopulates_and_saves(self):
         applet = _make_applet()


### PR DESCRIPTION
## Summary
- add shared entry-backed combo helpers for applet popups and dialogs
- enable currency code autocomplete in Currency FX pair selection
- move Unit Converter to a real dialog and add autocomplete for unit names and symbols

## Notes
- Unit Converter now uses a focusable GTK dialog because its selectors contain editable controls.
- Shared lightweight popup windows remain available for read-only or simple popup applets.