### PR TITLE
Require TLS 1.2 for Cert Watch checks

### DIFF
--- a/docking/applets/certwatch/api.py
+++ b/docking/applets/certwatch/api.py
@@ -94,6 +94,7 @@ def fetch_cert(
     status without crashing a background thread.
     """
     context = ssl.create_default_context()
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
     try:
         with (
             socket.create_connection((host, port), timeout=timeout) as raw,

--- a/tests/applets/test_certwatch.py
+++ b/tests/applets/test_certwatch.py
@@ -749,6 +749,7 @@ class _FakeSslContext:
         self.peer = peer
         self.error = error
         self.server_hostname = ""
+        self.minimum_version = None
 
     def wrap_socket(self, _raw, *, server_hostname: str):
         self.server_hostname = server_hostname
@@ -780,6 +781,7 @@ class TestCertApiFetch:
 
         info = fetch_cert(host="example.com", port=443)
 
+        assert context.minimum_version is certwatch_api.ssl.TLSVersion.TLSv1_2
         assert info.not_after == datetime(
             2026,
             6,


### PR DESCRIPTION
Fixes the CodeQL insecure-protocol alert for Cert Watch by setting the certificate fetch SSL context minimum version to TLS 1.2. The focused Cert Watch test now asserts the TLS floor is applied.