### PR TITLE
Improve Flatpak launcher integration

### DIFF
--- a/docking/platform/launcher.py
+++ b/docking/platform/launcher.py
@@ -128,6 +128,7 @@ from __future__ import annotations
 import os
 import re
 import shlex
+import shutil
 import subprocess
 from pathlib import Path
 from typing import NamedTuple
@@ -147,7 +148,23 @@ FALLBACK_ICON = "application-x-executable"
 DEFAULT_XDG_DATA_DIRS = "/usr/local/share:/usr/share"
 GNOME_APP_PREFIX = "org.gnome."
 FILE_ICON_CACHE_MAX_ENTRIES = 256
+SNAP_XDG_DATA_DIR = "/var/lib/snapd/desktop"
+HOST_XDG_DATA_DIRS = (
+    SNAP_XDG_DATA_DIR,
+    "/run/host/share",
+    "/run/host/usr/local/share",
+    "/run/host/usr/share",
+    "/run/host/var/lib/flatpak/exports/share",
+)
+HOST_PIXMAP_DIRS = tuple(f"{data_dir}/pixmaps" for data_dir in HOST_XDG_DATA_DIRS)
+HOST_FILESYSTEM_ROOT = Path("/run/host")
+ICON_FILE_EXTENSIONS = (".png", ".svg", ".xpm")
+
 log = with_context(get_logger(name="launcher"))
+
+
+def _is_flatpak_runtime() -> bool:
+    return Path("/.flatpak-info").exists()
 
 
 class DesktopInfo(NamedTuple):
@@ -168,6 +185,16 @@ class FileTargetInfo(NamedTuple):
     icon_name: str
     icon: GdkPixbuf.Pixbuf | None
     is_dir: bool
+
+
+class _ResolvedAppInfo(NamedTuple):
+    app_info: Gio.DesktopAppInfo
+    desktop_file: Path | None
+
+
+class _ResolvedDesktopLaunch(NamedTuple):
+    exec_line: str
+    desktop_file: Path | None
 
 
 def _normalized_exec_basename(exec_line: str) -> str:
@@ -195,11 +222,252 @@ def _desktop_match_aliases(info: DesktopInfo) -> list[str]:
     return list(dict.fromkeys(alias for alias in aliases if alias))
 
 
+def _desktop_entry_string(key_file: GLib.KeyFile, key: str) -> str:
+    try:
+        return key_file.get_string("Desktop Entry", key).strip()
+    except GLib.Error:
+        return ""
+
+
+def _desktop_entry_locale_string(key_file: GLib.KeyFile, key: str) -> str:
+    try:
+        return key_file.get_locale_string("Desktop Entry", key, None).strip()
+    except GLib.Error:
+        return _desktop_entry_string(key_file, key)
+
+
+def _desktop_entry_bool(key_file: GLib.KeyFile, key: str) -> bool:
+    try:
+        return bool(key_file.get_boolean("Desktop Entry", key))
+    except GLib.Error:
+        return False
+
+
+def _load_desktop_key_file(path: Path) -> GLib.KeyFile | None:
+    key_file = GLib.KeyFile()
+    try:
+        key_file.load_from_file(str(path), GLib.KeyFileFlags.NONE)
+        return key_file
+    except GLib.Error as exc:
+        log.bind(action="parse_desktop_file").debug(
+            "Failed to parse desktop file %s: %s",
+            path,
+            exc,
+        )
+        return None
+
+
+def _desktop_info_from_file(*, desktop_id: str, path: Path) -> DesktopInfo | None:
+    key_file = _load_desktop_key_file(path)
+    if key_file is None:
+        return None
+
+    if _desktop_entry_string(key_file, "Type") != "Application":
+        return None
+    if _desktop_entry_bool(key_file, "Hidden"):
+        return None
+
+    exec_line = _desktop_entry_string(key_file, "Exec")
+    wm_class = _desktop_entry_string(key_file, "StartupWMClass")
+    if not wm_class:
+        exec_basename = _normalized_exec_basename(exec_line)
+        wm_class = exec_basename or desktop_id.removesuffix(DESKTOP_SUFFIX)
+
+    return DesktopInfo(
+        desktop_id=desktop_id,
+        name=_desktop_entry_locale_string(key_file, "Name") or desktop_id,
+        icon_name=_desktop_entry_string(key_file, "Icon") or FALLBACK_ICON,
+        wm_class=wm_class,
+        exec_line=exec_line,
+    )
+
+
+def _host_icon_file_candidates(icon_name: str) -> list[Path]:
+    icon_path = Path(icon_name)
+    if not icon_path.is_absolute():
+        return []
+
+    candidates = [icon_path]
+    host_root = str(HOST_FILESYSTEM_ROOT)
+    if not str(icon_path).startswith(f"{host_root}{os.sep}"):
+        candidates.append(HOST_FILESYSTEM_ROOT / str(icon_path).lstrip(os.sep))
+    return candidates
+
+
+def _create_icon_theme() -> Gtk.IconTheme:
+    theme = Gtk.IconTheme.get_default()
+    if theme is None:
+        theme = Gtk.IconTheme()
+        theme.set_custom_theme("hicolor")
+    existing = set(theme.get_search_path())
+    for pixmaps_dir in HOST_PIXMAP_DIRS:
+        if Path(pixmaps_dir).is_dir() and pixmaps_dir not in existing:
+            theme.append_search_path(pixmaps_dir)
+            existing.add(pixmaps_dir)
+    return theme
+
+
+def _theme_icon_candidates(icon_name: str) -> list[str]:
+    candidates = [icon_name]
+    if Path(icon_name).parent == Path() and Path(icon_name).suffix.lower() in (
+        ".png",
+        ".svg",
+        ".xpm",
+    ):
+        candidates.append(Path(icon_name).stem)
+    if icon_name.startswith(GNOME_APP_PREFIX):
+        name = icon_name.removeprefix(GNOME_APP_PREFIX)
+        legacy = f"gnome-{name.replace('.', '-').lower()}"
+        candidates.append(legacy)
+        candidates.append(name.replace(".", "-").lower())
+    return list(dict.fromkeys(candidate for candidate in candidates if candidate))
+
+
+def _get_desktop_dirs() -> list[Path]:
+    """Get application .desktop file directories from XDG_DATA_DIRS."""
+    xdg = os.environ.get("XDG_DATA_DIRS", DEFAULT_XDG_DATA_DIRS)
+    dirs = []
+    for d in xdg.split(":"):
+        p = Path(d) / "applications"
+        if p.is_dir():
+            dirs.append(p)
+    for d in HOST_XDG_DATA_DIRS:
+        p = Path(d) / "applications"
+        if p.is_dir() and p not in dirs:
+            dirs.append(p)
+    local = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local/share"))
+    user_apps = local / "applications"
+    if user_apps.is_dir():
+        dirs.insert(0, user_apps)
+    if _is_flatpak_runtime():
+        host_user_apps = Path.home() / ".local" / "share" / "applications"
+        if host_user_apps.is_dir() and host_user_apps not in dirs:
+            dirs.insert(0, host_user_apps)
+    return dirs
+
+
+def _is_host_desktop_file(path: Path | None) -> bool:
+    if path is None:
+        return False
+    try:
+        path.relative_to(HOST_FILESYSTEM_ROOT)
+        return True
+    except ValueError:
+        pass
+
+    if not _is_flatpak_runtime():
+        return False
+    try:
+        path.relative_to(Path.home() / ".local" / "share" / "applications")
+        return True
+    except ValueError:
+        pass
+
+    try:
+        path.relative_to(Path(SNAP_XDG_DATA_DIR) / "applications")
+        return True
+    except ValueError:
+        return False
+
+
+def _find_desktop_file(desktop_id: str) -> Path | None:
+    for desktop_dir in _get_desktop_dirs():
+        path = desktop_dir / desktop_id
+        if path.exists():
+            return path
+    return None
+
+
+def _resolve_app_info(
+    desktop_id: str,
+    *,
+    action: str,
+    log_failures: bool = True,
+) -> _ResolvedAppInfo | None:
+    resolve_errors: list[str] = []
+    try:
+        app_info = Gio.DesktopAppInfo.new(desktop_id)
+    except (TypeError, GLib.Error) as exc:
+        resolve_errors.append(f"desktop app info: {exc}")
+        app_info = None
+    if app_info is not None:
+        return _ResolvedAppInfo(
+            app_info=app_info,
+            desktop_file=_find_desktop_file(desktop_id),
+        )
+
+    path = _find_desktop_file(desktop_id)
+    if path is not None:
+        try:
+            app_info = Gio.DesktopAppInfo.new_from_filename(str(path))
+        except (TypeError, GLib.Error) as exc:
+            resolve_errors.append(f"{path}: {exc}")
+        if app_info is not None:
+            return _ResolvedAppInfo(app_info=app_info, desktop_file=path)
+
+    if log_failures and resolve_errors:
+        log.bind(desktop_id=desktop_id, action=action).warning(
+            "Failed to resolve desktop app info: %s",
+            "; ".join(resolve_errors),
+        )
+    return None
+
+
+def _resolve_desktop_launch(
+    desktop_id: str, *, action: str
+) -> _ResolvedDesktopLaunch | None:
+    resolved = _resolve_app_info(desktop_id, action=action, log_failures=False)
+    if resolved is not None:
+        return _ResolvedDesktopLaunch(
+            exec_line=resolved.app_info.get_commandline() or "",
+            desktop_file=resolved.desktop_file,
+        )
+
+    path = _find_desktop_file(desktop_id)
+    if path is None:
+        return None
+    info = _desktop_info_from_file(desktop_id=desktop_id, path=path)
+    if info is None:
+        return None
+    return _ResolvedDesktopLaunch(exec_line=info.exec_line, desktop_file=path)
+
+
+def _desktop_file_actions(path: Path) -> list[DesktopAction]:
+    key_file = _load_desktop_key_file(path)
+    if key_file is None:
+        return []
+    try:
+        action_ids = key_file.get_string_list("Desktop Entry", "Actions")
+    except GLib.Error:
+        return []
+
+    result: list[DesktopAction] = []
+    for action_id in action_ids:
+        group = f"Desktop Action {action_id}"
+        try:
+            name = key_file.get_locale_string(group, "Name", None).strip()
+        except GLib.Error:
+            name = ""
+        if name:
+            result.append(DesktopAction(action_id, name))
+    return result
+
+
+def _desktop_file_action_exec(path: Path, action_id: str) -> str:
+    key_file = _load_desktop_key_file(path)
+    if key_file is None:
+        return ""
+    try:
+        return key_file.get_string(f"Desktop Action {action_id}", "Exec").strip()
+    except GLib.Error:
+        return ""
+
+
 class Launcher:
     """Resolves .desktop files via XDG_DATA_DIRS and loads icons."""
 
     def __init__(self) -> None:
-        self._desktop_dirs = self._get_desktop_dirs()
+        self._desktop_dirs = _get_desktop_dirs()
         self._icon_cache: dict[tuple[str, int], GdkPixbuf.Pixbuf | None] = {}
         self._file_icon_cache: dict[
             tuple[str, int, int, int], GdkPixbuf.Pixbuf | None
@@ -210,37 +478,37 @@ class Launcher:
         self, desktop_id: str, *, log_failures: bool = True
     ) -> DesktopInfo | None:
         """Resolve a desktop ID (e.g. 'firefox.desktop') to full info."""
+        resolve_errors: list[str] = []
         app_info = self._desktop_app_info_for_id(
             desktop_id=desktop_id,
-            log_failures=log_failures,
+            resolve_errors=resolve_errors,
         )
         if app_info is None:
+            info = self._resolve_desktop_file(desktop_id=desktop_id)
+        else:
+            info = self._desktop_info_from_app_info(
+                desktop_id=desktop_id,
+                app_info=app_info,
+            )
+        if info is None:
+            if log_failures and resolve_errors:
+                log.bind(desktop_id=desktop_id, action="resolve").warning(
+                    "Failed to resolve desktop file: %s",
+                    "; ".join(resolve_errors),
+                )
             return None
 
-        info = self._desktop_info_from_app_info(
-            desktop_id=desktop_id,
-            app_info=app_info,
-        )
-        if self._wm_class_index is not None:
-            # The install-wide index is lazy. Resolving one desktop file before
-            # the index exists should not force a full scan, but once the index
-            # has been built this keeps later direct resolves visible to
-            # resolve_by_wm_class.
-            for alias in _desktop_match_aliases(info):
-                self._wm_class_index.setdefault(alias, info)
+        self._cache_resolved_aliases(info=info)
         return info
 
     def _desktop_app_info_for_id(
-        self, *, desktop_id: str, log_failures: bool
+        self, *, desktop_id: str, resolve_errors: list[str]
     ) -> Gio.DesktopAppInfo | None:
         """Resolve desktop app info using Gio, then XDG desktop dirs."""
         try:
             app_info = Gio.DesktopAppInfo.new(desktop_id)
         except (TypeError, GLib.Error) as exc:
-            if log_failures:
-                log.bind(desktop_id=desktop_id, action="resolve").warning(
-                    f"Failed to resolve desktop app info: {exc}"
-                )
+            resolve_errors.append(f"desktop app info: {exc}")
             app_info = None
         # Use "is not None" deliberately. Gio objects may define truthiness in
         # surprising ways, and the old resolver only fell back when Gio returned
@@ -250,11 +518,11 @@ class Launcher:
             return app_info
         return self._desktop_app_info_from_xdg_dirs(
             desktop_id=desktop_id,
-            log_failures=log_failures,
+            resolve_errors=resolve_errors,
         )
 
     def _desktop_app_info_from_xdg_dirs(
-        self, *, desktop_id: str, log_failures: bool
+        self, *, desktop_id: str, resolve_errors: list[str]
     ) -> Gio.DesktopAppInfo | None:
         """Fallback desktop lookup by filename under XDG application dirs."""
         for directory in self._desktop_dirs:
@@ -264,12 +532,7 @@ class Launcher:
             try:
                 return Gio.DesktopAppInfo.new_from_filename(str(path))
             except (TypeError, GLib.Error) as exc:
-                if log_failures:
-                    log.bind(
-                        desktop_id=desktop_id,
-                        action="resolve_from_filename",
-                        path=str(path),
-                    ).warning(f"Failed to resolve desktop file by path: {exc}")
+                resolve_errors.append(f"{path}: {exc}")
         return None
 
     @staticmethod
@@ -305,6 +568,23 @@ class Launcher:
             exec_line=app_info.get_commandline() or "",
         )
 
+    def _resolve_desktop_file(self, *, desktop_id: str) -> DesktopInfo | None:
+        for desktop_dir in self._desktop_dirs:
+            path = desktop_dir / desktop_id
+            if path.is_file():
+                return _desktop_info_from_file(desktop_id=desktop_id, path=path)
+        return None
+
+    def _cache_resolved_aliases(self, *, info: DesktopInfo) -> None:
+        if self._wm_class_index is None:
+            return
+        # The install-wide index is lazy. Resolving one desktop file before
+        # the index exists should not force a full scan, but once the index
+        # has been built this keeps later direct resolves visible to
+        # resolve_by_wm_class.
+        for alias in _desktop_match_aliases(info):
+            self._wm_class_index.setdefault(alias, info)
+
     def resolve_by_wm_class(self, wm_class: str) -> DesktopInfo | None:
         """Resolve an installed desktop file by runtime WM_CLASS or executable alias."""
         lookup = wm_class.lower().strip()
@@ -324,6 +604,40 @@ class Launcher:
 
         pixbuf = self._try_load_icon(icon_name=icon_name, size=size)
         self._icon_cache[key] = pixbuf
+        return pixbuf
+
+    def load_desktop_icon(
+        self, info: DesktopInfo, size: int
+    ) -> GdkPixbuf.Pixbuf | None:
+        """Load an application icon with desktop-entry fallbacks."""
+        key = (f"desktop:{info.desktop_id}:{info.icon_name}:{info.exec_line}", size)
+        if key in self._icon_cache:
+            return self._icon_cache[key]
+
+        candidates = [info.icon_name, _normalized_exec_basename(info.exec_line)]
+        for icon_name in dict.fromkeys(
+            candidate for candidate in candidates if candidate
+        ):
+            pixbuf = self._try_load_icon_without_fallback(
+                icon_name=icon_name,
+                size=size,
+            )
+            if pixbuf is not None:
+                self._icon_cache[key] = pixbuf
+                return pixbuf
+            log.bind(
+                desktop_id=info.desktop_id,
+                icon_name=icon_name,
+                size=size,
+            ).debug("Desktop icon candidate failed, trying next")
+
+        pixbuf = self._try_load_fallback_icon(size=size)
+        self._icon_cache[key] = pixbuf
+        log.bind(
+            desktop_id=info.desktop_id,
+            size=size,
+            used_fallback=pixbuf is not None,
+        ).debug("Desktop icon fell back to generic")
         return pixbuf
 
     def load_gicon(self, gicon: Gio.Icon | None, size: int) -> GdkPixbuf.Pixbuf | None:
@@ -463,10 +777,7 @@ class Launcher:
         self._wm_class_index = index
 
     def _try_load_gicon(self, gicon: Gio.Icon, size: int) -> GdkPixbuf.Pixbuf | None:
-        theme = Gtk.IconTheme.get_default()
-        if theme is None:
-            theme = Gtk.IconTheme()
-            theme.set_custom_theme("hicolor")
+        theme = _create_icon_theme()
 
         lookup_by_gicon = getattr(theme, "lookup_by_gicon", None)
         if callable(lookup_by_gicon):
@@ -491,14 +802,19 @@ class Launcher:
 
     def _try_load_icon(self, icon_name: str, size: int) -> GdkPixbuf.Pixbuf | None:
         """Attempt to load icon from theme or file path."""
-        theme = Gtk.IconTheme.get_default()
-        if theme is None:
-            theme = Gtk.IconTheme()
-            theme.set_custom_theme("hicolor")
+        pixbuf = self._try_load_icon_without_fallback(icon_name=icon_name, size=size)
+        if pixbuf is not None:
+            return pixbuf
+        return self._try_load_fallback_icon(size=size)
 
-        # If it's an absolute path
-        icon_path = Path(icon_name)
-        if icon_path.is_absolute() and icon_path.exists():
+    def _try_load_icon_without_fallback(
+        self, icon_name: str, size: int
+    ) -> GdkPixbuf.Pixbuf | None:
+        theme = _create_icon_theme()
+
+        for icon_path in _host_icon_file_candidates(icon_name):
+            if not icon_path.exists():
+                continue
             try:
                 return GdkPixbuf.Pixbuf.new_from_file_at_scale(
                     str(icon_path), size, size, True
@@ -510,19 +826,32 @@ class Launcher:
                     exc,
                 )
 
-        # Try icon theme lookup
-        try:
-            return theme.load_icon(icon_name, size, Gtk.IconLookupFlags.FORCE_SIZE)
-        except GLib.Error as exc:
-            log.bind(action="load_icon").debug(
-                "Theme icon not found (%s): %s",
-                icon_name,
-                exc,
+        for candidate in _theme_icon_candidates(icon_name):
+            icon_info = theme.lookup_icon(
+                candidate, size, Gtk.IconLookupFlags.FORCE_SIZE
             )
+            if icon_info is None:
+                continue
+            try:
+                return icon_info.load_icon()
+            except GLib.Error as exc:
+                log.bind(action="load_icon").debug(
+                    "Theme icon not found (%s): %s",
+                    candidate,
+                    exc,
+                )
 
-        # Fallback
+        return None
+
+    def _try_load_fallback_icon(self, *, size: int) -> GdkPixbuf.Pixbuf | None:
+        theme = _create_icon_theme()
+        icon_info = theme.lookup_icon(
+            FALLBACK_ICON, size, Gtk.IconLookupFlags.FORCE_SIZE
+        )
+        if icon_info is None:
+            return None
         try:
-            return theme.load_icon(FALLBACK_ICON, size, Gtk.IconLookupFlags.FORCE_SIZE)
+            return icon_info.load_icon()
         except GLib.Error as exc:
             log.bind(action="load_icon").warning(
                 f"Failed to load fallback icon {FALLBACK_ICON}: {exc}"
@@ -531,19 +860,7 @@ class Launcher:
 
     @staticmethod
     def _get_desktop_dirs() -> list[Path]:
-        """Get application .desktop file directories from XDG_DATA_DIRS."""
-        xdg = os.environ.get("XDG_DATA_DIRS", DEFAULT_XDG_DATA_DIRS)
-        dirs = []
-        for d in xdg.split(":"):
-            p = Path(d) / "applications"
-            if p.is_dir():
-                dirs.append(p)
-        # Also check user-local
-        local = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local/share"))
-        user_apps = local / "applications"
-        if user_apps.is_dir():
-            dirs.insert(0, user_apps)
-        return dirs
+        return _get_desktop_dirs()
 
 
 class DesktopAction(NamedTuple):
@@ -555,15 +872,15 @@ class DesktopAction(NamedTuple):
 
 def get_actions(desktop_id: str) -> list[DesktopAction]:
     """Return .desktop Actions entries (e.g. "New Window", "New Incognito Window")."""
-    try:
-        app_info = Gio.DesktopAppInfo.new(desktop_id)
-    except (TypeError, GLib.Error) as exc:
-        log.bind(desktop_id=desktop_id, action="get_actions").warning(
-            f"Failed to read desktop actions: {exc}"
-        )
-        return []
-    if not app_info:
-        return []
+    resolved = _resolve_app_info(
+        desktop_id,
+        action="get_actions",
+        log_failures=False,
+    )
+    if resolved is None:
+        path = _find_desktop_file(desktop_id)
+        return _desktop_file_actions(path) if path is not None else []
+    app_info = resolved.app_info
     result = []
     for action_id in app_info.list_actions():
         name = app_info.get_action_name(action_id)
@@ -574,46 +891,54 @@ def get_actions(desktop_id: str) -> list[DesktopAction]:
 
 def launch_action(desktop_id: str, action_id: str) -> None:
     """Launch a named desktop action (from the .desktop [Desktop Action ...] group)."""
-    try:
-        app_info = Gio.DesktopAppInfo.new(desktop_id)
-    except (TypeError, GLib.Error) as exc:
-        log.bind(desktop_id=desktop_id, action="launch_action").warning(
-            f"Failed to resolve desktop app info for action {action_id}: {exc}"
+    resolved = _resolve_app_info(
+        desktop_id,
+        action="launch_action",
+        log_failures=False,
+    )
+    if resolved is None:
+        path = _find_desktop_file(desktop_id)
+        if path is None:
+            return
+        exec_line = _desktop_file_action_exec(path, action_id)
+        _launch_exec_line(
+            desktop_id=desktop_id,
+            exec_line=exec_line,
+            desktop_file=path,
+            action="launch_action",
         )
         return
-    if app_info:
-        try:
-            app_info.launch_action(action_id, None)
-        except GLib.Error as exc:
-            log.bind(desktop_id=desktop_id, action="launch_action").warning(
-                "Failed to launch action %s for %s: %s",
-                action_id,
-                desktop_id,
-                exc,
-            )
+    try:
+        resolved.app_info.launch_action(action_id, None)
+    except GLib.Error as exc:
+        log.bind(desktop_id=desktop_id, action="launch_action").warning(
+            "Failed to launch action %s for %s: %s",
+            action_id,
+            desktop_id,
+            exc,
+        )
 
 
 def launch_new_window(desktop_id: str) -> None:
     """Open a new application window when the desktop entry exposes that action."""
-    try:
-        app_info = Gio.DesktopAppInfo.new(desktop_id)
-    except (TypeError, GLib.Error) as exc:
-        log.bind(desktop_id=desktop_id, action="launch_new_window").warning(
-            f"Failed to resolve desktop app info for new window action: {exc}"
-        )
+    resolved = _resolve_app_info(
+        desktop_id,
+        action="launch_new_window",
+        log_failures=False,
+    )
+    if resolved is None:
         launch(desktop_id=desktop_id)
         return
-    if app_info is not None:
-        try:
-            if MiddleClickAction.NEW_WINDOW.value in app_info.list_actions():
-                app_info.launch_action(MiddleClickAction.NEW_WINDOW.value, None)
-                return
-        except GLib.Error as exc:
-            log.bind(desktop_id=desktop_id, action="launch_new_window").warning(
-                "Failed to launch new-window action for %s: %s",
-                desktop_id,
-                exc,
-            )
+    try:
+        if MiddleClickAction.NEW_WINDOW.value in resolved.app_info.list_actions():
+            resolved.app_info.launch_action(MiddleClickAction.NEW_WINDOW.value, None)
+            return
+    except GLib.Error as exc:
+        log.bind(desktop_id=desktop_id, action="launch_new_window").warning(
+            "Failed to launch new-window action for %s: %s",
+            desktop_id,
+            exc,
+        )
     launch(desktop_id=desktop_id)
 
 
@@ -624,13 +949,27 @@ def launch(desktop_id: str) -> None:
     session and process group. This prevents the child from receiving
     SIGHUP/SIGINT when the dock exits or the terminal sends Ctrl+C.
     """
-    app_info = Gio.DesktopAppInfo.new(desktop_id)
-    if not app_info:
+    resolved = _resolve_desktop_launch(desktop_id, action="launch")
+    if resolved is None:
         return
-    cmdline = app_info.get_commandline()
-    if not cmdline:
+    _launch_exec_line(
+        desktop_id=desktop_id,
+        exec_line=resolved.exec_line,
+        desktop_file=resolved.desktop_file,
+        action="launch",
+    )
+
+
+def _launch_exec_line(
+    *,
+    desktop_id: str,
+    exec_line: str,
+    desktop_file: Path | None,
+    action: str,
+) -> None:
+    if not exec_line:
         return
-    cmd = re.sub(r"%[uUfFdDnNickvm]", "", cmdline).strip()
+    cmd = re.sub(r"%[uUfFdDnNickvm]", "", exec_line).strip()
     if not cmd:
         return
     try:
@@ -642,6 +981,8 @@ def launch(desktop_id: str) -> None:
         return
     if not argv:
         return
+    if _is_host_desktop_file(desktop_file):
+        argv = ["flatpak-spawn", "--host", *argv]
     try:
         subprocess.Popen(
             argv,
@@ -652,7 +993,7 @@ def launch(desktop_id: str) -> None:
             stderr=subprocess.DEVNULL,
         )
     except OSError as e:
-        log.bind(desktop_id=desktop_id, action="launch").warning(
+        log.bind(desktop_id=desktop_id, action=action).warning(
             f"Failed to launch {desktop_id}: {e}"
         )
 
@@ -688,6 +1029,39 @@ def open_target(target: str) -> bool:
         uri = normalize_file_target(target)
     if uri is None:
         return False
+    if _is_flatpak_runtime() and urlparse(uri).scheme == "file":
+        flatpak_spawn = shutil.which("flatpak-spawn")
+        if flatpak_spawn is not None:
+            try:
+                subprocess.Popen(
+                    [
+                        flatpak_spawn,
+                        "--host",
+                        "env",
+                        "-u",
+                        "GIO_USE_VFS",
+                        "-u",
+                        "GI_TYPELIB_PATH",
+                        "-u",
+                        "GSETTINGS_SCHEMA_DIR",
+                        "-u",
+                        "XDG_DATA_DIRS",
+                        "gio",
+                        "open",
+                        uri,
+                    ],
+                    start_new_session=True,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                return True
+            except OSError as exc:
+                log.bind(target=target, action="open_target").warning(
+                    "Failed to open host target %s: %s",
+                    target,
+                    exc,
+                )
     try:
         Gio.AppInfo.launch_default_for_uri(uri, None)
         return True

--- a/docking/platform/model.py
+++ b/docking/platform/model.py
@@ -260,7 +260,7 @@ class DockModel:
             info = self._launcher.resolve(desktop_id=entry.target)
             if info is None:
                 return None
-            icon = self._launcher.load_icon(icon_name=info.icon_name, size=icon_size)
+            icon = self._launcher.load_desktop_icon(info=info, size=icon_size)
             return DockItem(
                 desktop_id=entry.id,
                 kind=APP_KIND,
@@ -295,7 +295,11 @@ class DockModel:
         )
         icon_size = self._config.scaled_icon_size
         icon_name = resolved.icon_name if resolved else "application-x-executable"
-        icon = self._launcher.load_icon(icon_name=icon_name, size=icon_size)
+        icon = (
+            self._launcher.load_desktop_icon(info=resolved, size=icon_size)
+            if resolved
+            else self._launcher.load_icon(icon_name=icon_name, size=icon_size)
+        )
         item = DockItem(
             desktop_id=desktop_id,
             kind=APP_KIND,

--- a/docking/ui/dnd.py
+++ b/docking/ui/dnd.py
@@ -691,11 +691,19 @@ class DnDHandler:
         """Build a pinned DockItem from an external URI drop."""
         desktop_id = self._uri_to_desktop_id(uri)
         icon_size = self._config.scaled_icon_size
+        log.debug("_item_from_uri: uri=%s desktop_id=%s", uri, desktop_id)
         if desktop_id:
             resolved = self._launcher.resolve(desktop_id)
             if resolved is None:
+                log.debug("_item_from_uri: resolve returned None for %s", desktop_id)
                 return None
-            icon = self._launcher.load_icon(resolved.icon_name, icon_size)
+            icon = self._launcher.load_desktop_icon(resolved, icon_size)
+            log.debug(
+                "_item_from_uri: desktop_id=%s icon_name=%s icon_loaded=%s",
+                desktop_id,
+                resolved.icon_name,
+                icon is not None,
+            )
             return DockItem(
                 desktop_id=desktop_id,
                 kind=APP_KIND,

--- a/tests/platform/test_launcher.py
+++ b/tests/platform/test_launcher.py
@@ -1,5 +1,6 @@
 """Tests for desktop file resolution."""
 
+import logging
 import os
 import sys
 from pathlib import Path
@@ -16,6 +17,7 @@ except Exception:
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
 from docking.core.config import MiddleClickAction
+from docking.platform import launcher as launcher_mod
 from docking.platform.launcher import (
     DesktopInfo,
     Launcher,
@@ -56,6 +58,49 @@ class TestGetDesktopDirs:
             launcher = Launcher()
         # Then
         assert Path("/nonexistent/path/applications") not in launcher._desktop_dirs
+
+    def test_includes_flatpak_host_desktop_dirs(self, tmp_path, monkeypatch):
+        # Given
+        host_share = tmp_path / "run" / "host" / "usr" / "share"
+        host_apps = host_share / "applications"
+        host_apps.mkdir(parents=True)
+        monkeypatch.setattr(launcher_mod, "HOST_XDG_DATA_DIRS", (str(host_share),))
+
+        # When
+        with patch.dict(os.environ, {"XDG_DATA_DIRS": "/nonexistent/path"}):
+            launcher = Launcher()
+
+        # Then
+        assert host_apps in launcher._desktop_dirs
+
+    def test_includes_snap_desktop_export_dir(self, tmp_path, monkeypatch):
+        snap_desktop = tmp_path / "var" / "lib" / "snapd" / "desktop"
+        snap_apps = snap_desktop / "applications"
+        snap_apps.mkdir(parents=True)
+        monkeypatch.setattr(launcher_mod, "HOST_XDG_DATA_DIRS", (str(snap_desktop),))
+
+        with patch.dict(os.environ, {"XDG_DATA_DIRS": "/nonexistent/path"}):
+            launcher = Launcher()
+
+        assert snap_apps in launcher._desktop_dirs
+
+    def test_includes_flatpak_host_user_desktop_dir(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        host_user_apps = home / ".local" / "share" / "applications"
+        host_user_apps.mkdir(parents=True)
+        monkeypatch.setattr(launcher_mod, "_is_flatpak_runtime", lambda: True)
+
+        with patch.dict(
+            os.environ,
+            {
+                "HOME": str(home),
+                "XDG_DATA_HOME": str(tmp_path / "sandbox-data"),
+                "XDG_DATA_DIRS": "/nonexistent/path",
+            },
+        ):
+            launcher = Launcher()
+
+        assert host_user_apps in launcher._desktop_dirs
 
 
 class TestIconCache:
@@ -101,6 +146,51 @@ class TestIconCache:
             name = launcher.default_directory_app_name()
 
         assert name is None
+
+    def test_resolve_parses_desktop_file_when_gio_rejects_it(self, tmp_path):
+        apps_dir = tmp_path / "share" / "applications"
+        apps_dir.mkdir(parents=True)
+        (apps_dir / "pycharm.desktop").write_text(
+            "\n".join(
+                [
+                    "[Desktop Entry]",
+                    "Type=Application",
+                    "Name=PyCharm",
+                    "Exec=/opt/pycharm/bin/pycharm %f",
+                    "Icon=/opt/pycharm/bin/pycharm.svg",
+                    "StartupWMClass=jetbrains-pycharm",
+                ]
+            )
+        )
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "XDG_DATA_DIRS": str(tmp_path / "share"),
+                    "XDG_DATA_HOME": str(tmp_path / "data"),
+                },
+            ),
+            patch.object(launcher_mod, "HOST_XDG_DATA_DIRS", ()),
+            patch(
+                "docking.platform.launcher.Gio.DesktopAppInfo.new",
+                return_value=None,
+            ),
+            patch(
+                "docking.platform.launcher.Gio.DesktopAppInfo.new_from_filename",
+                side_effect=TypeError("constructor returned NULL"),
+            ),
+        ):
+            launcher = Launcher()
+            info = launcher.resolve("pycharm.desktop")
+
+        assert info == DesktopInfo(
+            desktop_id="pycharm.desktop",
+            name="PyCharm",
+            icon_name="/opt/pycharm/bin/pycharm.svg",
+            wm_class="jetbrains-pycharm",
+            exec_line="/opt/pycharm/bin/pycharm %f",
+        )
 
     def test_resolve_file_icon_caches_image_thumbnail_by_file_stat(self, monkeypatch):
         from docking.platform import launcher as launcher_mod
@@ -256,6 +346,71 @@ class TestDesktopActions:
             actions = get_actions(desktop_id="broken.desktop")
         # Then
         assert actions == []
+
+    def test_get_actions_reads_host_desktop_file_when_id_lookup_fails(
+        self, tmp_path, monkeypatch
+    ):
+        host_apps = tmp_path / "run" / "host" / "usr" / "share" / "applications"
+        host_apps.mkdir(parents=True)
+        desktop_file = host_apps / "org.gnome.FileRoller.desktop"
+        desktop_file.write_text("[Desktop Entry]\nType=Application\n")
+
+        mock_app = MagicMock()
+        mock_app.list_actions.return_value = ["extract-here"]
+        mock_app.get_action_name.return_value = "Extract Here"
+        monkeypatch.setattr(launcher_mod, "_get_desktop_dirs", lambda: [host_apps])
+        monkeypatch.setattr(
+            launcher_mod.Gio.DesktopAppInfo,
+            "new",
+            lambda _desktop_id: None,
+        )
+        new_from_filename = MagicMock(return_value=mock_app)
+        monkeypatch.setattr(
+            launcher_mod.Gio.DesktopAppInfo,
+            "new_from_filename",
+            new_from_filename,
+        )
+
+        actions = get_actions(desktop_id="org.gnome.FileRoller.desktop")
+
+        assert actions == [("extract-here", "Extract Here")]
+        new_from_filename.assert_called_once_with(str(desktop_file))
+
+    def test_get_actions_parses_host_desktop_file_when_gio_filename_lookup_fails(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        host_apps = tmp_path / "run" / "host" / "usr" / "share" / "applications"
+        host_apps.mkdir(parents=True)
+        desktop_file = host_apps / "org.gnome.FileRoller.desktop"
+        desktop_file.write_text(
+            "\n".join(
+                [
+                    "[Desktop Entry]",
+                    "Type=Application",
+                    "Name=Archive Manager",
+                    "Exec=file-roller %U",
+                    "Actions=extract-here;",
+                    "",
+                    "[Desktop Action extract-here]",
+                    "Name=Extract Here",
+                    "Exec=file-roller --extract-here %U",
+                ]
+            )
+        )
+
+        monkeypatch.setattr(launcher_mod, "_get_desktop_dirs", lambda: [host_apps])
+        monkeypatch.setattr(launcher_mod.Gio.DesktopAppInfo, "new", lambda _id: None)
+        monkeypatch.setattr(
+            launcher_mod.Gio.DesktopAppInfo,
+            "new_from_filename",
+            lambda _path: None,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="docking.launcher"):
+            actions = get_actions(desktop_id="org.gnome.FileRoller.desktop")
+
+        assert actions == [("extract-here", "Extract Here")]
+        assert "constructor returned NULL" not in caplog.text
 
     def test_launch_action_ignores_gio_errors(self, monkeypatch):
         # Given
@@ -465,7 +620,167 @@ class TestTryLoadIcon:
 
         # Then
         assert out is pix
-        theme.load_icon.assert_not_called()
+        theme.lookup_icon.assert_not_called()
+
+    def test_loads_flatpak_host_icon_for_host_desktop_absolute_path(self, monkeypatch):
+        # Given
+        from docking.platform import launcher as launcher_mod
+
+        launcher = Launcher()
+        theme = MagicMock()
+        theme.get_search_path.return_value = []
+        monkeypatch.setattr(
+            launcher_mod.Gtk.IconTheme, "get_default", lambda: theme, raising=False
+        )
+        monkeypatch.setattr(
+            launcher_mod.Path,
+            "exists",
+            lambda self: str(self) == "/run/host/opt/app/icon.png",
+        )
+
+        pix = object()
+        pixbuf_cls = MagicMock()
+        pixbuf_cls.new_from_file_at_scale.return_value = pix
+        monkeypatch.setattr(launcher_mod.GdkPixbuf, "Pixbuf", pixbuf_cls, raising=False)
+
+        # When
+        out = launcher._try_load_icon("/opt/app/icon.png", 48)
+
+        # Then
+        assert out is pix
+        pixbuf_cls.new_from_file_at_scale.assert_called_once_with(
+            "/run/host/opt/app/icon.png",
+            48,
+            48,
+            True,
+        )
+        theme.lookup_icon.assert_not_called()
+
+    def test_loads_host_pixmap_icon_when_desktop_icon_includes_extension(
+        self, tmp_path, monkeypatch
+    ):
+        from docking.platform import launcher as launcher_mod
+
+        host_share = tmp_path / "run" / "host" / "usr" / "share"
+        pixmaps = host_share / "pixmaps"
+        pixmaps.mkdir(parents=True)
+        icon_file = pixmaps / "acvc-64.png"
+        icon_file.write_bytes(b"fake")
+        monkeypatch.setattr(launcher_mod, "HOST_PIXMAP_DIRS", (str(pixmaps),))
+        monkeypatch.setattr(launcher_mod.GLib, "Error", RuntimeError, raising=False)
+
+        launcher = Launcher()
+        theme = MagicMock()
+        theme.get_search_path.return_value = []
+        icon_info = MagicMock()
+        icon_info.load_icon.return_value = "pixbuf"
+        theme.lookup_icon.side_effect = [None, icon_info]
+        monkeypatch.setattr(
+            launcher_mod.Gtk.IconTheme, "get_default", lambda: theme, raising=False
+        )
+
+        out = launcher._try_load_icon("acvc-64.png", 48)
+
+        assert out == "pixbuf"
+        theme.append_search_path.assert_called_once_with(str(pixmaps))
+        assert [call.args[0] for call in theme.lookup_icon.call_args_list] == [
+            "acvc-64.png",
+            "acvc-64",
+        ]
+
+    def test_loads_host_pixmap_icon_for_extensionless_name(self, tmp_path, monkeypatch):
+        from docking.platform import launcher as launcher_mod
+
+        host_share = tmp_path / "run" / "host" / "usr" / "share"
+        pixmaps = host_share / "pixmaps"
+        pixmaps.mkdir(parents=True)
+        icon_file = pixmaps / "mongodb-compass.png"
+        icon_file.write_bytes(b"fake")
+        monkeypatch.setattr(launcher_mod, "HOST_PIXMAP_DIRS", (str(pixmaps),))
+        monkeypatch.setattr(launcher_mod.GLib, "Error", RuntimeError, raising=False)
+
+        launcher = Launcher()
+        theme = MagicMock()
+        theme.get_search_path.return_value = []
+        icon_info = MagicMock()
+        icon_info.load_icon.return_value = "pixbuf"
+        theme.lookup_icon.return_value = icon_info
+        monkeypatch.setattr(
+            launcher_mod.Gtk.IconTheme, "get_default", lambda: theme, raising=False
+        )
+
+        out = launcher._try_load_icon("mongodb-compass", 48)
+
+        assert out == "pixbuf"
+        theme.append_search_path.assert_called_once_with(str(pixmaps))
+        theme.lookup_icon.assert_called_once_with(
+            "mongodb-compass",
+            48,
+            launcher_mod.Gtk.IconLookupFlags.FORCE_SIZE,
+        )
+
+    def test_uses_gnome_legacy_icon_alias_before_fallback(self, monkeypatch):
+        # Given
+        from docking.platform import launcher as launcher_mod
+
+        launcher = Launcher()
+        monkeypatch.setattr(launcher_mod.GLib, "Error", RuntimeError, raising=False)
+        monkeypatch.setattr(launcher_mod.Path, "exists", lambda self: False)
+
+        theme = MagicMock()
+        theme.get_search_path.return_value = []
+        mock_info = MagicMock()
+        mock_info.load_icon.return_value = "calculator-pixbuf"
+        theme.lookup_icon.side_effect = [None, mock_info]
+        monkeypatch.setattr(
+            launcher_mod.Gtk.IconTheme, "get_default", lambda: theme, raising=False
+        )
+
+        # When
+        out = launcher._try_load_icon("org.gnome.Calculator", 48)
+
+        # Then
+        assert out == "calculator-pixbuf"
+        assert theme.lookup_icon.call_args_list[0].args[0] == "org.gnome.Calculator"
+        assert theme.lookup_icon.call_args_list[1].args[0] == "gnome-calculator"
+
+    def test_load_desktop_icon_uses_exec_basename_before_fallback(self, monkeypatch):
+        from docking.platform import launcher as launcher_mod
+
+        launcher = Launcher()
+        monkeypatch.setattr(launcher_mod.GLib, "Error", RuntimeError, raising=False)
+        monkeypatch.setattr(launcher_mod.Path, "exists", lambda self: False)
+
+        theme = MagicMock()
+        theme.get_search_path.return_value = []
+        mock_info = MagicMock()
+        mock_info.load_icon.return_value = "file-roller-pixbuf"
+        theme.lookup_icon.side_effect = [
+            None,
+            None,
+            None,
+            mock_info,
+        ]
+        monkeypatch.setattr(
+            launcher_mod.Gtk.IconTheme, "get_default", lambda: theme, raising=False
+        )
+        info = DesktopInfo(
+            desktop_id="org.gnome.FileRoller.desktop",
+            name="Archive Manager",
+            icon_name="org.gnome.ArchiveManager",
+            wm_class="file-roller",
+            exec_line="file-roller %U",
+        )
+
+        out = launcher.load_desktop_icon(info, 48)
+
+        assert out == "file-roller-pixbuf"
+        assert [call.args[0] for call in theme.lookup_icon.call_args_list] == [
+            "org.gnome.ArchiveManager",
+            "gnome-archivemanager",
+            "archivemanager",
+            "file-roller",
+        ]
 
     def test_uses_theme_fallback_when_primary_icon_lookup_fails(self, monkeypatch):
         # Given
@@ -475,7 +790,9 @@ class TestTryLoadIcon:
         monkeypatch.setattr(launcher_mod.GLib, "Error", RuntimeError, raising=False)
 
         theme = MagicMock()
-        theme.load_icon.side_effect = [RuntimeError("miss"), "fallback-pixbuf"]
+        mock_info = MagicMock()
+        mock_info.load_icon.return_value = "fallback-pixbuf"
+        theme.lookup_icon.side_effect = [None, mock_info]
         monkeypatch.setattr(
             launcher_mod.Gtk.IconTheme, "get_default", lambda: theme, raising=False
         )
@@ -486,7 +803,7 @@ class TestTryLoadIcon:
 
         # Then
         assert out == "fallback-pixbuf"
-        assert theme.load_icon.call_count == 2
+        assert theme.lookup_icon.call_count == 2
 
     def test_returns_none_when_all_icon_lookups_fail(self, monkeypatch):
         # Given
@@ -496,7 +813,7 @@ class TestTryLoadIcon:
         monkeypatch.setattr(launcher_mod.GLib, "Error", RuntimeError, raising=False)
 
         theme = MagicMock()
-        theme.load_icon.side_effect = [RuntimeError("miss"), RuntimeError("miss")]
+        theme.lookup_icon.return_value = None
         monkeypatch.setattr(
             launcher_mod.Gtk.IconTheme, "get_default", lambda: theme, raising=False
         )
@@ -615,6 +932,47 @@ class TestOpenTarget:
 
         launch_mock.assert_called_once_with(target.resolve().as_uri(), None)
 
+    def test_open_target_uses_host_gio_for_local_file_in_flatpak(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "example.txt"
+        target.write_text("hello")
+        monkeypatch.setattr(launcher_mod, "_is_flatpak_runtime", lambda: True)
+        monkeypatch.setattr(
+            launcher_mod.shutil,
+            "which",
+            lambda name: "/usr/bin/flatpak-spawn" if name == "flatpak-spawn" else None,
+        )
+
+        with (
+            patch("docking.platform.launcher.subprocess.Popen") as popen_mock,
+            patch(
+                "docking.platform.launcher.Gio.AppInfo.launch_default_for_uri"
+            ) as launch_mock,
+        ):
+            assert open_target(str(target)) is True
+
+        popen_mock.assert_called_once()
+        args, kwargs = popen_mock.call_args
+        assert args[0] == [
+            "/usr/bin/flatpak-spawn",
+            "--host",
+            "env",
+            "-u",
+            "GIO_USE_VFS",
+            "-u",
+            "GI_TYPELIB_PATH",
+            "-u",
+            "GSETTINGS_SCHEMA_DIR",
+            "-u",
+            "XDG_DATA_DIRS",
+            "gio",
+            "open",
+            target.resolve().as_uri(),
+        ]
+        assert kwargs["start_new_session"] is True
+        launch_mock.assert_not_called()
+
     def test_open_target_returns_false_for_unsupported_scheme(self):
         with patch(
             "docking.platform.launcher.Gio.AppInfo.launch_default_for_uri"
@@ -646,6 +1004,128 @@ class TestLaunch:
             "docking.platform.launcher.Gio.DesktopAppInfo.new", return_value=None
         ):
             launch(desktop_id="missing.desktop")
+        popen_mock.assert_not_called()
+
+    @patch("subprocess.Popen")
+    def test_launch_uses_host_spawn_for_host_desktop_file(
+        self, popen_mock, tmp_path, monkeypatch
+    ):
+        host_apps = tmp_path / "run" / "host" / "usr" / "share" / "applications"
+        host_apps.mkdir(parents=True)
+        desktop_file = host_apps / "org.gnome.FileRoller.desktop"
+        desktop_file.write_text("[Desktop Entry]\nType=Application\n")
+
+        mock_app = MagicMock()
+        mock_app.get_commandline.return_value = "file-roller %U"
+        monkeypatch.setattr(
+            launcher_mod, "HOST_FILESYSTEM_ROOT", tmp_path / "run" / "host"
+        )
+        monkeypatch.setattr(launcher_mod, "_get_desktop_dirs", lambda: [host_apps])
+        monkeypatch.setattr(
+            launcher_mod.Gio.DesktopAppInfo,
+            "new",
+            lambda _desktop_id: None,
+        )
+        monkeypatch.setattr(
+            launcher_mod.Gio.DesktopAppInfo,
+            "new_from_filename",
+            lambda _path: mock_app,
+        )
+
+        launch(desktop_id="org.gnome.FileRoller.desktop")
+
+        popen_mock.assert_called_once()
+        args, kwargs = popen_mock.call_args
+        assert args[0] == ["flatpak-spawn", "--host", "file-roller"]
+        assert kwargs["shell"] is False
+
+    @patch("subprocess.Popen")
+    def test_launch_uses_host_spawn_for_flatpak_host_user_desktop_file(
+        self, popen_mock, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        host_apps = home / ".local" / "share" / "applications"
+        host_apps.mkdir(parents=True)
+        (host_apps / "org.example.UserApp.desktop").write_text(
+            "[Desktop Entry]\nType=Application\n"
+        )
+
+        mock_app = MagicMock()
+        mock_app.get_commandline.return_value = "user-app %U"
+        monkeypatch.setattr(launcher_mod, "_is_flatpak_runtime", lambda: True)
+        monkeypatch.setattr(
+            launcher_mod.Gio.DesktopAppInfo,
+            "new",
+            lambda _desktop_id: mock_app,
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "HOME": str(home),
+                "XDG_DATA_HOME": str(tmp_path / "sandbox-data"),
+                "XDG_DATA_DIRS": "/nonexistent/path",
+            },
+        ):
+            launch(desktop_id="org.example.UserApp.desktop")
+
+        popen_mock.assert_called_once()
+        args, kwargs = popen_mock.call_args
+        assert args[0] == ["flatpak-spawn", "--host", "user-app"]
+        assert kwargs["shell"] is False
+
+    @patch("subprocess.Popen")
+    def test_launch_parses_host_desktop_file_when_gio_filename_lookup_fails(
+        self, popen_mock, tmp_path, monkeypatch, caplog
+    ):
+        host_apps = tmp_path / "run" / "host" / "usr" / "share" / "applications"
+        host_apps.mkdir(parents=True)
+        desktop_file = host_apps / "org.gnome.FileRoller.desktop"
+        desktop_file.write_text(
+            "\n".join(
+                [
+                    "[Desktop Entry]",
+                    "Type=Application",
+                    "Name=Archive Manager",
+                    "Exec=file-roller %U",
+                ]
+            )
+        )
+
+        monkeypatch.setattr(
+            launcher_mod, "HOST_FILESYSTEM_ROOT", tmp_path / "run" / "host"
+        )
+        monkeypatch.setattr(launcher_mod, "_get_desktop_dirs", lambda: [host_apps])
+        monkeypatch.setattr(launcher_mod.Gio.DesktopAppInfo, "new", lambda _id: None)
+        monkeypatch.setattr(
+            launcher_mod.Gio.DesktopAppInfo,
+            "new_from_filename",
+            lambda _path: None,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="docking.launcher"):
+            launch(desktop_id="org.gnome.FileRoller.desktop")
+
+        popen_mock.assert_called_once()
+        args, kwargs = popen_mock.call_args
+        assert args[0] == ["flatpak-spawn", "--host", "file-roller"]
+        assert kwargs["shell"] is False
+        assert "constructor returned NULL" not in caplog.text
+
+    @patch("subprocess.Popen")
+    def test_launch_returns_when_desktop_constructor_raises(
+        self, popen_mock, monkeypatch
+    ):
+        monkeypatch.setattr(launcher_mod.GLib, "Error", RuntimeError, raising=False)
+        monkeypatch.setattr(
+            launcher_mod.Gio.DesktopAppInfo,
+            "new",
+            MagicMock(side_effect=TypeError("constructor returned NULL")),
+        )
+        monkeypatch.setattr(launcher_mod, "_get_desktop_dirs", list)
+
+        launch(desktop_id="missing.desktop")
+
         popen_mock.assert_not_called()
 
     @patch("subprocess.Popen")


### PR DESCRIPTION
This splits the launcher/model integration work out of the larger Flathub preparation branch. It updates desktop-file resolution, host launcher handling, desktop icon loading, and the DockModel/DnD call sites that consume the launcher API.