### PR TITLE
Deduplicate Flatpak runtime detection

### DIFF
--- a/docking/platform/launcher.py
+++ b/docking/platform/launcher.py
@@ -142,6 +142,7 @@ from gi.repository import GdkPixbuf, Gio, GLib, Gtk
 
 from docking.core.config import MiddleClickAction
 from docking.log import get_logger, with_context
+from docking.platform.environment import is_flatpak
 
 DESKTOP_SUFFIX = ".desktop"
 FALLBACK_ICON = "application-x-executable"
@@ -161,10 +162,6 @@ HOST_FILESYSTEM_ROOT = Path("/run/host")
 ICON_FILE_EXTENSIONS = (".png", ".svg", ".xpm")
 
 log = with_context(get_logger(name="launcher"))
-
-
-def _is_flatpak_runtime() -> bool:
-    return Path("/.flatpak-info").exists()
 
 
 class DesktopInfo(NamedTuple):
@@ -339,7 +336,7 @@ def _get_desktop_dirs() -> list[Path]:
     user_apps = local / "applications"
     if user_apps.is_dir():
         dirs.insert(0, user_apps)
-    if _is_flatpak_runtime():
+    if is_flatpak():
         host_user_apps = Path.home() / ".local" / "share" / "applications"
         if host_user_apps.is_dir() and host_user_apps not in dirs:
             dirs.insert(0, host_user_apps)
@@ -355,7 +352,7 @@ def _is_host_desktop_file(path: Path | None) -> bool:
     except ValueError:
         pass
 
-    if not _is_flatpak_runtime():
+    if not is_flatpak():
         return False
     try:
         path.relative_to(Path.home() / ".local" / "share" / "applications")
@@ -1029,7 +1026,7 @@ def open_target(target: str) -> bool:
         uri = normalize_file_target(target)
     if uri is None:
         return False
-    if _is_flatpak_runtime() and urlparse(uri).scheme == "file":
+    if is_flatpak() and urlparse(uri).scheme == "file":
         flatpak_spawn = shutil.which("flatpak-spawn")
         if flatpak_spawn is not None:
             try:

--- a/tests/platform/test_launcher.py
+++ b/tests/platform/test_launcher.py
@@ -88,7 +88,7 @@ class TestGetDesktopDirs:
         home = tmp_path / "home"
         host_user_apps = home / ".local" / "share" / "applications"
         host_user_apps.mkdir(parents=True)
-        monkeypatch.setattr(launcher_mod, "_is_flatpak_runtime", lambda: True)
+        monkeypatch.setattr(launcher_mod, "is_flatpak", lambda: True)
 
         with patch.dict(
             os.environ,
@@ -937,7 +937,7 @@ class TestOpenTarget:
     ):
         target = tmp_path / "example.txt"
         target.write_text("hello")
-        monkeypatch.setattr(launcher_mod, "_is_flatpak_runtime", lambda: True)
+        monkeypatch.setattr(launcher_mod, "is_flatpak", lambda: True)
         monkeypatch.setattr(
             launcher_mod.shutil,
             "which",
@@ -1052,7 +1052,7 @@ class TestLaunch:
 
         mock_app = MagicMock()
         mock_app.get_commandline.return_value = "user-app %U"
-        monkeypatch.setattr(launcher_mod, "_is_flatpak_runtime", lambda: True)
+        monkeypatch.setattr(launcher_mod, "is_flatpak", lambda: True)
         monkeypatch.setattr(
             launcher_mod.Gio.DesktopAppInfo,
             "new",


### PR DESCRIPTION
Use the shared platform environment helper for Flatpak runtime detection in launcher code instead of keeping a duplicate private implementation.