### PR TITLE
Bundle NetworkManager in Flatpak

### DIFF
--- a/packaging/flatpak/cc.docking.Docking.json
+++ b/packaging/flatpak/cc.docking.Docking.json
@@ -37,6 +37,75 @@
       ]
     },
     {
+      "name": "libndp",
+      "buildsystem": "autotools",
+      "config-opts": [
+        "--disable-static"
+      ],
+      "cleanup": [
+        "/bin",
+        "/share/man"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://libndp.org/files/libndp-1.9.tar.gz",
+          "sha256": "a8ab214e01dc3a9b615276905395637f391298c84d77651f0cbf0b1082dd2dd4"
+        }
+      ]
+    },
+    {
+      "name": "NetworkManager",
+      "buildsystem": "meson",
+      "config-opts": [
+        "--libdir=lib",
+        "-Ddocs=false",
+        "-Dtests=no",
+        "-Dintrospection=true",
+        "-Dnmcli=false",
+        "-Dnmtui=false",
+        "-Dnm_cloud_setup=false",
+        "-Dpolkit=false",
+        "-Dselinux=false",
+        "-Dsystemd_journal=false",
+        "-Dlibaudit=no",
+        "-Dppp=false",
+        "-Dmodem_manager=false",
+        "-Dovs=false",
+        "-Dconcheck=false",
+        "-Dfirewalld_zone=false",
+        "-Dqt=false",
+        "-Dreadline=none",
+        "-Dcrypto=null",
+        "-Dudev_dir=no",
+        "-Ddbus_conf_dir=/app/etc/dbus-1/system.d",
+        "-Dsystemdsystemunitdir=no",
+        "-Dsession_tracking=no",
+        "-Dsuspend_resume=auto",
+        "-Dnbft=false",
+        "-Dvapi=false"
+      ],
+      "cleanup": [
+        "/bin",
+        "/etc",
+        "/lib/systemd",
+        "/lib/udev",
+        "/sbin",
+        "/share/bash-completion",
+        "/share/dbus-1",
+        "/share/doc",
+        "/share/man",
+        "/var"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/archive/1.54.3/NetworkManager-1.54.3.tar.gz",
+          "sha256": "16c1e954a8598a0afc71c9936a7e4f0ad949522438d96fec63aa1abb6f2207fe"
+        }
+      ]
+    },
+    {
       "name": "docking",
       "buildsystem": "simple",
       "build-commands": [


### PR DESCRIPTION
Adds libndp and NetworkManager to the in-repo Flatpak manifest so the Network applet can import the NM GObject introspection namespace inside the sandbox and keep its full feature set. Verified by building and installing the Flatpak bundle, confirming /app/lib/girepository-1.0/NM-1.0.typelib and /app/lib/libnm.so.0 are present, importing NM inside the installed Flatpak, and importing docking.applets.network.applet inside the installed Flatpak.