### PR TITLE
Add README project badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # Docking
 
 [![CI](https://github.com/edumucelli/docking/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/edumucelli/docking/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/edumucelli/docking?display_name=tag)](https://github.com/edumucelli/docking/releases)
 [![Coverage](https://codecov.io/gh/edumucelli/docking/branch/master/graph/badge.svg)](https://codecov.io/gh/edumucelli/docking)
-[![Last commit](https://img.shields.io/github/last-commit/edumucelli/docking)](https://github.com/edumucelli/docking/commits/master)
+[![Release](https://img.shields.io/github/v/release/edumucelli/docking?display_name=tag)](https://github.com/edumucelli/docking/releases)
+[![Downloads](https://img.shields.io/github/downloads/edumucelli/docking/total)](https://github.com/edumucelli/docking/releases)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/)
+[![GTK 3](https://img.shields.io/badge/GTK-3-blue)](#requirements)
+[![Platform](https://img.shields.io/badge/platform-Linux-lightgrey)](#requirements)
+[![License](https://img.shields.io/github/license/edumucelli/docking)](LICENSE)
+[![Last commit](https://img.shields.io/github/last-commit/edumucelli/docking)](https://github.com/edumucelli/docking/commits/master)
 
 <img src="images/docking.png" alt="Docking" height="48" style="display:block; margin:0 auto;">
 


### PR DESCRIPTION
Add README badges for the project license, total release downloads, Linux platform support, and GTK 3 runtime.