### PR TITLE
Add theme migration infrastructure

### DIFF
--- a/docking/core/theme/__init__.py
+++ b/docking/core/theme/__init__.py
@@ -1,0 +1,50 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Public theme API."""
+
+from docking.core.theme.migration import (
+    DEPRECATED_THEME_KEYS,
+    ThemeMigrationChange,
+    ThemeMigrationResult,
+    migrate_theme_dict,
+)
+from docking.core.theme.theme import (
+    _BUILTIN_THEMES_DIR,
+    _USER_THEME_TEMPLATE_NAME,
+    RGB,
+    RGBA,
+    IndicatorStyle,
+    Theme,
+    _rgba,
+    ensure_user_theme_template,
+    list_theme_names,
+    user_themes_dir,
+)
+
+__all__ = [
+    "DEPRECATED_THEME_KEYS",
+    "RGB",
+    "RGBA",
+    "_BUILTIN_THEMES_DIR",
+    "_USER_THEME_TEMPLATE_NAME",
+    "IndicatorStyle",
+    "Theme",
+    "ThemeMigrationChange",
+    "ThemeMigrationResult",
+    "_rgba",
+    "ensure_user_theme_template",
+    "list_theme_names",
+    "migrate_theme_dict",
+    "user_themes_dir",
+]

--- a/docking/core/theme/migration.py
+++ b/docking/core/theme/migration.py
@@ -1,0 +1,297 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Theme schema migration helpers."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import tempfile
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from docking.log import get_logger
+
+_THEME_MIGRATION_BACKUP_SUFFIX = ".pre-nested-schema.bak"
+_THEME_SAVE_LOCK = threading.RLock()
+log = get_logger("theme")
+
+# Future migrations should add entries like:
+#     "h_padding": "layout.horizontal_padding"
+# Keep this empty until a PR introduces the first real rename.
+DEPRECATED_THEME_KEYS: dict[str, str] = {}
+
+
+@dataclass(frozen=True)
+class ThemeMigrationChange:
+    """One legacy theme key moved or removed during schema migration."""
+
+    old_path: str
+    new_path: str
+    conflict: bool = False
+
+
+@dataclass(frozen=True)
+class ThemeMigrationResult:
+    """Pure result of applying schema migration rules to a theme payload."""
+
+    data: dict[str, Any]
+    changes: tuple[ThemeMigrationChange, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.changes)
+
+
+def migrate_theme_dict(
+    data: dict[str, Any],
+    deprecated_keys: Mapping[str, str] | None = None,
+) -> ThemeMigrationResult:
+    """Return a copy of ``data`` with registered legacy keys moved.
+
+    The function is deliberately pure: it does not mutate the caller's dict and
+    does not write to disk. File persistence is handled by theme loading only
+    after it knows the source path is a user theme.
+    """
+    migrated = copy.deepcopy(data)
+    changes: list[ThemeMigrationChange] = []
+    warnings: list[str] = []
+    registry = DEPRECATED_THEME_KEYS if deprecated_keys is None else deprecated_keys
+
+    for old_path, new_path in registry.items():
+        if old_path == new_path:
+            continue
+        old_found, old_value = _theme_path_value(migrated, old_path)
+        if not old_found:
+            continue
+
+        new_found, _new_value = _theme_path_value(migrated, new_path)
+        _theme_path_pop(migrated, old_path)
+        if new_found:
+            changes.append(
+                ThemeMigrationChange(
+                    old_path=old_path,
+                    new_path=new_path,
+                    conflict=True,
+                )
+            )
+            warnings.append(
+                "Deprecated theme key "
+                f"{old_path!r} ignored because {new_path!r} is already set"
+            )
+            continue
+
+        section_warnings = _theme_path_set(migrated, new_path, old_value)
+        warnings.extend(section_warnings)
+        changes.append(ThemeMigrationChange(old_path=old_path, new_path=new_path))
+
+    return ThemeMigrationResult(
+        data=migrated,
+        changes=tuple(changes),
+        warnings=tuple(warnings),
+    )
+
+
+def migrate_loaded_theme_data(
+    *,
+    data: dict[str, Any],
+    path: Path,
+    user_theme_dir: Path,
+) -> dict[str, Any]:
+    """Migrate loaded theme data and persist user-theme migrations."""
+    migration = migrate_theme_dict(data)
+    for warning in migration.warnings:
+        log.warning("%s in %s", warning, path)
+    if not migration.changed:
+        return migration.data
+
+    for change in migration.changes:
+        if change.conflict:
+            log.warning(
+                "Theme %s has both deprecated key %r and replacement %r; "
+                "keeping replacement",
+                path,
+                change.old_path,
+                change.new_path,
+            )
+        else:
+            log.info(
+                "Migrated theme key for %s: %s -> %s",
+                path,
+                change.old_path,
+                change.new_path,
+            )
+
+    if _is_user_theme_path(path=path, user_theme_dir=user_theme_dir):
+        try:
+            _persist_migrated_user_theme(path=path, data=migration.data)
+        except Exception as exc:
+            log.warning(
+                "Failed to rewrite migrated user theme %s; using in-memory "
+                "migration for this session: %s",
+                path,
+                exc,
+            )
+    return migration.data
+
+
+def _theme_path_parts(path: str) -> tuple[str, ...]:
+    return tuple(part for part in path.split(".") if part)
+
+
+def _theme_path_value(data: Mapping[str, Any], path: str) -> tuple[bool, Any]:
+    parts = _theme_path_parts(path)
+    if not parts:
+        return False, None
+    current: Any = data
+    for part in parts[:-1]:
+        if not isinstance(current, Mapping):
+            return False, None
+        current = current.get(part)
+    if not isinstance(current, Mapping):
+        return False, None
+    leaf = parts[-1]
+    if leaf not in current:
+        return False, None
+    return True, current[leaf]
+
+
+def _theme_path_pop(data: dict[str, Any], path: str) -> None:
+    parts = _theme_path_parts(path)
+    if not parts:
+        return
+    current: Any = data
+    for part in parts[:-1]:
+        if not isinstance(current, dict):
+            return
+        current = current.get(part)
+    if isinstance(current, dict):
+        current.pop(parts[-1], None)
+
+
+def _theme_path_set(data: dict[str, Any], path: str, value: Any) -> tuple[str, ...]:
+    parts = _theme_path_parts(path)
+    if not parts:
+        return ()
+    warnings: list[str] = []
+    current = data
+    for index, part in enumerate(parts[:-1]):
+        if part in current:
+            existing = current[part]
+            if isinstance(existing, dict):
+                current = existing
+                continue
+            section = ".".join(parts[: index + 1])
+            warnings.append(f"Theme section {section!r} is not an object; replacing it")
+        child: dict[str, Any] = {}
+        current[part] = child
+        current = child
+    current[parts[-1]] = value
+    return tuple(warnings)
+
+
+def _is_user_theme_path(*, path: Path, user_theme_dir: Path) -> bool:
+    try:
+        return path.resolve().parent == user_theme_dir.resolve()
+    except OSError:
+        return path.parent == user_theme_dir
+
+
+def _persist_migrated_user_theme(*, path: Path, data: dict[str, Any]) -> None:
+    with _THEME_SAVE_LOCK:
+        _create_theme_migration_backup(path=path)
+        _write_theme_json_atomic(path=path, payload=data)
+
+
+def _theme_migration_backup_path(path: Path) -> Path:
+    return path.with_name(f"{path.name}{_THEME_MIGRATION_BACKUP_SUFFIX}")
+
+
+def _create_theme_migration_backup(*, path: Path) -> Path:
+    backup_path = _theme_migration_backup_path(path)
+    if backup_path.exists() or not path.exists():
+        return backup_path
+    backup_tmp = _new_theme_tmp_path(path=backup_path)
+    try:
+        data = path.read_bytes()
+        with backup_tmp.open(mode="wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        backup_tmp.replace(backup_path)
+        _fsync_directory(backup_path.parent)
+    except Exception:
+        try:
+            backup_tmp.unlink(missing_ok=True)
+        except OSError as cleanup_exc:
+            log.warning(
+                "Failed to clean up theme backup temp file %s: %s",
+                backup_tmp,
+                cleanup_exc,
+            )
+        raise
+    return backup_path
+
+
+def _write_theme_json_atomic(*, path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = _new_theme_tmp_path(path=path)
+    try:
+        with tmp_path.open(mode="w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        with tmp_path.open(encoding="utf-8") as handle:
+            candidate = json.load(handle)
+        if not isinstance(candidate, dict):
+            raise ValueError("migrated theme payload is not a JSON object")
+        tmp_path.replace(path)
+        _fsync_directory(path.parent)
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError as cleanup_exc:
+            log.warning(
+                "Failed to clean up theme temp file %s: %s",
+                tmp_path,
+                cleanup_exc,
+            )
+        raise
+
+
+def _new_theme_tmp_path(*, path: Path) -> Path:
+    fd, tmp_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        text=True,
+    )
+    os.close(fd)
+    return Path(tmp_name)
+
+
+def _fsync_directory(directory: Path) -> None:
+    if os.name == "nt":
+        return
+    fd = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)

--- a/docking/core/theme/theme.py
+++ b/docking/core/theme/theme.py
@@ -139,10 +139,13 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
+from docking.core.theme.migration import migrate_loaded_theme_data
 from docking.log import get_logger
 
 # Bundled themes directory (relative to package)
-_BUILTIN_THEMES_DIR = Path(__file__).resolve().parent.parent / "assets" / "themes"
+_BUILTIN_THEMES_DIR = (
+    Path(__file__).resolve().parent.parent.parent / "assets" / "themes"
+)
 _USER_THEME_TEMPLATE_NAME = "template"
 log = get_logger("theme")
 
@@ -371,6 +374,11 @@ class Theme:
 
         with path.open(encoding="utf-8") as f:
             data: dict[str, Any] = json.load(fp=f)
+        data = migrate_loaded_theme_data(
+            data=data,
+            path=path,
+            user_theme_dir=user_themes_dir(),
+        )
 
         # --- Scale factor ---
         # All layout values in JSON use "tenths of percent of icon_size".

--- a/tests/core/test_theme.py
+++ b/tests/core/test_theme.py
@@ -1,16 +1,19 @@
 """Tests for theme loading, scaling unit system, and color parsing."""
 
 import json
+import logging
 from unittest.mock import patch
 
 import pytest
 
+import docking.core.theme.migration as theme_migration_mod
 from docking.core.theme import (
     _USER_THEME_TEMPLATE_NAME,
     Theme,
     _rgba,
     ensure_user_theme_template,
     list_theme_names,
+    migrate_theme_dict,
     user_themes_dir,
 )
 
@@ -70,7 +73,7 @@ class TestThemeLoad:
         theme_file = tmp_path / "custom.json"
         theme_file.write_text(json.dumps(theme_data))
         # When
-        with patch("docking.core.theme._BUILTIN_THEMES_DIR", tmp_path):
+        with patch("docking.core.theme.theme._BUILTIN_THEMES_DIR", tmp_path):
             t = Theme.load("custom", 48)
         # Then
         assert t.roundness == 16.0
@@ -166,6 +169,133 @@ class TestThemeLoad:
         assert t.fill_start[3] > 0.9
 
 
+class TestThemeMigration:
+    def test_migrate_theme_dict_is_idempotent_without_registered_keys(self):
+        data = {"roundness": 5, "meta": {"author": "custom"}}
+
+        result = migrate_theme_dict(data, deprecated_keys={})
+
+        assert result.changed is False
+        assert result.data == data
+        assert result.data is not data
+
+    def test_migrate_theme_dict_moves_legacy_key_and_preserves_unknowns(self):
+        data = {
+            "legacy_padding": 3,
+            "roundness": 5,
+            "metadata": {"author": "custom"},
+        }
+
+        result = migrate_theme_dict(
+            data,
+            deprecated_keys={"legacy_padding": "layout.horizontal_padding"},
+        )
+
+        assert result.changed is True
+        assert "legacy_padding" not in result.data
+        assert result.data["layout"]["horizontal_padding"] == 3
+        assert result.data["roundness"] == 5
+        assert result.data["metadata"] == {"author": "custom"}
+        assert "legacy_padding" in data
+
+    def test_migrate_theme_dict_prefers_new_value_when_both_exist(self):
+        data = {
+            "legacy_padding": 3,
+            "layout": {"horizontal_padding": 7},
+        }
+
+        result = migrate_theme_dict(
+            data,
+            deprecated_keys={"legacy_padding": "layout.horizontal_padding"},
+        )
+
+        assert "legacy_padding" not in result.data
+        assert result.data["layout"]["horizontal_padding"] == 7
+        assert result.changes[0].conflict is True
+        assert "ignored" in result.warnings[0]
+
+    def test_migrate_theme_dict_replaces_malformed_nested_section(self):
+        data = {"legacy_padding": 3, "layout": None}
+
+        result = migrate_theme_dict(
+            data,
+            deprecated_keys={"legacy_padding": "layout.horizontal_padding"},
+        )
+
+        assert result.data["layout"] == {"horizontal_padding": 3}
+        assert "not an object" in result.warnings[0]
+
+    def test_theme_load_rewrites_migrated_user_theme_and_creates_backup(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+        monkeypatch.setattr(
+            theme_migration_mod,
+            "DEPRECATED_THEME_KEYS",
+            {"legacy_padding": "layout.horizontal_padding"},
+        )
+        directory = user_themes_dir()
+        directory.mkdir(parents=True)
+        theme_file = directory / "custom.json"
+        original = {"roundness": 14, "legacy_padding": 3}
+        theme_file.write_text(json.dumps(original), encoding="utf-8")
+
+        theme = Theme.load("custom", 48)
+
+        migrated = json.loads(theme_file.read_text(encoding="utf-8"))
+        backup = theme_migration_mod._theme_migration_backup_path(theme_file)
+        assert theme.roundness == 14.0
+        assert migrated["layout"]["horizontal_padding"] == 3
+        assert "legacy_padding" not in migrated
+        assert backup.exists()
+        assert json.loads(backup.read_text(encoding="utf-8")) == original
+
+    def test_theme_migration_backup_is_not_listed_as_theme(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+        directory = user_themes_dir()
+        directory.mkdir(parents=True)
+        theme_file = directory / "custom.json"
+        theme_file.write_text("{}", encoding="utf-8")
+        backup = theme_migration_mod._theme_migration_backup_path(theme_file)
+        backup.write_text("{}", encoding="utf-8")
+
+        names = list_theme_names()
+
+        assert "custom" in names
+        assert backup.name not in names
+
+    def test_theme_load_uses_in_memory_migration_when_rewrite_fails(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+        monkeypatch.setattr(
+            theme_migration_mod,
+            "DEPRECATED_THEME_KEYS",
+            {"legacy_roundness": "roundness"},
+        )
+
+        def raise_permission(**_kwargs):
+            raise PermissionError("read-only")
+
+        monkeypatch.setattr(
+            theme_migration_mod,
+            "_write_theme_json_atomic",
+            raise_permission,
+        )
+        directory = user_themes_dir()
+        directory.mkdir(parents=True)
+        theme_file = directory / "custom.json"
+        original = {"legacy_roundness": 19}
+        theme_file.write_text(json.dumps(original), encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="docking.theme"):
+            theme = Theme.load("custom", 48)
+
+        assert theme.roundness == 19.0
+        assert json.loads(theme_file.read_text(encoding="utf-8")) == original
+        assert "Failed to rewrite migrated user theme" in caplog.text
+
+
 class TestScalingUnit:
     """Tests for the scaling unit system: JSON values * (icon_size / 10)."""
 
@@ -223,7 +353,7 @@ class TestScalingUnit:
         theme_file = tmp_path / "pos.json"
         theme_file.write_text(json.dumps(theme_data))
         # When
-        with patch("docking.core.theme._BUILTIN_THEMES_DIR", tmp_path):
+        with patch("docking.core.theme.theme._BUILTIN_THEMES_DIR", tmp_path):
             t = Theme.load("pos", 48)
         # Then
         assert t.h_padding == pytest.approx(14.4)
@@ -272,7 +402,7 @@ class TestShelfHeightDerivation:
         theme_file = tmp_path / "neg.json"
         theme_file.write_text(json.dumps(theme_data))
         # When
-        with patch("docking.core.theme._BUILTIN_THEMES_DIR", tmp_path):
+        with patch("docking.core.theme.theme._BUILTIN_THEMES_DIR", tmp_path):
             t = Theme.load("neg", 48)
         # Then
         assert t.shelf_height >= 0.0
@@ -315,7 +445,7 @@ class TestAnimationParams:
         theme_file = tmp_path / "minimal.json"
         theme_file.write_text(json.dumps(theme_data))
         # When
-        with patch("docking.core.theme._BUILTIN_THEMES_DIR", tmp_path):
+        with patch("docking.core.theme.theme._BUILTIN_THEMES_DIR", tmp_path):
             t = Theme.load("minimal", 48)
         # Then
         assert t.urgent_bounce_height == pytest.approx(1.66)


### PR DESCRIPTION
Add infrastructure for migrating deprecated theme keys into newer schema paths, including pure migration helpers, user-theme backup creation, and atomic rewrite support for migrated user themes.