### PR TITLE
Raise running indicator dot cap

### DIFF
--- a/docking/assets/themes/candy.json
+++ b/docking/assets/themes/candy.json
@@ -22,6 +22,6 @@
   "click_time_ms": 300,
   "hover_lighten": 0.18,
   "active_time_ms": 150,
-  "max_indicator_dots": 3,
+  "max_indicator_dots": 4,
   "glow_opacity": 0.45
 }

--- a/docking/assets/themes/default.json
+++ b/docking/assets/themes/default.json
@@ -19,7 +19,7 @@
   "click_time_ms": 300,
   "hover_lighten": 0.2,
   "active_time_ms": 150,
-  "max_indicator_dots": 3,
+  "max_indicator_dots": 4,
   "glow_opacity": 0.6,
   "indicator_style": "dots",
   "round_bottom": false,

--- a/docking/assets/themes/ember.json
+++ b/docking/assets/themes/ember.json
@@ -19,7 +19,7 @@
   "click_time_ms": 300,
   "hover_lighten": 0.2,
   "active_time_ms": 150,
-  "max_indicator_dots": 3,
+  "max_indicator_dots": 4,
   "glow_opacity": 0.6,
   "indicator_style": "dots",
   "round_bottom": false,

--- a/docking/assets/themes/glass.json
+++ b/docking/assets/themes/glass.json
@@ -22,6 +22,6 @@
   "click_time_ms": 300,
   "hover_lighten": 0.15,
   "active_time_ms": 150,
-  "max_indicator_dots": 3,
+  "max_indicator_dots": 4,
   "glow_opacity": 0.4
 }

--- a/docking/assets/themes/gruvbox.json
+++ b/docking/assets/themes/gruvbox.json
@@ -49,7 +49,7 @@
   "click_time_ms": 300,
   "hover_lighten": 0.2,
   "active_time_ms": 150,
-  "max_indicator_dots": 3,
+  "max_indicator_dots": 4,
   "glow_opacity": 0.6,
   "indicator_style": "dots",
   "round_bottom": false,

--- a/docking/assets/themes/nord.json
+++ b/docking/assets/themes/nord.json
@@ -49,7 +49,7 @@
   "click_time_ms": 300,
   "hover_lighten": 0.2,
   "active_time_ms": 150,
-  "max_indicator_dots": 3,
+  "max_indicator_dots": 4,
   "glow_opacity": 0.6,
   "indicator_style": "dashes",
   "round_bottom": false,

--- a/docking/assets/themes/olive.json
+++ b/docking/assets/themes/olive.json
@@ -19,7 +19,7 @@
   "click_time_ms": 300,
   "hover_lighten": 0.2,
   "active_time_ms": 150,
-  "max_indicator_dots": 3,
+  "max_indicator_dots": 4,
   "glow_opacity": 0.6,
   "indicator_style": "dots",
   "round_bottom": false,

--- a/docking/assets/themes/onyx.json
+++ b/docking/assets/themes/onyx.json
@@ -19,7 +19,7 @@
   "click_time_ms": 300,
   "hover_lighten": 0.2,
   "active_time_ms": 150,
-  "max_indicator_dots": 3,
+  "max_indicator_dots": 4,
   "glow_opacity": 0.6,
   "indicator_style": "dots",
   "round_bottom": false,

--- a/docking/assets/themes/paper.json
+++ b/docking/assets/themes/paper.json
@@ -22,6 +22,6 @@
   "click_time_ms": 300,
   "hover_lighten": 0.12,
   "active_time_ms": 150,
-  "max_indicator_dots": 3,
+  "max_indicator_dots": 4,
   "glow_opacity": 0.35
 }

--- a/docking/assets/themes/pill.json
+++ b/docking/assets/themes/pill.json
@@ -22,6 +22,6 @@
   "click_time_ms": 300,
   "hover_lighten": 0.16,
   "active_time_ms": 150,
-  "max_indicator_dots": 3,
+  "max_indicator_dots": 4,
   "glow_opacity": 0.45
 }

--- a/docking/assets/themes/slate.json
+++ b/docking/assets/themes/slate.json
@@ -22,6 +22,6 @@
   "click_time_ms": 300,
   "hover_lighten": 0.2,
   "active_time_ms": 150,
-  "max_indicator_dots": 3,
+  "max_indicator_dots": 4,
   "glow_opacity": 0.6
 }

--- a/docking/assets/themes/solarized.json
+++ b/docking/assets/themes/solarized.json
@@ -49,7 +49,7 @@
   "click_time_ms": 300,
   "hover_lighten": 0.2,
   "active_time_ms": 150,
-  "max_indicator_dots": 3,
+  "max_indicator_dots": 4,
   "glow_opacity": 0.6,
   "indicator_style": "dots",
   "round_bottom": false,

--- a/docking/assets/themes/transparent.json
+++ b/docking/assets/themes/transparent.json
@@ -19,7 +19,7 @@
   "click_time_ms": 300,
   "hover_lighten": 0.2,
   "active_time_ms": 150,
-  "max_indicator_dots": 3,
+  "max_indicator_dots": 4,
   "glow_opacity": 0.6,
   "indicator_style": "dots",
   "round_bottom": false,

--- a/docking/core/theme.py
+++ b/docking/core/theme.py
@@ -171,7 +171,7 @@ _USER_THEME_TEMPLATE = {
     "click_time_ms": 300,
     "hover_lighten": 0.2,
     "active_time_ms": 150,
-    "max_indicator_dots": 3,
+    "max_indicator_dots": 4,
     "glow_opacity": 0.6,
     "indicator_style": "dots",
     "round_bottom": False,
@@ -265,7 +265,7 @@ class Theme:
     click_time_ms: int = 300  # ms
     hover_lighten: float = 0.2  # 0.0-1.0 additive brightness
     active_time_ms: int = 150  # ms for hover fade in/out
-    max_indicator_dots: int = 3  # max running indicator dots
+    max_indicator_dots: int = 4  # max running indicator dots
     glow_opacity: float = 0.6  # active glow gradient max opacity
     urgent_glow_time_ms: int = 10000  # glow visible for 10s after urgency
     urgent_glow_pulse_ms: int = 2000  # one pulse cycle every 2s
@@ -443,7 +443,7 @@ class Theme:
         click_time_ms = int(data.get("click_time_ms", 300))
         hover_lighten = float(data.get("hover_lighten", 0.2))
         active_time_ms = int(data.get("active_time_ms", 150))
-        max_indicator_dots = int(data.get("max_indicator_dots", 3))
+        max_indicator_dots = int(data.get("max_indicator_dots", 4))
         glow_opacity = float(data.get("glow_opacity", 0.6))
         urgent_glow_time_ms = int(data.get("urgent_glow_time_ms", 10000))
         urgent_glow_pulse_ms = int(data.get("urgent_glow_pulse_ms", 2000))

--- a/tests/core/test_theme.py
+++ b/tests/core/test_theme.py
@@ -296,7 +296,7 @@ class TestAnimationParams:
     def test_default_visual_params(self):
         t = Theme.load("default", 48)
         assert t.hover_lighten == pytest.approx(0.2)
-        assert t.max_indicator_dots == 3
+        assert t.max_indicator_dots == 4
         assert t.glow_opacity == pytest.approx(0.6)
 
     def test_animation_params_same_at_different_icon_sizes(self):
@@ -322,7 +322,7 @@ class TestAnimationParams:
         assert t.launch_bounce_height == pytest.approx(0.625)
         assert t.click_time_ms == 300
         assert t.hover_lighten == pytest.approx(0.2)
-        assert t.max_indicator_dots == 3
+        assert t.max_indicator_dots == 4
         assert t.glow_opacity == pytest.approx(0.6)
 
 


### PR DESCRIPTION
Raises the running-app indicator cap from three dots to four across the default theme settings and built-in themes, so applications with four or more open windows can show a fourth indicator dot.