### PR TITLE
Add sysfs thermals backend

### DIFF
--- a/docking/applets/thermals/state.py
+++ b/docking/applets/thermals/state.py
@@ -1,4 +1,4 @@
-"""lm-sensors parsing and formatting helpers for the Thermals applet."""
+"""Thermal backend, parsing, and formatting helpers for the Thermals applet."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from docking.applets import temperature as temperature_display
@@ -25,6 +26,8 @@ SENSORS_BIN = "sensors"
 SENSORS_TIMEOUT_S = 0.6
 REFRESH_INTERVAL_S = 5
 STARTUP_FETCH_DELAY_S = 1
+HWMON_DIR = Path("/sys/class/hwmon")
+THERMAL_DIR = Path("/sys/class/thermal")
 TemperatureUnit = temperature_display.TemperatureUnit
 format_temperature_compact = temperature_display.format_temperature_compact
 normalize_temperature_unit = temperature_display.normalize_temperature_unit
@@ -75,6 +78,222 @@ class ThermalsPrefs:
     """Persisted Thermals applet preferences."""
 
     temperature_unit: TemperatureUnit = TemperatureUnit.CELSIUS
+
+
+class ThermalsBackend:
+    """Backend interface for reading current thermal state."""
+
+    def get_snapshot(self) -> ThermalSnapshot:
+        """Read current thermal state."""
+        raise NotImplementedError
+
+    @staticmethod
+    def has_readings(snapshot: ThermalSnapshot) -> bool:
+        """Return whether a snapshot contains live thermal data."""
+        return snapshot.hottest is not None or snapshot.fan is not None
+
+
+class SensorsThermalsBackend(ThermalsBackend):
+    """Thermals backend backed by the ``sensors`` command."""
+
+    def __init__(
+        self,
+        *,
+        which: Callable[[str], str | None] = shutil.which,
+        run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    ) -> None:
+        self._which = which
+        self._run = run
+
+    def get_snapshot(self) -> ThermalSnapshot:
+        """Read current thermal state from lm-sensors."""
+        if self._which(SENSORS_BIN) is None:
+            return ThermalSnapshot(
+                available=False,
+                error=_("lm-sensors not installed"),
+            )
+        try:
+            result = self._run(
+                [SENSORS_BIN],
+                capture_output=True,
+                text=True,
+                timeout=SENSORS_TIMEOUT_S,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            log.debug("Failed to run sensors: %s", exc)
+            return ThermalSnapshot(
+                available=True,
+                error=str(exc) or exc.__class__.__name__,
+            )
+
+        if result.returncode != 0:
+            error = (result.stderr or result.stdout).strip()
+            return ThermalSnapshot(
+                available=True,
+                error=error or _("sensors failed"),
+            )
+
+        snapshot = parse_sensors_output(result.stdout)
+        if not self.has_readings(snapshot):
+            return ThermalSnapshot(
+                available=True,
+                error=_("No thermal readings"),
+            )
+        return snapshot
+
+
+class SysfsThermalsBackend(ThermalsBackend):
+    """Thermals backend backed by kernel hwmon and thermal-zone sysfs."""
+
+    def __init__(
+        self,
+        *,
+        hwmon_dir: Path = HWMON_DIR,
+        thermal_dir: Path = THERMAL_DIR,
+    ) -> None:
+        self._hwmon_dir = hwmon_dir
+        self._thermal_dir = thermal_dir
+
+    def get_snapshot(self) -> ThermalSnapshot:
+        """Read thermal state directly from kernel sysfs."""
+        hottest: ThermalReading | None = None
+        fastest_fan: FanReading | None = None
+
+        for reading in self._read_hwmon_temperatures():
+            if hottest is None or reading.celsius > hottest.celsius:
+                hottest = reading
+        for reading in self._read_thermal_zone_temperatures():
+            if hottest is None or reading.celsius > hottest.celsius:
+                hottest = reading
+        for reading in self._read_hwmon_fans():
+            if fastest_fan is None or reading.rpm > fastest_fan.rpm:
+                fastest_fan = reading
+
+        return ThermalSnapshot(
+            available=True,
+            hottest=hottest,
+            fan=fastest_fan,
+        )
+
+    def _read_hwmon_temperatures(self) -> list[ThermalReading]:
+        readings: list[ThermalReading] = []
+        for chip_dir in self._iter_dirs(self._hwmon_dir, prefix="hwmon"):
+            chip = self._read_text(chip_dir / "name") or chip_dir.name
+            for input_path in sorted(chip_dir.glob("temp*_input")):
+                celsius = self._read_millivalue(input_path)
+                if celsius is None:
+                    continue
+                sensor_id = input_path.name.removeprefix("temp").removesuffix("_input")
+                label = (
+                    self._read_text(chip_dir / f"temp{sensor_id}_label")
+                    or input_path.name
+                )
+                readings.append(
+                    ThermalReading(
+                        chip=chip,
+                        label=_clean_label(label),
+                        celsius=celsius,
+                    )
+                )
+        return readings
+
+    def _read_thermal_zone_temperatures(self) -> list[ThermalReading]:
+        readings: list[ThermalReading] = []
+        for zone_dir in self._iter_dirs(self._thermal_dir, prefix="thermal_zone"):
+            celsius = self._read_millivalue(zone_dir / "temp")
+            if celsius is None:
+                continue
+            label = self._read_text(zone_dir / "type") or zone_dir.name
+            readings.append(
+                ThermalReading(
+                    chip=zone_dir.name,
+                    label=_clean_label(label),
+                    celsius=celsius,
+                )
+            )
+        return readings
+
+    def _read_hwmon_fans(self) -> list[FanReading]:
+        readings: list[FanReading] = []
+        for chip_dir in self._iter_dirs(self._hwmon_dir, prefix="hwmon"):
+            chip = self._read_text(chip_dir / "name") or chip_dir.name
+            for input_path in sorted(chip_dir.glob("fan*_input")):
+                rpm = self._read_int(input_path)
+                if rpm is None:
+                    continue
+                sensor_id = input_path.name.removeprefix("fan").removesuffix("_input")
+                label = (
+                    self._read_text(chip_dir / f"fan{sensor_id}_label")
+                    or input_path.name
+                )
+                readings.append(
+                    FanReading(
+                        chip=chip,
+                        label=_clean_label(label),
+                        rpm=rpm,
+                    )
+                )
+        return readings
+
+    @staticmethod
+    def _iter_dirs(path: Path, *, prefix: str) -> list[Path]:
+        try:
+            return sorted(
+                entry
+                for entry in path.iterdir()
+                if entry.name.startswith(prefix) and entry.is_dir()
+            )
+        except OSError as exc:
+            log.debug("Failed to inspect %s: %s", path, exc)
+        return []
+
+    @staticmethod
+    def _read_text(path: Path) -> str:
+        try:
+            return path.read_text().strip()
+        except OSError:
+            return ""
+
+    @classmethod
+    def _read_int(cls, path: Path) -> int | None:
+        try:
+            return int(cls._read_text(path))
+        except ValueError:
+            return None
+
+    @classmethod
+    def _read_millivalue(cls, path: Path) -> float | None:
+        value = cls._read_int(path)
+        if value is None:
+            return None
+        if abs(value) >= 1000:
+            return value / 1000.0
+        return float(value)
+
+
+class FallbackThermalsBackend(ThermalsBackend):
+    """Thermals backend that falls back when the primary has no readings."""
+
+    def __init__(
+        self,
+        *,
+        primary: ThermalsBackend,
+        fallback: ThermalsBackend,
+    ) -> None:
+        self._primary = primary
+        self._fallback = fallback
+
+    def get_snapshot(self) -> ThermalSnapshot:
+        """Return primary readings, or fallback readings when primary is empty."""
+        primary_snapshot = self._primary.get_snapshot()
+        if self.has_readings(primary_snapshot):
+            return primary_snapshot
+
+        fallback_snapshot = self._fallback.get_snapshot()
+        if self.has_readings(fallback_snapshot):
+            return fallback_snapshot
+        return primary_snapshot
 
 
 def prefs_from_mapping(prefs: Mapping[str, Any] | None) -> ThermalsPrefs:
@@ -141,39 +360,27 @@ def read_thermal_snapshot(
     *,
     which: Callable[[str], str | None] = shutil.which,
     run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    hwmon_dir: Path = HWMON_DIR,
+    thermal_dir: Path = THERMAL_DIR,
 ) -> ThermalSnapshot:
-    """Read current thermal state from ``sensors``."""
-    if which(SENSORS_BIN) is None:
-        return ThermalSnapshot(
-            available=False,
-            error=_("lm-sensors not installed"),
-        )
-    try:
-        result = run(
-            [SENSORS_BIN],
-            capture_output=True,
-            text=True,
-            timeout=SENSORS_TIMEOUT_S,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        log.debug("Failed to run sensors: %s", exc)
-        return ThermalSnapshot(available=True, error=str(exc) or exc.__class__.__name__)
+    """Read current thermal state from lm-sensors or kernel sysfs."""
+    backend = FallbackThermalsBackend(
+        primary=SensorsThermalsBackend(which=which, run=run),
+        fallback=SysfsThermalsBackend(hwmon_dir=hwmon_dir, thermal_dir=thermal_dir),
+    )
+    return backend.get_snapshot()
 
-    if result.returncode != 0:
-        error = (result.stderr or result.stdout).strip()
-        return ThermalSnapshot(
-            available=True,
-            error=error or _("sensors failed"),
-        )
 
-    snapshot = parse_sensors_output(result.stdout)
-    if snapshot.hottest is None and snapshot.fan is None:
-        return ThermalSnapshot(
-            available=True,
-            error=_("No thermal readings"),
-        )
-    return snapshot
+def read_sysfs_thermal_snapshot(
+    *,
+    hwmon_dir: Path = HWMON_DIR,
+    thermal_dir: Path = THERMAL_DIR,
+) -> ThermalSnapshot:
+    """Read thermal state directly from kernel hwmon and thermal-zone sysfs."""
+    return SysfsThermalsBackend(
+        hwmon_dir=hwmon_dir,
+        thermal_dir=thermal_dir,
+    ).get_snapshot()
 
 
 def build_tooltip(

--- a/tests/applets/test_brightness.py
+++ b/tests/applets/test_brightness.py
@@ -107,8 +107,9 @@ class TestGetBrightness:
         backend = Backend(output="HDMI-1", sysfs=tmp_path)
         assert get_brightness(backend=backend) == 0.40
 
-    def test_sysfs_handles_read_error(self, tmp_path):
+    def test_sysfs_handles_read_error(self, monkeypatch, tmp_path):
         # Given - missing files
+        monkeypatch.setattr(brightness_state, "is_wayland_session", lambda: True)
         backend = Backend(output="eDP-1", sysfs=tmp_path)
         # When / Then
         assert get_brightness(backend=backend) is None

--- a/tests/applets/test_thermals.py
+++ b/tests/applets/test_thermals.py
@@ -15,7 +15,10 @@ import docking.applets.thermals.applet as thermals_applet_mod
 from docking.applets.thermals.applet import ThermalsApplet
 from docking.applets.thermals.render import render_icon
 from docking.applets.thermals.state import (
+    FallbackThermalsBackend,
     FanReading,
+    SensorsThermalsBackend,
+    SysfsThermalsBackend,
     TemperatureUnit,
     ThermalReading,
     ThermalSnapshot,
@@ -47,6 +50,14 @@ class _ImmediateWorker:
             return
         if on_result is not None:
             on_result(result)
+
+
+class _StaticThermalsBackend:
+    def __init__(self, snapshot: ThermalSnapshot) -> None:
+        self.snapshot = snapshot
+
+    def get_snapshot(self) -> ThermalSnapshot:
+        return self.snapshot
 
 
 def _snapshot() -> ThermalSnapshot:
@@ -103,13 +114,79 @@ class TestThermalsState:
         assert snapshot.hottest is None
         assert snapshot.fan is None
 
-    def test_read_thermal_snapshot_without_sensors(self):
-        snapshot = read_thermal_snapshot(which=lambda _cmd: None)
+    def test_read_thermal_snapshot_without_sensors_or_sysfs(self, tmp_path):
+        snapshot = read_thermal_snapshot(
+            which=lambda _cmd: None,
+            hwmon_dir=tmp_path / "hwmon",
+            thermal_dir=tmp_path / "thermal",
+        )
 
         assert snapshot.available is False
         assert "lm-sensors" in snapshot.error
 
-    def test_read_thermal_snapshot_runs_sensors(self):
+    def test_fallback_backend_uses_sysfs_without_sensors(self, tmp_path):
+        hwmon = tmp_path / "hwmon"
+        chip = hwmon / "hwmon0"
+        chip.mkdir(parents=True)
+        (chip / "name").write_text("coretemp\n")
+        (chip / "temp1_label").write_text("Package id 0\n")
+        (chip / "temp1_input").write_text("65000\n")
+        (chip / "fan1_label").write_text("CPU fan\n")
+        (chip / "fan1_input").write_text("2400\n")
+
+        thermal = tmp_path / "thermal"
+        zone = thermal / "thermal_zone0"
+        zone.mkdir(parents=True)
+        (zone / "type").write_text("x86_pkg_temp\n")
+        (zone / "temp").write_text("94000\n")
+
+        snapshot = FallbackThermalsBackend(
+            primary=SensorsThermalsBackend(which=lambda _cmd: None),
+            fallback=SysfsThermalsBackend(hwmon_dir=hwmon, thermal_dir=thermal),
+        ).get_snapshot()
+
+        assert snapshot.available is True
+        assert snapshot.error == ""
+        assert snapshot.hottest is not None
+        assert snapshot.hottest.chip == "thermal_zone0"
+        assert snapshot.hottest.label == "x86_pkg_temp"
+        assert snapshot.hottest.celsius == pytest.approx(94.0)
+        assert snapshot.fan is not None
+        assert snapshot.fan.chip == "coretemp"
+        assert snapshot.fan.label == "CPU fan"
+        assert snapshot.fan.rpm == 2400
+
+    def test_read_thermal_snapshot_uses_backend_chain(self, tmp_path):
+        hwmon = tmp_path / "hwmon"
+        chip = hwmon / "hwmon0"
+        chip.mkdir(parents=True)
+        (chip / "name").write_text("coretemp\n")
+        (chip / "temp1_label").write_text("Package id 0\n")
+        (chip / "temp1_input").write_text("65000\n")
+
+        snapshot = read_thermal_snapshot(
+            which=lambda _cmd: None,
+            hwmon_dir=hwmon,
+            thermal_dir=tmp_path / "thermal",
+        )
+
+        assert snapshot.available is True
+        assert snapshot.error == ""
+        assert snapshot.hottest is not None
+        assert snapshot.hottest.label == "Package id 0"
+        assert snapshot.hottest.celsius == pytest.approx(65.0)
+
+    def test_sysfs_backend_handles_empty_dirs(self, tmp_path):
+        snapshot = SysfsThermalsBackend(
+            hwmon_dir=tmp_path / "hwmon",
+            thermal_dir=tmp_path / "thermal",
+        ).get_snapshot()
+
+        assert snapshot.available is True
+        assert snapshot.hottest is None
+        assert snapshot.fan is None
+
+    def test_sensors_backend_runs_sensors(self):
         def run(cmd, **kwargs):
             assert cmd == ["sensors"]
             assert kwargs["capture_output"] is True
@@ -120,14 +197,17 @@ class TestThermalsState:
                 stderr="",
             )
 
-        snapshot = read_thermal_snapshot(which=lambda _cmd: "/usr/bin/sensors", run=run)
+        snapshot = SensorsThermalsBackend(
+            which=lambda _cmd: "/usr/bin/sensors",
+            run=run,
+        ).get_snapshot()
 
         assert snapshot.hottest is not None
         assert snapshot.hottest.celsius == pytest.approx(51.0)
         assert snapshot.fan is not None
         assert snapshot.fan.rpm == 1200
 
-    def test_read_thermal_snapshot_reports_command_failure(self):
+    def test_read_thermal_snapshot_reports_command_failure(self, tmp_path):
         snapshot = read_thermal_snapshot(
             which=lambda _cmd: "/usr/bin/sensors",
             run=lambda cmd, **kwargs: subprocess.CompletedProcess(
@@ -136,10 +216,23 @@ class TestThermalsState:
                 stdout="",
                 stderr="no sensors",
             ),
+            hwmon_dir=tmp_path / "hwmon",
+            thermal_dir=tmp_path / "thermal",
         )
 
         assert snapshot.available is True
         assert snapshot.error == "no sensors"
+
+    def test_fallback_backend_keeps_primary_when_fallback_has_no_readings(self):
+        primary = ThermalSnapshot(available=True, error="No thermal readings")
+        fallback = ThermalSnapshot(available=True)
+
+        snapshot = FallbackThermalsBackend(
+            primary=_StaticThermalsBackend(primary),
+            fallback=_StaticThermalsBackend(fallback),
+        ).get_snapshot()
+
+        assert snapshot is primary
 
     def test_formatting_helpers(self):
         reading = ThermalReading(chip="coretemp", label="Package", celsius=61.4)


### PR DESCRIPTION
Adds a sysfs-backed Thermals backend so the applet can report temperatures and fan speed even when lm-sensors is not installed. The thermals state layer now has separate backend classes for sensors, sysfs, and fallback coordination while keeping the applet-facing read_thermal_snapshot API unchanged.

Also isolates the brightness sysfs read-error test from the host X11 fallback so the full pre-commit suite is deterministic. Validation passed through the pre-commit hook, including Ruff, ty, i18n checks, packaging checks, and the full pytest suite.