### PR TITLE
Prepare applets for Flatpak runtime

### DIFF
--- a/docking/applets/applications/state.py
+++ b/docking/applets/applications/state.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from pathlib import Path
+from typing import NamedTuple
 
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gio
+from gi.repository import Gio, GLib
+
+from docking.platform.launcher import Launcher
+from docking.platform.launcher import launch as launch_desktop_id
 
 # FreeDesktop main categories -> display label
 CATEGORY_LABELS: dict[str, str] = {
@@ -42,6 +47,41 @@ CATEGORY_ICONS: dict[str, str] = {
 }
 
 
+class ApplicationEntry(NamedTuple):
+    """Small app-info adapter for Gio and host-parsed desktop files."""
+
+    desktop_id: str
+    name: str
+    categories: str
+    icon_name: str
+    app_info: Gio.DesktopAppInfo | None = None
+
+    def get_id(self) -> str:
+        return self.desktop_id
+
+    def get_display_name(self) -> str:
+        return self.name
+
+    def get_categories(self) -> str:
+        return self.categories
+
+    def get_icon(self) -> Gio.Icon | None:
+        if self.app_info is not None:
+            return self.app_info.get_icon()
+        if not self.icon_name:
+            return None
+        icon_path = Path(self.icon_name)
+        if icon_path.is_absolute():
+            return Gio.FileIcon.new(Gio.File.new_for_path(str(icon_path)))
+        return Gio.ThemedIcon.new(self.icon_name)
+
+    def launch(self, files: list[object], context: object | None) -> None:
+        if self.app_info is not None:
+            self.app_info.launch(files, context)
+            return
+        launch_desktop_id(desktop_id=self.desktop_id)
+
+
 def _map_category(categories: str) -> str:
     """Map FreeDesktop category string to display category."""
     display_cat = "Other"
@@ -52,21 +92,16 @@ def _map_category(categories: str) -> str:
     return display_cat
 
 
-def _build_app_categories() -> dict[str, list[Gio.DesktopAppInfo]]:
+def _build_app_categories() -> dict[str, list[ApplicationEntry]]:
     """Group installed apps by FreeDesktop category.
 
     Returns {display_category: [app_info, ...]} sorted by app name.
     Apps that don't match any known category go into "Other".
     Hidden and no-display apps are excluded.
     """
-    categories: dict[str, list[Gio.DesktopAppInfo]] = defaultdict(list)
+    categories: dict[str, list[ApplicationEntry]] = defaultdict(list)
 
-    for app_info in Gio.AppInfo.get_all():
-        if not isinstance(app_info, Gio.DesktopAppInfo):
-            continue
-        if app_info.get_is_hidden() or app_info.get_nodisplay():
-            continue
-
+    for app_info in _all_desktop_app_infos():
         cats = app_info.get_categories() or ""
         categories[_map_category(categories=cats)].append(app_info)
 
@@ -75,3 +110,101 @@ def _build_app_categories() -> dict[str, list[Gio.DesktopAppInfo]]:
         apps.sort(key=lambda a: (a.get_display_name() or "").lower())
 
     return dict(categories)
+
+
+def _all_desktop_app_infos() -> list[ApplicationEntry]:
+    apps: list[ApplicationEntry] = []
+    seen: set[str] = set()
+
+    for app_info in Gio.AppInfo.get_all():
+        if isinstance(app_info, Gio.DesktopAppInfo):
+            if app_info.get_is_hidden() or app_info.get_nodisplay():
+                continue
+            app_id = app_info.get_id()
+            if app_id:
+                seen.add(app_id)
+            apps.append(
+                ApplicationEntry(
+                    desktop_id=app_id or "",
+                    name=app_info.get_display_name() or app_id or "Unknown",
+                    categories=app_info.get_categories() or "",
+                    icon_name=app_info.get_icon().to_string()
+                    if app_info.get_icon()
+                    else "",
+                    app_info=app_info,
+                )
+            )
+
+    for desktop_dir in Launcher._get_desktop_dirs():
+        for path in desktop_dir.rglob("*.desktop"):
+            if not path.is_file():
+                continue
+            desktop_id = path.relative_to(desktop_dir).as_posix()
+            if desktop_id in seen:
+                continue
+            try:
+                app_info = Gio.DesktopAppInfo.new_from_filename(str(path))
+            except (TypeError, GLib.Error):
+                app_info = None
+            if app_info is None:
+                entry = _entry_from_desktop_file(desktop_id=desktop_id, path=path)
+            else:
+                if app_info.get_is_hidden() or app_info.get_nodisplay():
+                    continue
+                entry = ApplicationEntry(
+                    desktop_id=desktop_id,
+                    name=app_info.get_display_name() or desktop_id,
+                    categories=app_info.get_categories() or "",
+                    icon_name=app_info.get_icon().to_string()
+                    if app_info.get_icon()
+                    else "",
+                    app_info=app_info,
+                )
+            if entry is None:
+                continue
+            seen.add(desktop_id)
+            apps.append(entry)
+
+    return apps
+
+
+def _entry_from_desktop_file(*, desktop_id: str, path: Path) -> ApplicationEntry | None:
+    key_file = GLib.KeyFile()
+    try:
+        key_file.load_from_file(str(path), GLib.KeyFileFlags.NONE)
+    except GLib.Error:
+        return None
+    if _desktop_string(key_file=key_file, key="Type") != "Application":
+        return None
+    if _desktop_bool(key_file=key_file, key="Hidden") or _desktop_bool(
+        key_file=key_file,
+        key="NoDisplay",
+    ):
+        return None
+    return ApplicationEntry(
+        desktop_id=desktop_id,
+        name=_desktop_locale_string(key_file=key_file, key="Name") or desktop_id,
+        categories=_desktop_string(key_file=key_file, key="Categories"),
+        icon_name=_desktop_string(key_file=key_file, key="Icon"),
+    )
+
+
+def _desktop_string(*, key_file: GLib.KeyFile, key: str) -> str:
+    try:
+        return key_file.get_string("Desktop Entry", key).strip()
+    except GLib.Error:
+        return ""
+
+
+def _desktop_locale_string(*, key_file: GLib.KeyFile, key: str) -> str:
+    try:
+        return key_file.get_locale_string("Desktop Entry", key, None).strip()
+    except GLib.Error:
+        return _desktop_string(key_file=key_file, key=key)
+
+
+def _desktop_bool(*, key_file: GLib.KeyFile, key: str) -> bool:
+    try:
+        return bool(key_file.get_boolean("Desktop Entry", key))
+    except GLib.Error:
+        return False

--- a/docking/applets/base.py
+++ b/docking/applets/base.py
@@ -164,8 +164,11 @@ def load_theme_icon(name: str, size: int) -> GdkPixbuf.Pixbuf | None:
     flags = Gtk.IconLookupFlags.FORCE_SIZE
     for icon_name in _icon_name_candidates(name=name):
         for theme in _icon_theme_candidates():
+            icon_info = theme.lookup_icon(icon_name, size, flags)
+            if icon_info is None:
+                continue
             try:
-                return theme.load_icon(icon_name, size, flags)
+                return icon_info.load_icon()
             except GLib.Error as exc:
                 log.debug(
                     "Theme icon lookup failed for %s at size %s: %s",

--- a/docking/applets/keyboardlayout/state.py
+++ b/docking/applets/keyboardlayout/state.py
@@ -186,6 +186,17 @@ def show_current_layout(layout_code: str) -> bool:
 
 
 def _run(cmd: list[str]) -> str | None:
+    result = _run_direct(cmd=cmd)
+    if result is not None:
+        return result
+    if environment.is_flatpak() and cmd[:2] != ["flatpak-spawn", "--host"]:
+        flatpak_spawn = shutil.which("flatpak-spawn")
+        if flatpak_spawn is not None:
+            return _run_direct(cmd=[flatpak_spawn, "--host", *cmd])
+    return None
+
+
+def _run_direct(cmd: list[str]) -> str | None:
     try:
         result = subprocess.run(
             cmd,

--- a/docking/applets/network/state.py
+++ b/docking/applets/network/state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import shutil
 import subprocess
 from typing import NamedTuple
@@ -10,6 +11,7 @@ from docking.applets.tooltip import structured_tooltip
 from docking.applets.units import format_compact_number
 from docking.i18n import _
 from docking.log import get_logger
+from docking.platform.environment import is_flatpak
 
 log = get_logger("network.state")
 
@@ -108,18 +110,12 @@ def format_compact_speed(bps: float) -> str:
 
 def connection_info_command() -> list[str] | None:
     """Return the first available desktop network-info/settings command."""
-    for cmd in _CONNECTION_INFO_COMMANDS:
-        if shutil.which(cmd[0]):
-            return list(cmd)
-    return None
+    return _available_desktop_command(_CONNECTION_INFO_COMMANDS)
 
 
 def edit_connections_command() -> list[str] | None:
     """Return the first available network-connections editor command."""
-    for cmd in _EDIT_CONNECTIONS_COMMANDS:
-        if shutil.which(cmd[0]):
-            return list(cmd)
-    return None
+    return _available_desktop_command(_EDIT_CONNECTIONS_COMMANDS)
 
 
 def open_connection_info() -> bool:
@@ -242,3 +238,42 @@ def _open_command(*, cmd: list[str] | None, action: str) -> bool:
         log.bind(action=action).warning("Failed to run %s: %s", cmd, exc)
         return False
     return True
+
+
+def _available_desktop_command(
+    candidates: tuple[tuple[str, ...], ...],
+) -> list[str] | None:
+    flatpak_spawn = _flatpak_spawn_command()
+    for cmd in candidates:
+        if flatpak_spawn is not None:
+            if _host_command_available(flatpak_spawn=flatpak_spawn, command=cmd[0]):
+                return [flatpak_spawn, "--host", *cmd]
+            continue
+        if shutil.which(cmd[0]):
+            return list(cmd)
+    return None
+
+
+def _flatpak_spawn_command() -> str | None:
+    if not is_flatpak():
+        return None
+    return shutil.which("flatpak-spawn")
+
+
+def _host_command_available(*, flatpak_spawn: str, command: str) -> bool:
+    try:
+        result = subprocess.run(
+            [
+                flatpak_spawn,
+                "--host",
+                "sh",
+                "-lc",
+                f"command -v {shlex.quote(command)} >/dev/null",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=1.5,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False

--- a/docking/applets/notifications/applet.py
+++ b/docking/applets/notifications/applet.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import shutil
 import subprocess
 import threading
@@ -21,6 +22,7 @@ from docking.applets.notifications import meta
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
 from docking.log import get_logger, with_context
+from docking.platform.environment import is_flatpak
 
 from .render import create_notifications_icon
 from .state import (
@@ -44,6 +46,8 @@ TOOLTIP_BODY_LIMIT = 96
 MAX_HISTORY_BADGE_COUNT = 99
 ACTIVITY_MONITOR_TERMINATE_TIMEOUT_S = 0.4
 ELLIPSIS_RESERVED_CHARS = 3
+NOTIFICATION_MONITOR_RULE = "interface='org.freedesktop.Notifications',member='Notify'"
+HOST_MONITOR_PID_PREFIX = "__DOCKING_HOST_DBUS_MONITOR_PID="
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,6 +72,7 @@ class NotificationsApplet(Applet):
         self._activity_clear_id: int = 0
         self._activity_monitor_proc: subprocess.Popen[str] | None = None
         self._activity_monitor_thread: threading.Thread | None = None
+        self._activity_monitor_host_pid: str | None = None
         self._history: list[NotificationEntry] = []
         self._history_index: int = 0
         self._worker = BackgroundWorker()
@@ -229,18 +234,15 @@ class NotificationsApplet(Applet):
     def _start_activity_monitor(self) -> None:
         if self._activity_monitor_proc is not None:
             return
-        if shutil.which("dbus-monitor") is None:
+        command = self._activity_monitor_command()
+        if command is None:
             log.bind(action="activity_monitor").warning(
                 "dbus-monitor not found; notification activity monitoring is disabled"
             )
             return
         try:
             self._activity_monitor_proc = subprocess.Popen(
-                [
-                    "dbus-monitor",
-                    "--session",
-                    "interface='org.freedesktop.Notifications',member='Notify'",
-                ],
+                command,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 text=True,
@@ -259,11 +261,36 @@ class NotificationsApplet(Applet):
         )
         self._activity_monitor_thread.start()
 
+    def _activity_monitor_command(self) -> list[str] | None:
+        if is_flatpak():
+            flatpak_spawn = shutil.which("flatpak-spawn")
+            if flatpak_spawn is None:
+                return None
+            monitor_rule = shlex.quote(NOTIFICATION_MONITOR_RULE)
+            return [
+                flatpak_spawn,
+                "--host",
+                "sh",
+                "-c",
+                "command -v dbus-monitor >/dev/null || exit 127; "
+                f"echo {HOST_MONITOR_PID_PREFIX}$$; "
+                f"exec dbus-monitor --session {monitor_rule}",
+            ]
+
+        dbus_monitor = shutil.which("dbus-monitor")
+        if dbus_monitor is None:
+            return None
+        return [dbus_monitor, "--session", NOTIFICATION_MONITOR_RULE]
+
     def _stop_activity_monitor(self) -> None:
         proc = self._activity_monitor_proc
         self._activity_monitor_proc = None
+        host_pid = self._activity_monitor_host_pid
+        self._activity_monitor_host_pid = None
         if proc is None:
             return
+        if host_pid is not None:
+            self._stop_host_activity_monitor(host_pid)
         try:
             proc.terminate()
             proc.wait(timeout=ACTIVITY_MONITOR_TERMINATE_TIMEOUT_S)
@@ -274,6 +301,21 @@ class NotificationsApplet(Applet):
             log.debug("Failed to stop dbus-monitor cleanly: %s", exc)
             return
 
+    def _stop_host_activity_monitor(self, pid: str) -> None:
+        flatpak_spawn = shutil.which("flatpak-spawn")
+        if flatpak_spawn is None:
+            return
+        try:
+            subprocess.run(
+                [flatpak_spawn, "--host", "kill", pid],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=ACTIVITY_MONITOR_TERMINATE_TIMEOUT_S,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            log.debug("Failed to stop host dbus-monitor %s: %s", pid, exc)
+
     def _activity_monitor_worker(self) -> None:
         proc = self._activity_monitor_proc
         if proc is None or proc.stdout is None:
@@ -282,6 +324,11 @@ class NotificationsApplet(Applet):
         notify_strings: list[str] = []
         try:
             for line in proc.stdout:
+                if line.startswith(HOST_MONITOR_PID_PREFIX):
+                    self._activity_monitor_host_pid = line[
+                        len(HOST_MONITOR_PID_PREFIX) :
+                    ].strip()
+                    continue
                 if "member=Notify" in line:
                     capture_notify = True
                     notify_strings = []

--- a/docking/applets/notifications/state.py
+++ b/docking/applets/notifications/state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -11,6 +12,7 @@ from typing import Protocol
 from docking.applets.notifications import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
+from docking.platform.environment import is_flatpak
 
 log = with_context(
     get_logger(name="notifications"),
@@ -57,7 +59,7 @@ def pending_badge_count(state: NotificationsState) -> int:
     return max(0, min(99, state.pending))
 
 
-def _run(cmd: list[str], timeout_s: float = 2.0) -> str | None:
+def _run_direct(cmd: list[str], timeout_s: float = 2.0) -> str | None:
     """Run command and return stdout when successful."""
     try:
         result = subprocess.run(
@@ -73,6 +75,25 @@ def _run(cmd: list[str], timeout_s: float = 2.0) -> str | None:
     if result.returncode != 0:
         return None
     return result.stdout.strip()
+
+
+def _host_command(cmd: list[str]) -> list[str] | None:
+    if not is_flatpak():
+        return None
+    flatpak_spawn = shutil.which("flatpak-spawn")
+    if flatpak_spawn is None:
+        return None
+    return [flatpak_spawn, "--host", *cmd]
+
+
+def _run(cmd: list[str], timeout_s: float = 2.0) -> str | None:
+    """Run host notification command when sandboxed, else run directly."""
+    host_cmd = _host_command(cmd)
+    if host_cmd is not None:
+        output = _run_direct(host_cmd, timeout_s=timeout_s)
+        if output is not None:
+            return output
+    return _run_direct(cmd, timeout_s=timeout_s)
 
 
 def _parse_bool(value: str | None) -> bool | None:
@@ -110,7 +131,23 @@ def _parse_pending_count(value: str | None) -> int | None:
 
 
 def _has_command(command: str) -> bool:
-    return shutil.which(command) is not None
+    if shutil.which(command) is not None:
+        return True
+    flatpak_spawn = shutil.which("flatpak-spawn")
+    if not is_flatpak() or flatpak_spawn is None:
+        return False
+    return (
+        _run_direct(
+            [
+                flatpak_spawn,
+                "--host",
+                "sh",
+                "-c",
+                f"command -v {shlex.quote(command)}",
+            ]
+        )
+        is not None
+    )
 
 
 class NotificationsBackend(Protocol):

--- a/docking/applets/screenshot/state.py
+++ b/docking/applets/screenshot/state.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal, NamedTuple
 
-from docking.platform.environment import is_wayland_session
+from docking.platform.environment import is_flatpak, is_wayland_session
 
 
 class Tool(NamedTuple):
@@ -33,7 +33,8 @@ _PORTAL_TOOL = Tool(
 )
 _PORTAL_DEST = "org.freedesktop.portal.Desktop"
 _PORTAL_PATH = "/org/freedesktop/portal/desktop"
-_PORTAL_METHOD = "org.freedesktop.portal.Screenshot.Screenshot"
+_PORTAL_INTERFACE = "org.freedesktop.portal.Screenshot"
+_PORTAL_METHOD = f"{_PORTAL_INTERFACE}.Screenshot"
 
 
 _TOOLS: tuple[Tool, ...] = (
@@ -52,7 +53,7 @@ _TOOLS: tuple[Tool, ...] = (
 
 
 def _portal_available() -> bool:
-    """True when the XDG screenshot portal is reachable via gdbus."""
+    """True when the XDG screenshot portal interface is available via gdbus."""
     gdbus = shutil.which("gdbus")
     if not gdbus:
         return False
@@ -60,14 +61,33 @@ def _portal_available() -> bool:
         result = subprocess.run(
             [
                 gdbus,
-                "call",
+                "introspect",
                 "--session",
                 "--dest",
                 _PORTAL_DEST,
                 "--object-path",
                 _PORTAL_PATH,
-                "--method",
-                "org.freedesktop.DBus.Peer.Ping",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=1.5,
+        )
+        return (
+            result.returncode == 0 and f"interface {_PORTAL_INTERFACE}" in result.stdout
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def _flatpak_host_tool_available(*, flatpak_spawn: str, command: str) -> bool:
+    try:
+        result = subprocess.run(
+            [
+                flatpak_spawn,
+                "--host",
+                "sh",
+                "-lc",
+                f"command -v {command} >/dev/null",
             ],
             capture_output=True,
             text=True,
@@ -78,6 +98,25 @@ def _portal_available() -> bool:
         return False
 
 
+def _detect_flatpak_host_tool() -> Tool | None:
+    flatpak_spawn = shutil.which("flatpak-spawn")
+    if flatpak_spawn is None:
+        return None
+    for tool in _TOOLS:
+        if _flatpak_host_tool_available(
+            flatpak_spawn=flatpak_spawn,
+            command=tool.command,
+        ):
+            return Tool(
+                command=tool.command,
+                full=tool.full,
+                window=tool.window,
+                region=tool.region,
+                backend="flatpak-host",
+            )
+    return None
+
+
 def _detect_tool() -> Tool | None:
     """Return the first available screenshot tool, or None."""
     if is_wayland_session() and _portal_available():
@@ -85,6 +124,10 @@ def _detect_tool() -> Tool | None:
     for tool in _TOOLS:
         if shutil.which(tool.command):
             return tool
+    if is_flatpak():
+        flatpak_host_tool = _detect_flatpak_host_tool()
+        if flatpak_host_tool is not None:
+            return flatpak_host_tool
     if _portal_available():
         return _PORTAL_TOOL
     return None
@@ -162,11 +205,10 @@ def _run(tool: Tool, mode: Mode, delay_seconds: int = 0) -> list[str]:
         _launch(cmd=cmd, delay_seconds=delay_seconds)
     else:
         args = _mode_args(tool=tool, mode=mode)
-        cmd = [
-            tool.command,
-            *args,
-            *_delay_args(tool=tool, delay_seconds=delay_seconds),
-        ]
+        command = [tool.command]
+        if tool.backend == "flatpak-host":
+            command = ["flatpak-spawn", "--host", tool.command]
+        cmd = [*command, *args, *_delay_args(tool=tool, delay_seconds=delay_seconds)]
         if tool.command == "scrot":
             cmd.append(_scrot_path())
         subprocess.Popen(cmd, start_new_session=True)

--- a/docking/applets/session/state.py
+++ b/docking/applets/session/state.py
@@ -10,6 +10,7 @@ from typing import NamedTuple
 from docking.applets.session import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
+from docking.platform.environment import is_flatpak
 
 log = with_context(get_logger(name="session"), applet_id=meta.id)
 
@@ -36,6 +37,23 @@ _LOCK_SCREEN_COMMAND_CANDIDATES: tuple[tuple[str, ...], ...] = (
     ("xdg-screensaver", "lock"),
     ("dm-tool", "lock"),
     ("loginctl", "lock-session"),
+)
+_LOCK_SCREEN_DBUS_CANDIDATES: tuple[tuple[str, str, str], ...] = (
+    (
+        "org.mate.ScreenSaver",
+        "/org/mate/ScreenSaver",
+        "org.mate.ScreenSaver.Lock",
+    ),
+    (
+        "org.gnome.ScreenSaver",
+        "/org/gnome/ScreenSaver",
+        "org.gnome.ScreenSaver.Lock",
+    ),
+    (
+        "org.freedesktop.ScreenSaver",
+        "/org/freedesktop/ScreenSaver",
+        "org.freedesktop.ScreenSaver.Lock",
+    ),
 )
 
 
@@ -69,18 +87,49 @@ def lock_screen() -> bool:
 
 def _run(*, cmd: list[str], action: str) -> None:
     """Run a session/power command, logging failures."""
+    resolved_cmd = _host_session_command(cmd)
     try:
-        subprocess.Popen(cmd, start_new_session=True)
+        subprocess.Popen(resolved_cmd, start_new_session=True)
     except OSError as exc:
         log.bind(action=action).warning(f"Failed to run {cmd}: {exc}")
 
 
+def _flatpak_spawn_command() -> str | None:
+    if not is_flatpak():
+        return None
+    return shutil.which("flatpak-spawn")
+
+
+def _host_session_command(cmd: list[str]) -> list[str]:
+    flatpak_spawn = _flatpak_spawn_command()
+    if flatpak_spawn is None:
+        return cmd
+    return [flatpak_spawn, "--host", *cmd]
+
+
 def _lock_screen_commands(*, session_id: str) -> list[list[str]]:
     commands: list[list[str]] = []
+    gdbus = shutil.which("gdbus")
+    if gdbus is not None:
+        for destination, object_path, method in _LOCK_SCREEN_DBUS_CANDIDATES:
+            commands.append(
+                [
+                    gdbus,
+                    "call",
+                    "--session",
+                    "--dest",
+                    destination,
+                    "--object-path",
+                    object_path,
+                    "--method",
+                    method,
+                ]
+            )
+    flatpak_spawn = _flatpak_spawn_command()
     for cmd in _LOCK_SCREEN_COMMAND_CANDIDATES:
-        if shutil.which(cmd[0]) is None:
+        if flatpak_spawn is None and shutil.which(cmd[0]) is None:
             continue
         if cmd[0] == "loginctl" and session_id:
-            commands.append([cmd[0], cmd[1], session_id])
-        commands.append(list(cmd))
+            commands.append(_host_session_command([cmd[0], cmd[1], session_id]))
+        commands.append(_host_session_command(list(cmd)))
     return commands

--- a/docking/applets/trash/backend.py
+++ b/docking/applets/trash/backend.py
@@ -21,6 +21,7 @@ from docking.log import get_logger, with_context
 from docking.platform.environment import (
     Desktop,
     detect_desktop,
+    is_flatpak,
     is_gnome_session,
     is_kde_session,
     is_mate_session,
@@ -53,6 +54,10 @@ def _xdg_data_home() -> Path:
     return Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
 
 
+def _host_user_data_home() -> Path:
+    return Path.home() / ".local" / "share"
+
+
 def _kde_trash_directory() -> Path:
     return _xdg_data_home() / "Trash"
 
@@ -65,8 +70,84 @@ def _kde_trash_info_directory() -> Path:
     return _kde_trash_directory() / "info"
 
 
+def _visible_trash_files_directory() -> Path:
+    if is_flatpak():
+        return _host_user_data_home() / "Trash" / "files"
+    return _xdg_data_home() / "Trash" / "files"
+
+
 def _kde_kiorc_file() -> Path:
     return Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "kiorc"
+
+
+def _open_trash_uri(uri: str) -> None:
+    if is_flatpak() and _open_host_trash_uri(uri=uri):
+        return
+
+    try:
+        Gio.AppInfo.launch_default_for_uri(uri, None)
+    except GLib.Error as exc:
+        log.bind(action="open_trash").warning("Failed to open trash: %s", exc)
+
+
+def _open_host_trash_uri(*, uri: str) -> bool:
+    flatpak_spawn = shutil.which("flatpak-spawn")
+    if flatpak_spawn is None:
+        return False
+    try:
+        subprocess.Popen([*_host_gio_command(flatpak_spawn=flatpak_spawn), "open", uri])
+        return True
+    except OSError as exc:
+        log.bind(action="open_trash").warning(
+            "Failed to open host trash with flatpak-spawn: %s",
+            exc,
+        )
+        return False
+
+
+def _empty_host_trash() -> bool:
+    if not is_flatpak():
+        return False
+    flatpak_spawn = shutil.which("flatpak-spawn")
+    if flatpak_spawn is None:
+        return False
+    try:
+        result = subprocess.run(
+            [*_host_gio_command(flatpak_spawn=flatpak_spawn), "trash", "--empty"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        log.bind(action="empty_trash_host").warning(
+            "Failed to empty host trash with flatpak-spawn: %s",
+            exc,
+        )
+        return False
+    if result.returncode == 0:
+        return True
+    log.bind(action="empty_trash_host").warning(
+        "Host trash empty command failed: %s",
+        result.stderr.strip() or result.stdout.strip() or result.returncode,
+    )
+    return False
+
+
+def _host_gio_command(*, flatpak_spawn: str) -> list[str]:
+    return [
+        flatpak_spawn,
+        "--host",
+        "env",
+        "-u",
+        "GIO_USE_VFS",
+        "-u",
+        "GI_TYPELIB_PATH",
+        "-u",
+        "GSETTINGS_SCHEMA_DIR",
+        "-u",
+        "XDG_DATA_DIRS",
+        "gio",
+    ]
 
 
 class GioTrashBackend:
@@ -82,6 +163,16 @@ class GioTrashBackend:
     confirmation_schema: tuple[str, str] | None = None
 
     def count_items(self) -> int:
+        if is_flatpak():
+            files_dir = _visible_trash_files_directory()
+            try:
+                return sum(1 for _child in files_dir.iterdir())
+            except OSError as exc:
+                log.bind(action="count_items").debug(
+                    "Could not enumerate visible trash files: %s", exc
+                )
+                return 0
+
         trash = Gio.File.new_for_uri(self.uri)
         try:
             enumerator = trash.enumerate_children(
@@ -100,20 +191,23 @@ class GioTrashBackend:
         return count
 
     def monitor_file(self) -> Gio.File:
+        if is_flatpak():
+            return Gio.File.new_for_path(str(_visible_trash_files_directory()))
         return Gio.File.new_for_uri(self.uri)
 
     def open(self) -> None:
-        try:
-            Gio.AppInfo.launch_default_for_uri(self.uri, None)
-        except GLib.Error as exc:
-            log.bind(action="open_trash").warning("Failed to open trash: %s", exc)
+        _open_trash_uri(self.uri)
 
     def empty(self, confirm: Callable[[], bool]) -> None:
         _ = confirm
         if self._confirmation_preference() is False:
+            if _empty_host_trash():
+                return
             self._delete_contents()
             return
         if self._empty_via_dbus():
+            return
+        if _empty_host_trash():
             return
         self._delete_contents()
 
@@ -272,10 +366,7 @@ class KdeTrashBackend:
                     exc,
                 )
 
-        try:
-            Gio.AppInfo.launch_default_for_uri(self.uri, None)
-        except GLib.Error as exc:
-            log.bind(action="open_trash").warning("Failed to open trash: %s", exc)
+        _open_trash_uri(self.uri)
 
     def empty(self, confirm: Callable[[], bool]) -> None:
         if self._confirmation_preference() is False or confirm():

--- a/docking/platform/environment.py
+++ b/docking/platform/environment.py
@@ -22,6 +22,7 @@ import os
 import re
 import shutil
 import subprocess
+from pathlib import Path
 
 from docking.log import get_logger
 
@@ -110,6 +111,11 @@ def detect_desktop() -> Desktop:
 def is_wayland_session() -> bool:
     """Return True when the desktop session itself is Wayland."""
     return os.environ.get("XDG_SESSION_TYPE", "").strip().lower() == "wayland"
+
+
+def is_flatpak() -> bool:
+    """Return True when running inside a Flatpak sandbox."""
+    return Path("/.flatpak-info").exists()
 
 
 def is_gnome_session(*, desktop: Desktop | None = None) -> bool:

--- a/tests/applets/test_applications.py
+++ b/tests/applets/test_applications.py
@@ -6,7 +6,10 @@ from unittest.mock import MagicMock, patch
 import docking.applets.applications.applet as applications_applet_mod
 import docking.applets.applications.render as applications_render_mod
 from docking.applets.applications.applet import ApplicationsApplet
-from docking.applets.applications.state import _build_app_categories
+from docking.applets.applications.state import (
+    _all_desktop_app_infos,
+    _build_app_categories,
+)
 
 
 class TestBuildAppCategories:
@@ -19,14 +22,76 @@ class TestBuildAppCategories:
         mock_app.get_is_hidden.return_value = True
         mock_app.get_nodisplay.return_value = False
 
-        with patch(
-            "docking.applets.applications.state.Gio.AppInfo.get_all",
-            return_value=[mock_app],
+        with (
+            patch(
+                "docking.applets.applications.state.Gio.AppInfo.get_all",
+                return_value=[mock_app],
+            ),
+            patch(
+                "docking.applets.applications.state.Launcher._get_desktop_dirs",
+                return_value=[],
+            ),
         ):
             cats = _build_app_categories()
         # Hidden app should not appear in any category
         total = sum(len(apps) for apps in cats.values())
         assert total == 0
+
+    def test_includes_host_desktop_files_not_returned_by_gio(
+        self, tmp_path, monkeypatch
+    ):
+        host_apps = tmp_path / "run" / "host" / "usr" / "share" / "applications"
+        host_apps.mkdir(parents=True)
+        desktop_file = host_apps / "org.example.Tool.desktop"
+        desktop_file.write_text(
+            "[Desktop Entry]\n"
+            "Type=Application\n"
+            "Name=Example Tool\n"
+            "Exec=example-tool\n"
+            "Categories=Development;IDE;\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "docking.applets.applications.state.Gio.AppInfo.get_all",
+            list,
+        )
+        monkeypatch.setattr(
+            "docking.applets.applications.state.Launcher._get_desktop_dirs",
+            lambda: [host_apps],
+        )
+
+        categories = _build_app_categories()
+
+        assert list(categories) == ["Development"]
+        assert categories["Development"][0].get_display_name() == "Example Tool"
+
+    def test_all_desktop_app_infos_deduplicates_desktop_ids(
+        self, tmp_path, monkeypatch
+    ):
+        first_apps = tmp_path / "first" / "applications"
+        second_apps = tmp_path / "second" / "applications"
+        first_apps.mkdir(parents=True)
+        second_apps.mkdir(parents=True)
+        for apps_dir in (first_apps, second_apps):
+            (apps_dir / "org.example.Tool.desktop").write_text(
+                "[Desktop Entry]\n"
+                "Type=Application\n"
+                "Name=Example Tool\n"
+                "Exec=example-tool\n",
+                encoding="utf-8",
+            )
+        monkeypatch.setattr(
+            "docking.applets.applications.state.Gio.AppInfo.get_all",
+            list,
+        )
+        monkeypatch.setattr(
+            "docking.applets.applications.state.Launcher._get_desktop_dirs",
+            lambda: [first_apps, second_apps],
+        )
+
+        apps = _all_desktop_app_infos()
+
+        assert [app.get_id() for app in apps] == ["org.example.Tool.desktop"]
 
 
 class TestApplicationsApplet:

--- a/tests/applets/test_keyboardlayout.py
+++ b/tests/applets/test_keyboardlayout.py
@@ -30,6 +30,7 @@ from docking.applets.keyboardlayout.state import (
     _parse_gsettings_string,
     _parse_gsettings_string_list,
     _parse_input_sources,
+    _run,
     _source_layout_code,
     current_layout_command,
     cycle_layout,
@@ -589,6 +590,63 @@ class TestXkbBackend:
 
         monkeypatch.setattr(kbl_state, "_run", lambda cmd: "rules: evdev")
         assert XkbBackend().query() == kbl_state.LayoutState("", [])
+
+    def test_run_falls_back_to_host_command_in_flatpak(self, monkeypatch):
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            calls.append(cmd)
+            if cmd == ["setxkbmap", "-query"]:
+                raise OSError("missing in sandbox")
+            if cmd == ["/usr/bin/flatpak-spawn", "--host", "setxkbmap", "-query"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout=SETXKBMAP_MULTI)
+            raise AssertionError(cmd)
+
+        monkeypatch.setattr(kbl_state.environment, "is_flatpak", lambda: True)
+        monkeypatch.setattr(
+            kbl_state.shutil,
+            "which",
+            lambda name: "/usr/bin/flatpak-spawn" if name == "flatpak-spawn" else None,
+        )
+        monkeypatch.setattr(kbl_state.subprocess, "run", fake_run)
+
+        assert _run(["setxkbmap", "-query"]) == SETXKBMAP_MULTI.strip()
+        assert calls == [
+            ["setxkbmap", "-query"],
+            ["/usr/bin/flatpak-spawn", "--host", "setxkbmap", "-query"],
+        ]
+
+    def test_run_falls_back_to_host_after_sandbox_command_failure(self, monkeypatch):
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **_kwargs):
+            calls.append(cmd)
+            if cmd == ["gsettings", "get", "schema", "key"]:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="missing")
+            if cmd == [
+                "/usr/bin/flatpak-spawn",
+                "--host",
+                "gsettings",
+                "get",
+                "schema",
+                "key",
+            ]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="'value'\n")
+            raise AssertionError(cmd)
+
+        monkeypatch.setattr(kbl_state.environment, "is_flatpak", lambda: True)
+        monkeypatch.setattr(
+            kbl_state.shutil,
+            "which",
+            lambda name: "/usr/bin/flatpak-spawn" if name == "flatpak-spawn" else None,
+        )
+        monkeypatch.setattr(kbl_state.subprocess, "run", fake_run)
+
+        assert _run(["gsettings", "get", "schema", "key"]) == "'value'"
+        assert calls == [
+            ["gsettings", "get", "schema", "key"],
+            ["/usr/bin/flatpak-spawn", "--host", "gsettings", "get", "schema", "key"],
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/applets/test_network.py
+++ b/tests/applets/test_network.py
@@ -1513,6 +1513,40 @@ class TestNetworkCommands:
         )
         assert connection_info_command() == ["gnome-control-center", "wifi"]
 
+    def test_connection_info_command_uses_host_tool_in_flatpak(self, monkeypatch):
+        monkeypatch.setattr(network_state_mod, "is_flatpak", lambda: True)
+        monkeypatch.setattr(
+            network_state_mod.shutil,
+            "which",
+            lambda binary: (
+                "/usr/bin/flatpak-spawn" if binary == "flatpak-spawn" else None
+            ),
+        )
+        seen: list[list[str]] = []
+
+        def fake_run(cmd, capture_output, text, timeout):
+            _ = (capture_output, text, timeout)
+            seen.append(list(cmd))
+            return SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(network_state_mod.subprocess, "run", fake_run)
+
+        assert connection_info_command() == [
+            "/usr/bin/flatpak-spawn",
+            "--host",
+            "gnome-control-center",
+            "wifi",
+        ]
+        assert seen == [
+            [
+                "/usr/bin/flatpak-spawn",
+                "--host",
+                "sh",
+                "-lc",
+                "command -v gnome-control-center >/dev/null",
+            ]
+        ]
+
     def test_edit_connections_command_picks_nm_connection_editor(self, monkeypatch):
         monkeypatch.setattr(
             network_state_mod.shutil,
@@ -1524,6 +1558,32 @@ class TestNetworkCommands:
             ),
         )
         assert edit_connections_command() == ["nm-connection-editor"]
+
+    def test_edit_connections_command_skips_missing_host_tool_in_flatpak(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(network_state_mod, "is_flatpak", lambda: True)
+        monkeypatch.setattr(
+            network_state_mod.shutil,
+            "which",
+            lambda binary: (
+                "/usr/bin/flatpak-spawn" if binary == "flatpak-spawn" else None
+            ),
+        )
+
+        def fake_run(cmd, capture_output, text, timeout):
+            _ = (capture_output, text, timeout)
+            return SimpleNamespace(
+                returncode=0 if "nm-connection-editor" in cmd[-1] else 1
+            )
+
+        monkeypatch.setattr(network_state_mod.subprocess, "run", fake_run)
+
+        assert edit_connections_command() == [
+            "/usr/bin/flatpak-spawn",
+            "--host",
+            "nm-connection-editor",
+        ]
 
     def test_open_connection_info_runs_command(self, monkeypatch):
         launched: list[tuple[str, ...]] = []

--- a/tests/applets/test_notifications.py
+++ b/tests/applets/test_notifications.py
@@ -91,6 +91,7 @@ class TestStateParsing:
                 self.returncode = code
                 self.stdout = out
 
+        monkeypatch.setattr(notifications_state_mod, "is_flatpak", lambda: False)
         monkeypatch.setattr(
             notifications_state_mod.subprocess,
             "run",
@@ -117,6 +118,59 @@ class TestStateParsing:
             notifications_state_mod.shutil, "which", lambda cmd: "/usr/bin/x"
         )
         assert notifications_state_mod._has_command("x") is True
+
+    def test_run_prefers_host_command_in_flatpak(self, monkeypatch):
+        class _Proc:
+            returncode = 0
+            stdout = "false\n"
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return _Proc()
+
+        monkeypatch.setattr(notifications_state_mod, "is_flatpak", lambda: True)
+        monkeypatch.setattr(
+            notifications_state_mod.shutil,
+            "which",
+            lambda cmd: "/usr/bin/flatpak-spawn" if cmd == "flatpak-spawn" else None,
+        )
+        monkeypatch.setattr(notifications_state_mod.subprocess, "run", fake_run)
+
+        assert (
+            notifications_state_mod._run(["gsettings", "get", "schema", "key"])
+            == "false"
+        )
+        assert calls == [
+            [
+                "/usr/bin/flatpak-spawn",
+                "--host",
+                "gsettings",
+                "get",
+                "schema",
+                "key",
+            ]
+        ]
+
+    def test_has_command_checks_host_in_flatpak(self, monkeypatch):
+        class _Proc:
+            returncode = 0
+            stdout = "/usr/bin/dunstctl\n"
+
+        monkeypatch.setattr(notifications_state_mod, "is_flatpak", lambda: True)
+        monkeypatch.setattr(
+            notifications_state_mod.shutil,
+            "which",
+            lambda cmd: "/usr/bin/flatpak-spawn" if cmd == "flatpak-spawn" else None,
+        )
+        monkeypatch.setattr(
+            notifications_state_mod.subprocess,
+            "run",
+            lambda *args, **kwargs: _Proc(),
+        )
+
+        assert notifications_state_mod._has_command("dunstctl") is True
 
     def test_dunst_backend_get_state(self, monkeypatch):
         def fake_run(cmd: list[str], timeout_s: float = 2.0) -> str | None:
@@ -594,6 +648,56 @@ class TestNotificationsApplet:
         applet._activity_monitor_proc = _ProcOSError()  # type: ignore[assignment]
         applet._stop_activity_monitor()
 
+    def test_activity_monitor_uses_host_dbus_monitor_in_flatpak(self, monkeypatch):
+        applet, _backend = _make_applet(monkeypatch, _state())
+        monkeypatch.setattr(notifications_applet_mod, "is_flatpak", lambda: True)
+        monkeypatch.setattr(
+            notifications_applet_mod.shutil,
+            "which",
+            lambda cmd: "/usr/bin/flatpak-spawn" if cmd == "flatpak-spawn" else None,
+        )
+
+        command = applet._activity_monitor_command()
+
+        assert command is not None
+        assert command[:3] == ["/usr/bin/flatpak-spawn", "--host", "sh"]
+        assert "dbus-monitor --session" in command[-1]
+        assert notifications_applet_mod.HOST_MONITOR_PID_PREFIX in command[-1]
+
+    def test_stop_activity_monitor_kills_host_monitor_pid(self, monkeypatch):
+        applet, _backend = _make_applet(monkeypatch, _state())
+        applet._activity_monitor_host_pid = "12345"
+        run_calls: list[list[str]] = []
+
+        class _Proc:
+            def __init__(self):
+                self.terminated = False
+
+            def terminate(self):
+                self.terminated = True
+
+            def wait(self, timeout=0.0):
+                return None
+
+        proc = _Proc()
+        applet._activity_monitor_proc = proc  # type: ignore[assignment]
+        monkeypatch.setattr(
+            notifications_applet_mod.shutil,
+            "which",
+            lambda cmd: "/usr/bin/flatpak-spawn" if cmd == "flatpak-spawn" else None,
+        )
+        monkeypatch.setattr(
+            notifications_applet_mod.subprocess,
+            "run",
+            lambda cmd, **kwargs: run_calls.append(cmd),
+        )
+
+        applet._stop_activity_monitor()
+
+        assert run_calls == [["/usr/bin/flatpak-spawn", "--host", "kill", "12345"]]
+        assert proc.terminated is True
+        assert applet._activity_monitor_host_pid is None
+
     def test_activity_monitor_worker_and_tooltip_helpers(self, monkeypatch, caplog):
         applet, _backend = _make_applet(monkeypatch, _state())
         idle_calls: list[tuple[object, ...]] = []
@@ -605,6 +709,7 @@ class TestNotificationsApplet:
 
         class _Proc:
             stdout: ClassVar = [
+                f"{notifications_applet_mod.HOST_MONITOR_PID_PREFIX}321\n",
                 "signal member=Notify\n",
                 '   string "Mail"\n',
                 '   string "Icon"\n',
@@ -618,6 +723,7 @@ class TestNotificationsApplet:
 
         applet._activity_monitor_proc = _Proc()
         applet._activity_monitor_worker()
+        assert applet._activity_monitor_host_pid == "321"
         assert any(call[0] == applet._on_notification_event for call in idle_calls)
         assert any(call[0] == applet._on_notification_activity for call in idle_calls)
 

--- a/tests/applets/test_screenshot.py
+++ b/tests/applets/test_screenshot.py
@@ -67,14 +67,47 @@ class TestDetectTool:
     def test_falls_back_to_portal_when_cli_tools_missing(self):
         with (
             patch.object(screenshot_state, "is_wayland_session", return_value=False),
+            patch.object(screenshot_state, "is_flatpak", return_value=False),
             patch.object(screenshot_state, "_portal_available", side_effect=[True]),
             patch("docking.applets.screenshot.state.shutil.which", return_value=None),
         ):
             assert _detect_tool() == screenshot_state._PORTAL_TOOL
 
+    def test_flatpak_falls_back_to_host_screenshot_tool(self):
+        def which(command: str) -> str | None:
+            if command == "flatpak-spawn":
+                return "/usr/bin/flatpak-spawn"
+            return None
+
+        with (
+            patch.object(screenshot_state, "is_wayland_session", return_value=False),
+            patch.object(screenshot_state, "is_flatpak", return_value=True),
+            patch.object(screenshot_state, "_portal_available", return_value=False),
+            patch("docking.applets.screenshot.state.shutil.which", side_effect=which),
+            patch(
+                "docking.applets.screenshot.state.subprocess.run",
+                return_value=subprocess.CompletedProcess(args=[], returncode=0),
+            ) as run,
+        ):
+            result = _detect_tool()
+
+        assert result == Tool("mate-screenshot", [], ["-w"], ["-a"], "flatpak-host")
+        run.assert_called_once_with(
+            [
+                "/usr/bin/flatpak-spawn",
+                "--host",
+                "sh",
+                "-lc",
+                "command -v mate-screenshot >/dev/null",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=1.5,
+        )
+
 
 class TestPortal:
-    def test_portal_available_requires_gdbus_and_ping(self):
+    def test_portal_available_requires_screenshot_interface(self):
         with patch("docking.applets.screenshot.state.shutil.which", return_value=None):
             assert screenshot_state._portal_available() is False
 
@@ -84,7 +117,11 @@ class TestPortal:
             ),
             patch(
                 "docking.applets.screenshot.state.subprocess.run",
-                return_value=subprocess.CompletedProcess(args=["gdbus"], returncode=0),
+                return_value=subprocess.CompletedProcess(
+                    args=["gdbus"],
+                    returncode=0,
+                    stdout="interface org.freedesktop.portal.Screenshot {",
+                ),
             ),
         ):
             assert screenshot_state._portal_available() is True
@@ -95,7 +132,26 @@ class TestPortal:
             ),
             patch(
                 "docking.applets.screenshot.state.subprocess.run",
-                return_value=subprocess.CompletedProcess(args=["gdbus"], returncode=1),
+                return_value=subprocess.CompletedProcess(
+                    args=["gdbus"],
+                    returncode=0,
+                    stdout="interface org.freedesktop.portal.FileChooser {",
+                ),
+            ),
+        ):
+            assert screenshot_state._portal_available() is False
+
+        with (
+            patch(
+                "docking.applets.screenshot.state.shutil.which", return_value="gdbus"
+            ),
+            patch(
+                "docking.applets.screenshot.state.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=["gdbus"],
+                    returncode=1,
+                    stdout="",
+                ),
             ),
         ):
             assert screenshot_state._portal_available() is False
@@ -280,6 +336,15 @@ class TestRun:
 
         assert timers[0].delay == 2
         assert timers[0].daemon is True
+
+    def test_flatpak_host_run_prefixes_host_spawn(self):
+        tool = Tool("mate-screenshot", [], ["-w"], ["-a"], "flatpak-host")
+        with patch("docking.applets.screenshot.state.subprocess.Popen") as p:
+            _run(tool=tool, mode="region", delay_seconds=3)
+        p.assert_called_once_with(
+            ["flatpak-spawn", "--host", "mate-screenshot", "-a", "-d", "3"],
+            start_new_session=True,
+        )
 
 
 class TestScreenshotApplet:

--- a/tests/applets/test_session.py
+++ b/tests/applets/test_session.py
@@ -93,6 +93,38 @@ class TestSessionApplet:
 
 
 class TestSessionState:
+    def test_lock_screen_prefers_screensaver_dbus(self, monkeypatch):
+        monkeypatch.delenv("XDG_SESSION_ID", raising=False)
+        monkeypatch.setattr(
+            session_state_mod.shutil,
+            "which",
+            lambda cmd: "/usr/bin/gdbus" if cmd == "gdbus" else None,
+        )
+
+        seen: list[list[str]] = []
+
+        def fake_run(cmd, capture_output, text, timeout, check):
+            _ = (capture_output, text, timeout, check)
+            seen.append(list(cmd))
+            return SimpleNamespace(returncode=0, stderr="")
+
+        monkeypatch.setattr(session_state_mod.subprocess, "run", fake_run)
+
+        assert lock_screen() is True
+        assert seen == [
+            [
+                "/usr/bin/gdbus",
+                "call",
+                "--session",
+                "--dest",
+                "org.mate.ScreenSaver",
+                "--object-path",
+                "/org/mate/ScreenSaver",
+                "--method",
+                "org.mate.ScreenSaver.Lock",
+            ]
+        ]
+
     def test_lock_screen_prefers_explicit_session_id(self, monkeypatch):
         monkeypatch.setenv("XDG_SESSION_ID", "2")
         monkeypatch.setattr(
@@ -177,6 +209,40 @@ class TestSessionState:
         assert lock_screen() is True
         assert seen == [["xdg-screensaver", "lock"], ["loginctl", "lock-session"]]
 
+    def test_lock_screen_uses_host_commands_in_flatpak(self, monkeypatch):
+        monkeypatch.setenv("XDG_SESSION_ID", "2")
+        monkeypatch.setattr(session_state_mod, "is_flatpak", lambda: True)
+        monkeypatch.setattr(
+            session_state_mod.shutil,
+            "which",
+            lambda cmd: "/usr/bin/flatpak-spawn" if cmd == "flatpak-spawn" else None,
+        )
+        seen: list[list[str]] = []
+
+        def fake_run(cmd, capture_output, text, timeout, check):
+            _ = (capture_output, text, timeout, check)
+            seen.append(list(cmd))
+            if "loginctl" in cmd:
+                return SimpleNamespace(returncode=0, stderr="")
+            return SimpleNamespace(returncode=1, stderr="missing")
+
+        monkeypatch.setattr(session_state_mod.subprocess, "run", fake_run)
+
+        assert lock_screen() is True
+        assert seen[0] == [
+            "/usr/bin/flatpak-spawn",
+            "--host",
+            "mate-screensaver-command",
+            "-l",
+        ]
+        assert seen[-1] == [
+            "/usr/bin/flatpak-spawn",
+            "--host",
+            "loginctl",
+            "lock-session",
+            "2",
+        ]
+
     def test_run_logs_popen_failure(self, monkeypatch):
         launched: list[list[str]] = []
         monkeypatch.setattr(
@@ -193,3 +259,23 @@ class TestSessionState:
             lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("boom")),
         )
         session_state_mod._run(cmd=["systemctl", "suspend"], action="suspend")
+
+    def test_run_uses_host_command_in_flatpak(self, monkeypatch):
+        launched: list[list[str]] = []
+        monkeypatch.setattr(session_state_mod, "is_flatpak", lambda: True)
+        monkeypatch.setattr(
+            session_state_mod.shutil,
+            "which",
+            lambda cmd: "/usr/bin/flatpak-spawn" if cmd == "flatpak-spawn" else None,
+        )
+        monkeypatch.setattr(
+            session_state_mod.subprocess,
+            "Popen",
+            lambda cmd, start_new_session=True: launched.append(list(cmd)),
+        )
+
+        session_state_mod._run(cmd=["systemctl", "suspend"], action="suspend")
+
+        assert launched == [
+            ["/usr/bin/flatpak-spawn", "--host", "systemctl", "suspend"]
+        ]

--- a/tests/applets/test_trash.py
+++ b/tests/applets/test_trash.py
@@ -60,12 +60,121 @@ class TestGioTrashBackend:
         ):
             assert GioTrashBackend().count_items() == 0
 
+    def test_counts_visible_trash_files_in_flatpak(self, tmp_path):
+        files_dir = tmp_path / "Trash" / "files"
+        files_dir.mkdir(parents=True)
+        (files_dir / "a.txt").write_text("a")
+        (files_dir / "b.txt").write_text("b")
+
+        with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=True),
+            patch(
+                "docking.applets.trash.backend._visible_trash_files_directory",
+                return_value=files_dir,
+            ),
+            patch("docking.applets.trash.backend.Gio.File.new_for_uri") as new_for_uri,
+        ):
+            assert GioTrashBackend().count_items() == 2
+
+        new_for_uri.assert_not_called()
+
+    def test_monitor_uses_visible_trash_files_in_flatpak(self, tmp_path):
+        with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=True),
+            patch(
+                "docking.applets.trash.backend._visible_trash_files_directory",
+                return_value=tmp_path,
+            ),
+            patch(
+                "docking.applets.trash.backend.Gio.File.new_for_path"
+            ) as new_for_path,
+            patch("docking.applets.trash.backend.Gio.File.new_for_uri") as new_for_uri,
+        ):
+            GioTrashBackend().monitor_file()
+
+        new_for_path.assert_called_once_with(str(tmp_path))
+        new_for_uri.assert_not_called()
+
     def test_open_launches_default_trash_uri(self):
-        with patch(
-            "docking.applets.trash.backend.Gio.AppInfo.launch_default_for_uri"
-        ) as launch:
+        with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=False),
+            patch(
+                "docking.applets.trash.backend.Gio.AppInfo.launch_default_for_uri"
+            ) as launch,
+        ):
             GioTrashBackend().open()
 
+        launch.assert_called_once_with("trash:///", None)
+
+    def test_open_prefers_sanitized_host_gio_in_flatpak(self):
+        with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=True),
+            patch(
+                "docking.applets.trash.backend.shutil.which",
+                return_value="/usr/bin/flatpak-spawn",
+            ),
+            patch("docking.applets.trash.backend.subprocess.Popen") as popen,
+            patch(
+                "docking.applets.trash.backend.Gio.AppInfo.launch_default_for_uri"
+            ) as launch,
+        ):
+            GioTrashBackend().open()
+
+        popen.assert_called_once_with(
+            [
+                "/usr/bin/flatpak-spawn",
+                "--host",
+                "env",
+                "-u",
+                "GIO_USE_VFS",
+                "-u",
+                "GI_TYPELIB_PATH",
+                "-u",
+                "GSETTINGS_SCHEMA_DIR",
+                "-u",
+                "XDG_DATA_DIRS",
+                "gio",
+                "open",
+                "trash:///",
+            ]
+        )
+        launch.assert_not_called()
+
+    def test_open_falls_back_to_gio_when_host_open_unavailable(self):
+        with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=True),
+            patch(
+                "docking.applets.trash.backend.shutil.which",
+                return_value="/usr/bin/flatpak-spawn",
+            ),
+            patch(
+                "docking.applets.trash.backend.subprocess.Popen",
+                side_effect=OSError("spawn failed"),
+            ) as popen,
+            patch(
+                "docking.applets.trash.backend.Gio.AppInfo.launch_default_for_uri",
+            ) as launch,
+        ):
+            GioTrashBackend().open()
+
+        popen.assert_called_once_with(
+            [
+                "/usr/bin/flatpak-spawn",
+                "--host",
+                "env",
+                "-u",
+                "GIO_USE_VFS",
+                "-u",
+                "GI_TYPELIB_PATH",
+                "-u",
+                "GSETTINGS_SCHEMA_DIR",
+                "-u",
+                "XDG_DATA_DIRS",
+                "gio",
+                "open",
+                "trash:///",
+            ]
+        )
         launch.assert_called_once_with("trash:///", None)
 
     def test_empty_trash_uses_dbus_first(self):
@@ -97,6 +206,71 @@ class TestGioTrashBackend:
             patch("docking.applets.trash.backend.Gio.bus_get_sync", return_value=bus),
             patch.object(backend, "_delete_contents") as delete_mock,
         ):
+            backend.empty(lambda: False)
+
+        delete_mock.assert_called_once()
+
+    def test_empty_trash_uses_host_gio_in_flatpak_after_dbus_failure(self):
+        from gi.repository import GLib
+
+        backend = GnomeTrashBackend()
+        bus = MagicMock()
+        bus.call_sync.side_effect = GLib.Error("nautilus")
+        with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=True),
+            patch(
+                "docking.applets.trash.backend.shutil.which",
+                return_value="/usr/bin/flatpak-spawn",
+            ),
+            patch("docking.applets.trash.backend.Gio.bus_get_sync", return_value=bus),
+            patch("docking.applets.trash.backend.subprocess.run") as run_mock,
+            patch.object(backend, "_delete_contents") as delete_mock,
+        ):
+            run_mock.return_value.returncode = 0
+            backend.empty(lambda: False)
+
+        run_mock.assert_called_once_with(
+            [
+                "/usr/bin/flatpak-spawn",
+                "--host",
+                "env",
+                "-u",
+                "GIO_USE_VFS",
+                "-u",
+                "GI_TYPELIB_PATH",
+                "-u",
+                "GSETTINGS_SCHEMA_DIR",
+                "-u",
+                "XDG_DATA_DIRS",
+                "gio",
+                "trash",
+                "--empty",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        delete_mock.assert_not_called()
+
+    def test_empty_trash_falls_back_to_delete_when_host_gio_fails(self):
+        from gi.repository import GLib
+
+        backend = GnomeTrashBackend()
+        bus = MagicMock()
+        bus.call_sync.side_effect = GLib.Error("nautilus")
+        with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=True),
+            patch(
+                "docking.applets.trash.backend.shutil.which",
+                return_value="/usr/bin/flatpak-spawn",
+            ),
+            patch("docking.applets.trash.backend.Gio.bus_get_sync", return_value=bus),
+            patch("docking.applets.trash.backend.subprocess.run") as run_mock,
+            patch.object(backend, "_delete_contents") as delete_mock,
+        ):
+            run_mock.return_value.returncode = 1
+            run_mock.return_value.stderr = "nope"
+            run_mock.return_value.stdout = ""
             backend.empty(lambda: False)
 
         delete_mock.assert_called_once()
@@ -170,6 +344,7 @@ class TestKdeTrashBackend:
     def test_open_uses_kde_open_command(self):
         backend = KdeTrashBackend()
         with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=False),
             patch.object(
                 backend, "_available_open_command", return_value=("dolphin", "trash:/")
             ),

--- a/tests/platform/test_environment.py
+++ b/tests/platform/test_environment.py
@@ -8,6 +8,7 @@ from docking.platform.environment import (
     _check_compositor,
     _parse_desktop,
     detect_desktop,
+    is_flatpak,
     is_gnome_session,
     is_kde_session,
     is_mate_session,
@@ -111,6 +112,13 @@ class TestSessionBackendDetection:
     def test_is_wayland_session_false(self):
         with patch.dict("os.environ", {"XDG_SESSION_TYPE": "x11"}, clear=True):
             assert is_wayland_session() is False
+
+    def test_is_flatpak_checks_runtime_marker(self):
+        with patch("docking.platform.environment.Path.exists", return_value=True):
+            assert is_flatpak() is True
+
+        with patch("docking.platform.environment.Path.exists", return_value=False):
+            assert is_flatpak() is False
 
     def test_is_x11_backend_true_for_x11_display(self):
         display_cls = type(


### PR DESCRIPTION
This splits the applet-facing Flatpak runtime work out of the larger Flathub preparation branch. It adds the shared Flatpak environment detection helper and updates applets that need host/runtime-aware behavior, including 
- applications
- keyboard layout
- network
- notifications
- screenshot
- session
- trash