### PR TITLE
Convert bundled themes to nested schema

### DIFF
--- a/docking/assets/themes/candy.json
+++ b/docking/assets/themes/candy.json
@@ -1,27 +1,41 @@
 {
-  "indicator_style": "dots",
-  "round_bottom": true,
-  "distance_from_edge": 6,
-  "fill_start": [255, 194, 204, 238],
-  "fill_end": [255, 170, 186, 238],
-  "stroke": [214, 108, 136, 235],
-  "stroke_width": 0.8,
-  "inner_stroke": [255, 236, 240, 220],
-  "roundness": 18,
-  "indicator_color": [255, 255, 255, 210],
-  "active_indicator_color": [123, 214, 196, 255],
-  "indicator_size": 5,
-  "h_padding": 3,
-  "top_padding": 2.5,
-  "bottom_padding": 3,
-  "item_padding": 2.2,
-  "urgent_bounce_height": 1.66,
-  "launch_bounce_height": 0.625,
-  "urgent_bounce_time_ms": 600,
-  "launch_bounce_time_ms": 600,
-  "click_time_ms": 300,
-  "hover_lighten": 0.18,
-  "active_time_ms": 150,
-  "max_indicator_dots": 4,
-  "glow_opacity": 0.45
+  "shelf": {
+    "fill_start_color": [255, 194, 204, 238],
+    "fill_end_color": [255, 170, 186, 238],
+    "stroke_color": [214, 108, 136, 235],
+    "stroke_width_px": 0.8,
+    "inner_stroke_color": [255, 236, 240, 220],
+    "corner_radius_px": 18,
+    "round_bottom": true
+  },
+  "layout": {
+    "horizontal_padding": 3,
+    "top_padding": 2.5,
+    "bottom_padding": 3,
+    "item_padding": 2.2,
+    "distance_from_edge_px": 6
+  },
+  "indicators": {
+    "inactive_color": [255, 255, 255, 210],
+    "active_color": [123, 214, 196, 255],
+    "size_px": 5,
+    "style": "dots",
+    "max_dots": 4
+  },
+  "items": {
+    "hover": {
+      "lighten_amount": 0.18,
+      "fade_ms": 150
+    },
+    "bounce": {
+      "urgent_height_ratio": 1.66,
+      "launch_height_ratio": 0.625,
+      "urgent_time_ms": 600,
+      "launch_time_ms": 600,
+      "click_time_ms": 300
+    },
+    "glow": {
+      "opacity_ratio": 0.45
+    }
+  }
 }

--- a/docking/assets/themes/default.json
+++ b/docking/assets/themes/default.json
@@ -1,27 +1,41 @@
 {
-  "fill_start": [222, 222, 222, 240],
-  "fill_end": [247, 247, 247, 240],
-  "stroke": [145, 145, 145, 255],
-  "stroke_width": 1.0,
-  "inner_stroke": [248, 248, 248, 255],
-  "roundness": 5,
-  "indicator_color": [80, 80, 80, 200],
-  "active_indicator_color": [50, 50, 50, 255],
-  "indicator_size": 5,
-  "h_padding": 0,
-  "top_padding": -7,
-  "bottom_padding": 1,
-  "item_padding": 2.5,
-  "urgent_bounce_height": 1.66,
-  "launch_bounce_height": 0.625,
-  "urgent_bounce_time_ms": 600,
-  "launch_bounce_time_ms": 600,
-  "click_time_ms": 300,
-  "hover_lighten": 0.2,
-  "active_time_ms": 150,
-  "max_indicator_dots": 4,
-  "glow_opacity": 0.6,
-  "indicator_style": "dots",
-  "round_bottom": false,
-  "distance_from_edge": 0
+  "shelf": {
+    "fill_start_color": [222, 222, 222, 240],
+    "fill_end_color": [247, 247, 247, 240],
+    "stroke_color": [145, 145, 145, 255],
+    "stroke_width_px": 1.0,
+    "inner_stroke_color": [248, 248, 248, 255],
+    "corner_radius_px": 5,
+    "round_bottom": false
+  },
+  "layout": {
+    "horizontal_padding": 0,
+    "top_padding": -7,
+    "bottom_padding": 1,
+    "item_padding": 2.5,
+    "distance_from_edge_px": 0
+  },
+  "indicators": {
+    "inactive_color": [80, 80, 80, 200],
+    "active_color": [50, 50, 50, 255],
+    "size_px": 5,
+    "style": "dots",
+    "max_dots": 4
+  },
+  "items": {
+    "hover": {
+      "lighten_amount": 0.2,
+      "fade_ms": 150
+    },
+    "bounce": {
+      "urgent_height_ratio": 1.66,
+      "launch_height_ratio": 0.625,
+      "urgent_time_ms": 600,
+      "launch_time_ms": 600,
+      "click_time_ms": 300
+    },
+    "glow": {
+      "opacity_ratio": 0.6
+    }
+  }
 }

--- a/docking/assets/themes/ember.json
+++ b/docking/assets/themes/ember.json
@@ -1,27 +1,41 @@
 {
-  "fill_start": [50, 48, 48, 240],
-  "fill_end": [29, 29, 29, 240],
-  "stroke": [35, 35, 35, 255],
-  "stroke_width": 1.0,
-  "inner_stroke": [145, 145, 145, 255],
-  "roundness": 5,
-  "indicator_color": [255, 255, 255, 200],
-  "active_indicator_color": [100, 180, 255, 255],
-  "indicator_size": 7,
-  "h_padding": 0,
-  "top_padding": -7,
-  "bottom_padding": 1,
-  "item_padding": 2.5,
-  "urgent_bounce_height": 1.66,
-  "launch_bounce_height": 0.625,
-  "urgent_bounce_time_ms": 600,
-  "launch_bounce_time_ms": 600,
-  "click_time_ms": 300,
-  "hover_lighten": 0.2,
-  "active_time_ms": 150,
-  "max_indicator_dots": 4,
-  "glow_opacity": 0.6,
-  "indicator_style": "dots",
-  "round_bottom": false,
-  "distance_from_edge": 0
+  "shelf": {
+    "fill_start_color": [50, 48, 48, 240],
+    "fill_end_color": [29, 29, 29, 240],
+    "stroke_color": [35, 35, 35, 255],
+    "stroke_width_px": 1.0,
+    "inner_stroke_color": [145, 145, 145, 255],
+    "corner_radius_px": 5,
+    "round_bottom": false
+  },
+  "layout": {
+    "horizontal_padding": 0,
+    "top_padding": -7,
+    "bottom_padding": 1,
+    "item_padding": 2.5,
+    "distance_from_edge_px": 0
+  },
+  "indicators": {
+    "inactive_color": [255, 255, 255, 200],
+    "active_color": [100, 180, 255, 255],
+    "size_px": 7,
+    "style": "dots",
+    "max_dots": 4
+  },
+  "items": {
+    "hover": {
+      "lighten_amount": 0.2,
+      "fade_ms": 150
+    },
+    "bounce": {
+      "urgent_height_ratio": 1.66,
+      "launch_height_ratio": 0.625,
+      "urgent_time_ms": 600,
+      "launch_time_ms": 600,
+      "click_time_ms": 300
+    },
+    "glow": {
+      "opacity_ratio": 0.6
+    }
+  }
 }

--- a/docking/assets/themes/glass.json
+++ b/docking/assets/themes/glass.json
@@ -1,27 +1,41 @@
 {
-  "indicator_style": "dots",
-  "round_bottom": true,
-  "distance_from_edge": 5,
-  "fill_start": [200, 210, 220, 100],
-  "fill_end": [180, 195, 210, 110],
-  "stroke": [255, 255, 255, 60],
-  "stroke_width": 0.5,
-  "inner_stroke": [255, 255, 255, 255],
-  "roundness": 16,
-  "indicator_color": [50, 50, 50, 180],
-  "active_indicator_color": [30, 30, 30, 255],
-  "indicator_size": 4,
-  "h_padding": 3,
-  "top_padding": 3,
-  "bottom_padding": 3,
-  "item_padding": 2,
-  "urgent_bounce_height": 1.66,
-  "launch_bounce_height": 0.625,
-  "urgent_bounce_time_ms": 600,
-  "launch_bounce_time_ms": 600,
-  "click_time_ms": 300,
-  "hover_lighten": 0.15,
-  "active_time_ms": 150,
-  "max_indicator_dots": 4,
-  "glow_opacity": 0.4
+  "shelf": {
+    "fill_start_color": [200, 210, 220, 100],
+    "fill_end_color": [180, 195, 210, 110],
+    "stroke_color": [255, 255, 255, 60],
+    "stroke_width_px": 0.5,
+    "inner_stroke_color": [255, 255, 255, 255],
+    "corner_radius_px": 16,
+    "round_bottom": true
+  },
+  "layout": {
+    "horizontal_padding": 3,
+    "top_padding": 3,
+    "bottom_padding": 3,
+    "item_padding": 2,
+    "distance_from_edge_px": 5
+  },
+  "indicators": {
+    "inactive_color": [50, 50, 50, 180],
+    "active_color": [30, 30, 30, 255],
+    "size_px": 4,
+    "style": "dots",
+    "max_dots": 4
+  },
+  "items": {
+    "hover": {
+      "lighten_amount": 0.15,
+      "fade_ms": 150
+    },
+    "bounce": {
+      "urgent_height_ratio": 1.66,
+      "launch_height_ratio": 0.625,
+      "urgent_time_ms": 600,
+      "launch_time_ms": 600,
+      "click_time_ms": 300
+    },
+    "glow": {
+      "opacity_ratio": 0.4
+    }
+  }
 }

--- a/docking/assets/themes/gruvbox.json
+++ b/docking/assets/themes/gruvbox.json
@@ -1,57 +1,41 @@
 {
-  "fill_start": [
-    60,
-    56,
-    54,
-    242
-  ],
-  "fill_end": [
-    40,
-    40,
-    40,
-    242
-  ],
-  "stroke": [
-    80,
-    73,
-    69,
-    255
-  ],
-  "stroke_width": 1.0,
-  "inner_stroke": [
-    146,
-    131,
-    116,
-    180
-  ],
-  "roundness": 6,
-  "indicator_color": [
-    235,
-    219,
-    178,
-    210
-  ],
-  "active_indicator_color": [
-    250,
-    189,
-    47,
-    255
-  ],
-  "indicator_size": 6,
-  "h_padding": 0,
-  "top_padding": -8,
-  "bottom_padding": 1.5,
-  "item_padding": 2.5,
-  "urgent_bounce_height": 1.66,
-  "launch_bounce_height": 0.625,
-  "urgent_bounce_time_ms": 600,
-  "launch_bounce_time_ms": 600,
-  "click_time_ms": 300,
-  "hover_lighten": 0.2,
-  "active_time_ms": 150,
-  "max_indicator_dots": 4,
-  "glow_opacity": 0.6,
-  "indicator_style": "dots",
-  "round_bottom": false,
-  "distance_from_edge": 0
+  "shelf": {
+    "fill_start_color": [60, 56, 54, 242],
+    "fill_end_color": [40, 40, 40, 242],
+    "stroke_color": [80, 73, 69, 255],
+    "stroke_width_px": 1.0,
+    "inner_stroke_color": [146, 131, 116, 180],
+    "corner_radius_px": 6,
+    "round_bottom": false
+  },
+  "layout": {
+    "horizontal_padding": 0,
+    "top_padding": -8,
+    "bottom_padding": 1.5,
+    "item_padding": 2.5,
+    "distance_from_edge_px": 0
+  },
+  "indicators": {
+    "inactive_color": [235, 219, 178, 210],
+    "active_color": [250, 189, 47, 255],
+    "size_px": 6,
+    "style": "dots",
+    "max_dots": 4
+  },
+  "items": {
+    "hover": {
+      "lighten_amount": 0.2,
+      "fade_ms": 150
+    },
+    "bounce": {
+      "urgent_height_ratio": 1.66,
+      "launch_height_ratio": 0.625,
+      "urgent_time_ms": 600,
+      "launch_time_ms": 600,
+      "click_time_ms": 300
+    },
+    "glow": {
+      "opacity_ratio": 0.6
+    }
+  }
 }

--- a/docking/assets/themes/nord.json
+++ b/docking/assets/themes/nord.json
@@ -1,57 +1,41 @@
 {
-  "fill_start": [
-    59,
-    66,
-    82,
-    240
-  ],
-  "fill_end": [
-    46,
-    52,
-    64,
-    240
-  ],
-  "stroke": [
-    47,
-    53,
-    66,
-    255
-  ],
-  "stroke_width": 1.0,
-  "inner_stroke": [
-    129,
-    161,
-    193,
-    180
-  ],
-  "roundness": 6,
-  "indicator_color": [
-    216,
-    222,
-    233,
-    200
-  ],
-  "active_indicator_color": [
-    136,
-    192,
-    208,
-    255
-  ],
-  "indicator_size": 6,
-  "h_padding": 0,
-  "top_padding": -8,
-  "bottom_padding": 1.5,
-  "item_padding": 2.5,
-  "urgent_bounce_height": 1.66,
-  "launch_bounce_height": 0.625,
-  "urgent_bounce_time_ms": 600,
-  "launch_bounce_time_ms": 600,
-  "click_time_ms": 300,
-  "hover_lighten": 0.2,
-  "active_time_ms": 150,
-  "max_indicator_dots": 4,
-  "glow_opacity": 0.6,
-  "indicator_style": "dashes",
-  "round_bottom": false,
-  "distance_from_edge": 0
+  "shelf": {
+    "fill_start_color": [59, 66, 82, 240],
+    "fill_end_color": [46, 52, 64, 240],
+    "stroke_color": [47, 53, 66, 255],
+    "stroke_width_px": 1.0,
+    "inner_stroke_color": [129, 161, 193, 180],
+    "corner_radius_px": 6,
+    "round_bottom": false
+  },
+  "layout": {
+    "horizontal_padding": 0,
+    "top_padding": -8,
+    "bottom_padding": 1.5,
+    "item_padding": 2.5,
+    "distance_from_edge_px": 0
+  },
+  "indicators": {
+    "inactive_color": [216, 222, 233, 200],
+    "active_color": [136, 192, 208, 255],
+    "size_px": 6,
+    "style": "dashes",
+    "max_dots": 4
+  },
+  "items": {
+    "hover": {
+      "lighten_amount": 0.2,
+      "fade_ms": 150
+    },
+    "bounce": {
+      "urgent_height_ratio": 1.66,
+      "launch_height_ratio": 0.625,
+      "urgent_time_ms": 600,
+      "launch_time_ms": 600,
+      "click_time_ms": 300
+    },
+    "glow": {
+      "opacity_ratio": 0.6
+    }
+  }
 }

--- a/docking/assets/themes/olive.json
+++ b/docking/assets/themes/olive.json
@@ -1,27 +1,41 @@
 {
-  "fill_start": [135, 165, 86, 100],
-  "fill_end": [135, 165, 86, 200],
-  "stroke": [135, 165, 86, 100],
-  "stroke_width": 0.0,
-  "inner_stroke": [135, 165, 86, 100],
-  "roundness": 50,
-  "indicator_color": [255, 255, 255, 200],
-  "active_indicator_color": [100, 180, 255, 255],
-  "indicator_size": 10,
-  "h_padding": 1,
-  "top_padding": -6,
-  "bottom_padding": 1.5,
-  "item_padding": 2,
-  "urgent_bounce_height": 1.66,
-  "launch_bounce_height": 0.625,
-  "urgent_bounce_time_ms": 600,
-  "launch_bounce_time_ms": 600,
-  "click_time_ms": 300,
-  "hover_lighten": 0.2,
-  "active_time_ms": 150,
-  "max_indicator_dots": 4,
-  "glow_opacity": 0.6,
-  "indicator_style": "dots",
-  "round_bottom": false,
-  "distance_from_edge": 0
+  "shelf": {
+    "fill_start_color": [135, 165, 86, 100],
+    "fill_end_color": [135, 165, 86, 200],
+    "stroke_color": [135, 165, 86, 100],
+    "stroke_width_px": 0.0,
+    "inner_stroke_color": [135, 165, 86, 100],
+    "corner_radius_px": 50,
+    "round_bottom": false
+  },
+  "layout": {
+    "horizontal_padding": 1,
+    "top_padding": -6,
+    "bottom_padding": 1.5,
+    "item_padding": 2,
+    "distance_from_edge_px": 0
+  },
+  "indicators": {
+    "inactive_color": [255, 255, 255, 200],
+    "active_color": [100, 180, 255, 255],
+    "size_px": 10,
+    "style": "dots",
+    "max_dots": 4
+  },
+  "items": {
+    "hover": {
+      "lighten_amount": 0.2,
+      "fade_ms": 150
+    },
+    "bounce": {
+      "urgent_height_ratio": 1.66,
+      "launch_height_ratio": 0.625,
+      "urgent_time_ms": 600,
+      "launch_time_ms": 600,
+      "click_time_ms": 300
+    },
+    "glow": {
+      "opacity_ratio": 0.6
+    }
+  }
 }

--- a/docking/assets/themes/onyx.json
+++ b/docking/assets/themes/onyx.json
@@ -1,27 +1,41 @@
 {
-  "fill_start": [41, 41, 41, 255],
-  "fill_end": [80, 80, 80, 255],
-  "stroke": [41, 41, 41, 255],
-  "stroke_width": 1.0,
-  "inner_stroke": [255, 255, 255, 255],
-  "roundness": 4,
-  "indicator_color": [255, 255, 255, 200],
-  "active_indicator_color": [100, 180, 255, 255],
-  "indicator_size": 5,
-  "h_padding": 0,
-  "top_padding": -11,
-  "bottom_padding": 2.5,
-  "item_padding": 2.5,
-  "urgent_bounce_height": 1.6666666666666667,
-  "launch_bounce_height": 0.625,
-  "urgent_bounce_time_ms": 600,
-  "launch_bounce_time_ms": 600,
-  "click_time_ms": 300,
-  "hover_lighten": 0.2,
-  "active_time_ms": 150,
-  "max_indicator_dots": 4,
-  "glow_opacity": 0.6,
-  "indicator_style": "dots",
-  "round_bottom": false,
-  "distance_from_edge": 0
+  "shelf": {
+    "fill_start_color": [41, 41, 41, 255],
+    "fill_end_color": [80, 80, 80, 255],
+    "stroke_color": [41, 41, 41, 255],
+    "stroke_width_px": 1.0,
+    "inner_stroke_color": [255, 255, 255, 255],
+    "corner_radius_px": 4,
+    "round_bottom": false
+  },
+  "layout": {
+    "horizontal_padding": 0,
+    "top_padding": -11,
+    "bottom_padding": 2.5,
+    "item_padding": 2.5,
+    "distance_from_edge_px": 0
+  },
+  "indicators": {
+    "inactive_color": [255, 255, 255, 200],
+    "active_color": [100, 180, 255, 255],
+    "size_px": 5,
+    "style": "dots",
+    "max_dots": 4
+  },
+  "items": {
+    "hover": {
+      "lighten_amount": 0.2,
+      "fade_ms": 150
+    },
+    "bounce": {
+      "urgent_height_ratio": 1.6666666666666667,
+      "launch_height_ratio": 0.625,
+      "urgent_time_ms": 600,
+      "launch_time_ms": 600,
+      "click_time_ms": 300
+    },
+    "glow": {
+      "opacity_ratio": 0.6
+    }
+  }
 }

--- a/docking/assets/themes/paper.json
+++ b/docking/assets/themes/paper.json
@@ -1,27 +1,41 @@
 {
-  "indicator_style": "dots",
-  "round_bottom": true,
-  "distance_from_edge": 5,
-  "fill_start": [244, 240, 232, 242],
-  "fill_end": [232, 226, 214, 242],
-  "stroke": [184, 176, 162, 230],
-  "stroke_width": 0.8,
-  "inner_stroke": [255, 250, 240, 220],
-  "roundness": 16,
-  "indicator_color": [108, 101, 94, 180],
-  "active_indicator_color": [92, 117, 132, 255],
-  "indicator_size": 4,
-  "h_padding": 3,
-  "top_padding": 3,
-  "bottom_padding": 3,
-  "item_padding": 2,
-  "urgent_bounce_height": 1.66,
-  "launch_bounce_height": 0.625,
-  "urgent_bounce_time_ms": 600,
-  "launch_bounce_time_ms": 600,
-  "click_time_ms": 300,
-  "hover_lighten": 0.12,
-  "active_time_ms": 150,
-  "max_indicator_dots": 4,
-  "glow_opacity": 0.35
+  "shelf": {
+    "fill_start_color": [244, 240, 232, 242],
+    "fill_end_color": [232, 226, 214, 242],
+    "stroke_color": [184, 176, 162, 230],
+    "stroke_width_px": 0.8,
+    "inner_stroke_color": [255, 250, 240, 220],
+    "corner_radius_px": 16,
+    "round_bottom": true
+  },
+  "layout": {
+    "horizontal_padding": 3,
+    "top_padding": 3,
+    "bottom_padding": 3,
+    "item_padding": 2,
+    "distance_from_edge_px": 5
+  },
+  "indicators": {
+    "inactive_color": [108, 101, 94, 180],
+    "active_color": [92, 117, 132, 255],
+    "size_px": 4,
+    "style": "dots",
+    "max_dots": 4
+  },
+  "items": {
+    "hover": {
+      "lighten_amount": 0.12,
+      "fade_ms": 150
+    },
+    "bounce": {
+      "urgent_height_ratio": 1.66,
+      "launch_height_ratio": 0.625,
+      "urgent_time_ms": 600,
+      "launch_time_ms": 600,
+      "click_time_ms": 300
+    },
+    "glow": {
+      "opacity_ratio": 0.35
+    }
+  }
 }

--- a/docking/assets/themes/pill.json
+++ b/docking/assets/themes/pill.json
@@ -1,27 +1,41 @@
 {
-  "indicator_style": "dots",
-  "round_bottom": true,
-  "distance_from_edge": 6,
-  "fill_start": [24, 24, 24, 245],
-  "fill_end": [14, 14, 14, 245],
-  "stroke": [24, 24, 24, 245],
-  "stroke_width": 0.8,
-  "inner_stroke": [255, 255, 255, 60],
-  "roundness": 999,
-  "indicator_color": [230, 230, 230, 190],
-  "active_indicator_color": [120, 190, 255, 255],
-  "indicator_size": 5,
-  "h_padding": 3,
-  "top_padding": 1.8,
-  "bottom_padding": 1.8,
-  "item_padding": 1.8,
-  "urgent_bounce_height": 1.66,
-  "launch_bounce_height": 0.625,
-  "urgent_bounce_time_ms": 600,
-  "launch_bounce_time_ms": 600,
-  "click_time_ms": 300,
-  "hover_lighten": 0.16,
-  "active_time_ms": 150,
-  "max_indicator_dots": 4,
-  "glow_opacity": 0.45
+  "shelf": {
+    "fill_start_color": [24, 24, 24, 245],
+    "fill_end_color": [14, 14, 14, 245],
+    "stroke_color": [24, 24, 24, 245],
+    "stroke_width_px": 0.8,
+    "inner_stroke_color": [255, 255, 255, 60],
+    "corner_radius_px": 999,
+    "round_bottom": true
+  },
+  "layout": {
+    "horizontal_padding": 3,
+    "top_padding": 1.8,
+    "bottom_padding": 1.8,
+    "item_padding": 1.8,
+    "distance_from_edge_px": 6
+  },
+  "indicators": {
+    "inactive_color": [230, 230, 230, 190],
+    "active_color": [120, 190, 255, 255],
+    "size_px": 5,
+    "style": "dots",
+    "max_dots": 4
+  },
+  "items": {
+    "hover": {
+      "lighten_amount": 0.16,
+      "fade_ms": 150
+    },
+    "bounce": {
+      "urgent_height_ratio": 1.66,
+      "launch_height_ratio": 0.625,
+      "urgent_time_ms": 600,
+      "launch_time_ms": 600,
+      "click_time_ms": 300
+    },
+    "glow": {
+      "opacity_ratio": 0.45
+    }
+  }
 }

--- a/docking/assets/themes/slate.json
+++ b/docking/assets/themes/slate.json
@@ -1,27 +1,41 @@
 {
-  "indicator_style": "dashes",
-  "round_bottom": true,
-  "distance_from_edge": 6,
-  "fill_start": [41, 41, 41, 245],
-  "fill_end": [60, 60, 60, 245],
-  "stroke": [30, 30, 30, 255],
-  "stroke_width": 1.0,
-  "inner_stroke": [255, 255, 255, 255],
-  "roundness": 12,
-  "indicator_color": [255, 255, 255, 200],
-  "active_indicator_color": [100, 180, 255, 255],
-  "indicator_size": 5,
-  "h_padding": 2,
-  "top_padding": 2.5,
-  "bottom_padding": 2.5,
-  "item_padding": 2.5,
-  "urgent_bounce_height": 1.66,
-  "launch_bounce_height": 0.625,
-  "urgent_bounce_time_ms": 600,
-  "launch_bounce_time_ms": 600,
-  "click_time_ms": 300,
-  "hover_lighten": 0.2,
-  "active_time_ms": 150,
-  "max_indicator_dots": 4,
-  "glow_opacity": 0.6
+  "shelf": {
+    "fill_start_color": [41, 41, 41, 245],
+    "fill_end_color": [60, 60, 60, 245],
+    "stroke_color": [30, 30, 30, 255],
+    "stroke_width_px": 1.0,
+    "inner_stroke_color": [255, 255, 255, 255],
+    "corner_radius_px": 12,
+    "round_bottom": true
+  },
+  "layout": {
+    "horizontal_padding": 2,
+    "top_padding": 2.5,
+    "bottom_padding": 2.5,
+    "item_padding": 2.5,
+    "distance_from_edge_px": 6
+  },
+  "indicators": {
+    "inactive_color": [255, 255, 255, 200],
+    "active_color": [100, 180, 255, 255],
+    "size_px": 5,
+    "style": "dashes",
+    "max_dots": 4
+  },
+  "items": {
+    "hover": {
+      "lighten_amount": 0.2,
+      "fade_ms": 150
+    },
+    "bounce": {
+      "urgent_height_ratio": 1.66,
+      "launch_height_ratio": 0.625,
+      "urgent_time_ms": 600,
+      "launch_time_ms": 600,
+      "click_time_ms": 300
+    },
+    "glow": {
+      "opacity_ratio": 0.6
+    }
+  }
 }

--- a/docking/assets/themes/solarized.json
+++ b/docking/assets/themes/solarized.json
@@ -1,57 +1,41 @@
 {
-  "fill_start": [
-    253,
-    246,
-    227,
-    245
-  ],
-  "fill_end": [
-    238,
-    232,
-    213,
-    245
-  ],
-  "stroke": [
-    147,
-    161,
-    161,
-    255
-  ],
-  "stroke_width": 1.0,
-  "inner_stroke": [
-    255,
-    255,
-    255,
-    210
-  ],
-  "roundness": 5,
-  "indicator_color": [
-    88,
-    110,
-    117,
-    210
-  ],
-  "active_indicator_color": [
-    38,
-    139,
-    210,
-    255
-  ],
-  "indicator_size": 5,
-  "h_padding": 0,
-  "top_padding": -7,
-  "bottom_padding": 1,
-  "item_padding": 2.5,
-  "urgent_bounce_height": 1.66,
-  "launch_bounce_height": 0.625,
-  "urgent_bounce_time_ms": 600,
-  "launch_bounce_time_ms": 600,
-  "click_time_ms": 300,
-  "hover_lighten": 0.2,
-  "active_time_ms": 150,
-  "max_indicator_dots": 4,
-  "glow_opacity": 0.6,
-  "indicator_style": "dots",
-  "round_bottom": false,
-  "distance_from_edge": 0
+  "shelf": {
+    "fill_start_color": [253, 246, 227, 245],
+    "fill_end_color": [238, 232, 213, 245],
+    "stroke_color": [147, 161, 161, 255],
+    "stroke_width_px": 1.0,
+    "inner_stroke_color": [255, 255, 255, 210],
+    "corner_radius_px": 5,
+    "round_bottom": false
+  },
+  "layout": {
+    "horizontal_padding": 0,
+    "top_padding": -7,
+    "bottom_padding": 1,
+    "item_padding": 2.5,
+    "distance_from_edge_px": 0
+  },
+  "indicators": {
+    "inactive_color": [88, 110, 117, 210],
+    "active_color": [38, 139, 210, 255],
+    "size_px": 5,
+    "style": "dots",
+    "max_dots": 4
+  },
+  "items": {
+    "hover": {
+      "lighten_amount": 0.2,
+      "fade_ms": 150
+    },
+    "bounce": {
+      "urgent_height_ratio": 1.66,
+      "launch_height_ratio": 0.625,
+      "urgent_time_ms": 600,
+      "launch_time_ms": 600,
+      "click_time_ms": 300
+    },
+    "glow": {
+      "opacity_ratio": 0.6
+    }
+  }
 }

--- a/docking/assets/themes/transparent.json
+++ b/docking/assets/themes/transparent.json
@@ -1,27 +1,41 @@
 {
-  "fill_start": [41, 41, 41, 255],
-  "fill_end": [80, 80, 80, 255],
-  "stroke": [41, 41, 41, 255],
-  "stroke_width": 0.0,
-  "inner_stroke": [255, 255, 255, 255],
-  "roundness": 0,
-  "indicator_color": [255, 255, 255, 200],
-  "active_indicator_color": [100, 180, 255, 255],
-  "indicator_size": 5,
-  "h_padding": 0,
-  "top_padding": -12,
-  "bottom_padding": 2,
-  "item_padding": 2.5,
-  "urgent_bounce_height": 1.66,
-  "launch_bounce_height": 0.625,
-  "urgent_bounce_time_ms": 600,
-  "launch_bounce_time_ms": 600,
-  "click_time_ms": 300,
-  "hover_lighten": 0.2,
-  "active_time_ms": 150,
-  "max_indicator_dots": 4,
-  "glow_opacity": 0.6,
-  "indicator_style": "dots",
-  "round_bottom": false,
-  "distance_from_edge": 0
+  "shelf": {
+    "fill_start_color": [41, 41, 41, 255],
+    "fill_end_color": [80, 80, 80, 255],
+    "stroke_color": [41, 41, 41, 255],
+    "stroke_width_px": 0.0,
+    "inner_stroke_color": [255, 255, 255, 255],
+    "corner_radius_px": 0,
+    "round_bottom": false
+  },
+  "layout": {
+    "horizontal_padding": 0,
+    "top_padding": -12,
+    "bottom_padding": 2,
+    "item_padding": 2.5,
+    "distance_from_edge_px": 0
+  },
+  "indicators": {
+    "inactive_color": [255, 255, 255, 200],
+    "active_color": [100, 180, 255, 255],
+    "size_px": 5,
+    "style": "dots",
+    "max_dots": 4
+  },
+  "items": {
+    "hover": {
+      "lighten_amount": 0.2,
+      "fade_ms": 150
+    },
+    "bounce": {
+      "urgent_height_ratio": 1.66,
+      "launch_height_ratio": 0.625,
+      "urgent_time_ms": 600,
+      "launch_time_ms": 600,
+      "click_time_ms": 300
+    },
+    "glow": {
+      "opacity_ratio": 0.6
+    }
+  }
 }

--- a/tests/core/test_theme.py
+++ b/tests/core/test_theme.py
@@ -8,6 +8,7 @@ import pytest
 
 import docking.core.theme.migration as theme_migration_mod
 from docking.core.theme import (
+    _BUILTIN_THEMES_DIR,
     _USER_THEME_TEMPLATE_NAME,
     DEPRECATED_THEME_KEYS,
     Theme,
@@ -174,6 +175,16 @@ class TestThemeLoad:
         assert t.distance_from_edge == 6
         assert t.roundness > t.shelf_height / 2
         assert t.fill_start[3] > 0.9
+
+    def test_builtin_themes_use_current_schema(self):
+        for theme_file in _BUILTIN_THEMES_DIR.glob("*.json"):
+            data = json.loads(theme_file.read_text(encoding="utf-8"))
+            assert not (set(data) & set(DEPRECATED_THEME_KEYS)), theme_file.name
+
+            theme = Theme.load(theme_file.stem, 48)
+            assert all(0 <= c <= 1 for c in theme.fill_start)
+            assert all(0 <= c <= 1 for c in theme.fill_end)
+            assert all(0 <= c <= 1 for c in theme.stroke)
 
     def test_load_final_nested_theme_schema(self, tmp_path):
         theme_data = {


### PR DESCRIPTION
Convert all bundled theme JSON files to the current nested schema and add a test that rejects top-level deprecated theme keys in bundled assets.\n\nValidated with the theme test suite, ruff checks for theme assets/tests, a JSON parse pass across all bundled themes, and a direct load smoke check for every bundled theme.