### PR TITLE
Simplify environment and XDG path helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ htmlcov/
 .ruff_cache/
 .pybuild/
 .claude/
+AGENTS.md
 artifacts/
 AppDir/
 result-nix

--- a/docking/applets/aiusage/backends/claude.py
+++ b/docking/applets/aiusage/backends/claude.py
@@ -24,6 +24,7 @@ from typing import Any, cast
 from docking.applets.aiusage.backends.base import ProviderSessions
 from docking.applets.aiusage.state import ModelUsage, Provider, _has_usage
 from docking.applets.aiusage.store import replace_session
+from docking.core.paths import ensure_parent_dir
 from docking.log import get_logger, with_context
 
 log = with_context(get_logger(name="aiusage.claude"))
@@ -108,7 +109,7 @@ def register_hooks() -> None:
 
     if changed:
         try:
-            _CLAUDE_SETTINGS.parent.mkdir(parents=True, exist_ok=True)
+            ensure_parent_dir(_CLAUDE_SETTINGS)
             _CLAUDE_SETTINGS.write_text(
                 json.dumps(settings, indent=2) + "\n",
                 encoding="utf-8",

--- a/docking/applets/aiusage/store.py
+++ b/docking/applets/aiusage/store.py
@@ -21,7 +21,9 @@ import os
 from pathlib import Path
 
 from docking.applets.aiusage import state as aiusage_state
+from docking.core.paths import ensure_parent_dir
 from docking.log import get_logger
+from docking.platform.environment import docking_config_dir
 
 PREFS_KEY = "aiusage"
 PREFS_KEY_LEGACY = "claude"
@@ -30,9 +32,7 @@ log = get_logger("aiusage.store")
 
 
 def config_path() -> Path:
-    xdg = os.environ.get("XDG_CONFIG_HOME", "")
-    base = Path(xdg) if xdg else Path.home() / ".config"
-    return base / "docking" / "dock.json"
+    return docking_config_dir() / "dock.json"
 
 
 def read_prefs_from_disk() -> dict | None:
@@ -57,7 +57,7 @@ def replace_session(
         return
 
     path = config_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
+    ensure_parent_dir(path)
 
     fd = os.open(str(path), os.O_RDWR | os.O_CREAT, 0o644)
     try:

--- a/docking/applets/apod/api.py
+++ b/docking/applets/apod/api.py
@@ -21,14 +21,14 @@ one image download per day.
 from __future__ import annotations
 
 import json
-import os
 import urllib.request
-from pathlib import Path
 from typing import NamedTuple
 
 from docking.applets.apod import meta
 from docking.applets.apod.state import ApodResult, build_page_url
+from docking.core.paths import ensure_dir
 from docking.log import get_logger, with_context
+from docking.platform.environment import docking_cache_dir
 
 log = with_context(get_logger(name="apod.api"), applet_id=meta.id)
 
@@ -37,9 +37,7 @@ DEFAULT_API_KEY = "DEMO_KEY"
 USER_AGENT = "docking-apod/1.0"
 REQUEST_TIMEOUT_S = 20.0
 
-CACHE_DIR = (
-    Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")) / "docking" / "apod"
-)
+CACHE_DIR = docking_cache_dir() / "apod"
 
 
 class ApodError(NamedTuple):
@@ -112,7 +110,7 @@ def _fetch_json(*, api_key: str) -> dict:
 
 
 def _download_image(*, url: str, date_iso: str) -> str:
-    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    ensure_dir(CACHE_DIR)
     suffix = _suffix_for_url(url)
     path = CACHE_DIR / f"{date_iso or 'unknown'}{suffix}"
     if path.exists() and path.stat().st_size > 0:

--- a/docking/applets/camshield/helper.py
+++ b/docking/applets/camshield/helper.py
@@ -31,6 +31,8 @@ from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 
+from docking.core.paths import ensure_dir
+
 STATE_DIR = Path("/var/lib/docking/camshield")
 STATE_FILE = STATE_DIR / "devices.json"
 DEV_ROOT = Path("/dev")
@@ -73,7 +75,7 @@ def lock_devices(
         print("No camera devices found.", file=sys.stderr)
         return 1
 
-    state_dir.mkdir(parents=True, exist_ok=True)
+    ensure_dir(state_dir)
     state = _read_state(state_dir=state_dir)
     changed = 0
     for device in devices:
@@ -157,7 +159,7 @@ def _save_acl_snapshot(*, device: Path, state_dir: Path) -> Path | None:
         return None
 
     acl_dir = state_dir / "acl"
-    acl_dir.mkdir(parents=True, exist_ok=True)
+    ensure_dir(acl_dir)
     acl_file = acl_dir / f"{device.name}.acl"
     try:
         with acl_file.open("w", encoding="utf-8") as handle:

--- a/docking/applets/trash/backend.py
+++ b/docking/applets/trash/backend.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import configparser
-import os
 import shutil
 import subprocess
 from collections.abc import Callable
@@ -39,6 +38,8 @@ from docking.platform.environment import (
     is_gnome_session,
     is_kde_session,
     is_mate_session,
+    xdg_config_home,
+    xdg_data_home,
 )
 
 log = with_context(get_logger(name="trash"), applet_id=meta.id)
@@ -64,16 +65,12 @@ class _CaseSensitiveConfigParser(configparser.ConfigParser):
         return optionstr
 
 
-def _xdg_data_home() -> Path:
-    return Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
-
-
 def _host_user_data_home() -> Path:
     return Path.home() / ".local" / "share"
 
 
 def _kde_trash_directory() -> Path:
-    return _xdg_data_home() / "Trash"
+    return xdg_data_home() / "Trash"
 
 
 def _kde_trash_files_directory() -> Path:
@@ -87,13 +84,13 @@ def _kde_trash_info_directory() -> Path:
 def _visible_trash_files_directory() -> Path:
     if is_flatpak():
         return _host_user_data_home() / "Trash" / "files"
-    return _xdg_data_home() / "Trash" / "files"
+    return xdg_data_home() / "Trash" / "files"
 
 
 def _kde_kiorc_file() -> Path:
     if is_flatpak():
         return Path.home() / ".config" / "kiorc"
-    return Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "kiorc"
+    return xdg_config_home() / "kiorc"
 
 
 def _open_trash_uri(uri: str) -> None:

--- a/docking/applets/weather/api.py
+++ b/docking/applets/weather/api.py
@@ -20,14 +20,14 @@ All functions are pure data -- no GTK dependency.
 
 from __future__ import annotations
 
-import os
 from datetime import datetime, timezone
 from functools import lru_cache
-from pathlib import Path
 from typing import Any, NamedTuple, cast
 
 from docking.applets.weather import meta
+from docking.core.paths import ensure_dir
 from docking.log import get_logger, with_context
+from docking.platform.environment import docking_cache_dir
 
 log = with_context(get_logger(name="weather.api"), applet_id=meta.id)
 
@@ -37,11 +37,7 @@ REFRESH_INTERVAL = 300  # 5 minutes
 API_RETRY_COUNT = 5
 API_RETRY_BACKOFF_FACTOR = 0.2
 
-_CACHE_DIR = (
-    Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
-    / "docking"
-    / "weather"
-)
+_CACHE_DIR = docking_cache_dir() / "weather"
 
 _API_URL = "https://api.open-meteo.com/v1/forecast"
 _AQI_URL = "https://air-quality-api.open-meteo.com/v1/air-quality"
@@ -132,7 +128,7 @@ def _get_client() -> Any:
     import requests_cache
     from retry_requests import retry
 
-    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    ensure_dir(_CACHE_DIR)
     cache_path = str(_CACHE_DIR / "responses")
     # Three-layer stack: openmeteo_requests wraps retry_requests wraps
     # requests_cache. Cache avoids redundant HTTP; retry handles failures.

--- a/docking/core/config.py
+++ b/docking/core/config.py
@@ -155,12 +155,12 @@ from urllib.parse import unquote, urlparse
 
 from docking.applets.identity import applet_desktop_id, is_applet_desktop_id
 from docking.core.items import APP_KIND, APPLET_KIND, FILE_KIND, FOLDER_KIND, ItemKind
+from docking.core.paths import ensure_parent_dir
 from docking.core.position import Position
 from docking.log import get_logger
+from docking.platform.environment import docking_config_dir
 
-DEFAULT_CONFIG_DIR = (
-    Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "docking"
-)
+DEFAULT_CONFIG_DIR = docking_config_dir()
 DEFAULT_CONFIG_FILE = DEFAULT_CONFIG_DIR / "dock.json"
 DEFAULT_CONFIG_BACKUP_FILE = DEFAULT_CONFIG_DIR / "dock.json.bak"
 
@@ -903,7 +903,7 @@ class Config:
     def save(self, path: Path | str | None = None) -> None:
         """Save config to JSON file."""
         path = Path(path) if path else self._path
-        path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_parent_dir(path)
         # Write to a sibling temp file and replace in one step so Ctrl+C or
         # process death never leaves the real config half-written.
         backup_path = _backup_path_for(path)

--- a/docking/core/greeting.py
+++ b/docking/core/greeting.py
@@ -31,20 +31,19 @@ XDG state storage rather than in ``dock.json``.
 from __future__ import annotations
 
 import json
-import os
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from docking.core.paths import ensure_parent_dir
 from docking.log import get_logger
+from docking.platform.environment import docking_state_dir
 
 logger = get_logger("greeting")
 
-DEFAULT_STATE_DIR = (
-    Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state")) / "docking"
-)
+DEFAULT_STATE_DIR = docking_state_dir()
 DEFAULT_STATE_FILE = DEFAULT_STATE_DIR / "startup.json"
 NEW_YEAR_GREETING_LAST_DAY = 15
 
@@ -96,7 +95,7 @@ def save_state(
 ) -> None:
     """Persist greeting state atomically."""
     state_path = Path(path) if path else DEFAULT_STATE_FILE
-    state_path.parent.mkdir(parents=True, exist_ok=True)
+    ensure_parent_dir(state_path)
 
     with tempfile.NamedTemporaryFile(
         "w",

--- a/docking/core/paths.py
+++ b/docking/core/paths.py
@@ -1,0 +1,32 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Filesystem path helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def ensure_dir(path: Path | str) -> Path:
+    """Create a directory path and return it as a Path."""
+    directory = Path(path)
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def ensure_parent_dir(path: Path | str) -> Path:
+    """Create the parent directory for a file path and return the file path."""
+    file_path = Path(path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    return file_path

--- a/docking/core/theme/migration.py
+++ b/docking/core/theme/migration.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from docking.core.paths import ensure_parent_dir
 from docking.log import get_logger
 
 _THEME_MIGRATION_BACKUP_SUFFIX = ".pre-nested-schema.bak"
@@ -284,7 +285,7 @@ def _create_theme_migration_backup(*, path: Path) -> Path:
 
 
 def _write_theme_json_atomic(*, path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+    ensure_parent_dir(path)
     tmp_path = _new_theme_tmp_path(path=path)
     try:
         with tmp_path.open(mode="w", encoding="utf-8") as handle:

--- a/docking/core/theme/theme.py
+++ b/docking/core/theme/theme.py
@@ -134,14 +134,15 @@ from __future__ import annotations
 
 import enum
 import json
-import os
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
+from docking.core.paths import ensure_dir
 from docking.core.theme.migration import migrate_loaded_theme_data
 from docking.log import get_logger
+from docking.platform.environment import docking_config_dir
 
 # Bundled themes directory (relative to package)
 _BUILTIN_THEMES_DIR = (
@@ -202,8 +203,7 @@ _USER_THEME_TEMPLATE = {
 
 def user_themes_dir() -> Path:
     """Return the user-writable theme directory."""
-    config_home = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
-    return config_home / "docking" / "themes"
+    return docking_config_dir() / "themes"
 
 
 def ensure_user_theme_template() -> None:
@@ -213,7 +213,7 @@ def ensure_user_theme_template() -> None:
     if template.exists():
         _migrate_existing_user_theme_template(path=template, directory=directory)
         return
-    directory.mkdir(parents=True, exist_ok=True)
+    ensure_dir(directory)
     template.write_text(
         json.dumps(_USER_THEME_TEMPLATE, indent=2) + "\n",
         encoding="utf-8",

--- a/docking/core/updates.py
+++ b/docking/core/updates.py
@@ -21,7 +21,6 @@ last check time, ignored versions, and reminder suppression.
 from __future__ import annotations
 
 import json
-import os
 import re
 import tempfile
 import urllib.error
@@ -31,7 +30,9 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import cast
 
+from docking.core.paths import ensure_parent_dir
 from docking.log import get_logger
+from docking.platform.environment import docking_state_dir
 
 logger = get_logger("updates")
 
@@ -39,9 +40,7 @@ GITHUB_LATEST_RELEASE_URL = (
     "https://api.github.com/repos/edumucelli/docking/releases/latest"
 )
 PROJECT_RELEASES_URL = "https://github.com/edumucelli/docking/releases"
-DEFAULT_STATE_DIR = (
-    Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state")) / "docking"
-)
+DEFAULT_STATE_DIR = docking_state_dir()
 DEFAULT_STATE_FILE = DEFAULT_STATE_DIR / "updates.json"
 DEFAULT_UPDATE_TIMEOUT_S = 6
 UPDATE_USER_AGENT = "Docking update checker"
@@ -105,7 +104,7 @@ def load_state(path: Path | str | None = None) -> UpdateState:
 def save_state(state: UpdateState, *, path: Path | str | None = None) -> None:
     """Persist update state atomically."""
     state_path = Path(path) if path is not None else DEFAULT_STATE_FILE
-    state_path.parent.mkdir(parents=True, exist_ok=True)
+    ensure_parent_dir(state_path)
     with tempfile.NamedTemporaryFile(
         "w",
         encoding="utf-8",

--- a/docking/platform/__init__.py
+++ b/docking/platform/__init__.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 
-"""Convenience exports for Docking's platform integration layer.
+"""Docking's platform integration layer.
 
 What the platform layer owns
 
@@ -20,12 +20,13 @@ desktop session: launchers, window tracking, environment quirks, struts,
 barriers, dodge behavior, and model-building rules that depend on what the
 window manager or desktop shell is doing.
 
-Why this module exists
+Why this module is a no-op
 
-Like ``docking.core.__init__``, this file is a stable import surface. Higher
-layers often only need the main platform-facing objects, not the entire module
-layout. Re-exporting them here keeps call sites simpler without collapsing the
-actual implementation into one file.
+Callers import directly from the submodules (``docking.platform.launcher``,
+``docking.platform.model``, etc.). Eager re-exports here previously created a
+cycle when low-level modules (e.g. ``docking.platform.environment.xdg``) were
+needed by ``docking.core.config`` -- loading the parent package triggered
+``launcher`` which imports ``config``, creating an import cycle.
 
 Why the boundary matters
 
@@ -33,8 +34,3 @@ This package is intentionally below the UI layer and above the pure core layer.
 It may know about X11, desktop IDs, running windows, and monitor/workspace
 state, but it should not become responsible for GTK widget trees or drawing.
 """
-
-from docking.platform.launcher import Launcher  # noqa: F401
-from docking.platform.model import DockItem, DockModel, LauncherEntryState  # noqa: F401
-from docking.platform.unity import UnityLauncherListener  # noqa: F401
-from docking.platform.window_tracker import WindowTracker  # noqa: F401

--- a/docking/platform/environment/__init__.py
+++ b/docking/platform/environment/__init__.py
@@ -11,287 +11,64 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 
-"""Desktop environment detection and DE-specific tweaks.
+"""Desktop environment detection and DE-specific tweaks (public API).
 
-Reads XDG_SESSION_DESKTOP, XDG_CURRENT_DESKTOP, and DESKTOP_SESSION
-(in that priority order, matching Plank Reloaded's Environment.vala)
-to determine the running desktop environment.
+Implementations live in:
 
-DE-specific tweaks applied at startup:
+- ``environment.py`` -- desktop detection, backend probing, apply_tweaks.
+- ``xdg.py`` -- XDG Base Directory resolution.
+- ``flatpak.py`` -- Flatpak host helpers.
 
-- **Xfce**: Disables xfwm4 dock shadow via xfconf-query. Without this,
-  xfwm4 draws a window shadow around the dock that looks wrong for a
-  panel-type window.
-
-- **Monitor geometry**: On GNOME/MATE/Cinnamon/Xfce/KDE the dock uses
-  full monitor geometry for positioning (these DEs handle panels via
-  struts). On unknown DEs, workarea is used as a safer fallback.
+This package re-exports the public surface so callers can stay on
+``from docking.platform.environment import detect_desktop`` etc.
 """
 
-from __future__ import annotations
+from docking.platform.environment.environment import (
+    Desktop,
+    apply_tweaks,
+    backend_name,
+    compositor_active,
+    detect_desktop,
+    is_flatpak,
+    is_gnome_session,
+    is_kde_session,
+    is_mate_session,
+    is_wayland_session,
+    is_x11_backend,
+    is_xwayland_session,
+    log_runtime_snapshot,
+)
+from docking.platform.environment.xdg import (
+    docking_cache_dir,
+    docking_config_dir,
+    docking_data_dir,
+    docking_state_dir,
+    xdg_cache_home,
+    xdg_config_home,
+    xdg_data_home,
+    xdg_state_home,
+)
 
-import enum
-import os
-import re
-import shutil
-import subprocess
-from pathlib import Path
-
-from docking.log import get_logger
-
-log = get_logger(name="environment")
-
-
-class Desktop(enum.Flag):
-    UNKNOWN = 0
-    GNOME = enum.auto()
-    KDE = enum.auto()
-    LXDE = enum.auto()
-    MATE = enum.auto()
-    XFCE = enum.auto()
-    CINNAMON = enum.auto()
-    PANTHEON = enum.auto()
-    UNITY = enum.auto()
-    UBUNTU = enum.auto()
-
-    @property
-    def uses_monitor_geometry(self) -> bool:
-        """Whether to use full monitor geometry instead of workarea.
-
-        These DEs handle panel space reservation via struts, so the dock
-        should position relative to the full monitor and let struts
-        carve out workspace.
-        """
-        known = (
-            Desktop.GNOME
-            | Desktop.UBUNTU
-            | Desktop.MATE
-            | Desktop.CINNAMON
-            | Desktop.XFCE
-            | Desktop.KDE
-        )
-        return bool(self & known)
-
-
-_DESKTOP_MAP: dict[str, Desktop] = {
-    "gnome": Desktop.GNOME,
-    "gnome-xorg": Desktop.GNOME,
-    "gnome-classic": Desktop.GNOME,
-    "gnome-flashback": Desktop.GNOME,
-    "ubuntu": Desktop.UBUNTU,
-    "ubuntu-xorg": Desktop.UBUNTU,
-    "kde": Desktop.KDE,
-    "lxde": Desktop.LXDE,
-    "lxqt": Desktop.LXDE,
-    "mate": Desktop.MATE,
-    "xfce": Desktop.XFCE,
-    "xubuntu": Desktop.XFCE,
-    "cinnamon": Desktop.CINNAMON,
-    "x-cinnamon": Desktop.CINNAMON,
-    "pantheon": Desktop.PANTHEON,
-    "unity": Desktop.UNITY,
-}
-
-
-def _parse_desktop(value: str) -> Desktop:
-    """Parse a desktop string, handling XDG desktop list separators."""
-    result = Desktop.UNKNOWN
-    for part in re.split(r"[:;]", value):
-        part = part.strip().lower()
-        if part:
-            result |= _DESKTOP_MAP.get(part, Desktop.UNKNOWN)
-    return result
-
-
-def detect_desktop() -> Desktop:
-    """Detect the desktop environment from XDG environment variables.
-
-    Checks XDG_SESSION_DESKTOP, XDG_CURRENT_DESKTOP, DESKTOP_SESSION
-    in that order (matching Plank Reloaded's priority).
-    """
-    for var in ("XDG_SESSION_DESKTOP", "XDG_CURRENT_DESKTOP", "DESKTOP_SESSION"):
-        value = os.environ.get(var, "")
-        if value:
-            desktop = _parse_desktop(value)
-            if desktop != Desktop.UNKNOWN:
-                log.debug("detected %s from %s=%s", desktop, var, value)
-                return desktop
-
-    log.warning("could not detect desktop environment")
-    return Desktop.UNKNOWN
-
-
-def is_wayland_session() -> bool:
-    """Return True when the desktop session itself is Wayland."""
-    return os.environ.get("XDG_SESSION_TYPE", "").strip().lower() == "wayland"
-
-
-def is_flatpak() -> bool:
-    """Return True when running inside a Flatpak sandbox."""
-    return Path("/.flatpak-info").exists()
-
-
-def is_gnome_session(*, desktop: Desktop | None = None) -> bool:
-    """Return True for GNOME-shell-like sessions."""
-    resolved = desktop if desktop is not None else detect_desktop()
-    return bool(resolved & (Desktop.GNOME | Desktop.UBUNTU))
-
-
-def is_mate_session(*, desktop: Desktop | None = None) -> bool:
-    """Return True for MATE sessions."""
-    resolved = desktop if desktop is not None else detect_desktop()
-    return bool(resolved & Desktop.MATE)
-
-
-def is_kde_session(*, desktop: Desktop | None = None) -> bool:
-    """Return True for KDE sessions."""
-    resolved = desktop if desktop is not None else detect_desktop()
-    return bool(resolved & Desktop.KDE)
-
-
-def is_x11_backend(*, display: object | None = None) -> bool:
-    """Return True when the current GTK backend is X11."""
-    if display is None:
-        try:
-            import gi
-
-            gi.require_version("Gdk", "3.0")
-            from gi.repository import Gdk
-
-            display = Gdk.Display.get_default()
-        except Exception:
-            return False
-    if display is None:
-        return False
-    cls = display.__class__
-    if cls.__name__ == "X11Display":
-        return True
-    if cls.__module__.endswith("GdkX11"):
-        return True
-    return callable(getattr(display, "get_xdisplay", None))
-
-
-def is_xwayland_session(*, display: object | None = None) -> bool:
-    """Return True when Docking runs as an X11 client inside a Wayland session."""
-    return is_wayland_session() and is_x11_backend(display=display)
-
-
-def backend_name(*, display: object | None = None) -> str:
-    """Return a compact backend class name for logging."""
-    if display is None:
-        try:
-            import gi
-
-            gi.require_version("Gdk", "3.0")
-            from gi.repository import Gdk
-
-            display = Gdk.Display.get_default()
-        except Exception:
-            return "unknown"
-    if display is None:
-        return "none"
-    cls = display.__class__
-    return f"{cls.__module__}.{cls.__name__}"
-
-
-def compositor_active(*, display: object | None = None) -> bool | None:
-    """Return compositor status for X11 backends, or None when unavailable."""
-    try:
-        import ctypes
-
-        from gi.repository import GdkX11
-
-        if display is None:
-            display = GdkX11.X11Display.get_default()
-        if display is None or not is_x11_backend(display=display):
-            return None
-        screen_num = display.get_default_screen()
-
-        xlib = ctypes.cdll.LoadLibrary("libX11.so.6")
-        xdisplay = ctypes.c_void_p(hash(display.get_xdisplay()))
-
-        xlib.XInternAtom.restype = ctypes.c_ulong
-        xlib.XInternAtom.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
-        xlib.XGetSelectionOwner.restype = ctypes.c_ulong
-        xlib.XGetSelectionOwner.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
-
-        atom = xlib.XInternAtom(xdisplay, f"_NET_WM_CM_S{screen_num}".encode(), 0)
-        owner = xlib.XGetSelectionOwner(xdisplay, atom)
-        return owner != 0
-    except Exception as exc:
-        log.warning("failed to check compositor status: %s", exc)
-        return None
-
-
-def log_runtime_snapshot(
-    *,
-    display: object | None = None,
-    desktop: Desktop | None = None,
-) -> None:
-    """Log a small startup snapshot for comparing good and bad runs."""
-    compositor = compositor_active(display=display)
-    log.info(
-        "runtime snapshot: desktop=%s session=%s backend=%s x11=%s xwayland=%s "
-        "compositor_active=%s DISPLAY=%r WAYLAND_DISPLAY=%r GDK_BACKEND=%r",
-        desktop if desktop is not None else detect_desktop(),
-        os.environ.get("XDG_SESSION_TYPE", "").strip().lower() or "unknown",
-        backend_name(display=display),
-        is_x11_backend(display=display),
-        is_xwayland_session(display=display),
-        compositor,
-        os.environ.get("DISPLAY"),
-        os.environ.get("WAYLAND_DISPLAY"),
-        os.environ.get("GDK_BACKEND"),
-    )
-
-
-def _disable_xfce_dock_shadow() -> None:
-    """Disable xfwm4's dock window shadow via xfconf-query."""
-    if not shutil.which("xfconf-query"):
-        log.warning("xfconf-query not found, cannot disable dock shadow")
-        return
-    try:
-        subprocess.run(
-            [
-                "xfconf-query",
-                "-c",
-                "xfwm4",
-                "-p",
-                "/general/show_dock_shadow",
-                "-s",
-                "false",
-            ],
-            check=True,
-            capture_output=True,
-        )
-        log.info("disabled xfce dock shadow")
-    except subprocess.CalledProcessError as e:
-        log.warning("failed to disable xfce dock shadow: %s", e)
-
-
-def _check_compositor() -> None:
-    """Warn if no compositing manager is active.
-
-    Checks _NET_WM_CM_S{screen} selection owner via Xlib directly.
-    Gdk.Screen.is_composited() can return stale True if the compositor
-    crashed without releasing the selection, so we bypass GDK's cache.
-    """
-    active = compositor_active()
-    if active is None:
-        return
-    if active:
-        return
-
-    log.warning(
-        "no compositing manager detected (it may have crashed) -- "
-        "dock may appear behind maximized windows and transparency may not work; "
-        "enable compositing in your desktop settings or install a compositor "
-        "(picom, compton, xcompmgr)"
-    )
-
-
-def apply_tweaks(desktop: Desktop) -> None:
-    """Apply DE-specific tweaks at startup."""
-    _check_compositor()
-    if desktop & Desktop.XFCE:
-        _disable_xfce_dock_shadow()
+__all__ = [
+    "Desktop",
+    "apply_tweaks",
+    "backend_name",
+    "compositor_active",
+    "detect_desktop",
+    "docking_cache_dir",
+    "docking_config_dir",
+    "docking_data_dir",
+    "docking_state_dir",
+    "is_flatpak",
+    "is_gnome_session",
+    "is_kde_session",
+    "is_mate_session",
+    "is_wayland_session",
+    "is_x11_backend",
+    "is_xwayland_session",
+    "log_runtime_snapshot",
+    "xdg_cache_home",
+    "xdg_config_home",
+    "xdg_data_home",
+    "xdg_state_home",
+]

--- a/docking/platform/environment/environment.py
+++ b/docking/platform/environment/environment.py
@@ -1,0 +1,297 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Desktop environment detection and DE-specific tweaks.
+
+Reads XDG_SESSION_DESKTOP, XDG_CURRENT_DESKTOP, and DESKTOP_SESSION
+(in that priority order, matching Plank Reloaded's Environment.vala)
+to determine the running desktop environment.
+
+DE-specific tweaks applied at startup:
+
+- **Xfce**: Disables xfwm4 dock shadow via xfconf-query. Without this,
+  xfwm4 draws a window shadow around the dock that looks wrong for a
+  panel-type window.
+
+- **Monitor geometry**: On GNOME/MATE/Cinnamon/Xfce/KDE the dock uses
+  full monitor geometry for positioning (these DEs handle panels via
+  struts). On unknown DEs, workarea is used as a safer fallback.
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+from docking.log import get_logger
+
+log = get_logger(name="environment")
+
+
+class Desktop(enum.Flag):
+    UNKNOWN = 0
+    GNOME = enum.auto()
+    KDE = enum.auto()
+    LXDE = enum.auto()
+    MATE = enum.auto()
+    XFCE = enum.auto()
+    CINNAMON = enum.auto()
+    PANTHEON = enum.auto()
+    UNITY = enum.auto()
+    UBUNTU = enum.auto()
+
+    @property
+    def uses_monitor_geometry(self) -> bool:
+        """Whether to use full monitor geometry instead of workarea.
+
+        These DEs handle panel space reservation via struts, so the dock
+        should position relative to the full monitor and let struts
+        carve out workspace.
+        """
+        known = (
+            Desktop.GNOME
+            | Desktop.UBUNTU
+            | Desktop.MATE
+            | Desktop.CINNAMON
+            | Desktop.XFCE
+            | Desktop.KDE
+        )
+        return bool(self & known)
+
+
+_DESKTOP_MAP: dict[str, Desktop] = {
+    "gnome": Desktop.GNOME,
+    "gnome-xorg": Desktop.GNOME,
+    "gnome-classic": Desktop.GNOME,
+    "gnome-flashback": Desktop.GNOME,
+    "ubuntu": Desktop.UBUNTU,
+    "ubuntu-xorg": Desktop.UBUNTU,
+    "kde": Desktop.KDE,
+    "lxde": Desktop.LXDE,
+    "lxqt": Desktop.LXDE,
+    "mate": Desktop.MATE,
+    "xfce": Desktop.XFCE,
+    "xubuntu": Desktop.XFCE,
+    "cinnamon": Desktop.CINNAMON,
+    "x-cinnamon": Desktop.CINNAMON,
+    "pantheon": Desktop.PANTHEON,
+    "unity": Desktop.UNITY,
+}
+
+
+def _parse_desktop(value: str) -> Desktop:
+    """Parse a desktop string, handling XDG desktop list separators."""
+    result = Desktop.UNKNOWN
+    for part in re.split(r"[:;]", value):
+        part = part.strip().lower()
+        if part:
+            result |= _DESKTOP_MAP.get(part, Desktop.UNKNOWN)
+    return result
+
+
+def detect_desktop() -> Desktop:
+    """Detect the desktop environment from XDG environment variables.
+
+    Checks XDG_SESSION_DESKTOP, XDG_CURRENT_DESKTOP, DESKTOP_SESSION
+    in that order (matching Plank Reloaded's priority).
+    """
+    for var in ("XDG_SESSION_DESKTOP", "XDG_CURRENT_DESKTOP", "DESKTOP_SESSION"):
+        value = os.environ.get(var, "")
+        if value:
+            desktop = _parse_desktop(value)
+            if desktop != Desktop.UNKNOWN:
+                log.debug("detected %s from %s=%s", desktop, var, value)
+                return desktop
+
+    log.warning("could not detect desktop environment")
+    return Desktop.UNKNOWN
+
+
+def is_wayland_session() -> bool:
+    """Return True when the desktop session itself is Wayland."""
+    return os.environ.get("XDG_SESSION_TYPE", "").strip().lower() == "wayland"
+
+
+def is_flatpak() -> bool:
+    """Return True when running inside a Flatpak sandbox."""
+    return Path("/.flatpak-info").exists()
+
+
+def is_gnome_session(*, desktop: Desktop | None = None) -> bool:
+    """Return True for GNOME-shell-like sessions."""
+    resolved = desktop if desktop is not None else detect_desktop()
+    return bool(resolved & (Desktop.GNOME | Desktop.UBUNTU))
+
+
+def is_mate_session(*, desktop: Desktop | None = None) -> bool:
+    """Return True for MATE sessions."""
+    resolved = desktop if desktop is not None else detect_desktop()
+    return bool(resolved & Desktop.MATE)
+
+
+def is_kde_session(*, desktop: Desktop | None = None) -> bool:
+    """Return True for KDE sessions."""
+    resolved = desktop if desktop is not None else detect_desktop()
+    return bool(resolved & Desktop.KDE)
+
+
+def is_x11_backend(*, display: object | None = None) -> bool:
+    """Return True when the current GTK backend is X11."""
+    if display is None:
+        try:
+            import gi
+
+            gi.require_version("Gdk", "3.0")
+            from gi.repository import Gdk
+
+            display = Gdk.Display.get_default()
+        except Exception:
+            return False
+    if display is None:
+        return False
+    cls = display.__class__
+    if cls.__name__ == "X11Display":
+        return True
+    if cls.__module__.endswith("GdkX11"):
+        return True
+    return callable(getattr(display, "get_xdisplay", None))
+
+
+def is_xwayland_session(*, display: object | None = None) -> bool:
+    """Return True when Docking runs as an X11 client inside a Wayland session."""
+    return is_wayland_session() and is_x11_backend(display=display)
+
+
+def backend_name(*, display: object | None = None) -> str:
+    """Return a compact backend class name for logging."""
+    if display is None:
+        try:
+            import gi
+
+            gi.require_version("Gdk", "3.0")
+            from gi.repository import Gdk
+
+            display = Gdk.Display.get_default()
+        except Exception:
+            return "unknown"
+    if display is None:
+        return "none"
+    cls = display.__class__
+    return f"{cls.__module__}.{cls.__name__}"
+
+
+def compositor_active(*, display: object | None = None) -> bool | None:
+    """Return compositor status for X11 backends, or None when unavailable."""
+    try:
+        import ctypes
+
+        from gi.repository import GdkX11
+
+        if display is None:
+            display = GdkX11.X11Display.get_default()
+        if display is None or not is_x11_backend(display=display):
+            return None
+        screen_num = display.get_default_screen()
+
+        xlib = ctypes.cdll.LoadLibrary("libX11.so.6")
+        xdisplay = ctypes.c_void_p(hash(display.get_xdisplay()))
+
+        xlib.XInternAtom.restype = ctypes.c_ulong
+        xlib.XInternAtom.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+        xlib.XGetSelectionOwner.restype = ctypes.c_ulong
+        xlib.XGetSelectionOwner.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+
+        atom = xlib.XInternAtom(xdisplay, f"_NET_WM_CM_S{screen_num}".encode(), 0)
+        owner = xlib.XGetSelectionOwner(xdisplay, atom)
+        return owner != 0
+    except Exception as exc:
+        log.warning("failed to check compositor status: %s", exc)
+        return None
+
+
+def log_runtime_snapshot(
+    *,
+    display: object | None = None,
+    desktop: Desktop | None = None,
+) -> None:
+    """Log a small startup snapshot for comparing good and bad runs."""
+    compositor = compositor_active(display=display)
+    log.info(
+        "runtime snapshot: desktop=%s session=%s backend=%s x11=%s xwayland=%s "
+        "compositor_active=%s DISPLAY=%r WAYLAND_DISPLAY=%r GDK_BACKEND=%r",
+        desktop if desktop is not None else detect_desktop(),
+        os.environ.get("XDG_SESSION_TYPE", "").strip().lower() or "unknown",
+        backend_name(display=display),
+        is_x11_backend(display=display),
+        is_xwayland_session(display=display),
+        compositor,
+        os.environ.get("DISPLAY"),
+        os.environ.get("WAYLAND_DISPLAY"),
+        os.environ.get("GDK_BACKEND"),
+    )
+
+
+def _disable_xfce_dock_shadow() -> None:
+    """Disable xfwm4's dock window shadow via xfconf-query."""
+    if not shutil.which("xfconf-query"):
+        log.warning("xfconf-query not found, cannot disable dock shadow")
+        return
+    try:
+        subprocess.run(
+            [
+                "xfconf-query",
+                "-c",
+                "xfwm4",
+                "-p",
+                "/general/show_dock_shadow",
+                "-s",
+                "false",
+            ],
+            check=True,
+            capture_output=True,
+        )
+        log.info("disabled xfce dock shadow")
+    except subprocess.CalledProcessError as e:
+        log.warning("failed to disable xfce dock shadow: %s", e)
+
+
+def _check_compositor() -> None:
+    """Warn if no compositing manager is active.
+
+    Checks _NET_WM_CM_S{screen} selection owner via Xlib directly.
+    Gdk.Screen.is_composited() can return stale True if the compositor
+    crashed without releasing the selection, so we bypass GDK's cache.
+    """
+    active = compositor_active()
+    if active is None:
+        return
+    if active:
+        return
+
+    log.warning(
+        "no compositing manager detected (it may have crashed) -- "
+        "dock may appear behind maximized windows and transparency may not work; "
+        "enable compositing in your desktop settings or install a compositor "
+        "(picom, compton, xcompmgr)"
+    )
+
+
+def apply_tweaks(desktop: Desktop) -> None:
+    """Apply DE-specific tweaks at startup."""
+    _check_compositor()
+    if desktop & Desktop.XFCE:
+        _disable_xfce_dock_shadow()

--- a/docking/platform/environment/xdg.py
+++ b/docking/platform/environment/xdg.py
@@ -1,0 +1,59 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""XDG Base Directory helpers."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def xdg_config_home() -> Path:
+    """Return XDG_CONFIG_HOME or its standard user default."""
+    return Path(os.environ.get("XDG_CONFIG_HOME") or Path.home() / ".config")
+
+
+def xdg_cache_home() -> Path:
+    """Return XDG_CACHE_HOME or its standard user default."""
+    return Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache")
+
+
+def xdg_data_home() -> Path:
+    """Return XDG_DATA_HOME or its standard user default."""
+    return Path(os.environ.get("XDG_DATA_HOME") or Path.home() / ".local" / "share")
+
+
+def xdg_state_home() -> Path:
+    """Return XDG_STATE_HOME or its standard user default."""
+    return Path(os.environ.get("XDG_STATE_HOME") or Path.home() / ".local" / "state")
+
+
+def docking_config_dir() -> Path:
+    """Return Docking's per-user configuration directory."""
+    return xdg_config_home() / "docking"
+
+
+def docking_cache_dir() -> Path:
+    """Return Docking's per-user cache directory."""
+    return xdg_cache_home() / "docking"
+
+
+def docking_data_dir() -> Path:
+    """Return Docking's per-user data directory."""
+    return xdg_data_home() / "docking"
+
+
+def docking_state_dir() -> Path:
+    """Return Docking's per-user state directory."""
+    return xdg_state_home() / "docking"

--- a/docking/platform/launcher.py
+++ b/docking/platform/launcher.py
@@ -154,7 +154,7 @@ from gi.repository import GdkPixbuf, Gio, GLib, Gtk
 
 from docking.core.config import MiddleClickAction
 from docking.log import get_logger, with_context
-from docking.platform.environment import flatpak, is_flatpak
+from docking.platform.environment import flatpak, is_flatpak, xdg_data_home
 
 DESKTOP_SUFFIX = ".desktop"
 FALLBACK_ICON = "application-x-executable"
@@ -344,8 +344,7 @@ def _get_desktop_dirs() -> list[Path]:
         p = Path(d) / "applications"
         if p.is_dir() and p not in dirs:
             dirs.append(p)
-    local = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local/share"))
-    user_apps = local / "applications"
+    user_apps = xdg_data_home() / "applications"
     if user_apps.is_dir():
         dirs.insert(0, user_apps)
     if is_flatpak():

--- a/tests/applets/test_keyboardlayout.py
+++ b/tests/applets/test_keyboardlayout.py
@@ -46,7 +46,12 @@ from docking.platform.environment import Desktop
 
 
 def _set_desktop(monkeypatch: pytest.MonkeyPatch, desktop: Desktop) -> None:
-    monkeypatch.setattr(kbl_state.environment, "detect_desktop", lambda: desktop)
+    # detect_desktop lives in environment.environment; the package __init__
+    # re-exports it but the session-helpers in environment.environment call
+    # it through their own module globals, so we patch at the source.
+    from docking.platform.environment import environment as env_impl
+
+    monkeypatch.setattr(env_impl, "detect_desktop", lambda: desktop)
 
 
 SETXKBMAP_MULTI = """\

--- a/tests/platform/test_environment.py
+++ b/tests/platform/test_environment.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 from docking.platform.environment import (
     Desktop,
-    _check_compositor,
-    _parse_desktop,
     detect_desktop,
     is_flatpak,
     is_gnome_session,
@@ -16,6 +14,7 @@ from docking.platform.environment import (
     is_x11_backend,
     is_xwayland_session,
 )
+from docking.platform.environment.environment import _check_compositor, _parse_desktop
 
 
 class TestParseDesktop:
@@ -114,10 +113,14 @@ class TestSessionBackendDetection:
             assert is_wayland_session() is False
 
     def test_is_flatpak_checks_runtime_marker(self):
-        with patch("docking.platform.environment.Path.exists", return_value=True):
+        with patch(
+            "docking.platform.environment.environment.Path.exists", return_value=True
+        ):
             assert is_flatpak() is True
 
-        with patch("docking.platform.environment.Path.exists", return_value=False):
+        with patch(
+            "docking.platform.environment.environment.Path.exists", return_value=False
+        ):
             assert is_flatpak() is False
 
     def test_is_x11_backend_true_for_x11_display(self):


### PR DESCRIPTION
Split desktop-environment detection from XDG path helpers, add shared path directory helpers, and route config, cache, state, and data path construction through those shared helpers. AGENTS.md is intentionally ignored so local agent instructions are not checked in.