### PR TITLE
Add KDE trash support and refactor into applet into backends

### DIFF
--- a/docking/applets/trash/applet.py
+++ b/docking/applets/trash/applet.py
@@ -18,9 +18,10 @@ from docking.applets.menu import menu_sections
 from docking.applets.trash import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
+from docking.platform.environment import detect_desktop
 
+from .backend import TrashBackend, select_trash_backend
 from .render import create_trash_icon, trash_tooltip
-from .state import _count_trash_items
 
 if TYPE_CHECKING:
     from docking.core.config import Config
@@ -36,7 +37,9 @@ class TrashApplet(Applet):
     icon_name = "user-trash"
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        self._item_count = _count_trash_items()
+        self._desktop = detect_desktop()
+        self._backend: TrashBackend = select_trash_backend(desktop=self._desktop)
+        self._item_count = self._backend.count_items()
         self._monitor: Gio.FileMonitor | None = None
         super().__init__(icon_size, config)
         self.present()
@@ -49,10 +52,7 @@ class TrashApplet(Applet):
 
     def on_clicked(self) -> None:
         """Open trash folder in the default file manager."""
-        try:
-            Gio.AppInfo.launch_default_for_uri("trash:///", None)
-        except GLib.Error as exc:
-            log.bind(action="open_trash").warning(f"Failed to open trash: {exc}")
+        self._backend.open()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         """Return 'Open Trash' and 'Empty Trash' menu items."""
@@ -66,11 +66,12 @@ class TrashApplet(Applet):
         return menu_sections(primary=[open_item], destructive=[empty_item], gtk=Gtk)
 
     def start(self, notify: Callable[[], None]) -> None:
-        """Start Gio.FileMonitor on trash:/// for real-time icon updates."""
+        """Start trash monitoring for real-time icon updates."""
         super().start(notify)
-        trash = Gio.File.new_for_uri("trash:///")
         try:
-            self._monitor = trash.monitor(Gio.FileMonitorFlags.NONE, None)
+            self._monitor = self._backend.monitor_file().monitor(
+                Gio.FileMonitorFlags.NONE, None
+            )
             self._monitor.connect("changed", self._on_trash_changed)
         except GLib.Error as exc:
             log.bind(action="monitor_trash").warning(
@@ -87,70 +88,27 @@ class TrashApplet(Applet):
 
     def _on_trash_changed(self, *_args: object) -> None:
         """File monitor callback: re-count items and update icon."""
-        self._item_count = _count_trash_items()
+        self._item_count = self._backend.count_items()
         self.present()
 
     def _empty_trash(self) -> None:
-        """Empty trash via DBus, with fallback to Gio deletion."""
-        try:
-            bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
-            for bus_name, obj_path in [
-                ("org.mate.Caja", "/org/mate/Caja"),
-                ("org.gnome.Nautilus", "/org/gnome/Nautilus"),
-            ]:
-                try:
-                    bus.call_sync(
-                        bus_name,
-                        obj_path,
-                        "org.gnome.Nautilus.FileOperations",
-                        "EmptyTrash",
-                        None,
-                        None,
-                        Gio.DBusCallFlags.NONE,
-                        -1,
-                        None,
-                    )
-                    return
-                except GLib.Error as exc:
-                    log.bind(action="empty_trash_dbus").debug(
-                        "DBus EmptyTrash failed for %s at %s: %s",
-                        bus_name,
-                        obj_path,
-                        exc,
-                    )
-        except GLib.Error as exc:
-            log.bind(action="empty_trash_dbus").debug(
-                "Could not connect to session bus for trash cleanup: %s",
-                exc,
-            )
+        """Empty trash through the selected backend."""
+        self._backend.empty(self._confirm_empty_trash)
 
-        self._delete_trash_contents()
-
-    def _delete_trash_contents(self) -> None:
-        """Delete all top-level items in trash via Gio.File.delete()."""
-        trash = Gio.File.new_for_uri("trash:///")
-        try:
-            enumerator = trash.enumerate_children(
-                Gio.FILE_ATTRIBUTE_STANDARD_NAME, Gio.FileQueryInfoFlags.NONE, None
-            )
-        except GLib.Error as exc:
-            log.bind(action="empty_trash_delete").debug(
-                "Could not enumerate trash for deletion: %s",
-                exc,
-            )
-            return
-
-        while True:
-            info = enumerator.next_file(None)
-            if info is None:
-                break
-            child = trash.get_child(info.get_name())
-            try:
-                child.delete(None)
-            except GLib.Error as exc:
-                log.bind(action="empty_trash_delete").debug(
-                    "Could not delete trash item %s: %s",
-                    info.get_name(),
-                    exc,
-                )
-        enumerator.close(None)
+    def _confirm_empty_trash(self) -> bool:
+        dialog = Gtk.MessageDialog(
+            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            message_type=Gtk.MessageType.WARNING,
+            buttons=Gtk.ButtonsType.NONE,
+            text=_("Empty all items from Trash?"),
+        )
+        dialog.format_secondary_text(
+            _("All items in the Trash will be permanently deleted."),
+        )
+        dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
+        dialog.add_button(_("Empty Trash"), Gtk.ResponseType.OK)
+        dialog.set_default_response(Gtk.ResponseType.CANCEL)
+        dialog.set_position(Gtk.WindowPosition.MOUSE)
+        response = dialog.run()
+        dialog.destroy()
+        return response == Gtk.ResponseType.OK

--- a/docking/applets/trash/backend.py
+++ b/docking/applets/trash/backend.py
@@ -1,0 +1,365 @@
+"""Trash backend adapters for desktop-specific behavior."""
+
+from __future__ import annotations
+
+import configparser
+import os
+import shutil
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol
+
+import gi
+
+gi.require_version("Gio", "2.0")
+gi.require_version("GLib", "2.0")
+from gi.repository import Gio, GLib
+
+from docking.applets.trash import meta
+from docking.log import get_logger, with_context
+from docking.platform.environment import (
+    Desktop,
+    detect_desktop,
+    is_gnome_session,
+    is_kde_session,
+    is_mate_session,
+)
+
+log = with_context(get_logger(name="trash"), applet_id=meta.id)
+
+
+class TrashBackend(Protocol):
+    """Desktop-specific trash behavior used by the Trash applet."""
+
+    name: str
+    uri: str
+
+    def count_items(self) -> int: ...
+
+    def monitor_file(self) -> Gio.File: ...
+
+    def open(self) -> None: ...
+
+    def empty(self, confirm: Callable[[], bool]) -> None: ...
+
+
+class _CaseSensitiveConfigParser(configparser.ConfigParser):
+    def optionxform(self, optionstr: str) -> str:
+        return optionstr
+
+
+def _xdg_data_home() -> Path:
+    return Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+
+
+def _kde_trash_directory() -> Path:
+    return _xdg_data_home() / "Trash"
+
+
+def _kde_trash_files_directory() -> Path:
+    return _kde_trash_directory() / "files"
+
+
+def _kde_trash_info_directory() -> Path:
+    return _kde_trash_directory() / "info"
+
+
+def _kde_kiorc_file() -> Path:
+    return Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "kiorc"
+
+
+class GioTrashBackend:
+    """Generic trash backend using Gio trash:/// behavior."""
+
+    name = "gio"
+    uri = "trash:///"
+    confirm_trash_key = "confirm-trash"
+    dbus_targets: tuple[tuple[str, str], ...] = (
+        ("org.mate.Caja", "/org/mate/Caja"),
+        ("org.gnome.Nautilus", "/org/gnome/Nautilus"),
+    )
+    confirmation_schema: tuple[str, str] | None = None
+
+    def count_items(self) -> int:
+        trash = Gio.File.new_for_uri(self.uri)
+        try:
+            enumerator = trash.enumerate_children(
+                Gio.FILE_ATTRIBUTE_STANDARD_NAME, Gio.FileQueryInfoFlags.NONE, None
+            )
+        except GLib.Error as exc:
+            log.bind(action="count_items").debug(
+                "Could not enumerate trash items: %s", exc
+            )
+            return 0
+
+        count = 0
+        while enumerator.next_file(None) is not None:
+            count += 1
+        enumerator.close(None)
+        return count
+
+    def monitor_file(self) -> Gio.File:
+        return Gio.File.new_for_uri(self.uri)
+
+    def open(self) -> None:
+        try:
+            Gio.AppInfo.launch_default_for_uri(self.uri, None)
+        except GLib.Error as exc:
+            log.bind(action="open_trash").warning("Failed to open trash: %s", exc)
+
+    def empty(self, confirm: Callable[[], bool]) -> None:
+        _ = confirm
+        if self._confirmation_preference() is False:
+            self._delete_contents()
+            return
+        if self._empty_via_dbus():
+            return
+        self._delete_contents()
+
+    def _confirmation_preference(self) -> bool | None:
+        if self.confirmation_schema is None:
+            return None
+        schema_id, path = self.confirmation_schema
+        schema_source = Gio.SettingsSchemaSource.get_default()
+        if schema_source is None:
+            return None
+        schema = schema_source.lookup(schema_id, True)
+        if schema is None or not schema.has_key(self.confirm_trash_key):
+            return None
+        try:
+            settings = Gio.Settings.new_full(schema, None, path)
+            return bool(settings.get_boolean(self.confirm_trash_key))
+        except Exception as exc:
+            log.bind(action="read_confirm_trash").debug(
+                "Could not read %s %s: %s",
+                schema_id,
+                self.confirm_trash_key,
+                exc,
+            )
+            return None
+
+    def _empty_via_dbus(self) -> bool:
+        try:
+            bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        except GLib.Error as exc:
+            log.bind(action="empty_trash_dbus").debug(
+                "Could not connect to session bus for trash cleanup: %s",
+                exc,
+            )
+            return False
+
+        for bus_name, obj_path in self.dbus_targets:
+            try:
+                bus.call_sync(
+                    bus_name,
+                    obj_path,
+                    "org.gnome.Nautilus.FileOperations",
+                    "EmptyTrash",
+                    None,
+                    None,
+                    Gio.DBusCallFlags.NONE,
+                    -1,
+                    None,
+                )
+                return True
+            except GLib.Error as exc:
+                log.bind(action="empty_trash_dbus").debug(
+                    "DBus EmptyTrash failed for %s at %s: %s",
+                    bus_name,
+                    obj_path,
+                    exc,
+                )
+        return False
+
+    def _delete_contents(self) -> None:
+        trash = Gio.File.new_for_uri(self.uri)
+        try:
+            enumerator = trash.enumerate_children(
+                Gio.FILE_ATTRIBUTE_STANDARD_NAME, Gio.FileQueryInfoFlags.NONE, None
+            )
+        except GLib.Error as exc:
+            log.bind(action="empty_trash_delete").debug(
+                "Could not enumerate trash for deletion: %s",
+                exc,
+            )
+            return
+
+        while True:
+            info = enumerator.next_file(None)
+            if info is None:
+                break
+            child = trash.get_child(info.get_name())
+            try:
+                child.delete(None)
+            except GLib.Error as exc:
+                log.bind(action="empty_trash_delete").debug(
+                    "Could not delete trash item %s: %s",
+                    info.get_name(),
+                    exc,
+                )
+        enumerator.close(None)
+
+
+class GnomeTrashBackend(GioTrashBackend):
+    """Trash backend for GNOME/Nautilus sessions."""
+
+    name = "gnome"
+    dbus_targets = (("org.gnome.Nautilus", "/org/gnome/Nautilus"),)
+
+
+class MateTrashBackend(GioTrashBackend):
+    """Trash backend for MATE/Caja sessions."""
+
+    name = "mate"
+    dbus_targets = (("org.mate.Caja", "/org/mate/Caja"),)
+    confirmation_schema = (
+        "org.mate.caja.preferences",
+        "/org/mate/caja/preferences/",
+    )
+
+
+class CinnamonTrashBackend(GioTrashBackend):
+    """Trash backend for Cinnamon/Nemo sessions."""
+
+    name = "cinnamon"
+    confirmation_schema = (
+        "org.nemo.preferences",
+        "/org/nemo/preferences/",
+    )
+
+
+class KdeTrashBackend:
+    """Trash backend for KDE's trash:/ KIO behavior."""
+
+    name = "kde"
+    uri = "trash:/"
+    confirm_empty_trash_key = "ConfirmEmptyTrash"
+    confirmations_section = "Confirmations"
+    open_commands: tuple[tuple[str, ...], ...] = (
+        ("kioclient6", "exec", uri),
+        ("kioclient5", "exec", uri),
+        ("kioclient", "exec", uri),
+        ("dolphin", uri),
+        ("kde-open5", uri),
+        ("kde-open", uri),
+    )
+
+    def count_items(self) -> int:
+        files_dir = _kde_trash_files_directory()
+        try:
+            return sum(1 for _child in files_dir.iterdir())
+        except OSError as exc:
+            log.bind(action="count_kde_items").debug(
+                "Could not enumerate KDE trash items: %s",
+                exc,
+            )
+            return 0
+
+    def monitor_file(self) -> Gio.File:
+        return Gio.File.new_for_path(str(_kde_trash_files_directory()))
+
+    def open(self) -> None:
+        command = self._available_open_command()
+        if command is not None:
+            try:
+                subprocess.Popen(command)
+                return
+            except OSError as exc:
+                log.bind(action="open_trash").warning(
+                    "Failed to open KDE trash with %s: %s",
+                    command[0],
+                    exc,
+                )
+
+        try:
+            Gio.AppInfo.launch_default_for_uri(self.uri, None)
+        except GLib.Error as exc:
+            log.bind(action="open_trash").warning("Failed to open trash: %s", exc)
+
+    def empty(self, confirm: Callable[[], bool]) -> None:
+        if self._confirmation_preference() is False or confirm():
+            self._delete_contents()
+
+    def _confirmation_preference(self) -> bool:
+        parser = _CaseSensitiveConfigParser()
+        try:
+            if not parser.read(_kde_kiorc_file()):
+                return True
+        except configparser.Error as exc:
+            log.bind(action="read_confirm_trash").debug(
+                "Could not read KDE trash confirmation preference: %s",
+                exc,
+            )
+            return True
+
+        if not parser.has_option(
+            self.confirmations_section, self.confirm_empty_trash_key
+        ):
+            return True
+        try:
+            return parser.getboolean(
+                self.confirmations_section,
+                self.confirm_empty_trash_key,
+            )
+        except ValueError as exc:
+            log.bind(action="read_confirm_trash").debug(
+                "Invalid KDE trash confirmation preference: %s",
+                exc,
+            )
+            return True
+
+    def _available_open_command(self) -> tuple[str, ...] | None:
+        for command in self.open_commands:
+            if shutil.which(command[0]):
+                return command
+        return None
+
+    def _delete_contents(self) -> None:
+        self._delete_directory_contents(_kde_trash_files_directory())
+        self._delete_directory_contents(_kde_trash_info_directory())
+
+    def _delete_directory_contents(self, directory: Path) -> None:
+        try:
+            children = list(directory.iterdir())
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            log.bind(action="empty_kde_trash").debug(
+                "Could not enumerate KDE trash directory %s: %s",
+                directory,
+                exc,
+            )
+            return
+
+        for child in children:
+            self._delete_path(child)
+
+    def _delete_path(self, path: Path) -> None:
+        try:
+            if path.is_dir() and not path.is_symlink():
+                for child in path.iterdir():
+                    self._delete_path(child)
+                path.rmdir()
+            else:
+                path.unlink()
+        except OSError as exc:
+            log.bind(action="empty_kde_trash").debug(
+                "Could not delete KDE trash item %s: %s",
+                path,
+                exc,
+            )
+
+
+def select_trash_backend(*, desktop: Desktop | None = None) -> TrashBackend:
+    """Select the trash backend for the current desktop session."""
+    resolved = desktop if desktop is not None else detect_desktop()
+    if is_kde_session(desktop=resolved):
+        return KdeTrashBackend()
+    if is_mate_session(desktop=resolved):
+        return MateTrashBackend()
+    if resolved & Desktop.CINNAMON:
+        return CinnamonTrashBackend()
+    if is_gnome_session(desktop=resolved):
+        return GnomeTrashBackend()
+    return GioTrashBackend()

--- a/docking/applets/trash/state.py
+++ b/docking/applets/trash/state.py
@@ -1,32 +1,4 @@
-"""State helpers for Trash applet."""
+"""State helpers for Trash applet.
 
-from __future__ import annotations
-
-import gi
-
-gi.require_version("Gio", "2.0")
-gi.require_version("GLib", "2.0")
-from gi.repository import Gio, GLib
-
-from docking.applets.trash import meta
-from docking.log import get_logger, with_context
-
-log = with_context(get_logger(name="trash"), applet_id=meta.id)
-
-
-def _count_trash_items() -> int:
-    """Count top-level items in trash:/// via Gio enumerator."""
-    trash = Gio.File.new_for_uri("trash:///")
-    try:
-        enumerator = trash.enumerate_children(
-            Gio.FILE_ATTRIBUTE_STANDARD_NAME, Gio.FileQueryInfoFlags.NONE, None
-        )
-    except GLib.Error as exc:
-        log.bind(action="count_items").debug("Could not enumerate trash items: %s", exc)
-        return 0
-
-    count = 0
-    while enumerator.next_file(None) is not None:
-        count += 1
-    enumerator.close(None)
-    return count
+Trash behavior is implemented by desktop-specific backend classes in backend.py.
+"""

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-05-01 21:13+0200\n"
+"POT-Creation-Date: 2026-05-06 21:07+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -141,7 +141,7 @@ msgid "Checks"
 msgstr ""
 
 #: docking/applets/apod/applet.py:118 docking/applets/certwatch/applet.py:128
-#: docking/applets/currencyfx/applet.py:183
+#: docking/applets/currencyfx/applet.py:187
 #: docking/applets/hackernews/applet.py:175
 #: docking/applets/speedtest/applet.py:103
 #: docking/applets/thermals/applet.py:134 docking/applets/tooltip.py:33
@@ -162,7 +162,7 @@ msgstr ""
 #: docking/applets/camshield/applet.py:114
 #: docking/applets/capslock/applet.py:84
 #: docking/applets/certwatch/applet.py:145
-#: docking/applets/currencyfx/applet.py:191
+#: docking/applets/currencyfx/applet.py:195
 #: docking/applets/hackernews/applet.py:192
 #: docking/applets/micshield/applet.py:118 docking/applets/moon/applet.py:124
 #: docking/applets/quote/applet.py:92 docking/applets/thermals/applet.py:144
@@ -634,7 +634,7 @@ msgid "Set Alarm"
 msgstr ""
 
 #: docking/applets/clock/applet.py:205 docking/applets/quicknote/applet.py:73
-#: docking/applets/weather/applet.py:258
+#: docking/applets/trash/applet.py:108 docking/applets/weather/applet.py:258
 msgid "Cancel"
 msgstr ""
 
@@ -660,65 +660,65 @@ msgstr ""
 msgid "Show Hex"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:84
+#: docking/applets/currencyfx/applet.py:88
 msgid "Currency FX"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:169
+#: docking/applets/currencyfx/applet.py:173
 #: docking/applets/currencyfx/state.py:726
 msgid "Day samples"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:187
+#: docking/applets/currencyfx/applet.py:191
 msgid "Swap Pair"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:197
+#: docking/applets/currencyfx/applet.py:201
 msgid "Chart Interval"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:199
+#: docking/applets/currencyfx/applet.py:203
 msgid "Day"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:200
+#: docking/applets/currencyfx/applet.py:204
 msgid "Week"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:201
+#: docking/applets/currencyfx/applet.py:205
 msgid "Month"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:216
+#: docking/applets/currencyfx/applet.py:220
 msgid "Added Pairs"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:226
+#: docking/applets/currencyfx/applet.py:230
 msgid "Remove Current Pair"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:233
+#: docking/applets/currencyfx/applet.py:237
 msgid "Add Pair..."
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:346
+#: docking/applets/currencyfx/applet.py:350
 msgid "No rate data"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:428
+#: docking/applets/currencyfx/applet.py:432
 #, python-brace-format
 msgid "{pair}: {rate} ({change})"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:471
+#: docking/applets/currencyfx/applet.py:475
 msgid "Add FX Pair"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:485
+#: docking/applets/currencyfx/applet.py:489
 msgid "Base"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:487 docking/applets/quote/applet.py:43
+#: docking/applets/currencyfx/applet.py:491 docking/applets/quote/applet.py:43
 #: docking/applets/quote/applet.py:83 docking/applets/quote/applet.py:208
 #: docking/applets/quote/applet.py:214
 msgid "Quote"
@@ -1667,30 +1667,30 @@ msgstr ""
 msgid "Celsius"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:53 docking/applets/thermals/state.py:199
-#: docking/applets/thermals/state.py:212 docking/applets/thermals/state.py:224
-#: docking/applets/thermals/state.py:258
+#: docking/applets/thermals/applet.py:53 docking/applets/thermals/state.py:406
+#: docking/applets/thermals/state.py:419 docking/applets/thermals/state.py:431
+#: docking/applets/thermals/state.py:465
 msgid "Thermals"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:96 docking/applets/thermals/state.py:149
-#: docking/applets/thermals/state.py:219
+#: docking/applets/thermals/applet.py:96 docking/applets/thermals/state.py:113
+#: docking/applets/thermals/state.py:426
 msgid "lm-sensors not installed"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:105 docking/applets/thermals/state.py:238
+#: docking/applets/thermals/applet.py:105 docking/applets/thermals/state.py:445
 #, python-brace-format
 msgid "Hot: {label} {temp}"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:119 docking/applets/thermals/state.py:250
+#: docking/applets/thermals/applet.py:119 docking/applets/thermals/state.py:457
 #, python-brace-format
 msgid "Fan: {label} {rpm}"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:139 docking/applets/thermals/state.py:205
-#: docking/applets/thermals/state.py:217 docking/applets/thermals/state.py:229
-#: docking/applets/thermals/state.py:265
+#: docking/applets/thermals/applet.py:139 docking/applets/thermals/state.py:412
+#: docking/applets/thermals/state.py:424 docking/applets/thermals/state.py:436
+#: docking/applets/thermals/state.py:472
 msgid "Samples"
 msgstr ""
 
@@ -1698,19 +1698,19 @@ msgstr ""
 msgid "Thermal readings unavailable"
 msgstr ""
 
-#: docking/applets/thermals/state.py:167
+#: docking/applets/thermals/state.py:134
 msgid "sensors failed"
 msgstr ""
 
-#: docking/applets/thermals/state.py:174
+#: docking/applets/thermals/state.py:141
 msgid "No thermal readings"
 msgstr ""
 
-#: docking/applets/thermals/state.py:246
+#: docking/applets/thermals/state.py:453
 msgid "Hot: unavailable"
 msgstr ""
 
-#: docking/applets/thermals/state.py:256
+#: docking/applets/thermals/state.py:463
 msgid "Fan: unavailable"
 msgstr ""
 
@@ -1741,7 +1741,7 @@ msgstr ""
 msgid "{year} - {title}"
 msgstr ""
 
-#: docking/applets/trash/applet.py:35
+#: docking/applets/trash/applet.py:36
 msgid "Trash"
 msgstr ""
 
@@ -1749,8 +1749,16 @@ msgstr ""
 msgid "Open Trash"
 msgstr ""
 
-#: docking/applets/trash/applet.py:62
+#: docking/applets/trash/applet.py:62 docking/applets/trash/applet.py:109
 msgid "Empty Trash"
+msgstr ""
+
+#: docking/applets/trash/applet.py:103
+msgid "Empty all items from Trash?"
+msgstr ""
+
+#: docking/applets/trash/applet.py:106
+msgid "All items in the Trash will be permanently deleted."
 msgstr ""
 
 #: docking/applets/trash/render.py:18
@@ -1808,16 +1816,17 @@ msgstr ""
 msgid "Correct: {answer}"
 msgstr ""
 
-#: docking/applets/unitconverter/applet.py:74
-#: docking/applets/unitconverter/applet.py:101
+#: docking/applets/unitconverter/applet.py:102
+#: docking/applets/unitconverter/applet.py:129
+#: docking/applets/unitconverter/applet.py:161
 msgid "Unit Converter"
 msgstr ""
 
-#: docking/applets/unitconverter/applet.py:166
+#: docking/applets/unitconverter/applet.py:210
 msgid "Swap units"
 msgstr ""
 
-#: docking/applets/unitconverter/applet.py:183
+#: docking/applets/unitconverter/applet.py:227
 msgid "Value"
 msgstr ""
 
@@ -2291,24 +2300,24 @@ msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
 
-#: docking/ui/update_popup.py:183
+#: docking/ui/update_popup.py:173
 #, python-brace-format
 msgid "Docking {version} is available"
 msgstr ""
 
-#: docking/ui/update_popup.py:189
+#: docking/ui/update_popup.py:179
 #, python-brace-format
 msgid "You are using {version}."
 msgstr ""
 
-#: docking/ui/update_popup.py:198
+#: docking/ui/update_popup.py:188
 msgid "View Release"
 msgstr ""
 
-#: docking/ui/update_popup.py:199
+#: docking/ui/update_popup.py:189
 msgid "Later"
 msgstr ""
 
-#: docking/ui/update_popup.py:200
+#: docking/ui/update_popup.py:190
 msgid "Ignore"
 msgstr ""

--- a/docking/platform/environment.py
+++ b/docking/platform/environment.py
@@ -124,6 +124,12 @@ def is_mate_session(*, desktop: Desktop | None = None) -> bool:
     return bool(resolved & Desktop.MATE)
 
 
+def is_kde_session(*, desktop: Desktop | None = None) -> bool:
+    """Return True for KDE sessions."""
+    resolved = desktop if desktop is not None else detect_desktop()
+    return bool(resolved & Desktop.KDE)
+
+
 def is_x11_backend(*, display: object | None = None) -> bool:
     """Return True when the current GTK backend is X11."""
     if display is None:

--- a/tests/applets/test_trash.py
+++ b/tests/applets/test_trash.py
@@ -1,12 +1,37 @@
 """Tests for the trash applet."""
 
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
+from docking.applets.trash import applet as trash_applet_mod
 from docking.applets.trash.applet import TrashApplet
-from docking.applets.trash.state import _count_trash_items
+from docking.applets.trash.backend import (
+    CinnamonTrashBackend,
+    GioTrashBackend,
+    GnomeTrashBackend,
+    KdeTrashBackend,
+    MateTrashBackend,
+    select_trash_backend,
+)
+from docking.platform.environment import Desktop
 
 
-class TestCountTrashItems:
+class TestTrashBackendSelection:
+    def test_selects_desktop_specific_backends(self):
+        assert isinstance(select_trash_backend(desktop=Desktop.KDE), KdeTrashBackend)
+        assert isinstance(select_trash_backend(desktop=Desktop.MATE), MateTrashBackend)
+        assert isinstance(
+            select_trash_backend(desktop=Desktop.CINNAMON), CinnamonTrashBackend
+        )
+        assert isinstance(
+            select_trash_backend(desktop=Desktop.GNOME), GnomeTrashBackend
+        )
+        assert isinstance(
+            select_trash_backend(desktop=Desktop.UNKNOWN), GioTrashBackend
+        )
+
+
+class TestGioTrashBackend:
     def test_counts_items(self):
         # Given an enumerator yielding 3 items
         mock_enum = MagicMock()
@@ -16,14 +41,14 @@ class TestCountTrashItems:
 
         # When
         with patch(
-            "docking.applets.trash.state.Gio.File.new_for_uri", return_value=mock_file
+            "docking.applets.trash.backend.Gio.File.new_for_uri", return_value=mock_file
         ):
-            count = _count_trash_items()
+            count = GioTrashBackend().count_items()
 
         # Then
         assert count == 3
 
-    def test_returns_zero_on_error(self):
+    def test_returns_zero_on_count_error(self):
         # Given enumerate_children raises
         from gi.repository import GLib
 
@@ -31,153 +56,64 @@ class TestCountTrashItems:
         mock_file.enumerate_children.side_effect = GLib.Error("fail")
 
         with patch(
-            "docking.applets.trash.state.Gio.File.new_for_uri", return_value=mock_file
+            "docking.applets.trash.backend.Gio.File.new_for_uri", return_value=mock_file
         ):
-            assert _count_trash_items() == 0
+            assert GioTrashBackend().count_items() == 0
 
-
-class TestTrashAppletIcon:
-    def test_empty_trash_uses_empty_icon(self):
-        # Given empty trash
-        with patch("docking.applets.trash.applet._count_trash_items", return_value=0):
-            applet = TrashApplet(48)
-
-        # When
-        pixbuf = applet.create_icon(48)
-
-        # Then
-        assert pixbuf is not None
-        assert applet.item.name == "No items in Trash"
-
-    def test_full_trash_uses_full_icon(self):
-        # Given trash with items
-        with patch("docking.applets.trash.applet._count_trash_items", return_value=5):
-            applet = TrashApplet(48)
-
-        # When
-        pixbuf = applet.create_icon(48)
-
-        # Then
-        assert pixbuf is not None
-        assert "5 items" in applet.item.name
-
-    def test_single_item_singular(self):
-        with patch("docking.applets.trash.applet._count_trash_items", return_value=1):
-            applet = TrashApplet(48)
-        applet.create_icon(48)
-        assert applet.item.name == "1 item in Trash"
-
-
-class TestTrashAppletMenu:
-    def test_returns_two_items(self):
-        with patch("docking.applets.trash.applet._count_trash_items", return_value=0):
-            applet = TrashApplet(48)
-        items = applet.get_menu_items()
-        assert [item.get_label() for item in items] == [
-            "Open Trash",
-            "",
-            "Empty Trash",
-        ]
-
-    def test_empty_trash_insensitive_when_empty(self):
-        with patch("docking.applets.trash.applet._count_trash_items", return_value=0):
-            applet = TrashApplet(48)
-        items = applet.get_menu_items()
-        empty_item = items[2]
-        assert not empty_item.get_sensitive()
-
-    def test_empty_trash_sensitive_when_full(self):
-        with patch("docking.applets.trash.applet._count_trash_items", return_value=3):
-            applet = TrashApplet(48)
-        items = applet.get_menu_items()
-        empty_item = items[2]
-        assert empty_item.get_sensitive()
-
-
-class TestTrashAppletLifecycle:
-    def test_start_sets_monitor_and_stop_cancels(self):
-        # Given
-        with patch("docking.applets.trash.applet._count_trash_items", return_value=0):
-            applet = TrashApplet(48)
-        monitor = MagicMock()
-        trash = MagicMock()
-        trash.monitor.return_value = monitor
+    def test_open_launches_default_trash_uri(self):
         with patch(
-            "docking.applets.trash.applet.Gio.File.new_for_uri", return_value=trash
-        ):
-            # When
-            applet.start(lambda: None)
-            # Then
-            assert applet._monitor is monitor
-            monitor.connect.assert_called_once()
+            "docking.applets.trash.backend.Gio.AppInfo.launch_default_for_uri"
+        ) as launch:
+            GioTrashBackend().open()
 
-            # When
-            applet.stop()
-            # Then
-            monitor.cancel.assert_called_once()
-            assert applet._monitor is None
+        launch.assert_called_once_with("trash:///", None)
 
-    def test_start_handles_monitor_error(self):
-        # Given
-        from gi.repository import GLib
-
-        with patch("docking.applets.trash.applet._count_trash_items", return_value=0):
-            applet = TrashApplet(48)
-        trash = MagicMock()
-        trash.monitor.side_effect = GLib.Error("monitor error")
-        with patch(
-            "docking.applets.trash.applet.Gio.File.new_for_uri", return_value=trash
-        ):
-            # When
-            applet.start(lambda: None)
-            # Then
-            assert applet._monitor is None
-
-    def test_on_clicked_handles_launch_error(self):
-        # Given
-        from gi.repository import GLib
-
-        with patch("docking.applets.trash.applet._count_trash_items", return_value=0):
-            applet = TrashApplet(48)
-        with patch(
-            "docking.applets.trash.applet.Gio.AppInfo.launch_default_for_uri",
-            side_effect=GLib.Error("boom"),
-        ):
-            # When / Then
-            applet.on_clicked()
-
-
-class TestTrashAppletDeletePaths:
     def test_empty_trash_uses_dbus_first(self):
-        # Given
-        with patch("docking.applets.trash.applet._count_trash_items", return_value=1):
-            applet = TrashApplet(48)
         bus = MagicMock()
-        with patch("docking.applets.trash.applet.Gio.bus_get_sync", return_value=bus):
-            # When
-            applet._empty_trash()
-            # Then
-            bus.call_sync.assert_called_once()
+        with patch("docking.applets.trash.backend.Gio.bus_get_sync", return_value=bus):
+            GioTrashBackend().empty(lambda: False)
+
+        bus.call_sync.assert_called_once()
+
+    def test_empty_trash_bypasses_dbus_when_file_manager_disables_confirmation(self):
+        backend = MateTrashBackend()
+        with (
+            patch.object(backend, "_confirmation_preference", return_value=False),
+            patch("docking.applets.trash.backend.Gio.bus_get_sync") as bus_get,
+            patch.object(backend, "_delete_contents") as delete_mock,
+        ):
+            backend.empty(lambda: False)
+
+        bus_get.assert_not_called()
+        delete_mock.assert_called_once()
 
     def test_empty_trash_falls_back_to_delete(self):
-        # Given
         from gi.repository import GLib
 
-        with patch("docking.applets.trash.applet._count_trash_items", return_value=1):
-            applet = TrashApplet(48)
+        backend = GnomeTrashBackend()
         bus = MagicMock()
-        bus.call_sync.side_effect = [GLib.Error("caja"), GLib.Error("nautilus")]
+        bus.call_sync.side_effect = GLib.Error("nautilus")
         with (
-            patch("docking.applets.trash.applet.Gio.bus_get_sync", return_value=bus),
-            patch.object(applet, "_delete_trash_contents") as delete_mock,
+            patch("docking.applets.trash.backend.Gio.bus_get_sync", return_value=bus),
+            patch.object(backend, "_delete_contents") as delete_mock,
         ):
-            # When
-            applet._empty_trash()
-            # Then
-            delete_mock.assert_called_once()
+            backend.empty(lambda: False)
+
+        delete_mock.assert_called_once()
+
+    def test_mate_confirmation_preference_uses_caja_schema(self):
+        assert MateTrashBackend.confirmation_schema == (
+            "org.mate.caja.preferences",
+            "/org/mate/caja/preferences/",
+        )
+
+    def test_cinnamon_confirmation_preference_uses_nemo_schema(self):
+        assert CinnamonTrashBackend.confirmation_schema == (
+            "org.nemo.preferences",
+            "/org/nemo/preferences/",
+        )
 
     def test_delete_trash_contents_deletes_children(self):
-        # Given
         info_a = MagicMock()
         info_a.get_name.return_value = "a.txt"
         info_b = MagicMock()
@@ -189,42 +125,247 @@ class TestTrashAppletDeletePaths:
         trash = MagicMock()
         trash.enumerate_children.return_value = enumerator
         trash.get_child.side_effect = [child_a, child_b]
-        with patch(
-            "docking.applets.trash.applet.Gio.File.new_for_uri", return_value=trash
-        ):
-            # When
-            with patch(
-                "docking.applets.trash.applet._count_trash_items", return_value=2
-            ):
-                applet = TrashApplet(48)
-            applet._delete_trash_contents()
-            # Then
-            child_a.delete.assert_called_once()
-            child_b.delete.assert_called_once()
-            enumerator.close.assert_called_once()
 
-    def test_delete_trash_contents_ignores_delete_errors(self):
-        # Given
+        with patch(
+            "docking.applets.trash.backend.Gio.File.new_for_uri", return_value=trash
+        ):
+            GioTrashBackend()._delete_contents()
+
+        child_a.delete.assert_called_once()
+        child_b.delete.assert_called_once()
+        enumerator.close.assert_called_once()
+
+
+class TestKdeTrashBackend:
+    def test_uses_kde_trash_uri(self):
+        assert KdeTrashBackend().uri == "trash:/"
+        assert GioTrashBackend().uri == "trash:///"
+
+    def test_counts_kde_trash_files(self, tmp_path, monkeypatch):
+        files_dir = tmp_path / "Trash" / "files"
+        files_dir.mkdir(parents=True)
+        (files_dir / "a.txt").write_text("a")
+        (files_dir / "b.txt").write_text("b")
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+        assert KdeTrashBackend().count_items() == 2
+
+    def test_deletes_kde_trash_files_and_info(self, tmp_path, monkeypatch):
+        files_dir = tmp_path / "Trash" / "files"
+        info_dir = tmp_path / "Trash" / "info"
+        files_dir.mkdir(parents=True)
+        info_dir.mkdir()
+        (files_dir / "a.txt").write_text("a")
+        nested_dir = files_dir / "nested"
+        nested_dir.mkdir()
+        (nested_dir / "b.txt").write_text("b")
+        (info_dir / "a.txt.trashinfo").write_text("[Trash Info]")
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+        KdeTrashBackend().empty(lambda: True)
+
+        assert list(files_dir.iterdir()) == []
+        assert list(info_dir.iterdir()) == []
+
+    def test_open_uses_kde_open_command(self):
+        backend = KdeTrashBackend()
+        with (
+            patch.object(
+                backend, "_available_open_command", return_value=("dolphin", "trash:/")
+            ),
+            patch("docking.applets.trash.backend.subprocess.Popen") as popen,
+        ):
+            backend.open()
+
+        popen.assert_called_once_with(("dolphin", "trash:/"))
+
+    def test_monitor_uses_kde_trash_files(self, tmp_path):
+        with (
+            patch(
+                "docking.applets.trash.backend._kde_trash_files_directory",
+                return_value=tmp_path,
+            ),
+            patch(
+                "docking.applets.trash.backend.Gio.File.new_for_path",
+            ) as new_for_path,
+        ):
+            KdeTrashBackend().monitor_file()
+
+        new_for_path.assert_called_once_with(str(tmp_path))
+
+    def test_confirmation_preference_reads_kiorc(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "kiorc"
+        config_file.write_text("[Confirmations]\nConfirmEmptyTrash=false\n")
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        backend = KdeTrashBackend()
+        with patch.object(backend, "_delete_contents") as delete:
+            backend.empty(lambda: False)
+
+        delete.assert_called_once()
+
+    def test_confirmation_preference_defaults_to_true_when_missing(
+        self, tmp_path, monkeypatch
+    ):
+        (tmp_path / "kiorc").write_text("[Confirmations]\n")
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        backend = KdeTrashBackend()
+        with patch.object(backend, "_delete_contents") as delete:
+            backend.empty(lambda: False)
+
+        delete.assert_not_called()
+
+    def test_asks_when_confirmation_enabled(self, tmp_path, monkeypatch):
+        (tmp_path / "kiorc").write_text("[Confirmations]\nConfirmEmptyTrash=true\n")
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        backend = KdeTrashBackend()
+        with patch.object(backend, "_delete_contents") as delete:
+            backend.empty(lambda: True)
+
+        delete.assert_called_once()
+
+
+class _StubBackend:
+    name = "stub"
+    uri = "trash:///"
+
+    def __init__(self, item_count: int = 0) -> None:
+        self.item_count = item_count
+        self.monitor = MagicMock()
+        self.monitor_file_mock = MagicMock()
+        self.monitor_file_mock.monitor.return_value = self.monitor
+        self.open_calls = 0
+        self.empty_confirm: Callable[[], bool] | None = None
+
+    def count_items(self) -> int:
+        return self.item_count
+
+    def monitor_file(self):
+        return self.monitor_file_mock
+
+    def open(self) -> None:
+        self.open_calls += 1
+
+    def empty(self, confirm: Callable[[], bool]) -> None:
+        self.empty_confirm = confirm
+
+
+def _make_applet(monkeypatch, backend: _StubBackend) -> TrashApplet:
+    monkeypatch.setattr(
+        trash_applet_mod,
+        "select_trash_backend",
+        lambda **_: backend,
+    )
+    return TrashApplet(48)
+
+
+class TestTrashAppletIcon:
+    def test_empty_trash_uses_empty_icon(self, monkeypatch):
+        applet = _make_applet(monkeypatch, _StubBackend(item_count=0))
+
+        pixbuf = applet.create_icon(48)
+
+        assert pixbuf is not None
+        assert applet.item.name == "No items in Trash"
+
+    def test_full_trash_uses_full_icon(self, monkeypatch):
+        applet = _make_applet(monkeypatch, _StubBackend(item_count=5))
+
+        pixbuf = applet.create_icon(48)
+
+        assert pixbuf is not None
+        assert "5 items" in applet.item.name
+
+    def test_single_item_singular(self, monkeypatch):
+        applet = _make_applet(monkeypatch, _StubBackend(item_count=1))
+        applet.create_icon(48)
+        assert applet.item.name == "1 item in Trash"
+
+
+class TestTrashAppletMenu:
+    def test_returns_two_items(self, monkeypatch):
+        applet = _make_applet(monkeypatch, _StubBackend(item_count=0))
+        items = applet.get_menu_items()
+        assert [item.get_label() for item in items] == [
+            "Open Trash",
+            "",
+            "Empty Trash",
+        ]
+
+    def test_empty_trash_insensitive_when_empty(self, monkeypatch):
+        applet = _make_applet(monkeypatch, _StubBackend(item_count=0))
+        items = applet.get_menu_items()
+        assert not items[2].get_sensitive()
+
+    def test_empty_trash_sensitive_when_full(self, monkeypatch):
+        applet = _make_applet(monkeypatch, _StubBackend(item_count=3))
+        items = applet.get_menu_items()
+        assert items[2].get_sensitive()
+
+
+class TestTrashAppletLifecycle:
+    def test_start_sets_monitor_and_stop_cancels(self, monkeypatch):
+        backend = _StubBackend()
+        applet = _make_applet(monkeypatch, backend)
+
+        applet.start(lambda: None)
+
+        assert applet._monitor is backend.monitor
+        backend.monitor.connect.assert_called_once()
+
+        applet.stop()
+
+        backend.monitor.cancel.assert_called_once()
+        assert applet._monitor is None
+
+    def test_start_handles_monitor_error(self, monkeypatch):
         from gi.repository import GLib
 
-        info = MagicMock()
-        info.get_name.return_value = "bad.txt"
-        enumerator = MagicMock()
-        enumerator.next_file.side_effect = [info, None]
-        child = MagicMock()
-        child.delete.side_effect = GLib.Error("cannot delete")
-        trash = MagicMock()
-        trash.enumerate_children.return_value = enumerator
-        trash.get_child.return_value = child
+        backend = _StubBackend()
+        backend.monitor_file_mock.monitor.side_effect = GLib.Error("monitor error")
+        applet = _make_applet(monkeypatch, backend)
+
+        applet.start(lambda: None)
+
+        assert applet._monitor is None
+
+    def test_on_clicked_delegates_to_backend(self, monkeypatch):
+        backend = _StubBackend()
+        applet = _make_applet(monkeypatch, backend)
+
+        applet.on_clicked()
+
+        assert backend.open_calls == 1
+
+    def test_on_trash_changed_recounts_from_backend(self, monkeypatch):
+        backend = _StubBackend(item_count=0)
+        applet = _make_applet(monkeypatch, backend)
+        backend.item_count = 4
+
+        applet._on_trash_changed()
+
+        assert applet._item_count == 4
+        assert "4 items" in applet.item.name
+
+    def test_empty_trash_delegates_confirmation_callback(self, monkeypatch):
+        backend = _StubBackend(item_count=1)
+        applet = _make_applet(monkeypatch, backend)
+
+        applet._empty_trash()
+
+        assert backend.empty_confirm == applet._confirm_empty_trash
+
+    def test_confirm_empty_trash_dialog(self, monkeypatch):
+        applet = _make_applet(monkeypatch, _StubBackend(item_count=1))
+        dialog = MagicMock()
+        dialog.run.return_value = trash_applet_mod.Gtk.ResponseType.OK
+
         with patch(
-            "docking.applets.trash.applet.Gio.File.new_for_uri", return_value=trash
+            "docking.applets.trash.applet.Gtk.MessageDialog",
+            return_value=dialog,
         ):
-            # When
-            with patch(
-                "docking.applets.trash.applet._count_trash_items", return_value=1
-            ):
-                applet = TrashApplet(48)
-            applet._delete_trash_contents()
-            # Then
-            child.delete.assert_called_once()
-            enumerator.close.assert_called_once()
+            assert applet._confirm_empty_trash() is True
+
+        dialog.destroy.assert_called_once()

--- a/tests/platform/test_environment.py
+++ b/tests/platform/test_environment.py
@@ -9,6 +9,7 @@ from docking.platform.environment import (
     _parse_desktop,
     detect_desktop,
     is_gnome_session,
+    is_kde_session,
     is_mate_session,
     is_wayland_session,
     is_x11_backend,
@@ -96,6 +97,10 @@ class TestDetectDesktop:
     def test_mate_session_helper(self):
         assert is_mate_session(desktop=Desktop.MATE) is True
         assert is_mate_session(desktop=Desktop.GNOME) is False
+
+    def test_kde_session_helper(self):
+        assert is_kde_session(desktop=Desktop.KDE) is True
+        assert is_kde_session(desktop=Desktop.GNOME) is False
 
 
 class TestSessionBackendDetection:


### PR DESCRIPTION
Adds KDE-specific handling for the Trash applet: KDE trash URI/open command support, direct monitoring of the KDE trash files directory, kiorc confirmation preference handling, and safe deletion of KDE trash files/info entries. Also updates trash applet tests and refreshes the gettext template for the new confirmation dialog strings.