### PR TITLE
Use relative freshness update labels

### DIFF
--- a/docking/applets/certwatch/state.py
+++ b/docking/applets/certwatch/state.py
@@ -323,6 +323,7 @@ def build_tooltip(
             updated_at=updated_at,
             cadence_seconds=cadence_seconds,
             cadence_verb=_("Checks"),
+            now=now,
         ),
         error=live_state_error(status=status, error=error),
         recovery=refresh_recovery_label(status),

--- a/docking/applets/freshness.py
+++ b/docking/applets/freshness.py
@@ -49,12 +49,35 @@ def on_demand_label(*, verb: str | None = None) -> str:
     return _("{verb} on demand").format(verb=verb or _("Updates"))
 
 
-def updated_label(timestamp: dt.datetime | str | None) -> str:
-    """Return a local-time updated label, or an empty string when unknown."""
+def updated_label(
+    timestamp: dt.datetime | str | None,
+    *,
+    now: dt.datetime | None = None,
+) -> str:
+    """Return a relative updated label, or an empty string when unknown."""
+    age = relative_time_label(timestamp=timestamp, now=now)
+    if not age:
+        return ""
+    return _("Updated: {age}").format(age=age)
+
+
+def relative_time_label(
+    timestamp: dt.datetime | str | None,
+    *,
+    now: dt.datetime | None = None,
+) -> str:
+    """Return a human relative age such as "5 minutes ago"."""
     parsed = parse_timestamp(timestamp)
     if parsed is None:
         return ""
-    return _("Updated: {time}").format(time=format_local_time(parsed))
+    reference = now or dt.datetime.now(dt.timezone.utc)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=dt.timezone.utc)
+    elapsed = reference.astimezone(dt.timezone.utc) - parsed.astimezone(dt.timezone.utc)
+    elapsed_seconds = max(0, int(elapsed.total_seconds()))
+    if elapsed_seconds == 0:
+        return _("just now")
+    return _("{age} ago").format(age=_format_relative_interval(elapsed_seconds))
 
 
 def parse_timestamp(timestamp: dt.datetime | str | None) -> dt.datetime | None:
@@ -81,3 +104,25 @@ def format_local_time(timestamp: dt.datetime) -> str:
     if timestamp.tzinfo is None:
         timestamp = timestamp.replace(tzinfo=dt.timezone.utc)
     return timestamp.astimezone().strftime("%Y-%m-%d %H:%M")
+
+
+def _format_relative_interval(seconds: int) -> str:
+    seconds = max(0, int(seconds))
+    if seconds < 60:
+        return (
+            _("1 second")
+            if seconds == 1
+            else _("{count} seconds").format(count=seconds)
+        )
+    minutes = seconds // 60
+    if minutes < 60:
+        return (
+            _("1 minute")
+            if minutes == 1
+            else _("{count} minutes").format(count=minutes)
+        )
+    hours = minutes // 60
+    if hours < 24:
+        return _("1 hour") if hours == 1 else _("{count} hours").format(count=hours)
+    days = hours // 24
+    return _("1 day") if days == 1 else _("{count} days").format(count=days)

--- a/docking/applets/live_state.py
+++ b/docking/applets/live_state.py
@@ -20,8 +20,8 @@ from enum import Enum
 
 from docking.applets.freshness import (
     cadence_label,
-    format_local_time,
     parse_timestamp,
+    relative_time_label,
     updated_label,
 )
 from docking.i18n import _
@@ -109,13 +109,14 @@ def live_freshness_lines(
     updated_at: dt.datetime | str | None = None,
     cadence_seconds: int | None = None,
     cadence_verb: str | None = None,
+    now: dt.datetime | None = None,
 ) -> tuple[str, ...]:
     """Build standard freshness/cadence lines for structured tooltips."""
     lines: list[str] = []
     if status is LiveDataStatus.STALE:
-        lines.append(stale_label(updated_at))
+        lines.append(stale_label(updated_at, now=now))
     else:
-        updated = updated_label(updated_at)
+        updated = updated_label(updated_at, now=now)
         if updated:
             lines.append(updated)
     if cadence_seconds:
@@ -123,12 +124,16 @@ def live_freshness_lines(
     return tuple(line for line in lines if line)
 
 
-def stale_label(updated_at: dt.datetime | str | None = None) -> str:
+def stale_label(
+    updated_at: dt.datetime | str | None = None,
+    *,
+    now: dt.datetime | None = None,
+) -> str:
     """Return a standard stale-data line, with last update when known."""
-    parsed = parse_timestamp(updated_at)
-    if parsed is None:
+    age = relative_time_label(timestamp=updated_at, now=now)
+    if not age:
         return _("Stale data")
-    return _("Stale: last updated {time}").format(time=format_local_time(parsed))
+    return _("Stale: last updated {age}").format(age=age)
 
 
 def refresh_recovery_label(status: LiveDataStatus) -> str | None:

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-05-17 00:29+0200\n"
+"POT-Creation-Date: 2026-05-19 20:58+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,2603 +18,2625 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: docking/applets/aiusage/applet.py:62
+#: docking/applets/aiusage/applet.py:75
 msgid "AI Usage"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:126
+#: docking/applets/aiusage/applet.py:139
 msgid "Auto"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:127
+#: docking/applets/aiusage/applet.py:140
 msgid "Claude"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:128
+#: docking/applets/aiusage/applet.py:141
 msgid "Codex"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:129
+#: docking/applets/aiusage/applet.py:142
 msgid "OpenCode"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:138
+#: docking/applets/aiusage/applet.py:151
 msgid "Show Cost"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:139
+#: docking/applets/aiusage/applet.py:152
 msgid "Show Tokens"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:146
-#: docking/applets/deskpresence/applet.py:103
+#: docking/applets/aiusage/applet.py:159
+#: docking/applets/deskpresence/applet.py:116
 msgid "Reset Today"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:207 docking/applets/aiusage/applet.py:222
+#: docking/applets/aiusage/applet.py:220 docking/applets/aiusage/applet.py:235
 #, python-brace-format
 msgid "{name}: no usage today"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:239
+#: docking/applets/aiusage/applet.py:252
 #, python-brace-format
 msgid "<b>{name}: {value}</b>"
 msgstr ""
 
-#: docking/applets/aiusage/applet.py:283
+#: docking/applets/aiusage/applet.py:296
 #, python-brace-format
 msgid "This week: {value}"
 msgstr ""
 
-#: docking/applets/aiusage/state.py:459
+#: docking/applets/aiusage/state.py:472
 msgid "no usage today"
 msgstr ""
 
-#: docking/applets/aiusage/state.py:463
+#: docking/applets/aiusage/state.py:476
 #, python-brace-format
 msgid "Today: {cost}"
 msgstr ""
 
-#: docking/applets/alarm/applet.py:54
+#: docking/applets/alarm/applet.py:67
 msgid "Alarm"
 msgstr ""
 
-#: docking/applets/alarm/applet.py:91 docking/applets/alarm/applet.py:199
+#: docking/applets/alarm/applet.py:104 docking/applets/alarm/applet.py:208
 msgid "Snooze"
 msgstr ""
 
-#: docking/applets/alarm/applet.py:93
+#: docking/applets/alarm/applet.py:106
 msgid "Dismiss"
 msgstr ""
 
-#: docking/applets/alarm/applet.py:97
+#: docking/applets/alarm/applet.py:110
 msgid "Add Alarm..."
 msgstr ""
 
-#: docking/applets/alarm/applet.py:119
+#: docking/applets/alarm/applet.py:132
 #, python-brace-format
 msgid "Edit {label}..."
 msgstr ""
 
-#: docking/applets/alarm/applet.py:147
+#: docking/applets/alarm/applet.py:160
 msgid "Edit Alarm"
 msgstr ""
 
-#: docking/applets/alarm/applet.py:147
+#: docking/applets/alarm/applet.py:160
 msgid "Add Alarm"
 msgstr ""
 
-#: docking/applets/alarm/applet.py:150 docking/applets/certwatch/state.py:233
-#: docking/applets/clock/applet.py:205 docking/applets/quicknote/applet.py:74
+#: docking/applets/alarm/applet.py:163 docking/applets/certwatch/state.py:246
+#: docking/applets/clock/applet.py:218 docking/applets/quicknote/applet.py:87
 msgid "OK"
 msgstr ""
 
-#: docking/applets/alarm/applet.py:150 docking/applets/clock/applet.py:205
-#: docking/applets/quicknote/applet.py:73 docking/applets/sunrise/applet.py:175
-#: docking/applets/trash/applet.py:114 docking/applets/weather/applet.py:258
+#: docking/applets/alarm/applet.py:163 docking/applets/clock/applet.py:218
+#: docking/applets/quicknote/applet.py:86 docking/applets/sunrise/applet.py:188
+#: docking/applets/trash/applet.py:127 docking/applets/weather/applet.py:271
 msgid "Cancel"
 msgstr ""
 
-#: docking/applets/alarm/applet.py:152 docking/applets/certwatch/applet.py:157
+#: docking/applets/alarm/applet.py:165 docking/applets/certwatch/applet.py:170
 msgid "Remove"
 msgstr ""
 
-#: docking/applets/alarm/applet.py:180
+#: docking/applets/alarm/applet.py:189
 msgid "Enabled"
 msgstr ""
 
-#: docking/applets/alarm/applet.py:193
+#: docking/applets/alarm/applet.py:202
 msgid "Label"
 msgstr ""
 
-#: docking/applets/alarm/applet.py:195 docking/applets/clock/applet.py:242
+#: docking/applets/alarm/applet.py:204 docking/applets/clock/applet.py:255
 msgid "Hour"
 msgstr ""
 
-#: docking/applets/alarm/applet.py:197 docking/applets/clock/applet.py:244
+#: docking/applets/alarm/applet.py:206 docking/applets/clock/applet.py:257
 msgid "Minute"
 msgstr ""
 
-#: docking/applets/alarm/applet.py:202
+#: docking/applets/alarm/applet.py:211
 msgid "Repeat"
 msgstr ""
 
-#: docking/applets/alarm/state.py:17
+#: docking/applets/alarm/state.py:30
 msgid "Mon"
 msgstr ""
 
-#: docking/applets/alarm/state.py:18
+#: docking/applets/alarm/state.py:31
 msgid "Tue"
 msgstr ""
 
-#: docking/applets/alarm/state.py:19
+#: docking/applets/alarm/state.py:32
 msgid "Wed"
 msgstr ""
 
-#: docking/applets/alarm/state.py:20
+#: docking/applets/alarm/state.py:33
 msgid "Thu"
 msgstr ""
 
-#: docking/applets/alarm/state.py:21
+#: docking/applets/alarm/state.py:34
 msgid "Fri"
 msgstr ""
 
-#: docking/applets/alarm/state.py:22
+#: docking/applets/alarm/state.py:35
 msgid "Sat"
 msgstr ""
 
-#: docking/applets/alarm/state.py:23
+#: docking/applets/alarm/state.py:36
 msgid "Sun"
 msgstr ""
 
-#: docking/applets/alarm/state.py:204
+#: docking/applets/alarm/state.py:217
 msgid "Ring"
-msgstr ""
-
-#: docking/applets/alarm/state.py:213
-#, python-brace-format
-msgid "{hours}h"
-msgstr ""
-
-#: docking/applets/alarm/state.py:214 docking/applets/alarm/state.py:293
-#: docking/applets/battery/state.py:131 docking/applets/sunrise/state.py:404
-#, python-brace-format
-msgid "{minutes}m"
-msgstr ""
-
-#: docking/applets/alarm/state.py:222
-#, python-brace-format
-msgid "Alarm ringing: {label}"
-msgstr ""
-
-#: docking/applets/alarm/state.py:225
-msgid "Alarm: no enabled alarms"
 msgstr ""
 
 #: docking/applets/alarm/state.py:226
 #, python-brace-format
-msgid "Next alarm: {label} at {time}"
+msgid "{hours}h"
+msgstr ""
+
+#: docking/applets/alarm/state.py:227 docking/applets/alarm/state.py:306
+#: docking/applets/battery/state.py:144 docking/applets/sunrise/state.py:417
+#, python-brace-format
+msgid "{minutes}m"
+msgstr ""
+
+#: docking/applets/alarm/state.py:235
+#, python-brace-format
+msgid "Alarm ringing: {label}"
 msgstr ""
 
 #: docking/applets/alarm/state.py:238
-msgid "No enabled alarms"
+msgid "Alarm: no enabled alarms"
 msgstr ""
 
 #: docking/applets/alarm/state.py:239
 #, python-brace-format
+msgid "Next alarm: {label} at {time}"
+msgstr ""
+
+#: docking/applets/alarm/state.py:251
+msgid "No enabled alarms"
+msgstr ""
+
+#: docking/applets/alarm/state.py:252
+#, python-brace-format
 msgid "{label}: {time} ({duration})"
 msgstr ""
 
-#: docking/applets/alarm/state.py:249
+#: docking/applets/alarm/state.py:262
 msgid "on"
 msgstr ""
 
-#: docking/applets/alarm/state.py:249
+#: docking/applets/alarm/state.py:262
 msgid "off"
 msgstr ""
 
-#: docking/applets/alarm/state.py:250
+#: docking/applets/alarm/state.py:263
 #, python-brace-format
 msgid "{time} {label} - {repeat}, {state}"
 msgstr ""
 
-#: docking/applets/alarm/state.py:262
+#: docking/applets/alarm/state.py:275
 msgid "once"
 msgstr ""
 
-#: docking/applets/alarm/state.py:264
+#: docking/applets/alarm/state.py:277
 msgid "weekdays"
 msgstr ""
 
-#: docking/applets/alarm/state.py:266
+#: docking/applets/alarm/state.py:279
 msgid "weekends"
 msgstr ""
 
-#: docking/applets/alarm/state.py:268
+#: docking/applets/alarm/state.py:281
 msgid "daily"
 msgstr ""
 
-#: docking/applets/alarm/state.py:290
+#: docking/applets/alarm/state.py:303
 #, python-brace-format
 msgid "{days}d {hours}h"
 msgstr ""
 
-#: docking/applets/alarm/state.py:292 docking/applets/sunrise/state.py:403
+#: docking/applets/alarm/state.py:305 docking/applets/sunrise/state.py:416
 #, python-brace-format
 msgid "{hours}h {minutes}m"
 msgstr ""
 
-#: docking/applets/ambient/applet.py:66 docking/applets/ambient/state.py:87
+#: docking/applets/ambient/applet.py:79 docking/applets/ambient/state.py:100
 msgid "Ambient"
 msgstr ""
 
-#: docking/applets/ambient/state.py:24
+#: docking/applets/ambient/state.py:37
 msgid "Birds"
 msgstr ""
 
-#: docking/applets/ambient/state.py:25
+#: docking/applets/ambient/state.py:38
 msgid "Boat"
 msgstr ""
 
-#: docking/applets/ambient/state.py:26
+#: docking/applets/ambient/state.py:39
 msgid "Coffee Shop"
 msgstr ""
 
-#: docking/applets/ambient/state.py:27
+#: docking/applets/ambient/state.py:40
 msgid "Fireplace"
 msgstr ""
 
-#: docking/applets/ambient/state.py:28
+#: docking/applets/ambient/state.py:41
 msgid "Stream"
 msgstr ""
 
-#: docking/applets/ambient/state.py:29
+#: docking/applets/ambient/state.py:42
 msgid "Summer Night"
 msgstr ""
 
-#: docking/applets/ambient/state.py:30
+#: docking/applets/ambient/state.py:43
 msgid "Wind"
 msgstr ""
 
-#: docking/applets/ambient/state.py:35
+#: docking/applets/ambient/state.py:48
 msgid "White Noise"
 msgstr ""
 
-#: docking/applets/ambient/state.py:36
+#: docking/applets/ambient/state.py:49
 msgid "Pink Noise"
 msgstr ""
 
-#: docking/applets/ambient/state.py:84
+#: docking/applets/ambient/state.py:97
 #, python-brace-format
 msgid "Playing: {sound} ({pct}%)"
 msgstr ""
 
-#: docking/applets/apod/applet.py:55 docking/applets/apod/state.py:101
-#: docking/applets/apod/state.py:119
+#: docking/applets/apod/applet.py:68 docking/applets/apod/state.py:114
+#: docking/applets/apod/state.py:132
 msgid "Astronomy Picture of the Day"
 msgstr ""
 
-#: docking/applets/apod/applet.py:95
+#: docking/applets/apod/applet.py:108
 #, python-brace-format
 msgid "{date}: {title}"
 msgstr ""
 
-#: docking/applets/apod/applet.py:97
+#: docking/applets/apod/applet.py:110
 msgid "Untitled"
 msgstr ""
 
-#: docking/applets/apod/applet.py:106 docking/applets/apod/state.py:106
-#: docking/applets/apod/state.py:125 docking/applets/certwatch/applet.py:134
-#: docking/applets/certwatch/state.py:312
+#: docking/applets/apod/applet.py:119 docking/applets/apod/state.py:119
+#: docking/applets/apod/state.py:138 docking/applets/certwatch/applet.py:147
+#: docking/applets/certwatch/state.py:325
 msgid "Checks"
 msgstr ""
 
-#: docking/applets/apod/applet.py:118 docking/applets/certwatch/applet.py:128
-#: docking/applets/currencyfx/applet.py:187
-#: docking/applets/hackernews/applet.py:175
-#: docking/applets/speedtest/applet.py:103
-#: docking/applets/thermals/applet.py:134 docking/applets/tooltip.py:33
-#: docking/applets/weather/applet.py:168 docking/applets/weather/applet.py:525
+#: docking/applets/apod/applet.py:131 docking/applets/certwatch/applet.py:141
+#: docking/applets/currencyfx/applet.py:200
+#: docking/applets/hackernews/applet.py:188
+#: docking/applets/speedtest/applet.py:116
+#: docking/applets/thermals/applet.py:147 docking/applets/tooltip.py:46
+#: docking/applets/weather/applet.py:181 docking/applets/weather/applet.py:538
 #, python-brace-format
 msgid "Error: {msg}"
 msgstr ""
 
-#: docking/applets/apod/applet.py:121
+#: docking/applets/apod/applet.py:134
 msgid "Open on apod.nasa.gov"
 msgstr ""
 
-#: docking/applets/apod/applet.py:126
+#: docking/applets/apod/applet.py:139
 msgid "Copy Explanation"
 msgstr ""
 
-#: docking/applets/apod/applet.py:130 docking/applets/bluetooth/applet.py:204
-#: docking/applets/camshield/applet.py:114
-#: docking/applets/capslock/applet.py:84
-#: docking/applets/certwatch/applet.py:145
-#: docking/applets/currencyfx/applet.py:195
-#: docking/applets/hackernews/applet.py:192
-#: docking/applets/micshield/applet.py:118 docking/applets/moon/applet.py:124
-#: docking/applets/quote/applet.py:92 docking/applets/thermals/applet.py:144
-#: docking/applets/todayinhistory/applet.py:99
-#: docking/applets/trivia/applet.py:115 docking/applets/weather/applet.py:175
+#: docking/applets/apod/applet.py:143 docking/applets/bluetooth/applet.py:217
+#: docking/applets/camshield/applet.py:127
+#: docking/applets/capslock/applet.py:97
+#: docking/applets/certwatch/applet.py:158
+#: docking/applets/currencyfx/applet.py:208
+#: docking/applets/hackernews/applet.py:205
+#: docking/applets/micshield/applet.py:131 docking/applets/moon/applet.py:137
+#: docking/applets/quote/applet.py:105 docking/applets/thermals/applet.py:157
+#: docking/applets/todayinhistory/applet.py:112
+#: docking/applets/trivia/applet.py:128 docking/applets/weather/applet.py:188
 msgid "Refresh Now"
 msgstr ""
 
-#: docking/applets/apod/state.py:115
+#: docking/applets/apod/state.py:128
 #, python-brace-format
 msgid "(c) {who}"
 msgstr ""
 
-#: docking/applets/applications/applet.py:36
+#: docking/applets/applications/applet.py:49
 msgid "Applications"
 msgstr ""
 
-#: docking/applets/applications/applet.py:77
+#: docking/applets/applications/applet.py:90
 msgid "Search applications..."
 msgstr ""
 
-#: docking/applets/battery/applet.py:35
+#: docking/applets/battery/applet.py:48
 msgid "Battery"
 msgstr ""
 
-#: docking/applets/battery/applet.py:72
+#: docking/applets/battery/applet.py:85
 msgid "Show Percent"
 msgstr ""
 
-#: docking/applets/battery/applet.py:79
+#: docking/applets/battery/applet.py:92
 msgid "Power Settings"
 msgstr ""
 
-#: docking/applets/battery/state.py:104
+#: docking/applets/battery/state.py:117
 msgid "No battery"
-msgstr ""
-
-#: docking/applets/battery/state.py:105
-#, python-brace-format
-msgid "Battery: {pct}%"
 msgstr ""
 
 #: docking/applets/battery/state.py:118
 #, python-brace-format
+msgid "Battery: {pct}%"
+msgstr ""
+
+#: docking/applets/battery/state.py:131
+#, python-brace-format
 msgid "{time} left"
 msgstr ""
 
-#: docking/applets/battery/state.py:120
+#: docking/applets/battery/state.py:133
 #, python-brace-format
 msgid "{time} until full"
 msgstr ""
 
-#: docking/applets/battery/state.py:130
+#: docking/applets/battery/state.py:143
 #, python-brace-format
 msgid "{hours}h {minutes:02d}m"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:68
+#: docking/applets/bluetooth/applet.py:81
 msgid "Bluetooth"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:168
+#: docking/applets/bluetooth/applet.py:181
 msgid "Bluetooth unavailable"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:172
+#: docking/applets/bluetooth/applet.py:185
 msgid "No Bluetooth adapter"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:174
-#: docking/applets/bluetooth/state.py:142 docking/applets/capslock/state.py:99
+#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/state.py:155 docking/applets/capslock/state.py:112
 msgid "On"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:174
-#: docking/applets/bluetooth/state.py:142 docking/applets/capslock/state.py:99
+#: docking/applets/bluetooth/applet.py:187
+#: docking/applets/bluetooth/state.py:155 docking/applets/capslock/state.py:112
 msgid "Off"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:183
+#: docking/applets/bluetooth/applet.py:196
 #, python-brace-format
 msgid "{alias} ({powered}) - Connected {connected}"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:194
+#: docking/applets/bluetooth/applet.py:207
 msgid "Continuous Discovery"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:226
+#: docking/applets/bluetooth/applet.py:239
 msgid "Turn Bluetooth Off"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:226
+#: docking/applets/bluetooth/applet.py:239
 msgid "Turn Bluetooth On"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:242
+#: docking/applets/bluetooth/applet.py:255
 #, python-brace-format
 msgid "Disconnect {device}"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:256
+#: docking/applets/bluetooth/applet.py:269
 msgid "Send Files to Device..."
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:264
+#: docking/applets/bluetooth/applet.py:277
 msgid "Devices..."
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:270
+#: docking/applets/bluetooth/applet.py:283
 msgid "Adapters..."
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:276
+#: docking/applets/bluetooth/applet.py:289
 msgid "Local Services..."
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:283
+#: docking/applets/bluetooth/applet.py:296
 msgid "Recent Connections"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:288
+#: docking/applets/bluetooth/applet.py:301
 msgid "No recent connections"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:312
+#: docking/applets/bluetooth/applet.py:325
 msgid "Adapter"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:330
+#: docking/applets/bluetooth/applet.py:343
 msgid "Connected Devices"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:331
+#: docking/applets/bluetooth/applet.py:344
 msgid "Paired Devices"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:332
+#: docking/applets/bluetooth/applet.py:345
 msgid "Discovered Devices"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:357
+#: docking/applets/bluetooth/applet.py:370
 msgid "Disconnect"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:366
+#: docking/applets/bluetooth/applet.py:379
 msgid "Connect"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:376
+#: docking/applets/bluetooth/applet.py:389
 msgid "Pair"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:390
+#: docking/applets/bluetooth/applet.py:403
 msgid "Remove Pairing"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:402
+#: docking/applets/bluetooth/applet.py:415
 msgid "Trusted"
 msgstr ""
 
-#: docking/applets/bluetooth/applet.py:417
+#: docking/applets/bluetooth/applet.py:430
 #, python-brace-format
 msgid "Battery: {percent}%"
 msgstr ""
 
-#: docking/applets/bluetooth/state.py:135
+#: docking/applets/bluetooth/state.py:148
 #, python-brace-format
 msgid "Bluetooth: {error}"
 msgstr ""
 
-#: docking/applets/bluetooth/state.py:136
-#: docking/applets/bluetooth/state.py:140
+#: docking/applets/bluetooth/state.py:149
+#: docking/applets/bluetooth/state.py:153
 msgid "Bluetooth: No adapter/service"
 msgstr ""
 
-#: docking/applets/bluetooth/state.py:147
+#: docking/applets/bluetooth/state.py:160
 #, python-brace-format
 msgid "Bluetooth: {state}"
 msgstr ""
 
-#: docking/applets/bluetooth/state.py:148
+#: docking/applets/bluetooth/state.py:161
 #, python-brace-format
 msgid "Adapter: {name}"
 msgstr ""
 
-#: docking/applets/bluetooth/state.py:149
+#: docking/applets/bluetooth/state.py:162
 #, python-brace-format
 msgid "Connected: {n}"
 msgstr ""
 
-#: docking/applets/bluetooth/state.py:150
+#: docking/applets/bluetooth/state.py:163
 #, python-brace-format
 msgid "Paired: {n}"
 msgstr ""
 
-#: docking/applets/bluetooth/state.py:151
+#: docking/applets/bluetooth/state.py:164
 #, python-brace-format
 msgid "Discovering: {state}"
 msgstr ""
 
-#: docking/applets/bluetooth/state.py:152
+#: docking/applets/bluetooth/state.py:165
 msgid "Yes"
 msgstr ""
 
-#: docking/applets/bluetooth/state.py:152
+#: docking/applets/bluetooth/state.py:165
 msgid "No"
 msgstr ""
 
-#: docking/applets/bookmarks/applet.py:42
+#: docking/applets/bookmarks/applet.py:55
 msgid "Bookmarks"
 msgstr ""
 
-#: docking/applets/bookmarks/applet.py:74
+#: docking/applets/bookmarks/applet.py:87
 msgid "Add Bookmark..."
 msgstr ""
 
-#: docking/applets/bookmarks/applet.py:77
+#: docking/applets/bookmarks/applet.py:90
 msgid "Remove All"
 msgstr ""
 
-#: docking/applets/bookmarks/applet.py:98
+#: docking/applets/bookmarks/applet.py:111
 msgid "Add Bookmark"
 msgstr ""
 
-#: docking/applets/bookmarks/applet.py:111
+#: docking/applets/bookmarks/applet.py:124
 msgid "Bookmark name"
 msgstr ""
 
-#: docking/applets/bookmarks/applet.py:116
+#: docking/applets/bookmarks/applet.py:129
 msgid "https://..."
 msgstr ""
 
-#: docking/applets/brightness/applet.py:43
+#: docking/applets/brightness/applet.py:56
 msgid "Brightness"
 msgstr ""
 
-#: docking/applets/brightness/applet.py:72
+#: docking/applets/brightness/applet.py:85
 #, python-brace-format
 msgid "Brightness: {pct}%"
 msgstr ""
 
-#: docking/applets/brightness/applet.py:96 docking/applets/volume/applet.py:113
+#: docking/applets/brightness/applet.py:109
+#: docking/applets/volume/applet.py:126
 msgid "Show Level"
 msgstr ""
 
-#: docking/applets/calculator/applet.py:64
-#: docking/applets/calculator/applet.py:82
+#: docking/applets/calculator/applet.py:77
+#: docking/applets/calculator/applet.py:95
 msgid "Calculator"
 msgstr ""
 
-#: docking/applets/calendar/applet.py:33 docking/applets/calendar/applet.py:39
+#: docking/applets/calendar/applet.py:46 docking/applets/calendar/applet.py:52
 msgid "Calendar"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:49 docking/applets/camshield/state.py:58
+#: docking/applets/camshield/applet.py:62 docking/applets/camshield/state.py:71
 msgid "Cam Shield"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:93 docking/applets/camshield/state.py:60
+#: docking/applets/camshield/applet.py:106
+#: docking/applets/camshield/state.py:73
 msgid "No camera devices found"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:95 docking/applets/camshield/state.py:64
+#: docking/applets/camshield/applet.py:108
+#: docking/applets/camshield/state.py:77
 msgid "Camera idle"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:97 docking/applets/camshield/state.py:67
+#: docking/applets/camshield/applet.py:110
+#: docking/applets/camshield/state.py:80
 msgid "Camera active"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:101
+#: docking/applets/camshield/applet.py:114
 msgid "Lock Camera"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:105
+#: docking/applets/camshield/applet.py:118
 msgid "Unlock Camera"
 msgstr ""
 
-#: docking/applets/camshield/applet.py:111
+#: docking/applets/camshield/applet.py:124
 msgid "Camera lock helper unavailable"
 msgstr ""
 
-#: docking/applets/camshield/state.py:70
+#: docking/applets/camshield/state.py:83
 #, python-brace-format
 msgid "{command} (PID {pid}) using {devices}"
 msgstr ""
 
-#: docking/applets/camshield/state.py:78 docking/applets/micshield/state.py:210
-#: docking/applets/usbwatch/state.py:85
+#: docking/applets/camshield/state.py:91 docking/applets/micshield/state.py:223
+#: docking/applets/usbwatch/state.py:98
 #, python-brace-format
 msgid "{count} more"
 msgstr ""
 
-#: docking/applets/camshield/state.py:84
+#: docking/applets/camshield/state.py:97
 #, python-brace-format
 msgid "{command} (PID {pid}) - {devices}"
 msgstr ""
 
-#: docking/applets/camshield/state.py:179
-#: docking/applets/deskpresence/state.py:171
-#: docking/applets/micshield/state.py:180 docking/applets/music/state.py:82
-#: docking/applets/powerprofiles/state.py:137
+#: docking/applets/camshield/state.py:192
+#: docking/applets/deskpresence/state.py:184
+#: docking/applets/micshield/state.py:193 docking/applets/music/state.py:95
+#: docking/applets/powerprofiles/state.py:150
 msgid "Unknown"
 msgstr ""
 
-#: docking/applets/capslock/applet.py:38 docking/applets/capslock/applet.py:75
-#: docking/applets/capslock/state.py:86
+#: docking/applets/capslock/applet.py:51 docking/applets/capslock/applet.py:88
+#: docking/applets/capslock/state.py:99
 msgid "Caps Lock"
 msgstr ""
 
-#: docking/applets/capslock/applet.py:70 docking/applets/capslock/state.py:82
+#: docking/applets/capslock/applet.py:83 docking/applets/capslock/state.py:95
 msgid "Keyboard lock state unavailable"
 msgstr ""
 
-#: docking/applets/capslock/applet.py:80
+#: docking/applets/capslock/applet.py:93
 msgid "Num Lock"
 msgstr ""
 
-#: docking/applets/capslock/state.py:87
+#: docking/applets/capslock/state.py:100
 #, python-brace-format
 msgid "Caps Lock: {state}"
 msgstr ""
 
-#: docking/applets/capslock/state.py:88
+#: docking/applets/capslock/state.py:101
 #, python-brace-format
 msgid "Num Lock: {state}"
 msgstr ""
 
-#: docking/applets/capslock/state.py:95
+#: docking/applets/capslock/state.py:108
 #, python-brace-format
 msgid "{name}: {state}"
 msgstr ""
 
-#: docking/applets/certwatch/applet.py:63
-#: docking/applets/certwatch/state.py:278
-#: docking/applets/certwatch/state.py:306
+#: docking/applets/certwatch/applet.py:76
+#: docking/applets/certwatch/state.py:291
+#: docking/applets/certwatch/state.py:319
 msgid "Cert Watch"
 msgstr ""
 
-#: docking/applets/certwatch/applet.py:117
-#: docking/applets/certwatch/state.py:251
-#: docking/applets/certwatch/state.py:299
+#: docking/applets/certwatch/applet.py:130
+#: docking/applets/certwatch/state.py:264
+#: docking/applets/certwatch/state.py:312
 #, python-brace-format
 msgid "{host}: loading..."
 msgstr ""
 
-#: docking/applets/certwatch/applet.py:139
+#: docking/applets/certwatch/applet.py:152
 msgid "Add Domain..."
 msgstr ""
 
-#: docking/applets/certwatch/applet.py:293
+#: docking/applets/certwatch/applet.py:306
 msgid "Add Domain"
 msgstr ""
 
-#: docking/applets/certwatch/applet.py:306
+#: docking/applets/certwatch/applet.py:319
 msgid "example.com or example.com:8443"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:234
+#: docking/applets/certwatch/state.py:247
 msgid "Warn"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:235
+#: docking/applets/certwatch/state.py:248
 msgid "Critical"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:236
+#: docking/applets/certwatch/state.py:249
 msgid "Expired"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:237
+#: docking/applets/certwatch/state.py:250
 msgid "Error"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:238
-#: docking/applets/speedtest/applet.py:61
+#: docking/applets/certwatch/state.py:251
+#: docking/applets/speedtest/applet.py:74
 msgid "..."
 msgstr ""
 
-#: docking/applets/certwatch/state.py:247
+#: docking/applets/certwatch/state.py:260
 #, python-brace-format
 msgid "{host}: error ({reason})"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:254
+#: docking/applets/certwatch/state.py:267
 #, python-brace-format
 msgid "{host}: unknown"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:256
+#: docking/applets/certwatch/state.py:269
 #, python-brace-format
 msgid "{host}: expired {days}d ago"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:257
+#: docking/applets/certwatch/state.py:270
 #, python-brace-format
 msgid "{host}: {label}, {days}d left"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:279
+#: docking/applets/certwatch/state.py:292
 msgid "No domains configured"
 msgstr ""
 
-#: docking/applets/certwatch/state.py:297
+#: docking/applets/certwatch/state.py:310
 #, python-brace-format
 msgid "{host}: unavailable"
 msgstr ""
 
-#: docking/applets/clippy/applet.py:35
+#: docking/applets/clippy/applet.py:48
 msgid "Clippy"
 msgstr ""
 
-#: docking/applets/clippy/applet.py:95
+#: docking/applets/clippy/applet.py:108
 msgid "Clear"
 msgstr ""
 
-#: docking/applets/clippy/state.py:22
+#: docking/applets/clippy/state.py:35
 msgid "Clippy (empty)"
 msgstr ""
 
-#: docking/applets/clock/applet.py:40
+#: docking/applets/clock/applet.py:53
 msgid "Clock"
 msgstr ""
 
-#: docking/applets/clock/applet.py:87
+#: docking/applets/clock/applet.py:100
 msgid "Digital Clock"
 msgstr ""
 
-#: docking/applets/clock/applet.py:91
+#: docking/applets/clock/applet.py:104
 msgid "24-Hour Clock"
 msgstr ""
 
-#: docking/applets/clock/applet.py:95
+#: docking/applets/clock/applet.py:108
 msgid "Show Date"
 msgstr ""
 
-#: docking/applets/clock/applet.py:100
+#: docking/applets/clock/applet.py:113
 msgid "Show Seconds"
 msgstr ""
 
-#: docking/applets/clock/applet.py:104
+#: docking/applets/clock/applet.py:117
 msgid "Set Alarm..."
 msgstr ""
 
-#: docking/applets/clock/applet.py:110
+#: docking/applets/clock/applet.py:123
 msgid "Clear Alarm"
 msgstr ""
 
-#: docking/applets/clock/applet.py:115
+#: docking/applets/clock/applet.py:128
 msgid "Acknowledge Alarm"
 msgstr ""
 
-#: docking/applets/clock/applet.py:202
+#: docking/applets/clock/applet.py:215
 msgid "Set Alarm"
 msgstr ""
 
-#: docking/applets/colorpicker/applet.py:44
-#: docking/applets/colorpicker/applet.py:75
+#: docking/applets/colorpicker/applet.py:57
+#: docking/applets/colorpicker/applet.py:88
 msgid "Color Picker"
 msgstr ""
 
-#: docking/applets/colorpicker/applet.py:85
+#: docking/applets/colorpicker/applet.py:98
 #, python-brace-format
 msgid "Copy {hex}"
 msgstr ""
 
-#: docking/applets/colorpicker/applet.py:89
+#: docking/applets/colorpicker/applet.py:102
 msgid "Show Hex"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:88
+#: docking/applets/currencyfx/applet.py:101
 msgid "Currency FX"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:173
-#: docking/applets/currencyfx/state.py:726
+#: docking/applets/currencyfx/applet.py:186
+#: docking/applets/currencyfx/state.py:739
 msgid "Day samples"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:191
+#: docking/applets/currencyfx/applet.py:204
 msgid "Swap Pair"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:201
+#: docking/applets/currencyfx/applet.py:214
 msgid "Chart Interval"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:203
-#: docking/applets/sunrise/state.py:369
+#: docking/applets/currencyfx/applet.py:216
+#: docking/applets/sunrise/state.py:382
 msgid "Day"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:204
+#: docking/applets/currencyfx/applet.py:217
 msgid "Week"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:205
+#: docking/applets/currencyfx/applet.py:218
 msgid "Month"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:220
+#: docking/applets/currencyfx/applet.py:233
 msgid "Added Pairs"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:230
+#: docking/applets/currencyfx/applet.py:243
 msgid "Remove Current Pair"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:237
+#: docking/applets/currencyfx/applet.py:250
 msgid "Add Pair..."
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:350
+#: docking/applets/currencyfx/applet.py:363
 msgid "No rate data"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:432
+#: docking/applets/currencyfx/applet.py:445
 #, python-brace-format
 msgid "{pair}: {rate} ({change})"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:475
+#: docking/applets/currencyfx/applet.py:488
 msgid "Add FX Pair"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:489
+#: docking/applets/currencyfx/applet.py:502
 msgid "Base"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:491 docking/applets/quote/applet.py:43
-#: docking/applets/quote/applet.py:83 docking/applets/quote/applet.py:208
-#: docking/applets/quote/applet.py:214
+#: docking/applets/currencyfx/applet.py:504 docking/applets/quote/applet.py:56
+#: docking/applets/quote/applet.py:96 docking/applets/quote/applet.py:221
+#: docking/applets/quote/applet.py:227
 msgid "Quote"
 msgstr ""
 
-#: docking/applets/currencyfx/state.py:730 docking/applets/live_state.py:78
-#: docking/applets/weather/state.py:166
+#: docking/applets/currencyfx/state.py:743 docking/applets/live_state.py:91
+#: docking/applets/weather/state.py:179
 msgid "Unavailable"
 msgstr ""
 
-#: docking/applets/currencyfx/state.py:751
+#: docking/applets/currencyfx/state.py:764
 #, python-brace-format
 msgid "1 {base} = {rate} {quote}"
 msgstr ""
 
-#: docking/applets/currencyfx/state.py:756
+#: docking/applets/currencyfx/state.py:769
 #, python-brace-format
 msgid "Change: {change}"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:52
-#: docking/applets/deskpresence/state.py:192
+#: docking/applets/deskpresence/applet.py:65
+#: docking/applets/deskpresence/state.py:205
 msgid "Desk Presence"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:84
+#: docking/applets/deskpresence/applet.py:97
 #, python-brace-format
 msgid "{status}"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:92
+#: docking/applets/deskpresence/applet.py:105
 msgid "Idle Threshold"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:190
-#: docking/applets/deskpresence/state.py:169
+#: docking/applets/deskpresence/applet.py:203
+#: docking/applets/deskpresence/state.py:182
 msgid "At desk"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:191
-#: docking/applets/deskpresence/state.py:170
+#: docking/applets/deskpresence/applet.py:204
+#: docking/applets/deskpresence/state.py:183
 msgid "Away"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:192
+#: docking/applets/deskpresence/applet.py:205
 msgid "Status unknown"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:199
+#: docking/applets/deskpresence/applet.py:212
 #, python-brace-format
 msgid "{m} min"
 msgstr ""
 
-#: docking/applets/deskpresence/applet.py:200
+#: docking/applets/deskpresence/applet.py:213
 #, python-brace-format
 msgid "{s} sec"
 msgstr ""
 
-#: docking/applets/deskpresence/state.py:151
+#: docking/applets/deskpresence/state.py:164
 #, python-brace-format
 msgid "{h}h {m}m"
 msgstr ""
 
-#: docking/applets/deskpresence/state.py:152
-#: docking/applets/deskpresence/state.py:164
+#: docking/applets/deskpresence/state.py:165
+#: docking/applets/deskpresence/state.py:177
 #, python-brace-format
 msgid "{m}m"
 msgstr ""
 
-#: docking/applets/deskpresence/state.py:163
+#: docking/applets/deskpresence/state.py:176
 #, python-brace-format
 msgid "{h}h"
 msgstr ""
 
-#: docking/applets/deskpresence/state.py:193
+#: docking/applets/deskpresence/state.py:206
 #, python-brace-format
 msgid "Status: {s}"
 msgstr ""
 
-#: docking/applets/deskpresence/state.py:195
+#: docking/applets/deskpresence/state.py:208
 #, python-brace-format
 msgid "Session: {d}"
 msgstr ""
 
-#: docking/applets/deskpresence/state.py:197
+#: docking/applets/deskpresence/state.py:210
 #, python-brace-format
 msgid "Today at desk: {d}"
 msgstr ""
 
-#: docking/applets/deskpresence/state.py:199
+#: docking/applets/deskpresence/state.py:212
 #, python-brace-format
 msgid "Today away: {d}"
 msgstr ""
 
-#: docking/applets/deskpresence/state.py:203
+#: docking/applets/deskpresence/state.py:216
 msgid "Last 7 days"
 msgstr ""
 
-#: docking/applets/deskpresence/state.py:206
-#: docking/applets/deskpresence/state.py:213
+#: docking/applets/deskpresence/state.py:219
+#: docking/applets/deskpresence/state.py:226
 #, python-brace-format
 msgid "  {day}: {d}"
 msgstr ""
 
-#: docking/applets/deskpresence/state.py:220
+#: docking/applets/deskpresence/state.py:233
 #, python-brace-format
 msgid "Week total at desk: {d}"
 msgstr ""
 
-#: docking/applets/desktop/applet.py:27 docking/applets/workspaces/applet.py:82
+#: docking/applets/desktop/applet.py:40 docking/applets/workspaces/applet.py:95
 msgid "Desktop"
 msgstr ""
 
-#: docking/applets/dragshare/applet.py:40
-#: docking/applets/dragshare/applet.py:60
-#: docking/applets/dragshare/applet.py:66
-#: docking/applets/dragshare/applet.py:72
+#: docking/applets/dragshare/applet.py:53
+#: docking/applets/dragshare/applet.py:73
 #: docking/applets/dragshare/applet.py:79
-#: docking/applets/dragshare/applet.py:84
+#: docking/applets/dragshare/applet.py:85
+#: docking/applets/dragshare/applet.py:92
+#: docking/applets/dragshare/applet.py:97
 msgid "Drag Share"
 msgstr ""
 
-#: docking/applets/dragshare/applet.py:61
+#: docking/applets/dragshare/applet.py:74
 #, python-brace-format
 msgid "Uploading {file}..."
 msgstr ""
 
-#: docking/applets/dragshare/applet.py:67
+#: docking/applets/dragshare/applet.py:80
 #, python-brace-format
 msgid "Uploaded {file}; URL copied"
 msgstr ""
 
-#: docking/applets/dragshare/applet.py:73
-#: docking/applets/dragshare/applet.py:140
+#: docking/applets/dragshare/applet.py:86
+#: docking/applets/dragshare/applet.py:153
 msgid "Upload failed"
 msgstr ""
 
-#: docking/applets/dragshare/applet.py:80
+#: docking/applets/dragshare/applet.py:93
 msgid "Click to copy last URL"
 msgstr ""
 
-#: docking/applets/dragshare/applet.py:85
+#: docking/applets/dragshare/applet.py:98
 msgid "Drop a file to upload"
 msgstr ""
 
-#: docking/applets/dragshare/applet.py:93
+#: docking/applets/dragshare/applet.py:106
 msgid "Upload already in progress"
 msgstr ""
 
-#: docking/applets/dragshare/applet.py:98
+#: docking/applets/dragshare/applet.py:111
 msgid "Drop a local file to upload"
 msgstr ""
 
-#: docking/applets/dragshare/applet.py:109
+#: docking/applets/dragshare/applet.py:122
 msgid "Copy Last URL"
 msgstr ""
 
-#: docking/applets/freshness.py:15
+#: docking/applets/freshness.py:28 docking/applets/freshness.py:126
 msgid "1 hour"
 msgstr ""
 
-#: docking/applets/freshness.py:15
+#: docking/applets/freshness.py:28 docking/applets/freshness.py:126
 #, python-brace-format
 msgid "{count} hours"
 msgstr ""
 
-#: docking/applets/freshness.py:19
+#: docking/applets/freshness.py:32 docking/applets/freshness.py:120
 msgid "1 minute"
 msgstr ""
 
-#: docking/applets/freshness.py:21
+#: docking/applets/freshness.py:34 docking/applets/freshness.py:122
 #, python-brace-format
 msgid "{count} minutes"
 msgstr ""
 
-#: docking/applets/freshness.py:23
+#: docking/applets/freshness.py:36 docking/applets/freshness.py:113
 msgid "1 second"
 msgstr ""
 
-#: docking/applets/freshness.py:23
+#: docking/applets/freshness.py:36 docking/applets/freshness.py:115
 #, python-brace-format
 msgid "{count} seconds"
 msgstr ""
 
-#: docking/applets/freshness.py:28
+#: docking/applets/freshness.py:41
 #, python-brace-format
 msgid "{verb} every {interval}"
 msgstr ""
 
-#: docking/applets/freshness.py:29 docking/applets/freshness.py:36
-#: docking/ui/settings.py:194
+#: docking/applets/freshness.py:42 docking/applets/freshness.py:49
+#: docking/ui/settings.py:208
 msgid "Updates"
 msgstr ""
 
-#: docking/applets/freshness.py:36
+#: docking/applets/freshness.py:49
 #, python-brace-format
 msgid "{verb} on demand"
 msgstr ""
 
-#: docking/applets/freshness.py:44
+#: docking/applets/freshness.py:61
 #, python-brace-format
-msgid "Updated: {time}"
+msgid "Updated: {age}"
 msgstr ""
 
-#: docking/applets/hackernews/applet.py:55
-#: docking/applets/hackernews/state.py:150
+#: docking/applets/freshness.py:79
+msgid "just now"
+msgstr ""
+
+#: docking/applets/freshness.py:80
+#, python-brace-format
+msgid "{age} ago"
+msgstr ""
+
+#: docking/applets/freshness.py:128
+msgid "1 day"
+msgstr ""
+
+#: docking/applets/freshness.py:128
+#, python-brace-format
+msgid "{count} days"
+msgstr ""
+
+#: docking/applets/hackernews/applet.py:68
+#: docking/applets/hackernews/state.py:163
 msgid "Hacker News"
 msgstr ""
 
-#: docking/applets/hackernews/applet.py:147
-#: docking/applets/hackernews/state.py:156
-#: docking/applets/hackernews/state.py:189
+#: docking/applets/hackernews/applet.py:160
+#: docking/applets/hackernews/state.py:169
+#: docking/applets/hackernews/state.py:202
 msgid "Refreshes"
 msgstr ""
 
-#: docking/applets/hackernews/applet.py:159
-#: docking/applets/hackernews/state.py:171
+#: docking/applets/hackernews/applet.py:172
+#: docking/applets/hackernews/state.py:184
 #, python-brace-format
 msgid "{score} points, {comments} comments"
 msgstr ""
 
-#: docking/applets/hackernews/applet.py:180
+#: docking/applets/hackernews/applet.py:193
 msgid "Open Story"
 msgstr ""
 
-#: docking/applets/hackernews/applet.py:184
+#: docking/applets/hackernews/applet.py:197
 msgid "Open Comments"
 msgstr ""
 
-#: docking/applets/hackernews/applet.py:188
+#: docking/applets/hackernews/applet.py:201
 msgid "Next Headline"
 msgstr ""
 
-#: docking/applets/hackernews/applet.py:314
+#: docking/applets/hackernews/applet.py:327
 msgid "No Hacker News stories"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:107
+#: docking/applets/hackernews/state.py:120
 msgid "now"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:110
+#: docking/applets/hackernews/state.py:123
 #, python-brace-format
 msgid "{minutes}m ago"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:113
+#: docking/applets/hackernews/state.py:126
 #, python-brace-format
 msgid "{hours}h ago"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:115
+#: docking/applets/hackernews/state.py:128
 #, python-brace-format
 msgid "{days}d ago"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:164
+#: docking/applets/hackernews/state.py:177
 #, python-brace-format
 msgid "{source} {rank}"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:180
+#: docking/applets/hackernews/state.py:193
 msgid "Loading next stories..."
 msgstr ""
 
-#: docking/applets/hydration/applet.py:40
+#: docking/applets/hydration/applet.py:53
 msgid "Hydration"
 msgstr ""
 
-#: docking/applets/hydration/applet.py:114
-#: docking/applets/pomodoro/applet.py:157
+#: docking/applets/hydration/applet.py:127
+#: docking/applets/pomodoro/applet.py:170
 msgid "Show Timer"
 msgstr ""
 
-#: docking/applets/hydration/applet.py:120
-#: docking/applets/pomodoro/applet.py:166
+#: docking/applets/hydration/applet.py:133
 #: docking/applets/pomodoro/applet.py:179
 #: docking/applets/pomodoro/applet.py:192
-#: docking/applets/stretchcoach/applet.py:92
+#: docking/applets/pomodoro/applet.py:205
+#: docking/applets/stretchcoach/applet.py:105
 #, python-brace-format
 msgid "{mins} min"
 msgstr ""
 
-#: docking/applets/hydration/state.py:56
+#: docking/applets/hydration/state.py:69
 msgid "Drink water!"
 msgstr ""
 
-#: docking/applets/hydration/state.py:57
+#: docking/applets/hydration/state.py:70
 #, python-brace-format
 msgid "Next in {time}"
 msgstr ""
 
-#: docking/applets/keyboardlayout/applet.py:47
+#: docking/applets/keyboardlayout/applet.py:60
 msgid "Keyboard Layout"
 msgstr ""
 
-#: docking/applets/keyboardlayout/applet.py:76
+#: docking/applets/keyboardlayout/applet.py:89
 msgid "No keyboard layout detected"
 msgstr ""
 
-#: docking/applets/keyboardlayout/applet.py:122
+#: docking/applets/keyboardlayout/applet.py:135
 msgid "Keyboard Settings"
 msgstr ""
 
-#: docking/applets/keyboardlayout/applet.py:128
+#: docking/applets/keyboardlayout/applet.py:141
 msgid "Show Current Layout"
 msgstr ""
 
-#: docking/applets/live_state.py:74
+#: docking/applets/live_state.py:87
 msgid "No data yet"
 msgstr ""
 
-#: docking/applets/live_state.py:75
+#: docking/applets/live_state.py:88
 msgid "Loading..."
 msgstr ""
 
-#: docking/applets/live_state.py:77 docking/applets/live_state.py:117
+#: docking/applets/live_state.py:90 docking/applets/live_state.py:135
 msgid "Stale data"
 msgstr ""
 
-#: docking/applets/live_state.py:118
+#: docking/applets/live_state.py:136
 #, python-brace-format
-msgid "Stale: last updated {time}"
+msgid "Stale: last updated {age}"
 msgstr ""
 
-#: docking/applets/live_state.py:128
+#: docking/applets/live_state.py:146
 msgid "Use Refresh Now from the menu."
 msgstr ""
 
-#: docking/applets/micshield/applet.py:44
-#: docking/applets/micshield/state.py:195
+#: docking/applets/micshield/applet.py:57
+#: docking/applets/micshield/state.py:208
 msgid "Mic Shield"
 msgstr ""
 
-#: docking/applets/micshield/applet.py:93
-#: docking/applets/micshield/state.py:197
+#: docking/applets/micshield/applet.py:106
+#: docking/applets/micshield/state.py:210
 msgid "No microphone source found"
 msgstr ""
 
-#: docking/applets/micshield/applet.py:97
-#: docking/applets/micshield/state.py:200
+#: docking/applets/micshield/applet.py:110
+#: docking/applets/micshield/state.py:213
 msgid "Microphone muted"
 msgstr ""
 
-#: docking/applets/micshield/applet.py:99
-#: docking/applets/micshield/state.py:200
+#: docking/applets/micshield/applet.py:112
+#: docking/applets/micshield/state.py:213
 msgid "Microphone unmuted"
 msgstr ""
 
-#: docking/applets/micshield/applet.py:105
-#: docking/applets/micshield/state.py:205
+#: docking/applets/micshield/applet.py:118
+#: docking/applets/micshield/state.py:218
 msgid "Microphone active"
 msgstr ""
 
-#: docking/applets/micshield/applet.py:109
-#: docking/applets/micshield/state.py:202
+#: docking/applets/micshield/applet.py:122
+#: docking/applets/micshield/state.py:215
 msgid "Microphone idle"
 msgstr ""
 
-#: docking/applets/micshield/applet.py:112
+#: docking/applets/micshield/applet.py:125
 msgid "Unmute Microphone"
 msgstr ""
 
-#: docking/applets/micshield/applet.py:112
+#: docking/applets/micshield/applet.py:125
 msgid "Mute Microphone"
 msgstr ""
 
-#: docking/applets/micshield/state.py:218
+#: docking/applets/micshield/state.py:231
 #, python-brace-format
 msgid "{command} (PID {pid})"
 msgstr ""
 
-#: docking/applets/moon/applet.py:49
+#: docking/applets/moon/applet.py:62
 msgid "Moon"
 msgstr ""
 
-#: docking/applets/moon/applet.py:92
+#: docking/applets/moon/applet.py:105
 msgid "Moon (loading...)"
 msgstr ""
 
-#: docking/applets/moon/applet.py:99
+#: docking/applets/moon/applet.py:112
 #, python-brace-format
 msgid "Illumination: {pct}%"
 msgstr ""
 
-#: docking/applets/moon/applet.py:120
+#: docking/applets/moon/applet.py:133
 msgid "Show Phase Name"
 msgstr ""
 
-#: docking/applets/moon/offline.py:216 docking/applets/moon/state.py:130
+#: docking/applets/moon/offline.py:229 docking/applets/moon/state.py:143
 msgid "New"
 msgstr ""
 
-#: docking/applets/moon/offline.py:218 docking/applets/moon/state.py:132
+#: docking/applets/moon/offline.py:231 docking/applets/moon/state.py:145
 msgid "Full"
 msgstr ""
 
-#: docking/applets/moon/offline.py:220
+#: docking/applets/moon/offline.py:233
 msgid "Crescent"
 msgstr ""
 
-#: docking/applets/moon/offline.py:221
+#: docking/applets/moon/offline.py:234
 msgid "Gibbous"
 msgstr ""
 
-#: docking/applets/moon/offline.py:234
+#: docking/applets/moon/offline.py:247
 msgid "new moon"
 msgstr ""
 
-#: docking/applets/moon/offline.py:236
+#: docking/applets/moon/offline.py:249
 msgid "first quarter"
 msgstr ""
 
-#: docking/applets/moon/offline.py:238
+#: docking/applets/moon/offline.py:251
 msgid "full moon"
 msgstr ""
 
-#: docking/applets/moon/offline.py:240
+#: docking/applets/moon/offline.py:253
 msgid "last quarter"
 msgstr ""
 
-#: docking/applets/moon/offline.py:242
+#: docking/applets/moon/offline.py:255
 #, python-brace-format
 msgid "{days} days after new moon"
 msgstr ""
 
-#: docking/applets/moon/offline.py:247
+#: docking/applets/moon/offline.py:260
 #, python-brace-format
 msgid "{days} days after full moon"
 msgstr ""
 
-#: docking/applets/moon/state.py:121
+#: docking/applets/moon/state.py:134
 msgid "Waxing Crescent"
 msgstr ""
 
-#: docking/applets/moon/state.py:123
+#: docking/applets/moon/state.py:136
 msgid "Waxing Gibbous"
 msgstr ""
 
-#: docking/applets/moon/state.py:125
+#: docking/applets/moon/state.py:138
 msgid "Waning Gibbous"
 msgstr ""
 
-#: docking/applets/moon/state.py:127
+#: docking/applets/moon/state.py:140
 msgid "Waning Crescent"
 msgstr ""
 
-#: docking/applets/moon/state.py:134
+#: docking/applets/moon/state.py:147
 msgid "1st Quarter"
 msgstr ""
 
-#: docking/applets/moon/state.py:136
+#: docking/applets/moon/state.py:149
 msgid "3rd Quarter"
 msgstr ""
 
-#: docking/applets/music/applet.py:45 docking/applets/music/state.py:129
-#: docking/applets/music/state.py:143
+#: docking/applets/music/applet.py:58 docking/applets/music/state.py:142
+#: docking/applets/music/state.py:156
 msgid "Music"
 msgstr ""
 
-#: docking/applets/music/applet.py:105 docking/applets/music/state.py:130
+#: docking/applets/music/applet.py:118 docking/applets/music/state.py:143
 msgid "No active player"
 msgstr ""
 
-#: docking/applets/music/applet.py:107
+#: docking/applets/music/applet.py:120
 msgid "Previous"
 msgstr ""
 
-#: docking/applets/music/applet.py:115
+#: docking/applets/music/applet.py:128
 msgid "Next"
 msgstr ""
 
-#: docking/applets/music/applet.py:119
+#: docking/applets/music/applet.py:132
 msgid "Volume Up"
 msgstr ""
 
-#: docking/applets/music/applet.py:125
+#: docking/applets/music/applet.py:138
 msgid "Volume Down"
 msgstr ""
 
-#: docking/applets/music/state.py:69
+#: docking/applets/music/state.py:82
 msgid "Pause"
 msgstr ""
 
-#: docking/applets/music/state.py:69
+#: docking/applets/music/state.py:82
 msgid "Play"
 msgstr ""
 
-#: docking/applets/music/state.py:76
+#: docking/applets/music/state.py:89
 msgid "Playing"
 msgstr ""
 
-#: docking/applets/music/state.py:78
+#: docking/applets/music/state.py:91
 msgid "Paused"
 msgstr ""
 
-#: docking/applets/music/state.py:80
+#: docking/applets/music/state.py:93
 msgid "Stopped"
 msgstr ""
 
-#: docking/applets/network/applet.py:64 docking/applets/network/state.py:214
-#: docking/applets/network/state.py:225
+#: docking/applets/network/applet.py:77 docking/applets/network/state.py:227
+#: docking/applets/network/state.py:238
 msgid "Network"
 msgstr ""
 
-#: docking/applets/network/applet.py:118
+#: docking/applets/network/applet.py:131
 #, python-brace-format
 msgid "WiFi: {ssid} ({pct}%)"
 msgstr ""
 
-#: docking/applets/network/applet.py:127
+#: docking/applets/network/applet.py:140
 #, python-brace-format
 msgid "Ethernet: {iface}"
 msgstr ""
 
-#: docking/applets/network/applet.py:132 docking/applets/network/state.py:215
+#: docking/applets/network/applet.py:145 docking/applets/network/state.py:228
 msgid "Not connected"
 msgstr ""
 
-#: docking/applets/network/applet.py:136
+#: docking/applets/network/applet.py:149
 #, python-brace-format
 msgid "IP: {ip}"
 msgstr ""
 
-#: docking/applets/network/applet.py:147
+#: docking/applets/network/applet.py:160
 msgid "Connection Information"
 msgstr ""
 
-#: docking/applets/network/applet.py:153
+#: docking/applets/network/applet.py:166
 msgid "Edit Connections..."
 msgstr ""
 
-#: docking/applets/network/applet.py:163
+#: docking/applets/network/applet.py:176
 msgid "Connect to Hidden Wi-Fi Network..."
 msgstr ""
 
-#: docking/applets/network/applet.py:170
+#: docking/applets/network/applet.py:183
 msgid "Create New Wi-Fi Network..."
 msgstr ""
 
-#: docking/applets/network/applet.py:174
+#: docking/applets/network/applet.py:187
 msgid "Enable Networking"
 msgstr ""
 
-#: docking/applets/network/applet.py:185
+#: docking/applets/network/applet.py:198
 msgid "Enable Wi-Fi"
 msgstr ""
 
-#: docking/applets/network/applet.py:202
+#: docking/applets/network/applet.py:215
 msgid "Show Download"
 msgstr ""
 
-#: docking/applets/network/applet.py:203
+#: docking/applets/network/applet.py:216
 msgid "Show Upload"
 msgstr ""
 
-#: docking/applets/network/applet.py:204
+#: docking/applets/network/applet.py:217
 msgid "Hide Speeds"
 msgstr ""
 
-#: docking/applets/network/applet.py:255
+#: docking/applets/network/applet.py:268
 msgid "Available Networks"
 msgstr ""
 
-#: docking/applets/network/applet.py:259
+#: docking/applets/network/applet.py:272
 #, python-brace-format
 msgid "{ssid} ({pct}%)"
 msgstr ""
 
-#: docking/applets/network/applet.py:261
+#: docking/applets/network/applet.py:274
 #, python-brace-format
 msgid "Connected: {label}"
 msgstr ""
 
-#: docking/applets/network/applet.py:270
+#: docking/applets/network/applet.py:283
 msgid "No networks found"
 msgstr ""
 
-#: docking/applets/network/applet.py:282
+#: docking/applets/network/applet.py:295
 msgid "VPN Connections"
 msgstr ""
 
-#: docking/applets/network/applet.py:285
+#: docking/applets/network/applet.py:298
 msgid "Unnamed VPN"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:64
-#: docking/applets/notifications/state.py:49
+#: docking/applets/notifications/applet.py:77
+#: docking/applets/notifications/state.py:62
 msgid "Notifications"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:132
+#: docking/applets/notifications/applet.py:145
 msgid "No notification backend available"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:134
+#: docking/applets/notifications/applet.py:147
 msgid "Do Not Disturb"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:142
-#: docking/applets/notifications/state.py:47
+#: docking/applets/notifications/applet.py:155
+#: docking/applets/notifications/state.py:60
 #, python-brace-format
 msgid "Pending: {n}"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:147
+#: docking/applets/notifications/applet.py:160
 msgid "Clear History"
 msgstr ""
 
-#: docking/applets/notifications/applet.py:152
+#: docking/applets/notifications/applet.py:165
 msgid "Clear Notifications"
 msgstr ""
 
-#: docking/applets/notifications/state.py:43
+#: docking/applets/notifications/state.py:56
 msgid "Notifications: No backend available"
 msgstr ""
 
-#: docking/applets/pet/applet.py:41
+#: docking/applets/pet/applet.py:54
 msgid "Pet"
 msgstr ""
 
-#: docking/applets/pet/state.py:60
+#: docking/applets/pet/state.py:73
 msgid "Sleeping"
 msgstr ""
 
-#: docking/applets/pet/state.py:61
+#: docking/applets/pet/state.py:74
 msgid "Sleepy"
 msgstr ""
 
-#: docking/applets/pet/state.py:62
+#: docking/applets/pet/state.py:75
 msgid "Drowsy"
 msgstr ""
 
-#: docking/applets/pet/state.py:63
+#: docking/applets/pet/state.py:76
 msgid "Relaxed"
 msgstr ""
 
-#: docking/applets/pet/state.py:64
+#: docking/applets/pet/state.py:77
 msgid "Happy"
 msgstr ""
 
-#: docking/applets/pet/state.py:65
+#: docking/applets/pet/state.py:78
 msgid "Focused"
 msgstr ""
 
-#: docking/applets/pet/state.py:66
+#: docking/applets/pet/state.py:79
 msgid "Busy"
 msgstr ""
 
-#: docking/applets/pet/state.py:67
+#: docking/applets/pet/state.py:80
 msgid "Stressed"
 msgstr ""
 
-#: docking/applets/pet/state.py:68
+#: docking/applets/pet/state.py:81
 msgid "Excited!"
 msgstr ""
 
-#: docking/applets/pet/state.py:191
+#: docking/applets/pet/state.py:204
 #, python-brace-format
 msgid "{mood} | CPU: {cpu}%"
 msgstr ""
 
-#: docking/applets/pomodoro/applet.py:48 docking/applets/pomodoro/state.py:64
+#: docking/applets/pomodoro/applet.py:61 docking/applets/pomodoro/state.py:77
 msgid "Pomodoro"
 msgstr ""
 
-#: docking/applets/pomodoro/applet.py:154
+#: docking/applets/pomodoro/applet.py:167
 msgid "Reset"
 msgstr ""
 
-#: docking/applets/pomodoro/applet.py:162 docking/applets/pomodoro/state.py:68
+#: docking/applets/pomodoro/applet.py:175 docking/applets/pomodoro/state.py:81
 msgid "Work"
 msgstr ""
 
-#: docking/applets/pomodoro/applet.py:175 docking/applets/pomodoro/state.py:69
+#: docking/applets/pomodoro/applet.py:188 docking/applets/pomodoro/state.py:82
 msgid "Break"
 msgstr ""
 
-#: docking/applets/pomodoro/applet.py:188 docking/applets/pomodoro/state.py:70
+#: docking/applets/pomodoro/applet.py:201 docking/applets/pomodoro/state.py:83
 msgid "Long Break"
 msgstr ""
 
-#: docking/applets/pomodoro/state.py:66
+#: docking/applets/pomodoro/state.py:79
 #, python-brace-format
 msgid "Paused - {time}"
 msgstr ""
 
-#: docking/applets/pomodoro/state.py:72
+#: docking/applets/pomodoro/state.py:85
 #, python-brace-format
 msgid "{label}: {time} remaining"
 msgstr ""
 
-#: docking/applets/powerprofiles/applet.py:58
+#: docking/applets/powerprofiles/applet.py:71
 msgid "Power Profiles"
 msgstr ""
 
-#: docking/applets/powerprofiles/applet.py:123
-#: docking/applets/powerprofiles/state.py:170
-#: docking/applets/powerprofiles/state.py:171
+#: docking/applets/powerprofiles/applet.py:136
+#: docking/applets/powerprofiles/state.py:183
+#: docking/applets/powerprofiles/state.py:184
 msgid "Power Profiles unavailable"
 msgstr ""
 
-#: docking/applets/powerprofiles/applet.py:126
+#: docking/applets/powerprofiles/applet.py:139
 msgid "Select Profile"
 msgstr ""
 
-#: docking/applets/powerprofiles/applet.py:145
+#: docking/applets/powerprofiles/applet.py:158
 #, python-brace-format
 msgid "Limited: {reason}"
 msgstr ""
 
-#: docking/applets/powerprofiles/state.py:131
+#: docking/applets/powerprofiles/state.py:144
 msgid "Power Saver"
 msgstr ""
 
-#: docking/applets/powerprofiles/state.py:133
+#: docking/applets/powerprofiles/state.py:146
 msgid "Balanced"
 msgstr ""
 
-#: docking/applets/powerprofiles/state.py:135
+#: docking/applets/powerprofiles/state.py:148
 msgid "Performance"
 msgstr ""
 
-#: docking/applets/quicknote/applet.py:41
-#: docking/applets/quicknote/applet.py:70
+#: docking/applets/quicknote/applet.py:54
+#: docking/applets/quicknote/applet.py:83
 msgid "Quick Note"
 msgstr ""
 
-#: docking/applets/quicknote/applet.py:60
+#: docking/applets/quicknote/applet.py:73
 msgid "Edit Note"
 msgstr ""
 
-#: docking/applets/quicknote/applet.py:63
+#: docking/applets/quicknote/applet.py:76
 msgid "Clear Note"
 msgstr ""
 
-#: docking/applets/quote/applet.py:86
+#: docking/applets/quote/applet.py:99
 msgid "Next Quote"
 msgstr ""
 
-#: docking/applets/quote/applet.py:89
+#: docking/applets/quote/applet.py:102
 msgid "Copy Quote"
 msgstr ""
 
-#: docking/applets/quote/applet.py:96
+#: docking/applets/quote/applet.py:109
 msgid "Source"
 msgstr ""
 
-#: docking/applets/quote/applet.py:207
+#: docking/applets/quote/applet.py:220
 #, python-brace-format
 msgid "{source}: loading..."
 msgstr ""
 
-#: docking/applets/recentfiles/applet.py:35
+#: docking/applets/recentfiles/applet.py:48
 msgid "Recent Files"
 msgstr ""
 
-#: docking/applets/recentfiles/applet.py:82
+#: docking/applets/recentfiles/applet.py:95
 msgid "Clear Recent Files"
 msgstr ""
 
-#: docking/applets/screenshot/applet.py:40
+#: docking/applets/screenshot/applet.py:53
 msgid "Screenshot"
 msgstr ""
 
-#: docking/applets/screenshot/applet.py:77
+#: docking/applets/screenshot/applet.py:90
 #, python-brace-format
 msgid "Full Screen in {delay}s"
 msgstr ""
 
-#: docking/applets/separator/applet.py:38
+#: docking/applets/separator/applet.py:51
 msgid "Separator"
 msgstr ""
 
-#: docking/applets/separator/applet.py:119
+#: docking/applets/separator/applet.py:132
 msgid "Increase Gap"
 msgstr ""
 
-#: docking/applets/separator/applet.py:121
+#: docking/applets/separator/applet.py:134
 msgid "Decrease Gap"
 msgstr ""
 
-#: docking/applets/separator/applet.py:124
+#: docking/applets/separator/applet.py:137
 msgid "Style"
 msgstr ""
 
-#: docking/applets/separator/applet.py:126
+#: docking/applets/separator/applet.py:139
 msgid "Line"
 msgstr ""
 
-#: docking/applets/separator/applet.py:127
+#: docking/applets/separator/applet.py:140
 msgid "Space"
 msgstr ""
 
-#: docking/applets/separator/applet.py:134
+#: docking/applets/separator/applet.py:147
 msgid "Invert Color"
 msgstr ""
 
-#: docking/applets/session/applet.py:28
+#: docking/applets/session/applet.py:41
 msgid "Session"
 msgstr ""
 
-#: docking/applets/session/applet.py:56 docking/applets/session/state.py:29
+#: docking/applets/session/applet.py:69 docking/applets/session/state.py:42
 msgid "Suspend"
 msgstr ""
 
-#: docking/applets/session/state.py:25
+#: docking/applets/session/state.py:38
 msgid "Lock Screen"
 msgstr ""
 
-#: docking/applets/session/state.py:28
+#: docking/applets/session/state.py:41
 msgid "Log Out"
 msgstr ""
 
-#: docking/applets/session/state.py:30
+#: docking/applets/session/state.py:43
 msgid "Restart"
 msgstr ""
 
-#: docking/applets/session/state.py:31
+#: docking/applets/session/state.py:44
 msgid "Shut Down"
 msgstr ""
 
-#: docking/applets/speedtest/applet.py:42 docking/applets/speedtest/state.py:76
-#: docking/applets/speedtest/state.py:82 docking/applets/speedtest/state.py:88
-#: docking/applets/speedtest/state.py:108
+#: docking/applets/speedtest/applet.py:55 docking/applets/speedtest/state.py:89
+#: docking/applets/speedtest/state.py:95 docking/applets/speedtest/state.py:101
+#: docking/applets/speedtest/state.py:121
 msgid "Speedtest"
 msgstr ""
 
-#: docking/applets/speedtest/applet.py:80 docking/applets/speedtest/state.py:73
+#: docking/applets/speedtest/applet.py:93 docking/applets/speedtest/state.py:86
 msgid "Runs"
 msgstr ""
 
-#: docking/applets/speedtest/applet.py:83
-#: docking/applets/speedtest/applet.py:101
-#: docking/applets/speedtest/state.py:77
+#: docking/applets/speedtest/applet.py:96
+#: docking/applets/speedtest/applet.py:114
+#: docking/applets/speedtest/state.py:90
 msgid "Running..."
 msgstr ""
 
-#: docking/applets/speedtest/applet.py:83
+#: docking/applets/speedtest/applet.py:96
 msgid "Run Test"
 msgstr ""
 
-#: docking/applets/speedtest/applet.py:90
+#: docking/applets/speedtest/applet.py:103
 msgid "Copy Last Result"
 msgstr ""
 
-#: docking/applets/speedtest/applet.py:106
+#: docking/applets/speedtest/applet.py:119
 #, python-brace-format
 msgid "Down {d:.1f} / Up {u:.1f} Mbps"
 msgstr ""
 
-#: docking/applets/speedtest/applet.py:163
+#: docking/applets/speedtest/applet.py:176
 #, python-brace-format
 msgid ""
 "Down: {d:.2f} Mbps, Up: {u:.2f} Mbps, Ping: {p:.1f} ms, Jitter: {j:.1f} ms "
 "({when})"
 msgstr ""
 
-#: docking/applets/speedtest/state.py:89
+#: docking/applets/speedtest/state.py:102
 msgid "Click to run a test"
-msgstr ""
-
-#: docking/applets/speedtest/state.py:92
-#, python-brace-format
-msgid "Down: {d:.1f} Mbps   Up: {u:.1f} Mbps"
-msgstr ""
-
-#: docking/applets/speedtest/state.py:96
-#, python-brace-format
-msgid "Ping: {p:.1f} ms   Jitter: {j:.1f} ms"
-msgstr ""
-
-#: docking/applets/speedtest/state.py:101
-#, python-brace-format
-msgid "Server: {s}"
 msgstr ""
 
 #: docking/applets/speedtest/state.py:105
 #, python-brace-format
+msgid "Down: {d:.1f} Mbps   Up: {u:.1f} Mbps"
+msgstr ""
+
+#: docking/applets/speedtest/state.py:109
+#, python-brace-format
+msgid "Ping: {p:.1f} ms   Jitter: {j:.1f} ms"
+msgstr ""
+
+#: docking/applets/speedtest/state.py:114
+#, python-brace-format
+msgid "Server: {s}"
+msgstr ""
+
+#: docking/applets/speedtest/state.py:118
+#, python-brace-format
 msgid "At: {t}"
 msgstr ""
 
-#: docking/applets/stretchcoach/applet.py:41
+#: docking/applets/stretchcoach/applet.py:54
 msgid "Stretch Coach"
 msgstr ""
 
-#: docking/applets/stretchcoach/applet.py:79
+#: docking/applets/stretchcoach/applet.py:92
 msgid "Acknowledge Break"
 msgstr ""
 
-#: docking/applets/stretchcoach/applet.py:79
+#: docking/applets/stretchcoach/applet.py:92
 msgid "Take Break Now"
 msgstr ""
 
-#: docking/applets/stretchcoach/applet.py:83
+#: docking/applets/stretchcoach/applet.py:96
 msgid "Show Random Stretch"
 msgstr ""
 
-#: docking/applets/stretchcoach/applet.py:86
+#: docking/applets/stretchcoach/applet.py:99
 msgid "Random Stretch Cards"
 msgstr ""
 
-#: docking/applets/stretchcoach/state.py:152
+#: docking/applets/stretchcoach/state.py:165
 msgid "Time to stretch!"
 msgstr ""
 
-#: docking/applets/stretchcoach/state.py:156
+#: docking/applets/stretchcoach/state.py:169
 #, python-brace-format
 msgid "Next stretch in {time}"
 msgstr ""
 
-#: docking/applets/sunrise/applet.py:51 docking/applets/sunrise/state.py:476
+#: docking/applets/sunrise/applet.py:64 docking/applets/sunrise/state.py:489
 msgid "Sunrise"
 msgstr ""
 
-#: docking/applets/sunrise/applet.py:103
+#: docking/applets/sunrise/applet.py:116
 msgid "Times shown in system timezone"
 msgstr ""
 
-#: docking/applets/sunrise/applet.py:108
+#: docking/applets/sunrise/applet.py:121
 msgid "Change City..."
 msgstr ""
 
-#: docking/applets/sunrise/applet.py:113
+#: docking/applets/sunrise/applet.py:126
 msgid "Label Mode"
 msgstr ""
 
-#: docking/applets/sunrise/applet.py:135 docking/applets/weather/applet.py:203
+#: docking/applets/sunrise/applet.py:148 docking/applets/weather/applet.py:216
 #, python-brace-format
 msgid "Remove {city}"
 msgstr ""
 
-#: docking/applets/sunrise/applet.py:172 docking/applets/weather/applet.py:255
+#: docking/applets/sunrise/applet.py:185 docking/applets/weather/applet.py:268
 msgid "Search for the city"
 msgstr ""
 
-#: docking/applets/sunrise/applet.py:185 docking/applets/weather/applet.py:268
+#: docking/applets/sunrise/applet.py:198 docking/applets/weather/applet.py:281
 msgid "Type city name..."
 msgstr ""
 
-#: docking/applets/sunrise/state.py:315
+#: docking/applets/sunrise/state.py:328
 msgid "Sunrise: no city selected"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:318
+#: docking/applets/sunrise/state.py:331
 #, python-brace-format
 msgid "{phase} now"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:322
+#: docking/applets/sunrise/state.py:335
 #, python-brace-format
 msgid "{event} in {duration}"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:354 docking/applets/sunrise/state.py:365
+#: docking/applets/sunrise/state.py:367 docking/applets/sunrise/state.py:378
 msgid "Night"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:355
+#: docking/applets/sunrise/state.py:368
 msgid "Astronomical twilight"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:356
+#: docking/applets/sunrise/state.py:369
 msgid "Nautical twilight"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:357
+#: docking/applets/sunrise/state.py:370
 msgid "Civil twilight"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:358
+#: docking/applets/sunrise/state.py:371
 msgid "Daylight"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:366
+#: docking/applets/sunrise/state.py:379
 msgid "Astro"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:367
+#: docking/applets/sunrise/state.py:380
 msgid "Naut"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:368
+#: docking/applets/sunrise/state.py:381
 msgid "Civil"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:376
-#: docking/applets/todayinhistory/applet.py:96
+#: docking/applets/sunrise/state.py:389
+#: docking/applets/todayinhistory/applet.py:109
 msgid "Next Event"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:377
+#: docking/applets/sunrise/state.py:390
 msgid "Current Phase"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:378
+#: docking/applets/sunrise/state.py:391
 msgid "Sunrise/Sunset"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:385 docking/applets/weather/state.py:164
+#: docking/applets/sunrise/state.py:398 docking/applets/weather/state.py:177
 msgid "No city selected"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:387
+#: docking/applets/sunrise/state.py:400
 #, python-brace-format
 msgid "{city}: {phase}"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:391
+#: docking/applets/sunrise/state.py:404
 #, python-brace-format
 msgid "{city}: {event} in {duration}"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:458
+#: docking/applets/sunrise/state.py:471
 msgid "Astronomical dawn"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:464
+#: docking/applets/sunrise/state.py:477
 msgid "Nautical dawn"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:470
+#: docking/applets/sunrise/state.py:483
 msgid "Civil dawn"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:482
+#: docking/applets/sunrise/state.py:495
 msgid "Solar noon"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:488
+#: docking/applets/sunrise/state.py:501
 msgid "Sunset"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:494
+#: docking/applets/sunrise/state.py:507
 msgid "Civil dusk"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:500
+#: docking/applets/sunrise/state.py:513
 msgid "Nautical dusk"
 msgstr ""
 
-#: docking/applets/sunrise/state.py:506
+#: docking/applets/sunrise/state.py:519
 msgid "Astronomical dusk"
 msgstr ""
 
-#: docking/applets/systemmonitor/applet.py:51
-#: docking/applets/systemmonitor/state.py:168
+#: docking/applets/systemmonitor/applet.py:64
+#: docking/applets/systemmonitor/state.py:181
 msgid "System Monitor"
 msgstr ""
 
-#: docking/applets/systemmonitor/applet.py:85
+#: docking/applets/systemmonitor/applet.py:98
 msgid "Show Disk Usage"
 msgstr ""
 
-#: docking/applets/systemmonitor/applet.py:90
-#: docking/applets/thermals/applet.py:149 docking/applets/weather/applet.py:186
+#: docking/applets/systemmonitor/applet.py:103
+#: docking/applets/thermals/applet.py:162 docking/applets/weather/applet.py:199
 msgid "Temperature Unit"
 msgstr ""
 
-#: docking/applets/systemmonitor/state.py:151
+#: docking/applets/systemmonitor/state.py:164
 #, python-brace-format
 msgid "CPU: {cpu}% | Mem: {mem}%"
 msgstr ""
 
-#: docking/applets/systemmonitor/state.py:155
+#: docking/applets/systemmonitor/state.py:168
 #, python-brace-format
 msgid "{text} | Temp: {temp}"
 msgstr ""
 
-#: docking/applets/systemmonitor/state.py:166
+#: docking/applets/systemmonitor/state.py:179
 #, python-brace-format
 msgid "Disk: {usage}"
 msgstr ""
 
-#: docking/applets/temperature.py:31
+#: docking/applets/temperature.py:44
 msgid "Fahrenheit"
 msgstr ""
 
-#: docking/applets/temperature.py:32
+#: docking/applets/temperature.py:45
 msgid "Celsius"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:53 docking/applets/thermals/state.py:407
-#: docking/applets/thermals/state.py:420 docking/applets/thermals/state.py:432
-#: docking/applets/thermals/state.py:466
+#: docking/applets/thermals/applet.py:66 docking/applets/thermals/state.py:420
+#: docking/applets/thermals/state.py:433 docking/applets/thermals/state.py:445
+#: docking/applets/thermals/state.py:479
 msgid "Thermals"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:96 docking/applets/thermals/state.py:114
-#: docking/applets/thermals/state.py:427
+#: docking/applets/thermals/applet.py:109 docking/applets/thermals/state.py:127
+#: docking/applets/thermals/state.py:440
 msgid "lm-sensors not installed"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:105 docking/applets/thermals/state.py:446
+#: docking/applets/thermals/applet.py:118 docking/applets/thermals/state.py:459
 #, python-brace-format
 msgid "Hot: {label} {temp}"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:119 docking/applets/thermals/state.py:458
+#: docking/applets/thermals/applet.py:132 docking/applets/thermals/state.py:471
 #, python-brace-format
 msgid "Fan: {label} {rpm}"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:139 docking/applets/thermals/state.py:413
-#: docking/applets/thermals/state.py:425 docking/applets/thermals/state.py:437
-#: docking/applets/thermals/state.py:473
+#: docking/applets/thermals/applet.py:152 docking/applets/thermals/state.py:426
+#: docking/applets/thermals/state.py:438 docking/applets/thermals/state.py:450
+#: docking/applets/thermals/state.py:486
 msgid "Samples"
 msgstr ""
 
-#: docking/applets/thermals/applet.py:257
+#: docking/applets/thermals/applet.py:270
 msgid "Thermal readings unavailable"
 msgstr ""
 
-#: docking/applets/thermals/state.py:135
+#: docking/applets/thermals/state.py:148
 msgid "sensors failed"
 msgstr ""
 
-#: docking/applets/thermals/state.py:142
+#: docking/applets/thermals/state.py:155
 msgid "No thermal readings"
 msgstr ""
 
-#: docking/applets/thermals/state.py:454
+#: docking/applets/thermals/state.py:467
 msgid "Hot: unavailable"
 msgstr ""
 
-#: docking/applets/thermals/state.py:464
+#: docking/applets/thermals/state.py:477
 msgid "Fan: unavailable"
 msgstr ""
 
-#: docking/applets/todayinhistory/applet.py:47
-#: docking/applets/todayinhistory/applet.py:117
-#: docking/applets/todayinhistory/applet.py:129
+#: docking/applets/todayinhistory/applet.py:60
+#: docking/applets/todayinhistory/applet.py:130
+#: docking/applets/todayinhistory/applet.py:142
 msgid "Today in History"
 msgstr ""
 
-#: docking/applets/todayinhistory/applet.py:92
+#: docking/applets/todayinhistory/applet.py:105
 msgid "Open Article"
 msgstr ""
 
-#: docking/applets/todayinhistory/applet.py:112
+#: docking/applets/todayinhistory/applet.py:125
 msgid "Today in History: loading..."
 msgstr ""
 
-#: docking/applets/todayinhistory/state.py:26
+#: docking/applets/todayinhistory/state.py:39
 msgid "Offline fallback"
 msgstr ""
 
-#: docking/applets/todayinhistory/state.py:46
+#: docking/applets/todayinhistory/state.py:59
 #, python-brace-format
 msgid "{year} - {title}"
 msgstr ""
 
-#: docking/applets/trash/applet.py:36
+#: docking/applets/trash/applet.py:49
 msgid "Trash"
 msgstr ""
 
-#: docking/applets/trash/applet.py:65
+#: docking/applets/trash/applet.py:78
 msgid "Open Trash"
 msgstr ""
 
-#: docking/applets/trash/applet.py:68 docking/applets/trash/applet.py:115
+#: docking/applets/trash/applet.py:81 docking/applets/trash/applet.py:128
 msgid "Empty Trash"
 msgstr ""
 
-#: docking/applets/trash/applet.py:109
+#: docking/applets/trash/applet.py:122
 msgid "Empty all items from Trash?"
 msgstr ""
 
-#: docking/applets/trash/applet.py:112
+#: docking/applets/trash/applet.py:125
 msgid "All items in the Trash will be permanently deleted."
 msgstr ""
 
-#: docking/applets/trash/render.py:18
+#: docking/applets/trash/render.py:31
 msgid "No items in Trash"
 msgstr ""
 
-#: docking/applets/trash/render.py:20 docking/applets/trash/render.py:21
+#: docking/applets/trash/render.py:33 docking/applets/trash/render.py:34
 #, python-brace-format
 msgid "{n} item in Trash"
 msgid_plural "{n} items in Trash"
 msgstr[0] ""
 msgstr[1] ""
 
-#: docking/applets/trivia/applet.py:42 docking/applets/trivia/applet.py:186
+#: docking/applets/trivia/applet.py:55 docking/applets/trivia/applet.py:199
 msgid "Random Trivia"
 msgstr ""
 
-#: docking/applets/trivia/applet.py:77 docking/applets/trivia/state.py:102
+#: docking/applets/trivia/applet.py:90 docking/applets/trivia/state.py:115
 #, python-brace-format
 msgid "{category} / {difficulty}"
 msgstr ""
 
-#: docking/applets/trivia/applet.py:96 docking/applets/trivia/state.py:113
+#: docking/applets/trivia/applet.py:109 docking/applets/trivia/state.py:126
 #, python-brace-format
 msgid "Correct answer: {answer}"
 msgstr ""
 
-#: docking/applets/trivia/applet.py:105 docking/applets/trivia/state.py:112
+#: docking/applets/trivia/applet.py:118 docking/applets/trivia/state.py:125
 #, python-brace-format
 msgid "Your answer: {answer}"
 msgstr ""
 
-#: docking/applets/trivia/applet.py:112
+#: docking/applets/trivia/applet.py:125
 msgid "Next Trivia"
 msgstr ""
 
-#: docking/applets/trivia/applet.py:181
+#: docking/applets/trivia/applet.py:194
 msgid "Trivia: loading..."
 msgstr ""
 
-#: docking/applets/trivia/state.py:88
+#: docking/applets/trivia/state.py:101
 msgid "Easy"
 msgstr ""
 
-#: docking/applets/trivia/state.py:89
+#: docking/applets/trivia/state.py:102
 msgid "Medium"
 msgstr ""
 
-#: docking/applets/trivia/state.py:90
+#: docking/applets/trivia/state.py:103
 msgid "Hard"
 msgstr ""
 
-#: docking/applets/trivia/state.py:110
+#: docking/applets/trivia/state.py:123
 #, python-brace-format
 msgid "Correct: {answer}"
 msgstr ""
 
-#: docking/applets/unitconverter/applet.py:102
-#: docking/applets/unitconverter/applet.py:129
-#: docking/applets/unitconverter/applet.py:161
+#: docking/applets/unitconverter/applet.py:115
+#: docking/applets/unitconverter/applet.py:142
+#: docking/applets/unitconverter/applet.py:174
 msgid "Unit Converter"
 msgstr ""
 
-#: docking/applets/unitconverter/applet.py:210
+#: docking/applets/unitconverter/applet.py:223
 msgid "Swap units"
 msgstr ""
 
-#: docking/applets/unitconverter/applet.py:227
+#: docking/applets/unitconverter/applet.py:240
 msgid "Value"
 msgstr ""
 
-#: docking/applets/urlshortener/applet.py:59
-#: docking/applets/urlshortener/applet.py:80
-#: docking/applets/urlshortener/applet.py:98
+#: docking/applets/urlshortener/applet.py:72
+#: docking/applets/urlshortener/applet.py:93
+#: docking/applets/urlshortener/applet.py:111
 msgid "URL Shortener"
 msgstr ""
 
-#: docking/applets/urlshortener/applet.py:117
+#: docking/applets/urlshortener/applet.py:130
 msgid "Shorten"
 msgstr ""
 
-#: docking/applets/urlshortener/applet.py:143
+#: docking/applets/urlshortener/applet.py:156
 msgid "Shortening..."
 msgstr ""
 
-#: docking/applets/urlshortener/applet.py:177
-#: docking/applets/urlshortener/applet.py:196
+#: docking/applets/urlshortener/applet.py:190
+#: docking/applets/urlshortener/applet.py:209
 msgid "Copy"
 msgstr ""
 
-#: docking/applets/urlshortener/applet.py:191
+#: docking/applets/urlshortener/applet.py:204
 msgid "Copied!"
 msgstr ""
 
-#: docking/applets/usbwatch/applet.py:37 docking/applets/usbwatch/state.py:80
-#: docking/applets/usbwatch/state.py:87
+#: docking/applets/usbwatch/applet.py:50 docking/applets/usbwatch/state.py:93
+#: docking/applets/usbwatch/state.py:100
 msgid "USB Watch"
 msgstr ""
 
-#: docking/applets/usbwatch/applet.py:61 docking/applets/usbwatch/state.py:81
+#: docking/applets/usbwatch/applet.py:74 docking/applets/usbwatch/state.py:94
 msgid "No mounted USB devices"
 msgstr ""
 
-#: docking/applets/usbwatch/applet.py:70
+#: docking/applets/usbwatch/applet.py:83
 #, python-brace-format
 msgid "Safely Remove {name}"
 msgstr ""
 
-#: docking/applets/usbwatch/state.py:88
+#: docking/applets/usbwatch/state.py:101
 #, python-brace-format
 msgid "{count} mounted device(s)"
 msgstr ""
 
-#: docking/applets/usbwatch/state.py:95
+#: docking/applets/usbwatch/state.py:108
 msgid "Removable Drive"
 msgstr ""
 
-#: docking/applets/volume/applet.py:42
+#: docking/applets/volume/applet.py:55
 msgid "Volume"
 msgstr ""
 
-#: docking/applets/volume/applet.py:66
+#: docking/applets/volume/applet.py:79
 msgid "Muted"
 msgstr ""
 
-#: docking/applets/volume/applet.py:66
+#: docking/applets/volume/applet.py:79
 #, python-brace-format
 msgid "Volume: {pct}%"
 msgstr ""
 
-#: docking/applets/volume/applet.py:120
+#: docking/applets/volume/applet.py:133
 msgid "Volume Settings"
 msgstr ""
 
-#: docking/applets/weather/applet.py:70 docking/applets/weather/state.py:163
+#: docking/applets/weather/applet.py:83 docking/applets/weather/state.py:176
 msgid "Weather"
 msgstr ""
 
-#: docking/applets/weather/applet.py:179
+#: docking/applets/weather/applet.py:192
 msgid "Show Temperature"
 msgstr ""
 
-#: docking/applets/weather/applet.py:425
+#: docking/applets/weather/applet.py:438
 msgid "No weather data"
 msgstr ""
 
-#: docking/applets/weather/applet.py:481 docking/applets/weather/state.py:198
+#: docking/applets/weather/applet.py:494 docking/applets/weather/state.py:211
 #, python-brace-format
 msgid "{temp}, {desc}"
 msgstr ""
 
-#: docking/applets/weather/applet.py:494 docking/applets/weather/state.py:188
+#: docking/applets/weather/applet.py:507 docking/applets/weather/state.py:201
 #, python-brace-format
 msgid "Air: {label}"
 msgstr ""
 
-#: docking/applets/weather/applet.py:506
+#: docking/applets/weather/applet.py:519
 #, python-brace-format
 msgid "{date}: {temp_range}"
 msgstr ""
 
-#: docking/applets/weather/state.py:139
+#: docking/applets/weather/state.py:152
 #, python-brace-format
 msgid "{city}: {temp}"
 msgstr ""
 
-#: docking/applets/windowkiller/applet.py:64
+#: docking/applets/windowkiller/applet.py:77
 msgid "Window Killer"
 msgstr ""
 
-#: docking/applets/windowkiller/applet.py:76
+#: docking/applets/windowkiller/applet.py:89
 msgid "Click, then select a window to kill"
 msgstr ""
 
-#: docking/applets/workspaces/applet.py:41
+#: docking/applets/workspaces/applet.py:54
 msgid "Workspaces"
 msgstr ""
 
-#: docking/ui/about.py:55
+#: docking/ui/about.py:68
 msgid "Website"
 msgstr ""
 
-#: docking/ui/dock_window.py:379
+#: docking/ui/dock_window.py:392
 msgid "Docking"
 msgstr ""
 
-#: docking/ui/folder/_browser.py:26
+#: docking/ui/folder/_browser.py:39
 msgid "Name"
 msgstr ""
 
-#: docking/ui/folder/_browser.py:27
+#: docking/ui/folder/_browser.py:40
 msgid "Kind"
 msgstr ""
 
-#: docking/ui/folder/_browser.py:28
+#: docking/ui/folder/_browser.py:41
 msgid "Size"
 msgstr ""
 
-#: docking/ui/folder/_browser.py:29
+#: docking/ui/folder/_browser.py:42
 msgid "Created"
 msgstr ""
 
-#: docking/ui/folder/_browser.py:30
+#: docking/ui/folder/_browser.py:43
 msgid "Modified"
 msgstr ""
 
-#: docking/ui/folder/stack.py:660
+#: docking/ui/folder/stack.py:673
 msgid "Folder not found"
 msgstr ""
 
-#: docking/ui/folder/stack.py:674
+#: docking/ui/folder/stack.py:687
 msgid "Folder is empty"
 msgstr ""
 
-#: docking/ui/folder/stack.py:1131
+#: docking/ui/folder/stack.py:1144
 #, python-format
 msgid "Open in %s"
 msgstr ""
 
-#: docking/ui/folder/stack.py:1133
+#: docking/ui/folder/stack.py:1146
 #, python-format
 msgid "%d More in %s"
 msgstr ""
 
-#: docking/ui/folder/stack.py:1136
+#: docking/ui/folder/stack.py:1149
 msgid "Open Folder"
 msgstr ""
 
-#: docking/ui/folder/stack.py:1138
+#: docking/ui/folder/stack.py:1151
 #, python-format
 msgid "%d More in Folder"
 msgstr ""
 
-#: docking/ui/menu.py:377
+#: docking/ui/menu.py:390
 msgid "Icon"
 msgstr ""
 
-#: docking/ui/menu.py:379
+#: docking/ui/menu.py:392
 msgid "Docking Icon"
 msgstr ""
 
-#: docking/ui/menu.py:380
+#: docking/ui/menu.py:393
 msgid "System Icon"
 msgstr ""
 
-#: docking/ui/menu.py:423 docking/ui/menu.py:443 docking/ui/menu.py:459
-#: docking/ui/menu.py:507
+#: docking/ui/menu.py:436 docking/ui/menu.py:456 docking/ui/menu.py:472
+#: docking/ui/menu.py:520
 msgid "Remove from Dock"
 msgstr ""
 
-#: docking/ui/menu.py:436
+#: docking/ui/menu.py:449
 msgid "Open"
 msgstr ""
 
-#: docking/ui/menu.py:466
+#: docking/ui/menu.py:479
 msgid "Keep in Dock"
 msgstr ""
 
-#: docking/ui/menu.py:475
+#: docking/ui/menu.py:488
 msgid "Close All"
 msgstr ""
 
-#: docking/ui/menu.py:475
+#: docking/ui/menu.py:488
 msgid "Close"
 msgstr ""
 
-#: docking/ui/menu.py:492
+#: docking/ui/menu.py:505
 msgid "Sort By"
 msgstr ""
 
-#: docking/ui/menu.py:500
+#: docking/ui/menu.py:513
 msgid "Show Hidden Files"
 msgstr ""
 
-#: docking/ui/menu.py:537
+#: docking/ui/menu.py:550
 msgid "Add Applet"
 msgstr ""
 
-#: docking/ui/menu.py:575
+#: docking/ui/menu.py:588
 msgid "No Applets Available"
 msgstr ""
 
-#: docking/ui/menu.py:582
+#: docking/ui/menu.py:595
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:592 docking/ui/settings.py:167
+#: docking/ui/menu.py:605 docking/ui/settings.py:181
 msgid "Preferences"
 msgstr ""
 
-#: docking/ui/menu.py:597
+#: docking/ui/menu.py:610
 msgid "About"
 msgstr ""
 
-#: docking/ui/menu.py:602
+#: docking/ui/menu.py:615
 msgid "Get Support"
 msgstr ""
 
-#: docking/ui/menu.py:609
+#: docking/ui/menu.py:622
 msgid "Quit"
 msgstr ""
 
-#: docking/ui/menu.py:646
+#: docking/ui/menu.py:659
 msgid "Window"
 msgstr ""
 
-#: docking/ui/new_year.py:163
+#: docking/ui/new_year.py:176
 #, python-brace-format
 msgid "Happy new year {year} !!!"
 msgstr ""
 
-#: docking/ui/placement.py:225
+#: docking/ui/placement.py:238
 #, python-brace-format
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-#: docking/ui/settings.py:191
+#: docking/ui/settings.py:205
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:192 docking/ui/settings.py:380
+#: docking/ui/settings.py:206 docking/ui/settings.py:396
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:193
+#: docking/ui/settings.py:207
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:212
+#: docking/ui/settings.py:226
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:213
+#: docking/ui/settings.py:227
 msgid "Always on Top"
 msgstr ""
 
-#: docking/ui/settings.py:214
+#: docking/ui/settings.py:228
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:215
+#: docking/ui/settings.py:229
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:216
+#: docking/ui/settings.py:230
 msgid "Dodge Active Window"
 msgstr ""
 
-#: docking/ui/settings.py:217
+#: docking/ui/settings.py:231
 msgid "Dodge All Windows"
 msgstr ""
 
-#: docking/ui/settings.py:218
+#: docking/ui/settings.py:232
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:249
 msgid "Toggle Focus"
 msgstr ""
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:250
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:251
 msgid "Most Recent Window"
 msgstr ""
 
-#: docking/ui/settings.py:244
+#: docking/ui/settings.py:258
 msgid "New Window"
 msgstr ""
 
-#: docking/ui/settings.py:245
+#: docking/ui/settings.py:259
 msgid "Minimize Windows"
 msgstr ""
 
-#: docking/ui/settings.py:246
+#: docking/ui/settings.py:260
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:253
+#: docking/ui/settings.py:267
 msgid "Click"
 msgstr ""
 
-#: docking/ui/settings.py:254
+#: docking/ui/settings.py:268
 msgid "Hover"
 msgstr ""
 
-#: docking/ui/settings.py:270
+#: docking/ui/settings.py:285
 msgid "Daily"
 msgstr ""
 
-#: docking/ui/settings.py:271
+#: docking/ui/settings.py:286
 msgid "Weekly"
 msgstr ""
 
-#: docking/ui/settings.py:324
+#: docking/ui/settings.py:339
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:326
+#: docking/ui/settings.py:341
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:327
+#: docking/ui/settings.py:342
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:328
+#: docking/ui/settings.py:343
 msgid "Transparency"
 msgstr ""
 
-#: docking/ui/settings.py:329
+#: docking/ui/settings.py:344
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:330
+#: docking/ui/settings.py:345
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:331
+#: docking/ui/settings.py:346
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:332
+#: docking/ui/settings.py:347
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:337
+#: docking/ui/settings.py:353
 msgid "Placement"
 msgstr ""
 
-#: docking/ui/settings.py:339
+#: docking/ui/settings.py:355
 msgid "Position"
 msgstr ""
 
-#: docking/ui/settings.py:340
+#: docking/ui/settings.py:356
 msgid "Follow Cursor"
 msgstr ""
 
-#: docking/ui/settings.py:341
+#: docking/ui/settings.py:357
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:362
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:348
+#: docking/ui/settings.py:364
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:349
+#: docking/ui/settings.py:365
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:350
+#: docking/ui/settings.py:366
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:372
+#: docking/ui/settings.py:388
 msgid "Mouse"
 msgstr ""
 
-#: docking/ui/settings.py:374
+#: docking/ui/settings.py:390
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:375
+#: docking/ui/settings.py:391
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:382
+#: docking/ui/settings.py:398
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:383
+#: docking/ui/settings.py:399
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:384
+#: docking/ui/settings.py:400
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:389
+#: docking/ui/settings.py:405
 msgid "Folder Stacks"
 msgstr ""
 
-#: docking/ui/settings.py:391
+#: docking/ui/settings.py:407
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:416
+#: docking/ui/settings.py:432
 msgid "Check Now"
 msgstr ""
 
-#: docking/ui/settings.py:418
+#: docking/ui/settings.py:434
 msgid "View Releases"
 msgstr ""
 
-#: docking/ui/settings.py:430
+#: docking/ui/settings.py:446
 msgid "Update Checks"
 msgstr ""
 
-#: docking/ui/settings.py:432
+#: docking/ui/settings.py:448
 msgid "Check Automatically"
 msgstr ""
 
-#: docking/ui/settings.py:433
+#: docking/ui/settings.py:449
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:434
+#: docking/ui/settings.py:450
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:435
+#: docking/ui/settings.py:451
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:841
+#: docking/ui/settings.py:862
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:845
+#: docking/ui/settings.py:866
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:847
+#: docking/ui/settings.py:868
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:882
+#: docking/ui/settings.py:903
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:884
+#: docking/ui/settings.py:905
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:887
+#: docking/ui/settings.py:908
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:889
+#: docking/ui/settings.py:910
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:891
+#: docking/ui/settings.py:912
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:893
+#: docking/ui/settings.py:914
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:896
+#: docking/ui/settings.py:917
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
 
-#: docking/ui/update_popup.py:173
+#: docking/ui/update_popup.py:186
 #, python-brace-format
 msgid "Docking {version} is available"
 msgstr ""
 
-#: docking/ui/update_popup.py:179
+#: docking/ui/update_popup.py:192
 #, python-brace-format
 msgid "You are using {version}."
 msgstr ""
 
-#: docking/ui/update_popup.py:188
+#: docking/ui/update_popup.py:201
 msgid "View Release"
 msgstr ""
 
-#: docking/ui/update_popup.py:189
+#: docking/ui/update_popup.py:202
 msgid "Later"
 msgstr ""
 
-#: docking/ui/update_popup.py:190
+#: docking/ui/update_popup.py:203
 msgid "Ignore"
 msgstr ""

--- a/tests/applets/test_certwatch.py
+++ b/tests/applets/test_certwatch.py
@@ -261,7 +261,7 @@ class TestTooltip:
         assert "a.test" in text
         assert "b.test" in text
         assert "5d" in text
-        assert "Updated:" in text
+        assert "Updated: just now" in text
         assert "Checks every 1 hour" in text
 
     def test_loading_line_when_cert_missing(self):

--- a/tests/applets/test_freshness.py
+++ b/tests/applets/test_freshness.py
@@ -4,8 +4,11 @@ from docking.applets.freshness import (
     cadence_label,
     format_interval,
     on_demand_label,
+    relative_time_label,
     updated_label,
 )
+
+NOW = dt.datetime(2026, 4, 27, 12, 0, tzinfo=dt.timezone.utc)
 
 
 def test_format_interval_prefers_largest_clean_unit():
@@ -23,9 +26,28 @@ def test_on_demand_label():
     assert on_demand_label(verb="Runs") == "Runs on demand"
 
 
-def test_updated_label_formats_valid_timestamp():
-    timestamp = dt.datetime(2026, 4, 27, 12, 0, tzinfo=dt.timezone.utc)
+def test_relative_time_label_formats_recent_timestamps():
+    assert relative_time_label(NOW, now=NOW) == "just now"
+    assert relative_time_label(NOW - dt.timedelta(seconds=1), now=NOW) == "1 second ago"
+    assert (
+        relative_time_label(NOW - dt.timedelta(seconds=42), now=NOW) == "42 seconds ago"
+    )
+    assert relative_time_label(NOW - dt.timedelta(minutes=1), now=NOW) == "1 minute ago"
+    assert (
+        relative_time_label(NOW - dt.timedelta(minutes=5), now=NOW) == "5 minutes ago"
+    )
+    assert relative_time_label(NOW - dt.timedelta(hours=1), now=NOW) == "1 hour ago"
+    assert relative_time_label(NOW - dt.timedelta(hours=2), now=NOW) == "2 hours ago"
+    assert relative_time_label(NOW - dt.timedelta(days=1), now=NOW) == "1 day ago"
+    assert relative_time_label(NOW - dt.timedelta(days=3), now=NOW) == "3 days ago"
 
-    assert "Updated:" in updated_label(timestamp)
-    assert "2026-04-27" in updated_label(timestamp)
+
+def test_relative_time_label_clamps_future_timestamps():
+    assert relative_time_label(NOW + dt.timedelta(seconds=30), now=NOW) == "just now"
+
+
+def test_updated_label_formats_relative_timestamp():
+    timestamp = NOW - dt.timedelta(minutes=5)
+
+    assert updated_label(timestamp, now=NOW) == "Updated: 5 minutes ago"
     assert updated_label("") == ""

--- a/tests/applets/test_live_state.py
+++ b/tests/applets/test_live_state.py
@@ -53,16 +53,33 @@ def test_live_state_label_and_error_detail():
 
 def test_live_freshness_uses_stale_label_before_cadence():
     updated = dt.datetime(2026, 4, 30, 10, 0, tzinfo=dt.timezone.utc)
+    now = dt.datetime(2026, 4, 30, 10, 10, tzinfo=dt.timezone.utc)
 
     lines = live_freshness_lines(
         status=LiveDataStatus.STALE,
         updated_at=updated,
         cadence_seconds=300,
+        now=now,
     )
 
-    assert lines[0].startswith("Stale: last updated")
+    assert lines[0] == "Stale: last updated 10 minutes ago"
     assert lines[1] == "Updates every 5 minutes"
     assert stale_label(None) == "Stale data"
+
+
+def test_live_freshness_uses_relative_updated_label_before_cadence():
+    updated = dt.datetime(2026, 4, 30, 10, 0, tzinfo=dt.timezone.utc)
+    now = dt.datetime(2026, 4, 30, 10, 2, tzinfo=dt.timezone.utc)
+
+    lines = live_freshness_lines(
+        status=LiveDataStatus.READY,
+        updated_at=updated,
+        cadence_seconds=300,
+        now=now,
+    )
+
+    assert lines[0] == "Updated: 2 minutes ago"
+    assert lines[1] == "Updates every 5 minutes"
 
 
 def test_refresh_recovery_label_only_for_non_ready_states():


### PR DESCRIPTION
Show freshness and stale-data timestamps as relative ages, including shared helpers for update labels used by live applet state.