### PR TITLE
Rename theme horizontal padding field

### DIFF
--- a/docking/core/layout.py
+++ b/docking/core/layout.py
@@ -156,7 +156,7 @@ def compute_layout(
     config: Config,
     cursor_x: float,
     item_padding: float = 6.0,
-    h_padding: float = 12.0,
+    horizontal_padding: float = 12.0,
     zoom_progress: float = 1.0,
 ) -> list[LayoutItem]:
     """Compute dock item positions and scales for the current pointer state."""
@@ -172,7 +172,7 @@ def compute_layout(
     widths = [int((item.main_size or icon_size) * item.insert_factor) for item in items]
 
     rest_centers: list[float] = []
-    x = h_padding
+    x = horizontal_padding
     for w in widths:
         pad = item_padding if w > 0 else 0
         x += w / 2
@@ -213,12 +213,12 @@ def compute_layout(
 def content_bounds(
     layout: list[LayoutItem],
     icon_size: int,
-    h_padding: float,
+    horizontal_padding: float,
     item_padding: float = 0.0,
 ) -> Bounds:
     """Compute the left and right edges of the content including padding."""
     half_item_pad = item_padding / 2
-    pad = h_padding + half_item_pad
+    pad = horizontal_padding + half_item_pad
     if not layout:
         return Bounds(left=0.0, right=2 * pad)
     first = layout[0]

--- a/docking/core/theme/migration.py
+++ b/docking/core/theme/migration.py
@@ -31,10 +31,9 @@ _THEME_MIGRATION_BACKUP_SUFFIX = ".pre-nested-schema.bak"
 _THEME_SAVE_LOCK = threading.RLock()
 log = get_logger("theme")
 
-# Future migrations should add entries like:
-#     "h_padding": "layout.horizontal_padding"
-# Keep this empty until a PR introduces the first real rename.
-DEPRECATED_THEME_KEYS: dict[str, str] = {}
+DEPRECATED_THEME_KEYS: dict[str, str] = {
+    "h_padding": "layout.horizontal_padding",
+}
 
 
 @dataclass(frozen=True)

--- a/docking/core/theme/theme.py
+++ b/docking/core/theme/theme.py
@@ -135,6 +135,7 @@ from __future__ import annotations
 import enum
 import json
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
@@ -163,7 +164,9 @@ _USER_THEME_TEMPLATE = {
     "indicator_color": [80, 80, 80, 200],
     "active_indicator_color": [50, 50, 50, 255],
     "indicator_size": 5,
-    "h_padding": 0,
+    "layout": {
+        "horizontal_padding": 0,
+    },
     "top_padding": -7,
     "bottom_padding": 1,
     "item_padding": 2.5,
@@ -234,6 +237,15 @@ def _multiply_alpha(color: RGBA, multiplier: float) -> RGBA:
     return color[0], color[1], color[2], color[3] * multiplier
 
 
+def _theme_value(data: Mapping[str, Any], path: str, default: Any) -> Any:
+    current: Any = data
+    for part in path.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return default
+        current = current[part]
+    return current
+
+
 @dataclass(frozen=True)
 class Theme:
     """Visual theme for the dock.
@@ -254,7 +266,7 @@ class Theme:
 
     # --- Layout (stored as px after scaling) ---
     indicator_radius: float = 2.5
-    h_padding: float = 12.0
+    horizontal_padding: float = 12.0
     top_padding: float = 4.0
     bottom_padding: float = 8.0
     item_padding: float = 6.0
@@ -303,7 +315,8 @@ class Theme:
 
             JSON value   x  scale   =  pixel value
             ---------      -----      -----------
-            h_padding=0     4.8        0.0 px
+            horizontal_padding=0
+                            4.8        0.0 px
             item_padding=2.5 4.8       12.0 px
             top_padding=-7   4.8      -33.6 px  (negative = icons above shelf)
             bottom_padding=1 4.8        4.8 px
@@ -348,9 +361,9 @@ class Theme:
             ================== |   <- shelf bottom = screen bottom
               bottom_offset        (bottom_padding)
 
-        The Plank h_padding fallback:
-            When h_padding <= 0 in the JSON (producing 0px or negative),
-            effective h_padding becomes 2 * stroke_width.  This mirrors
+        The Plank horizontal padding fallback:
+            When horizontal_padding <= 0 in the JSON (producing 0px or negative),
+            effective horizontal_padding becomes 2 * stroke_width.  This mirrors
             Plank's `items_offset = 2*LineWidth + (HorizPadding>0 ? HorizPadding : 0)`.
 
         Animation parameters (bounce heights, durations, etc.) are loaded
@@ -403,11 +416,14 @@ class Theme:
         # indicator_size is stored as raw pixels (diameter), halved to radius.
         indicator_radius = float(data.get("indicator_size", 5)) / 2.0
 
-        # h_padding: Plank fallback -- when JSON value <= 0, use 2*stroke_width
-        raw_h_padding = float(data.get("h_padding", 0))
-        h_padding_px = raw_h_padding * scaled
-        if h_padding_px <= 0:
-            h_padding_px = 2.0 * stroke_width
+        # horizontal_padding: Plank fallback -- when JSON value <= 0,
+        # use 2*stroke_width.
+        raw_horizontal_padding = float(
+            _theme_value(data, "layout.horizontal_padding", 0)
+        )
+        horizontal_padding_px = raw_horizontal_padding * scaled
+        if horizontal_padding_px <= 0:
+            horizontal_padding_px = 2.0 * stroke_width
 
         top_padding_px = float(data.get("top_padding", -7)) * scaled
         bottom_padding_px = float(data.get("bottom_padding", 1)) * scaled
@@ -480,7 +496,7 @@ class Theme:
             indicator_color=indicator_color,
             active_indicator_color=active_indicator_color,
             indicator_radius=indicator_radius,
-            h_padding=h_padding_px,
+            horizontal_padding=horizontal_padding_px,
             top_padding=top_padding_px,
             bottom_padding=bottom_padding_px,
             item_padding=item_padding_px,

--- a/docking/ui/geometry.py
+++ b/docking/ui/geometry.py
@@ -532,14 +532,14 @@ def build_geometry_frame(
             config,
             local_cursor_main,
             item_padding=theme.item_padding,
-            h_padding=theme.h_padding,
+            horizontal_padding=theme.horizontal_padding,
             zoom_progress=zoom_progress,
         )
     )
     left_edge, right_edge = content_bounds(
         layout=list(layout),
         icon_size=config.icon_size,
-        h_padding=theme.h_padding,
+        horizontal_padding=theme.horizontal_padding,
         item_padding=theme.item_padding,
     )
     zoomed_w = right_edge - left_edge
@@ -671,7 +671,7 @@ def _local_cursor_main(
 ) -> float:
     if cursor_main < 0:
         return NO_CURSOR_SENTINEL
-    pad = theme.h_padding + theme.item_padding / 2
+    pad = theme.horizontal_padding + theme.item_padding / 2
     total_main = sum(item.main_size or config.icon_size for item in items)
     base_w = pad * 2 + total_main + max(0, len(items) - 1) * theme.item_padding
     return cursor_main - (main_size - base_w) / 2
@@ -954,7 +954,7 @@ def _compute_background_rect(
     gap = max(0, int(theme.distance_from_edge))
     shelf_cross = max(1, round(theme.shelf_height))
     stroke_width = max(0.0, float(theme.stroke_width))
-    main_padding = theme.item_padding + 2 * theme.h_padding + 4 * stroke_width
+    main_padding = theme.item_padding + 2 * theme.horizontal_padding + 4 * stroke_width
 
     if draw_rects:
         if is_horizontal(pos=pos):

--- a/docking/ui/renderer.py
+++ b/docking/ui/renderer.py
@@ -597,7 +597,7 @@ class DockRenderer:
         icon_size = config.icon_size
         total_main = sum(item.main_size or icon_size for item in items)
         width = int(
-            theme.h_padding * 2
+            theme.horizontal_padding * 2
             + total_main
             + max(0, num_items - 1) * theme.item_padding
         )

--- a/tests/bdd_support/harness.py
+++ b/tests/bdd_support/harness.py
@@ -207,7 +207,7 @@ class DockHarness:
                 _redraw_source_id=None,
                 hit_test=MagicMock(return_value=self._folder_item),
                 model=MagicMock(),
-                theme=SimpleNamespace(item_padding=8, h_padding=10),
+                theme=SimpleNamespace(item_padding=8, horizontal_padding=10),
                 window_tracker=MagicMock(),
                 tooltip=MagicMock(),
                 preview=None,
@@ -452,7 +452,7 @@ class DockHarness:
         )
         model = MagicMock()
         renderer = SimpleNamespace(slide_offsets={}, prev_positions={})
-        theme = SimpleNamespace(item_padding=8, h_padding=10)
+        theme = SimpleNamespace(item_padding=8, horizontal_padding=10)
         launcher = MagicMock()
         pointer = MagicMock()
         pointer.get_position.return_value = (None, 0, 0)
@@ -562,7 +562,7 @@ class DockHarness:
         )
         self._hover_theme = SimpleNamespace(
             item_padding=8,
-            h_padding=10,
+            horizontal_padding=10,
             bottom_padding=12,
             launch_bounce_height=0.5,
         )

--- a/tests/core/test_theme.py
+++ b/tests/core/test_theme.py
@@ -114,7 +114,10 @@ class TestThemeLoad:
         names = list_theme_names()
 
         template = user_themes_dir() / f"{_USER_THEME_TEMPLATE_NAME}.json"
+        template_data = json.loads(template.read_text(encoding="utf-8"))
         assert template.exists()
+        assert template_data["layout"]["horizontal_padding"] == 0
+        assert "h_padding" not in template_data
         assert _USER_THEME_TEMPLATE_NAME not in names
         assert "default" in names
 
@@ -339,24 +342,66 @@ class TestScalingUnit:
         assert t64.top_padding == pytest.approx(t48.top_padding * ratio, rel=1e-6)
         assert t64.bottom_padding == pytest.approx(t48.bottom_padding * ratio, rel=1e-6)
 
-    def test_h_padding_fallback_when_zero(self):
+    def test_horizontal_padding_fallback_when_zero(self):
         # Given
-        # When h_padding <= 0, fallback = 2 * stroke_width = 2.0
+        # When horizontal_padding <= 0, fallback = 2 * stroke_width = 2.0
         t = Theme.load("default", 48)
         # Then
-        assert t.h_padding == pytest.approx(2.0)
+        assert t.horizontal_padding == pytest.approx(2.0)
 
-    def test_h_padding_positive_uses_scaled(self, tmp_path):
+    def test_legacy_h_padding_migrates_to_nested_horizontal_padding(
+        self, tmp_path, monkeypatch
+    ):
         # Given
         # 3 * 4.8 = 14.4 > 0, so no fallback
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+        directory = user_themes_dir()
+        directory.mkdir(parents=True)
         theme_data = {"h_padding": 3, "stroke_width": 1.0}
+        theme_file = directory / "pos.json"
+        theme_file.write_text(json.dumps(theme_data), encoding="utf-8")
+        # When
+        t = Theme.load("pos", 48)
+        # Then
+        migrated = json.loads(theme_file.read_text(encoding="utf-8"))
+        assert t.horizontal_padding == pytest.approx(14.4)
+        assert migrated["layout"]["horizontal_padding"] == 3
+        assert "h_padding" not in migrated
+
+    def test_nested_horizontal_padding_uses_scaled(self, tmp_path):
+        # Given
+        theme_data = {"layout": {"horizontal_padding": 3}, "stroke_width": 1.0}
         theme_file = tmp_path / "pos.json"
         theme_file.write_text(json.dumps(theme_data))
         # When
         with patch("docking.core.theme.theme._BUILTIN_THEMES_DIR", tmp_path):
             t = Theme.load("pos", 48)
         # Then
-        assert t.h_padding == pytest.approx(14.4)
+        assert t.horizontal_padding == pytest.approx(14.4)
+
+    def test_nested_horizontal_padding_wins_over_legacy(self, tmp_path, monkeypatch):
+        # Given
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+        directory = user_themes_dir()
+        directory.mkdir(parents=True)
+        theme_file = directory / "custom.json"
+        theme_file.write_text(
+            json.dumps(
+                {
+                    "h_padding": 1,
+                    "layout": {"horizontal_padding": 3},
+                    "stroke_width": 1.0,
+                }
+            ),
+            encoding="utf-8",
+        )
+        # When
+        t = Theme.load("custom", 48)
+        # Then
+        migrated = json.loads(theme_file.read_text(encoding="utf-8"))
+        assert t.horizontal_padding == pytest.approx(14.4)
+        assert migrated["layout"]["horizontal_padding"] == 3
+        assert "h_padding" not in migrated
 
     def test_indicator_radius_from_size(self):
         # Given

--- a/tests/core/test_zoom.py
+++ b/tests/core/test_zoom.py
@@ -5,7 +5,7 @@ formula derived from Plank's PositionManager.  Each icon is displaced from
 its REST position based on distance from the cursor, then scaled using a
 parabolic curve.
 
-The scaling unit for h_padding and item_padding is pixels (already scaled
+The scaling unit for horizontal_padding and item_padding is pixels (already scaled
 from the theme's "tenths of one percent of icon_size" at load time).
 """
 
@@ -49,14 +49,14 @@ class TestRestPositions:
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(5)]
         # When
         layout = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=10, h_padding=12
+            items, config, NO_CURSOR_SENTINEL, item_padding=10, horizontal_padding=12
         )
         # Then
         for i in range(1, len(layout)):
             gap = layout[i].x - layout[i - 1].x
             assert gap == pytest.approx(48 + 10)  # icon_size + item_padding
 
-    def test_first_icon_starts_at_h_padding(self):
+    def test_first_icon_starts_at_horizontal_padding(self):
         # Given
         config = MagicMock(main_size=0, insert_factor=1.0)
         config.icon_size = 48
@@ -66,7 +66,7 @@ class TestRestPositions:
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(3)]
         # When
         layout = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=10, h_padding=12
+            items, config, NO_CURSOR_SENTINEL, item_padding=10, horizontal_padding=12
         )
         # Then
         assert layout[0].x == pytest.approx(12.0)
@@ -84,11 +84,13 @@ class TestZoomedPositions:
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(5)]
         rest = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=10, h_padding=12
+            items, config, NO_CURSOR_SENTINEL, item_padding=10, horizontal_padding=12
         )
         # When
         center_x = rest[2].x + 24  # center of 3rd icon
-        layout = compute_layout(items, config, center_x, item_padding=10, h_padding=12)
+        layout = compute_layout(
+            items, config, center_x, item_padding=10, horizontal_padding=12
+        )
         # Then
         assert layout[2].scale == pytest.approx(config.zoom_percent)
 
@@ -101,11 +103,11 @@ class TestZoomedPositions:
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(10)]
         rest = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=10, h_padding=12
+            items, config, NO_CURSOR_SENTINEL, item_padding=10, horizontal_padding=12
         )
         # When
         layout = compute_layout(
-            items, config, rest[0].x + 24, item_padding=10, h_padding=12
+            items, config, rest[0].x + 24, item_padding=10, horizontal_padding=12
         )
         # Then
         assert layout[-1].scale == pytest.approx(1.0)
@@ -119,11 +121,11 @@ class TestZoomedPositions:
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(5)]
         rest = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=10, h_padding=12
+            items, config, NO_CURSOR_SENTINEL, item_padding=10, horizontal_padding=12
         )
         # When
         layout = compute_layout(
-            items, config, rest[2].x + 24, item_padding=10, h_padding=12
+            items, config, rest[2].x + 24, item_padding=10, horizontal_padding=12
         )
         # Then
         for li in layout:
@@ -138,11 +140,11 @@ class TestZoomedPositions:
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0)]
         rest = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=10, h_padding=12
+            items, config, NO_CURSOR_SENTINEL, item_padding=10, horizontal_padding=12
         )
         # When
         layout = compute_layout(
-            items, config, rest[0].x + 24, item_padding=10, h_padding=12
+            items, config, rest[0].x + 24, item_padding=10, horizontal_padding=12
         )
         # Then
         assert layout[0].scale == pytest.approx(1.5)
@@ -159,11 +161,11 @@ class TestZoomedPositions:
             SimpleNamespace(main_size=0, allow_zoom=True, insert_factor=1.0),
         ]
         rest = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=10, h_padding=12
+            items, config, NO_CURSOR_SENTINEL, item_padding=10, horizontal_padding=12
         )
 
         layout = compute_layout(
-            items, config, rest[1].x + 8, item_padding=10, h_padding=12
+            items, config, rest[1].x + 8, item_padding=10, horizontal_padding=12
         )
 
         assert layout[1].scale == pytest.approx(1.0)
@@ -185,7 +187,9 @@ class TestEdgeCases:
         config.zoom_percent = 1.5
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(3)]
-        layout = compute_layout(items, config, 99999.0, item_padding=10, h_padding=12)
+        layout = compute_layout(
+            items, config, 99999.0, item_padding=10, horizontal_padding=12
+        )
         for li in layout:
             assert li.scale == pytest.approx(1.0)
 
@@ -201,11 +205,13 @@ class TestEdgeCases:
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(2)]
         rest = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=10, h_padding=12
+            items, config, NO_CURSOR_SENTINEL, item_padding=10, horizontal_padding=12
         )
         # When
         center_x = (rest[0].x + rest[1].x + 48) / 2
-        layout = compute_layout(items, config, center_x, item_padding=10, h_padding=12)
+        layout = compute_layout(
+            items, config, center_x, item_padding=10, horizontal_padding=12
+        )
         # Then
         assert layout[0].scale == pytest.approx(layout[1].scale, abs=0.01)
 
@@ -218,11 +224,11 @@ class TestEdgeCases:
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(5)]
         rest = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=10, h_padding=12
+            items, config, NO_CURSOR_SENTINEL, item_padding=10, horizontal_padding=12
         )
         # When
         layout = compute_layout(
-            items, config, rest[0].x + 24, item_padding=10, h_padding=12
+            items, config, rest[0].x + 24, item_padding=10, horizontal_padding=12
         )
         # Then
         assert layout[0].scale == pytest.approx(1.5)
@@ -237,14 +243,16 @@ class TestEdgeCases:
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(5)]
 
-        layout = compute_layout(items, config, -2.0, item_padding=10, h_padding=12)
+        layout = compute_layout(
+            items, config, -2.0, item_padding=10, horizontal_padding=12
+        )
 
         assert layout[0].scale > 1.0
 
 
 class TestContentBounds:
     def test_no_layout_returns_zero_and_padding(self):
-        # Given / When -- with item_padding, total pad = h_padding + item_padding/2
+        # Given / When -- with item_padding, total pad = horizontal_padding + item_padding/2
         left, right = content_bounds([], 48, 12, item_padding=10)
         # Then
         assert left == 0.0
@@ -264,7 +272,7 @@ class TestContentBounds:
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(3)]
         layout = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=10, h_padding=12
+            items, config, NO_CURSOR_SENTINEL, item_padding=10, horizontal_padding=12
         )
         # When
         left, right = content_bounds(layout, 48, 12, item_padding=10)
@@ -282,7 +290,7 @@ class TestContentBounds:
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(3)]
         layout = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=10, h_padding=12
+            items, config, NO_CURSOR_SENTINEL, item_padding=10, horizontal_padding=12
         )
         # When
         with_ipad = content_bounds(layout, 48, 12, item_padding=10)
@@ -300,11 +308,13 @@ class TestContentBounds:
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(5)]
         rest = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=10, h_padding=12
+            items, config, NO_CURSOR_SENTINEL, item_padding=10, horizontal_padding=12
         )
         rest_l, rest_r = content_bounds(rest, 48, 12, item_padding=10)
         # When
-        zoomed = compute_layout(items, config, 150.0, item_padding=10, h_padding=12)
+        zoomed = compute_layout(
+            items, config, 150.0, item_padding=10, horizontal_padding=12
+        )
         zoom_l, zoom_r = content_bounds(zoomed, 48, 12, item_padding=10)
         # Then
         assert (zoom_r - zoom_l) >= (rest_r - rest_l)
@@ -319,11 +329,11 @@ class TestContentBounds:
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(5)]
         rest = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=10, h_padding=12
+            items, config, NO_CURSOR_SENTINEL, item_padding=10, horizontal_padding=12
         )
         # When
         zoomed = compute_layout(
-            items, config, rest[-1].x + 24, item_padding=10, h_padding=12
+            items, config, rest[-1].x + 24, item_padding=10, horizontal_padding=12
         )
         left, _ = content_bounds(zoomed, 48, 12, item_padding=10)
         # Then
@@ -342,7 +352,7 @@ class TestBaseWConsistency:
 
     def test_base_w_matches_rest_content_width(self):
         # Given
-        h_padding = 2.0
+        horizontal_padding = 2.0
         item_padding = 12.0
         icon_size = 48
         n = 5
@@ -353,19 +363,19 @@ class TestBaseWConsistency:
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(n)]
         # When
-        pad = h_padding + item_padding / 2
+        pad = horizontal_padding + item_padding / 2
         base_w = pad * 2 + n * icon_size + max(0, n - 1) * item_padding
         layout = compute_layout(
             items,
             config,
             NO_CURSOR_SENTINEL,
             item_padding=item_padding,
-            h_padding=h_padding,
+            horizontal_padding=horizontal_padding,
         )
         left, right = content_bounds(
             layout=layout,
             icon_size=icon_size,
-            h_padding=h_padding,
+            horizontal_padding=horizontal_padding,
             item_padding=item_padding,
         )
         bounds_w = right - left
@@ -374,20 +384,27 @@ class TestBaseWConsistency:
 
     def test_consistency_across_item_counts(self):
         for n in (1, 2, 5, 11):
-            h_pad, i_pad, size = 2.0, 12.0, 48
+            horizontal_pad, i_pad, size = 2.0, 12.0, 48
             config = MagicMock(main_size=0, insert_factor=1.0)
             config.icon_size = size
             config.zoom_enabled = False
             config.zoom_percent = 1.0
             config.zoom_range = 3
             items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(n)]
-            pad = h_pad + i_pad / 2
+            pad = horizontal_pad + i_pad / 2
             base_w = pad * 2 + n * size + max(0, n - 1) * i_pad
             layout = compute_layout(
-                items, config, NO_CURSOR_SENTINEL, item_padding=i_pad, h_padding=h_pad
+                items,
+                config,
+                NO_CURSOR_SENTINEL,
+                item_padding=i_pad,
+                horizontal_padding=horizontal_pad,
             )
             left, right = content_bounds(
-                layout=layout, icon_size=size, h_padding=h_pad, item_padding=i_pad
+                layout=layout,
+                icon_size=size,
+                horizontal_padding=horizontal_pad,
+                item_padding=i_pad,
             )
             assert base_w == pytest.approx(right - left), f"mismatch at n={n}"
 
@@ -403,19 +420,19 @@ class TestBaseWConsistency:
         config.zoom_percent = 1.0
         config.zoom_range = 3
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(n)]
-        pad = theme.h_padding + theme.item_padding / 2
+        pad = theme.horizontal_padding + theme.item_padding / 2
         base_w = pad * 2 + n * 48 + max(0, n - 1) * theme.item_padding
         layout = compute_layout(
             items,
             config,
             NO_CURSOR_SENTINEL,
             item_padding=theme.item_padding,
-            h_padding=theme.h_padding,
+            horizontal_padding=theme.horizontal_padding,
         )
         left, right = content_bounds(
             layout=layout,
             icon_size=48,
-            h_padding=theme.h_padding,
+            horizontal_padding=theme.horizontal_padding,
             item_padding=theme.item_padding,
         )
         assert base_w == pytest.approx(right - left)
@@ -442,12 +459,17 @@ class TestZoomProgressDecay:
         config = self._make_config()
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(5)]
         rest = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=12, h_padding=2
+            items, config, NO_CURSOR_SENTINEL, item_padding=12, horizontal_padding=2
         )
         cursor = rest[2].x + 24
         # When
         full = compute_layout(
-            items, config, cursor, item_padding=12, h_padding=2, zoom_progress=1.0
+            items,
+            config,
+            cursor,
+            item_padding=12,
+            horizontal_padding=2,
+            zoom_progress=1.0,
         )
         # Then
         assert full[2].scale == pytest.approx(1.5)
@@ -457,12 +479,17 @@ class TestZoomProgressDecay:
         config = self._make_config()
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(5)]
         rest = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=12, h_padding=2
+            items, config, NO_CURSOR_SENTINEL, item_padding=12, horizontal_padding=2
         )
         cursor = rest[2].x + 24
         # When
         decayed = compute_layout(
-            items, config, cursor, item_padding=12, h_padding=2, zoom_progress=0.0
+            items,
+            config,
+            cursor,
+            item_padding=12,
+            horizontal_padding=2,
+            zoom_progress=0.0,
         )
         # Then
         for li in decayed:
@@ -474,18 +501,33 @@ class TestZoomProgressDecay:
         config = self._make_config()
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(5)]
         rest = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=12, h_padding=2
+            items, config, NO_CURSOR_SENTINEL, item_padding=12, horizontal_padding=2
         )
         cursor = rest[2].x + 24
         full = compute_layout(
-            items, config, cursor, item_padding=12, h_padding=2, zoom_progress=1.0
+            items,
+            config,
+            cursor,
+            item_padding=12,
+            horizontal_padding=2,
+            zoom_progress=1.0,
         )
         # When
         half = compute_layout(
-            items, config, cursor, item_padding=12, h_padding=2, zoom_progress=0.5
+            items,
+            config,
+            cursor,
+            item_padding=12,
+            horizontal_padding=2,
+            zoom_progress=0.5,
         )
         decayed = compute_layout(
-            items, config, cursor, item_padding=12, h_padding=2, zoom_progress=0.0
+            items,
+            config,
+            cursor,
+            item_padding=12,
+            horizontal_padding=2,
+            zoom_progress=0.0,
         )
         # Then
         full_spread = full[-1].x - full[0].x
@@ -501,21 +543,35 @@ class TestZoomProgressDecay:
         config = self._make_config()
         items = [MagicMock(main_size=0, insert_factor=1.0) for _ in range(5)]
         rest = compute_layout(
-            items, config, NO_CURSOR_SENTINEL, item_padding=12, h_padding=2
+            items, config, NO_CURSOR_SENTINEL, item_padding=12, horizontal_padding=2
         )
         cursor = rest[2].x + 24
         full = compute_layout(
-            items, config, cursor, item_padding=12, h_padding=2, zoom_progress=1.0
+            items,
+            config,
+            cursor,
+            item_padding=12,
+            horizontal_padding=2,
+            zoom_progress=1.0,
         )
         decayed = compute_layout(
-            items, config, cursor, item_padding=12, h_padding=2, zoom_progress=0.0
+            items,
+            config,
+            cursor,
+            item_padding=12,
+            horizontal_padding=2,
+            zoom_progress=0.0,
         )
         # When
-        fl, fr = content_bounds(layout=full, icon_size=48, h_padding=2, item_padding=12)
-        dl, dr = content_bounds(
-            layout=decayed, icon_size=48, h_padding=2, item_padding=12
+        fl, fr = content_bounds(
+            layout=full, icon_size=48, horizontal_padding=2, item_padding=12
         )
-        rl, rr = content_bounds(layout=rest, icon_size=48, h_padding=2, item_padding=12)
+        dl, dr = content_bounds(
+            layout=decayed, icon_size=48, horizontal_padding=2, item_padding=12
+        )
+        rl, rr = content_bounds(
+            layout=rest, icon_size=48, horizontal_padding=2, item_padding=12
+        )
         # Then
         assert (fr - fl) > (dr - dl)
         assert (dr - dl) == pytest.approx(rr - rl)

--- a/tests/ui/test_dnd_integration.py
+++ b/tests/ui/test_dnd_integration.py
@@ -53,7 +53,7 @@ def _make_handler(monkeypatch, lock_icons: bool = False):
         save=MagicMock(),
     )
     renderer = SimpleNamespace(slide_offsets={}, prev_positions={})
-    theme = SimpleNamespace(item_padding=8, h_padding=10)
+    theme = SimpleNamespace(item_padding=8, horizontal_padding=10)
     launcher = MagicMock()
     autohide = SimpleNamespace(
         enabled=True,

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -94,7 +94,9 @@ def _make_stub(item: DockItem | None = None):
     stub.model = MagicMock()
     stub.model.visible_items.return_value = [item]
     stub.model.get_applet = MagicMock()
-    stub.theme = SimpleNamespace(item_padding=8, h_padding=10, urgent_glow_time_ms=500)
+    stub.theme = SimpleNamespace(
+        item_padding=8, horizontal_padding=10, urgent_glow_time_ms=500
+    )
     stub.window_tracker = MagicMock()
     stub._menu = MagicMock()
     stub._menu.open_folder_stack_item_id.return_value = None
@@ -667,7 +669,7 @@ class TestLeaveEnterFlow:
         theme = SimpleNamespace(
             distance_from_edge=6,
             item_padding=8,
-            h_padding=12,
+            horizontal_padding=12,
             top_padding=0,
             bottom_padding=4,
             shelf_height=21,
@@ -967,7 +969,7 @@ class TestDockWindowStrutsAndRegion:
         theme = SimpleNamespace(
             distance_from_edge=6,
             item_padding=8,
-            h_padding=12,
+            horizontal_padding=12,
             top_padding=0,
             bottom_padding=4,
             shelf_height=21,

--- a/tests/ui/test_edges.py
+++ b/tests/ui/test_edges.py
@@ -39,7 +39,7 @@ def _theme() -> SimpleNamespace:
     return SimpleNamespace(
         distance_from_edge=0,
         item_padding=8,
-        h_padding=12,
+        horizontal_padding=12,
         top_padding=0,
         bottom_padding=4,
         shelf_height=21,
@@ -99,7 +99,7 @@ class _Harness:
         )
         self.theme = SimpleNamespace(
             item_padding=8,
-            h_padding=12,
+            horizontal_padding=12,
             top_padding=0,
             bottom_padding=4,
             shelf_height=21,

--- a/tests/ui/test_geometry.py
+++ b/tests/ui/test_geometry.py
@@ -28,7 +28,7 @@ def _theme(distance_from_edge: int = 0) -> SimpleNamespace:
     return SimpleNamespace(
         distance_from_edge=distance_from_edge,
         item_padding=8,
-        h_padding=12,
+        horizontal_padding=12,
         top_padding=0,
         bottom_padding=4,
         shelf_height=21,
@@ -200,7 +200,7 @@ class TestDockGeometryFrame:
         left, right = content_bounds(
             layout=list(frame.layout),
             icon_size=48,
-            h_padding=12,
+            horizontal_padding=12,
             item_padding=8,
         )
         shelf_width = right - left

--- a/tests/ui/test_hover_integration.py
+++ b/tests/ui/test_hover_integration.py
@@ -47,7 +47,7 @@ def _make_hover():
         icon_size=48,
         pos=Position.BOTTOM,
     )
-    theme = SimpleNamespace(item_padding=8, h_padding=10, bottom_padding=12)
+    theme = SimpleNamespace(item_padding=8, horizontal_padding=10, bottom_padding=12)
     tooltip = MagicMock()
     hover = hover_mod.HoverManager(
         window,

--- a/tests/ui/test_interaction.py
+++ b/tests/ui/test_interaction.py
@@ -36,7 +36,9 @@ def _make_window(item: DockItem | None = None):
     window = SimpleNamespace(
         config=SimpleNamespace(pos=Position.BOTTOM),
         model=MagicMock(),
-        theme=SimpleNamespace(item_padding=8, h_padding=10, urgent_glow_time_ms=500),
+        theme=SimpleNamespace(
+            item_padding=8, horizontal_padding=10, urgent_glow_time_ms=500
+        ),
         _menu=MagicMock(),
         tooltip=MagicMock(),
         hover=MagicMock(),

--- a/tests/ui/test_pointer_scenarios.py
+++ b/tests/ui/test_pointer_scenarios.py
@@ -75,7 +75,7 @@ class _ScenarioHarness:
         )
         self.theme = SimpleNamespace(
             item_padding=8,
-            h_padding=12,
+            horizontal_padding=12,
             top_padding=0,
             bottom_padding=4,
             shelf_height=21,

--- a/tests/ui/test_tooltip.py
+++ b/tests/ui/test_tooltip.py
@@ -699,7 +699,7 @@ class TestTooltipIntegrationBranches:
         )
         model = MagicMock()
         model.visible_items.return_value = []
-        theme = SimpleNamespace(h_padding=8, item_padding=8, bottom_padding=4)
+        theme = SimpleNamespace(horizontal_padding=8, item_padding=8, bottom_padding=4)
         tooltip = TooltipManager(window, config, model, theme)
         hide = MagicMock()
         tooltip.hide = hide  # type: ignore[method-assign]
@@ -730,7 +730,7 @@ class TestTooltipIntegrationBranches:
         built_widget = MagicMock()
         item.tooltip_builder = MagicMock(return_value=built_widget)
         model.visible_items.return_value = [item]
-        theme = SimpleNamespace(h_padding=8, item_padding=8, bottom_padding=4)
+        theme = SimpleNamespace(horizontal_padding=8, item_padding=8, bottom_padding=4)
         tooltip = TooltipManager(window, config, model, theme)
         show_tooltip = MagicMock()
         tooltip._show_tooltip = show_tooltip  # type: ignore[method-assign]


### PR DESCRIPTION
Rename the runtime theme field from h_padding to horizontal_padding and move the JSON schema value to layout.horizontal_padding. Legacy user themes using h_padding migrate through the theme migration infrastructure