### PR TITLE
Document theme schema naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,19 @@ Theme examples:
 
 All layout values use a **scaling unit** (tenths of a percent of `icon_size`). This means themes adapt automatically to any icon size.
 
-Theme layout also controls edge spacing through `distance_from_edge`, which is how floating themes such as `slate` keep the dock visually separated from the screen edge.
+Theme field names use suffixes to make value types clear:
+
+- `_px` means a raw pixel value in JSON/runtime, such as `shelf.stroke_width_px` or `layout.distance_from_edge_px`.
+- No unit suffix means a theme scale unit in JSON, converted to pixels at runtime, such as `layout.horizontal_padding`, `layout.top_padding`, `layout.bottom_padding`, and `layout.item_padding`.
+- `_ms` means milliseconds.
+- `_ratio` means a relative fraction, such as a bounce height relative to icon size.
+- `_color` means an RGBA color array stored as `[red, green, blue, alpha]` in 0-255 values.
+
+Boolean, enum/string-choice, and count fields are exceptions and stay semantic without a type suffix, for example `shelf.round_bottom`, `indicators.style`, and `indicators.max_dots`.
+
+Theme layout also controls edge spacing through `layout.distance_from_edge_px`, which is how floating themes such as `slate` keep the dock visually separated from the screen edge.
+
+Older flat theme fields such as `h_padding` are migrated automatically when a user theme is loaded.
 
 **Creating a custom theme:**
 - Docking creates `~/.config/docking/themes/template.json` on startup.

--- a/docking/core/theme/migration.py
+++ b/docking/core/theme/migration.py
@@ -31,6 +31,14 @@ _THEME_MIGRATION_BACKUP_SUFFIX = ".pre-nested-schema.bak"
 _THEME_SAVE_LOCK = threading.RLock()
 log = get_logger("theme")
 
+# Theme schema naming convention:
+# - `_px`: raw pixel values in JSON/runtime.
+# - no unit suffix: theme scale units in JSON, converted to pixels at runtime.
+# - `_ms`: milliseconds.
+# - `_ratio`: relative fractions.
+# - `_color`: RGBA color arrays.
+# Boolean, enum/string-choice, and count fields stay semantic without a type
+# suffix, for example `shelf.round_bottom`, `indicators.style`, `max_dots`.
 DEPRECATED_THEME_KEYS: dict[str, str] = {
     "fill_start": "shelf.fill_start_color",
     "fill_end": "shelf.fill_end_color",

--- a/docking/core/theme/theme.py
+++ b/docking/core/theme/theme.py
@@ -155,33 +155,48 @@ RGB = tuple[float, float, float]
 RGBA = tuple[float, float, float, float]
 
 _USER_THEME_TEMPLATE = {
-    "fill_start": [222, 222, 222, 240],
-    "fill_end": [247, 247, 247, 240],
-    "stroke": [145, 145, 145, 255],
-    "stroke_width": 1.0,
-    "inner_stroke": [248, 248, 248, 255],
-    "roundness": 5,
-    "indicator_color": [80, 80, 80, 200],
-    "active_indicator_color": [50, 50, 50, 255],
-    "indicator_size": 5,
+    "shelf": {
+        "fill_start_color": [222, 222, 222, 240],
+        "fill_end_color": [247, 247, 247, 240],
+        "stroke_color": [145, 145, 145, 255],
+        "stroke_width_px": 1.0,
+        "inner_stroke_color": [248, 248, 248, 255],
+        "corner_radius_px": 5,
+        "round_bottom": False,
+    },
     "layout": {
         "horizontal_padding": 0,
+        "top_padding": -7,
+        "bottom_padding": 1,
+        "item_padding": 2.5,
+        "distance_from_edge_px": 0,
     },
-    "top_padding": -7,
-    "bottom_padding": 1,
-    "item_padding": 2.5,
-    "urgent_bounce_height": 1.66,
-    "launch_bounce_height": 0.625,
-    "urgent_bounce_time_ms": 600,
-    "launch_bounce_time_ms": 600,
-    "click_time_ms": 300,
-    "hover_lighten": 0.2,
-    "active_time_ms": 150,
-    "max_indicator_dots": 4,
-    "glow_opacity": 0.6,
-    "indicator_style": "dots",
-    "round_bottom": False,
-    "distance_from_edge": 0,
+    "indicators": {
+        "inactive_color": [80, 80, 80, 200],
+        "active_color": [50, 50, 50, 255],
+        "size_px": 5,
+        "style": "dots",
+        "max_dots": 4,
+    },
+    "items": {
+        "hover": {
+            "lighten_amount": 0.2,
+            "fade_ms": 150,
+        },
+        "bounce": {
+            "urgent_height_ratio": 1.66,
+            "launch_height_ratio": 0.625,
+            "urgent_time_ms": 600,
+            "launch_time_ms": 600,
+            "click_time_ms": 300,
+        },
+        "glow": {
+            "opacity_ratio": 0.6,
+            "urgent_time_ms": 10000,
+            "urgent_pulse_ms": 2000,
+            "urgent_size_ratio": 0.6,
+        },
+    },
 }
 
 
@@ -196,12 +211,29 @@ def ensure_user_theme_template() -> None:
     directory = user_themes_dir()
     template = directory / f"{_USER_THEME_TEMPLATE_NAME}.json"
     if template.exists():
+        _migrate_existing_user_theme_template(path=template, directory=directory)
         return
     directory.mkdir(parents=True, exist_ok=True)
     template.write_text(
         json.dumps(_USER_THEME_TEMPLATE, indent=2) + "\n",
         encoding="utf-8",
     )
+
+
+def _migrate_existing_user_theme_template(*, path: Path, directory: Path) -> None:
+    try:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+    except Exception as exc:
+        log.warning("Failed to inspect user theme template %s: %s", path, exc)
+        return
+    if not isinstance(data, dict):
+        log.warning(
+            "User theme template %s is not a JSON object; leaving it unchanged",
+            path,
+        )
+        return
+    migrate_loaded_theme_data(data=data, path=path, user_theme_dir=directory)
 
 
 def _theme_paths(name: str) -> list[Path]:

--- a/tests/core/test_theme.py
+++ b/tests/core/test_theme.py
@@ -9,6 +9,7 @@ import pytest
 import docking.core.theme.migration as theme_migration_mod
 from docking.core.theme import (
     _USER_THEME_TEMPLATE_NAME,
+    DEPRECATED_THEME_KEYS,
     Theme,
     _rgba,
     ensure_user_theme_template,
@@ -117,7 +118,7 @@ class TestThemeLoad:
         template_data = json.loads(template.read_text(encoding="utf-8"))
         assert template.exists()
         assert template_data["layout"]["horizontal_padding"] == 0
-        assert "h_padding" not in template_data
+        assert not (set(template_data) & set(DEPRECATED_THEME_KEYS))
         assert _USER_THEME_TEMPLATE_NAME not in names
         assert "default" in names
 
@@ -129,9 +130,7 @@ class TestThemeLoad:
         template = user_themes_dir() / f"{_USER_THEME_TEMPLATE_NAME}.json"
         assert template.exists()
 
-    def test_existing_user_theme_template_is_not_overwritten(
-        self, tmp_path, monkeypatch
-    ):
+    def test_existing_user_theme_template_is_migrated(self, tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
         template = user_themes_dir() / f"{_USER_THEME_TEMPLATE_NAME}.json"
         template.parent.mkdir(parents=True)
@@ -139,7 +138,12 @@ class TestThemeLoad:
 
         ensure_user_theme_template()
 
-        assert template.read_text(encoding="utf-8") == '{"roundness": 33}\n'
+        data = json.loads(template.read_text(encoding="utf-8"))
+        backup = theme_migration_mod._theme_migration_backup_path(template)
+        assert data["shelf"]["corner_radius_px"] == 33
+        assert "roundness" not in data
+        assert backup.exists()
+        assert json.loads(backup.read_text(encoding="utf-8")) == {"roundness": 33}
 
     @pytest.mark.parametrize(
         ("theme_name", "expected_roundness"),


### PR DESCRIPTION
Document the theme schema naming conventions in the README and align the generated user theme template with the final nested schema. Existing generated templates are migrated through the theme migration path