### PR TITLE
Snap count badge geometry to pixels

### DIFF
--- a/docking/ui/overlays.py
+++ b/docking/ui/overlays.py
@@ -23,6 +23,25 @@ from docking.applets.draw import rounded_rect
 from docking.core.theme import RGB, RGBA
 
 
+def _snap_badge_rect(
+    *,
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+) -> tuple[float, float, float, float]:
+    snapped_width = float(max(1, round(width)))
+    snapped_height = float(max(1, round(height)))
+    center_x = x + width / 2.0
+    center_y = y + height / 2.0
+    return (
+        float(round(center_x - snapped_width / 2.0)),
+        float(round(center_y - snapped_height / 2.0)),
+        snapped_width,
+        snapped_height,
+    )
+
+
 def draw_circle_badge(
     *,
     cr: cairo.Context,
@@ -58,6 +77,12 @@ def draw_count_badge(
     font_family: str = "Sans",
 ) -> None:
     """Draw a rounded count badge with centered text."""
+    x, y, width, height = _snap_badge_rect(
+        x=x,
+        y=y,
+        width=width,
+        height=height,
+    )
     text = "99+" if badge_count > 99 else str(badge_count)
     corner = min(height / 2, max(height * 0.35, 4.0))
 

--- a/tests/ui/test_overlays.py
+++ b/tests/ui/test_overlays.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import cairo
 
-from docking.ui.overlays import draw_circle_badge, draw_count_badge, draw_progress_bar
+import docking.ui.overlays as overlays_mod
+from docking.ui.overlays import (
+    _snap_badge_rect,
+    draw_circle_badge,
+    draw_count_badge,
+    draw_progress_bar,
+)
 
 
 def _context(size: int = 64) -> tuple[cairo.ImageSurface, cairo.Context]:
@@ -47,6 +53,33 @@ def test_draw_count_badge_supports_all_label_lengths():
     draw_count_badge(cr=cr, x=2, y=28, width=28, height=16, badge_count=120)
 
     assert _non_empty(surface)
+
+
+def test_snap_badge_rect_keeps_badges_on_whole_pixels():
+    assert _snap_badge_rect(x=10.3, y=4.2, width=18.6, height=15.6) == (
+        10.0,
+        4.0,
+        19.0,
+        16.0,
+    )
+
+
+def test_draw_count_badge_uses_snapped_geometry(monkeypatch):
+    _, cr = _context()
+    calls = []
+
+    monkeypatch.setattr(
+        overlays_mod,
+        "rounded_rect",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    draw_count_badge(cr=cr, x=10.3, y=4.2, width=18.6, height=15.6, badge_count=7)
+
+    assert calls[0]["x"] == 10.0
+    assert calls[0]["y"] == 4.0
+    assert calls[0]["width"] == 19.0
+    assert calls[0]["height"] == 16.0
 
 
 def test_draw_progress_bar_clamps_and_switches_dark_fill():


### PR DESCRIPTION
Snap existing icon count badge rectangles to whole pixels before drawing so their rounded shape and centered text share the same pixel grid. This keeps the existing font ascent/descent centering but avoids fractional badge geometry that can make badges look slightly off by one pixel.