### PR TITLE
Fix HiDPI pointer barrier placement

### DIFF
--- a/docking/platform/barriers.py
+++ b/docking/platform/barriers.py
@@ -206,28 +206,36 @@ class PointerBarrier:
         monitor_y: int,
         monitor_w: int,
         monitor_h: int,
+        scale: int = 1,
     ) -> None:
-        """Create or recreate the barrier at the monitor's dock edge."""
+        """Create or recreate the barrier at the monitor's dock edge.
+
+        Monitor coordinates are in GDK logical pixels. XFixes operates on the
+        X11 root window in physical pixels, so the scale factor is applied
+        before creating the barrier.
+        """
         if not self._supported or self._libs is None:
             return
 
         self.destroy()
 
         xlib, xfixes, _ = self._libs
+        mx, my = monitor_x * scale, monitor_y * scale
+        mw, mh = monitor_w * scale, monitor_h * scale
 
         # Barrier line spans the full dock edge of the monitor
         if position == Position.BOTTOM:
-            x1, y1 = monitor_x, monitor_y + monitor_h
-            x2, y2 = monitor_x + monitor_w, monitor_y + monitor_h
+            x1, y1 = mx, my + mh
+            x2, y2 = mx + mw, my + mh
         elif position == Position.TOP:
-            x1, y1 = monitor_x, monitor_y
-            x2, y2 = monitor_x + monitor_w, monitor_y
+            x1, y1 = mx, my
+            x2, y2 = mx + mw, my
         elif position == Position.LEFT:
-            x1, y1 = monitor_x, monitor_y
-            x2, y2 = monitor_x, monitor_y + monitor_h
+            x1, y1 = mx, my
+            x2, y2 = mx, my + mh
         else:  # RIGHT
-            x1, y1 = monitor_x + monitor_w, monitor_y
-            x2, y2 = monitor_x + monitor_w, monitor_y + monitor_h
+            x1, y1 = mx + mw, my
+            x2, y2 = mx + mw, my + mh
 
         xlib.XDefaultRootWindow.restype = ctypes.c_ulong
         xlib.XDefaultRootWindow.argtypes = [ctypes.c_void_p]

--- a/docking/ui/placement.py
+++ b/docking/ui/placement.py
@@ -177,7 +177,9 @@ class DockPlacementController:
         barrier: PointerBarrier | None = None,
     ) -> None:
         self._window = window
-        self._barrier = barrier or PointerBarrier()
+        self._barrier: PointerBarrier = (
+            barrier if barrier is not None else PointerBarrier()
+        )
         self._active_display_timer: int = 0
         self._active_monitor: Gdk.Monitor | None = None
         self._screen_signal_handlers: list[tuple[object, int]] = []
@@ -417,6 +419,7 @@ class DockPlacementController:
             monitor_y=geom.y,
             monitor_w=geom.width,
             monitor_h=geom.height,
+            scale=self._window.get_scale_factor(),
         )
 
     def clear_struts(self) -> None:

--- a/tests/platform/test_barriers.py
+++ b/tests/platform/test_barriers.py
@@ -1,7 +1,11 @@
 """Tests for pointer barrier support detection and lifecycle."""
 
+import ctypes
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from docking.core.position import Position
 from docking.platform.barriers import PointerBarrier, _load_libs
 
 
@@ -82,3 +86,78 @@ class TestPointerBarrierInitialize:
             # won't behave like real ctypes; test the load path
             result = barrier.initialize(gdk_display=self._make_mock_display())
             assert isinstance(result, bool)
+
+
+class TestPointerBarrierCoordinates:
+    """Coordinate space delivered to XFixesCreatePointerBarrier.
+
+    Issue #76 hypothesis: PointerBarrier.update receives logical pixels
+    from its caller and forwards them to XFixesCreatePointerBarrier without
+    any scale-factor multiplication. XFixes operates on the X11 root window,
+    which uses physical pixels. On a HiDPI display (scale > 1) this places
+    the barrier line at the wrong absolute Y -- visible to the user as an
+    invisible horizontal mouse-blocking line at logical y = H_physical / S^2.
+
+    These tests pin down where coordinates currently flow so the fix can be
+    verified and regressions caught.
+    """
+
+    @staticmethod
+    def _make_supported_barrier():
+        xlib = MagicMock()
+        xlib.XDefaultRootWindow.return_value = 1
+        xfixes = MagicMock()
+        xfixes.XFixesCreatePointerBarrier.return_value = 42
+        barrier = PointerBarrier()
+        barrier._supported = True
+        barrier._libs = (xlib, xfixes, MagicMock())
+        barrier._xdisplay = ctypes.c_void_p(99)
+        return barrier, xlib, xfixes
+
+    def test_update_forwards_caller_coords_unchanged_to_xfixes(self):
+        """PointerBarrier.update is a thin wrapper -- whatever x/y/w/h the
+        caller hands in is what XFixes receives. This pins the current
+        contract: scale handling, if any, belongs to the caller.
+
+        If the fix introduces an internal scale parameter on update(),
+        this test should be updated to reflect the new contract (and the
+        end-to-end placement test below will still cover the user-visible
+        behavior)."""
+        barrier, _xlib, xfixes = self._make_supported_barrier()
+
+        barrier.update(
+            position=Position.BOTTOM,
+            monitor_x=0,
+            monitor_y=0,
+            monitor_w=1920,
+            monitor_h=1080,
+        )
+
+        x1, y1, x2, y2 = xfixes.XFixesCreatePointerBarrier.call_args.args[2:6]
+        assert (x1, y1, x2, y2) == (0, 1080, 1920, 1080)
+
+    @pytest.mark.parametrize(
+        "position,expected",
+        [
+            (Position.BOTTOM, (0, 1080, 1920, 1080)),
+            (Position.TOP, (0, 0, 1920, 0)),
+            (Position.LEFT, (0, 0, 0, 1080)),
+            (Position.RIGHT, (1920, 0, 1920, 1080)),
+        ],
+    )
+    def test_update_barrier_line_geometry_per_edge(self, position, expected):
+        """The barrier line spans the dock edge of the monitor. This locks
+        in the per-edge endpoint computation independently of scaling, so a
+        scale-factor fix cannot accidentally swap axes or corners."""
+        barrier, _xlib, xfixes = self._make_supported_barrier()
+
+        barrier.update(
+            position=position,
+            monitor_x=0,
+            monitor_y=0,
+            monitor_w=1920,
+            monitor_h=1080,
+        )
+
+        coords = xfixes.XFixesCreatePointerBarrier.call_args.args[2:6]
+        assert coords == expected

--- a/tests/ui/test_placement.py
+++ b/tests/ui/test_placement.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 import docking.ui.placement as placement_mod
 from docking.core.position import Position
 
@@ -29,6 +31,7 @@ def _make_window(**overrides):
         get_display=MagicMock(),
         get_screen=MagicMock(),
         get_window=MagicMock(),
+        get_scale_factor=MagicMock(return_value=1),
         get_realized=MagicMock(return_value=True),
         set_size_request=MagicMock(),
         resize=MagicMock(),
@@ -619,7 +622,8 @@ class TestPlacementControllerStruts:
         geom = SimpleNamespace(x=100, y=50, width=1280, height=720)
         monitor = SimpleNamespace(get_geometry=lambda: geom)
         window = _make_window(
-            config=SimpleNamespace(hide_mode="autohide", pos=Position.RIGHT)
+            config=SimpleNamespace(hide_mode="autohide", pos=Position.RIGHT),
+            get_scale_factor=lambda: 1,
         )
         controller = placement_mod.DockPlacementController(window, barrier=barrier)
         controller._resolve_target_monitor = MagicMock(return_value=monitor)
@@ -632,7 +636,95 @@ class TestPlacementControllerStruts:
             monitor_y=50,
             monitor_w=1280,
             monitor_h=720,
+            scale=1,
         )
+
+    def test_update_barrier_delivers_physical_coords_to_xfixes_on_hidpi(
+        self, monkeypatch
+    ):
+        """Issue #76 regression.
+
+        Scenario: bottom dock, 4K monitor at scale_factor=2.
+        Gdk reports monitor geometry as logical (0, 0, 1920, 1080) but X11's
+        root window is 3840x2160 physical. XFixesCreatePointerBarrier operates
+        in physical pixels (root-window space). If logical coords leak into
+        XFixes, the BOTTOM barrier lands at physical y=1080 -- the middle of
+        the 2160 physical screen -- which the user sees at logical y=540
+        (the reported "invisible mouse-blocking line at the midpoint")."""
+        import ctypes
+
+        from docking.platform.barriers import PointerBarrier
+
+        xlib = MagicMock()
+        xlib.XDefaultRootWindow.return_value = 1
+        xfixes = MagicMock()
+        xfixes.XFixesCreatePointerBarrier.return_value = 42
+        real_barrier = PointerBarrier()
+        real_barrier._supported = True
+        real_barrier._libs = (xlib, xfixes, MagicMock())
+        real_barrier._xdisplay = ctypes.c_void_p(99)
+
+        geom = SimpleNamespace(x=0, y=0, width=1920, height=1080)
+        monitor = SimpleNamespace(get_geometry=lambda: geom)
+        window = _make_window(
+            config=SimpleNamespace(hide_mode="autohide", pos=Position.BOTTOM),
+            get_scale_factor=lambda: 2,
+        )
+        controller = placement_mod.DockPlacementController(window, barrier=real_barrier)
+        controller._resolve_target_monitor = MagicMock(return_value=monitor)
+
+        controller.update_barrier()
+
+        x1, y1, x2, y2 = xfixes.XFixesCreatePointerBarrier.call_args.args[2:6]
+        assert (x1, y1, x2, y2) == (0, 2160, 3840, 2160), (
+            f"XFixes received {(x1, y1, x2, y2)} for a 1920x1080 logical "
+            "monitor at scale=2; expected physical (0, 2160, 3840, 2160). "
+            "Logical coords leaking into XFixes is the root cause of "
+            "issue #76 (midpoint mouse-blocking line on HiDPI)."
+        )
+
+    @pytest.mark.parametrize(
+        "scale,physical_w,physical_h",
+        [
+            (1, 1920, 1080),  # baseline: no scaling, no bug
+            (2, 3840, 2160),  # reported scenario: 200% scaling
+            (3, 5760, 3240),  # reported scenario: 300% scaling
+        ],
+    )
+    def test_update_barrier_scales_with_display_scale_factor(
+        self, scale, physical_w, physical_h, monkeypatch
+    ):
+        """Cross-scale check of the hypothesis.
+
+        At scale=1 the bug is absent (logical == physical). At scale=2 and
+        scale=3 the barrier coords must scale with the display, mirroring
+        how struts.py already handles physical-pixel X11 properties."""
+        import ctypes
+
+        from docking.platform.barriers import PointerBarrier
+
+        xlib = MagicMock()
+        xlib.XDefaultRootWindow.return_value = 1
+        xfixes = MagicMock()
+        xfixes.XFixesCreatePointerBarrier.return_value = 42
+        real_barrier = PointerBarrier()
+        real_barrier._supported = True
+        real_barrier._libs = (xlib, xfixes, MagicMock())
+        real_barrier._xdisplay = ctypes.c_void_p(99)
+
+        geom = SimpleNamespace(x=0, y=0, width=1920, height=1080)
+        monitor = SimpleNamespace(get_geometry=lambda: geom)
+        window = _make_window(
+            config=SimpleNamespace(hide_mode="autohide", pos=Position.BOTTOM),
+            get_scale_factor=lambda: scale,
+        )
+        controller = placement_mod.DockPlacementController(window, barrier=real_barrier)
+        controller._resolve_target_monitor = MagicMock(return_value=monitor)
+
+        controller.update_barrier()
+
+        x1, y1, x2, y2 = xfixes.XFixesCreatePointerBarrier.call_args.args[2:6]
+        assert (x1, y1, x2, y2) == (0, physical_h, physical_w, physical_h)
 
     def test_update_struts_refreshes_barrier_and_struts(self):
         controller = placement_mod.DockPlacementController(_make_window())


### PR DESCRIPTION
Fixes pointer barrier placement on HiDPI X11 displays by passing the dock window scale factor into the barrier update path before creating the XFixes barrier. Adds focused regression coverage for the #76 geometry case.