### PR TITLE
Add shared math clamp helpers

### DIFF
--- a/docking/applets/alarm/state.py
+++ b/docking/applets/alarm/state.py
@@ -20,6 +20,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from typing import Any
 
+from docking.core.math import clamp_int
 from docking.i18n import _
 
 DEFAULT_SNOOZE_MINUTES = 5
@@ -313,10 +314,10 @@ def normalize_preset(preset: AlarmPreset) -> AlarmPreset:
     return replace(
         preset,
         label=label,
-        hour=max(0, min(23, int(preset.hour))),
-        minute=max(0, min(59, int(preset.minute))),
+        hour=clamp_int(int(preset.hour), 0, 23),
+        minute=clamp_int(int(preset.minute), 0, 59),
         repeat_days=repeat_days,
-        snooze_minutes=max(1, min(120, int(preset.snooze_minutes))),
+        snooze_minutes=clamp_int(int(preset.snooze_minutes), 1, 120),
     )
 
 

--- a/docking/applets/ambient/applet.py
+++ b/docking/applets/ambient/applet.py
@@ -42,6 +42,7 @@ from docking.applets.ambient.state import (
 )
 from docking.applets.base import Applet
 from docking.applets.menu import menu_sections
+from docking.core.math import clamp
 from docking.i18n import _
 from docking.log import get_logger
 
@@ -105,7 +106,7 @@ class AmbientApplet(Applet):
     def _volume(self, value: float) -> None:
         self._state = AmbientState(
             current=self._state.current,
-            volume=max(0.0, min(1.0, value)),
+            volume=clamp(value, 0.0, 1.0),
             playing=self._state.playing,
         )
 

--- a/docking/applets/battery/render.py
+++ b/docking/applets/battery/render.py
@@ -25,6 +25,7 @@ from gi.repository import Gdk, GdkPixbuf
 from docking.applets.base import draw_icon_label
 from docking.applets.battery.state import BatteryState
 from docking.applets.draw import rounded_rect
+from docking.core.math import clamp
 
 _GREEN = (0.00, 0.62, 0.32)
 _GREEN_DARK = (0.00, 0.55, 0.28)
@@ -101,7 +102,7 @@ def _draw_battery(
     iy = y + inner_pad
     iw = w - inner_pad * 2
     ih = h - inner_pad * 2
-    ratio = max(0.0, min(1.0, capacity / 100.0))
+    ratio = clamp(capacity / 100.0, 0.0, 1.0)
 
     if ratio > 0:
         fill_h = ih * ratio

--- a/docking/applets/camshield/render.py
+++ b/docking/applets/camshield/render.py
@@ -25,6 +25,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import Gdk, GdkPixbuf
 
 from docking.applets.draw import rounded_rect
+from docking.core.math import clamp
 from docking.ui.overlays import draw_circle_badge
 
 
@@ -48,7 +49,7 @@ def render_icon(
         cx = size - radius - size * 0.06
         cy = radius + size * 0.06
         if pulse_phase is not None:
-            phase = max(0.0, min(1.0, pulse_phase))
+            phase = clamp(pulse_phase, 0.0, 1.0)
             pulse_radius = radius * (1.15 + 0.65 * phase)
             pulse_alpha = 0.46 * (1.0 - phase)
             if pulse_alpha > 0.02:

--- a/docking/applets/currencyfx/applet.py
+++ b/docking/applets/currencyfx/applet.py
@@ -74,6 +74,7 @@ from docking.applets.popup import (
     prepare_dialog_content,
 )
 from docking.applets.worker import BackgroundWorker
+from docking.core.math import clamp_index
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -394,7 +395,7 @@ class CurrencyFxApplet(Applet):
         """Switch active pair by index from scroll or the Added Pairs menu."""
         if not self._pairs:
             return
-        index = max(0, min(index, len(self._pairs) - 1))
+        index = clamp_index(index, len(self._pairs))
         if index == self._active_index:
             return
         self._active_index = index

--- a/docking/applets/currencyfx/render.py
+++ b/docking/applets/currencyfx/render.py
@@ -41,6 +41,7 @@ from gi.repository import Gdk, GdkPixbuf
 from docking.applets.base import draw_icon_label
 from docking.applets.currencyfx.state import FxPoint, FxSnapshot, percent_change
 from docking.applets.draw import rounded_rect
+from docking.core.math import clamp
 
 _BG_TOP = (0.08, 0.11, 0.15)
 _BG_BOTTOM = (0.12, 0.16, 0.22)
@@ -195,7 +196,7 @@ def _draw_sparkline(
     last_x, last_y = coords[-1]
     dot_radius = max(1.7, size * 0.055)
     if pulse_phase is not None:
-        phase = max(0.0, min(1.0, pulse_phase))
+        phase = clamp(pulse_phase, 0.0, 1.0)
         pulse_radius = dot_radius * (1.18 + 0.82 * phase)
         pulse_alpha = 0.46 * (1.0 - phase)
         if pulse_alpha > 0.02:

--- a/docking/applets/currencyfx/state.py
+++ b/docking/applets/currencyfx/state.py
@@ -54,6 +54,7 @@ from docking.applets.live_state import (
 )
 from docking.applets.tooltip import structured_tooltip
 from docking.applets.unitconverter.state import Unit, fetch_currency_rates
+from docking.core.math import clamp_index
 from docking.i18n import _
 from docking.log import get_logger
 
@@ -206,7 +207,7 @@ def prefs_from_mapping(prefs: Mapping[str, Any] | None) -> CurrencyFxPrefs:
         active_index = int(prefs.get("active_index", 0))
     except (TypeError, ValueError):
         active_index = 0
-    active_index = max(0, min(active_index, len(pairs) - 1))
+    active_index = clamp_index(active_index, len(pairs))
 
     return CurrencyFxPrefs(
         pairs=pairs,
@@ -235,7 +236,7 @@ def prefs_payload(
     file stays canonical after any menu or dialog action.
     """
     normalized_pairs = normalize_pairs(pairs)
-    active_index = max(0, min(active_index, len(normalized_pairs) - 1))
+    active_index = clamp_index(active_index, len(normalized_pairs))
     interval = normalize_chart_interval(chart_interval)
     return {
         "pairs": [

--- a/docking/applets/deskpresence/applet.py
+++ b/docking/applets/deskpresence/applet.py
@@ -42,6 +42,7 @@ from docking.applets.deskpresence.state import (
     state_from_prefs,
 )
 from docking.applets.menu import disabled_menu_item, menu_sections, radio_submenu
+from docking.core.math import clamp
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -182,7 +183,7 @@ class DeskpresenceApplet(Applet):
         return True
 
     def _set_threshold(self, *, seconds: float) -> None:
-        clamped = max(MIN_IDLE_THRESHOLD_S, min(MAX_IDLE_THRESHOLD_S, seconds))
+        clamped = clamp(seconds, MIN_IDLE_THRESHOLD_S, MAX_IDLE_THRESHOLD_S)
         self._state.idle_threshold_s = clamped
         self._save_prefs()
         self.present()

--- a/docking/applets/deskpresence/render.py
+++ b/docking/applets/deskpresence/render.py
@@ -26,6 +26,7 @@ from gi.repository import Gdk, GdkPixbuf
 
 from docking.applets.base import draw_icon_label
 from docking.applets.deskpresence.state import Presence, format_badge
+from docking.core.math import clamp
 
 # Per-status color of strokes and (when applicable) fills.
 _STATUS_COLORS: dict[Presence, tuple[float, float, float]] = {
@@ -125,7 +126,7 @@ def _draw_presence(
     # draws while AT_DESK, and only when the applet supplies a live phase
     # (catalog thumbnails and tests render without it).
     if pulse_phase is not None and presence is Presence.AT_DESK:
-        phase = max(0.0, min(1.0, pulse_phase))
+        phase = clamp(pulse_phase, 0.0, 1.0)
         pulse_r = size * (0.40 + 0.12 * phase)
         pulse_alpha = 0.55 * (1.0 - phase)
         if pulse_alpha > 0.02:

--- a/docking/applets/deskpresence/state.py
+++ b/docking/applets/deskpresence/state.py
@@ -21,6 +21,7 @@ from datetime import date, datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, cast
 
+from docking.core.math import clamp
 from docking.i18n import _
 
 DEFAULT_IDLE_THRESHOLD_S = 120.0
@@ -281,7 +282,7 @@ def prefs_from_mapping(prefs: Mapping[str, Any] | None) -> DeskpresencePrefs:
         threshold = float(prefs.get("idle_threshold_s", DEFAULT_IDLE_THRESHOLD_S))
     except (TypeError, ValueError):
         return DeskpresencePrefs()
-    threshold = max(MIN_IDLE_THRESHOLD_S, min(MAX_IDLE_THRESHOLD_S, threshold))
+    threshold = clamp(threshold, MIN_IDLE_THRESHOLD_S, MAX_IDLE_THRESHOLD_S)
     raw_history = prefs.get("history")
     history = _parse_history(raw_history, today=_today_utc())
     return DeskpresencePrefs(

--- a/docking/applets/draw.py
+++ b/docking/applets/draw.py
@@ -19,6 +19,8 @@ import math
 
 import cairo
 
+from docking.core.math import clamp
+
 
 def rounded_rect(
     *,
@@ -30,7 +32,7 @@ def rounded_rect(
     radius: float,
 ) -> None:
     """Add a closed rounded-rectangle sub-path to *cr*."""
-    radius = max(0.0, min(radius, min(width, height) / 2))
+    radius = clamp(radius, 0.0, min(width, height) / 2)
     cr.new_sub_path()
     cr.arc(x + width - radius, y + radius, radius, -math.pi / 2, 0)
     cr.arc(x + width - radius, y + height - radius, radius, 0, math.pi / 2)

--- a/docking/applets/hackernews/state.py
+++ b/docking/applets/hackernews/state.py
@@ -39,6 +39,7 @@ from docking.applets.live_state import (
     resolve_live_status,
 )
 from docking.applets.tooltip import structured_tooltip
+from docking.core.math import clamp_index
 from docking.i18n import _
 from docking.log import get_logger
 
@@ -137,7 +138,7 @@ def normalize_active_index(*, index: int, count: int) -> int:
     """Clamp active index for the current story list."""
     if count <= 0:
         return 0
-    return max(0, min(index, count - 1))
+    return clamp_index(index, count)
 
 
 def build_tooltip(

--- a/docking/applets/micshield/render.py
+++ b/docking/applets/micshield/render.py
@@ -24,6 +24,7 @@ gi.require_version("Gdk", "3.0")
 gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import Gdk, GdkPixbuf
 
+from docking.core.math import clamp
 from docking.ui.overlays import draw_circle_badge
 
 _BODY_ACTIVE = (0.22, 0.62, 0.86)
@@ -131,7 +132,7 @@ def _draw_privacy_dot(
     cx = size - radius - size * 0.06
     cy = radius + size * 0.06
     if pulse_phase is not None:
-        phase = max(0.0, min(1.0, pulse_phase))
+        phase = clamp(pulse_phase, 0.0, 1.0)
         pulse_radius = radius * (1.15 + 0.65 * phase)
         pulse_alpha = 0.46 * (1.0 - phase)
         if pulse_alpha > 0.02:

--- a/docking/applets/notifications/applet.py
+++ b/docking/applets/notifications/applet.py
@@ -33,6 +33,7 @@ from docking.applets.base import Applet
 from docking.applets.menu import disabled_menu_item, menu_sections
 from docking.applets.notifications import meta
 from docking.applets.worker import BackgroundWorker
+from docking.core.math import clamp_index, clamp_int
 from docking.i18n import _
 from docking.log import get_logger, with_context
 from docking.platform.environment import flatpak, is_flatpak
@@ -221,7 +222,7 @@ class NotificationsApplet(Applet):
         )
 
     def _history_badge_count(self) -> int:
-        return max(0, min(MAX_HISTORY_BADGE_COUNT, len(self._history)))
+        return clamp_int(len(self._history), 0, MAX_HISTORY_BADGE_COUNT)
 
     def _on_notification_activity(self, force_refresh: bool = False) -> bool:
         previous = self._show_activity_badge()
@@ -389,7 +390,7 @@ class NotificationsApplet(Applet):
     def _current_notification_lines(self) -> list[str]:
         if not self._history:
             return []
-        idx = max(0, min(self._history_index, len(self._history) - 1))
+        idx = clamp_index(self._history_index, len(self._history))
         entry = self._history[idx]
         lines = [f"Notification {idx + 1}/{len(self._history)}:"]
         if entry.summary:

--- a/docking/applets/speedtest/render.py
+++ b/docking/applets/speedtest/render.py
@@ -26,6 +26,7 @@ from gi.repository import Gdk, GdkPixbuf
 
 from docking.applets.base import draw_icon_label
 from docking.applets.speedtest.state import format_speed, speed_tier
+from docking.core.math import clamp
 
 # Visible tick positions along the dial (0.0..1.0).
 _TICK_STEPS = (0.0, 0.25, 0.5, 0.75, 1.0)
@@ -110,7 +111,7 @@ def _draw_needle(
     tier: str,
 ) -> None:
     cx, cy, radius = _dial_center(size)
-    fraction = max(0.0, min(1.0, download_mbps / _NEEDLE_FULL_SCALE_MBPS))
+    fraction = clamp(download_mbps / _NEEDLE_FULL_SCALE_MBPS, 0.0, 1.0)
     angle = math.pi + fraction * math.pi
 
     length = radius - size * 0.04

--- a/docking/applets/sunrise/render.py
+++ b/docking/applets/sunrise/render.py
@@ -34,6 +34,7 @@ from docking.applets.sunrise.state import (
     SolarSnapshot,
     icon_label,
 )
+from docking.core.math import clamp
 
 RGBA = tuple[float, float, float, float]
 
@@ -329,8 +330,8 @@ def _stroke_segment(
     end_minute: float,
     color: RGBA,
 ) -> None:
-    start = max(0.0, min(float(DAY_MINUTES), start_minute))
-    end = max(0.0, min(float(DAY_MINUTES), end_minute))
+    start = clamp(start_minute, 0.0, float(DAY_MINUTES))
+    end = clamp(end_minute, 0.0, float(DAY_MINUTES))
     if end <= start:
         return
     cr.set_source_rgba(*color)

--- a/docking/applets/sunrise/state.py
+++ b/docking/applets/sunrise/state.py
@@ -24,6 +24,7 @@ from functools import lru_cache
 from typing import Any, NamedTuple
 
 from docking.applets.cities import CityEntry, load_cities
+from docking.core.math import clamp_index
 from docking.i18n import _
 
 REFRESH_INTERVAL_S = 60
@@ -132,7 +133,7 @@ def prefs_from_mapping(prefs: Mapping[str, Any] | None) -> SunrisePrefs:
             )
 
     active_index = int(prefs.get("active_index", 0))
-    active_index = max(0, min(active_index, len(cities) - 1)) if cities else 0
+    active_index = clamp_index(active_index, len(cities))
     return SunrisePrefs(
         cities=cities,
         active_index=active_index,

--- a/docking/applets/systemmonitor/render.py
+++ b/docking/applets/systemmonitor/render.py
@@ -25,6 +25,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import Gdk, GdkPixbuf
 
 from docking.applets.systemmonitor.state import cpu_hue_rgb
+from docking.core.math import clamp
 
 RADIUS_PERCENT = 0.9
 
@@ -37,7 +38,7 @@ def _render_gauge(cr: cairo.Context, size: int, cpu: float, mem: float) -> None:
     r, g, b = cpu_hue_rgb(cpu=cpu)
     base_alpha = 0.5
     # *1.3 exaggerates display so ~77% CPU fills the gauge (makes low usage visible)
-    cpu_clamped = max(0.001, min(cpu * 1.3, 1.0))
+    cpu_clamped = clamp(cpu * 1.3, 0.001, 1.0)
 
     # 1. Black underlay
     cr.arc(center, center, radius, 0, math.tau)

--- a/docking/applets/thermals/state.py
+++ b/docking/applets/thermals/state.py
@@ -33,6 +33,7 @@ from docking.applets.live_state import (
     resolve_live_status,
 )
 from docking.applets.tooltip import structured_tooltip
+from docking.core.math import clamp
 from docking.i18n import _
 from docking.log import get_logger
 
@@ -530,7 +531,7 @@ def thermal_level(celsius: float | None) -> float:
     """Map temperature to a 0..1 visual severity value."""
     if celsius is None:
         return 0.0
-    return max(0.0, min(1.0, (celsius - 35.0) / 55.0))
+    return clamp((celsius - 35.0) / 55.0, 0.0, 1.0)
 
 
 def thermal_color(celsius: float | None) -> tuple[float, float, float]:

--- a/docking/applets/unitconverter/applet.py
+++ b/docking/applets/unitconverter/applet.py
@@ -70,6 +70,7 @@ from docking.applets.unitconverter.state import (
     set_currency_units,
 )
 from docking.applets.worker import BackgroundWorker
+from docking.core.math import clamp_index
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -130,7 +131,7 @@ class UnitConverterApplet(Applet):
         self._to_idx = int(prefs.get("to_index", 1))
 
         cats = get_categories()
-        self._cat_idx = max(0, min(self._cat_idx, len(cats) - 1))
+        self._cat_idx = clamp_index(self._cat_idx, len(cats))
 
         super().__init__(icon_size=icon_size, config=config)
         self.present()
@@ -207,7 +208,7 @@ class UnitConverterApplet(Applet):
         self._cat_combo = Gtk.ComboBoxText()
         for cat in cats:
             self._cat_combo.append_text(cat.value)
-        self._cat_idx = max(0, min(self._cat_idx, len(cats) - 1))
+        self._cat_idx = clamp_index(self._cat_idx, len(cats))
         self._cat_combo.set_active(self._cat_idx)
         self._cat_combo.connect("changed", self._on_category_changed)
         box.pack_start(self._cat_combo, False, False, 0)
@@ -259,14 +260,14 @@ class UnitConverterApplet(Applet):
             self._from_combo.remove_all()
             for u in units:
                 self._from_combo.append_text(_unit_label(u))
-            idx = max(0, min(self._from_idx, len(units) - 1))
+            idx = clamp_index(self._from_idx, len(units))
             self._from_combo.set_active(idx)
 
         if self._to_combo:
             self._to_combo.remove_all()
             for u in units:
                 self._to_combo.append_text(_unit_label(u))
-            idx = max(0, min(self._to_idx, len(units) - 1))
+            idx = clamp_index(self._to_idx, len(units))
             self._to_combo.set_active(idx)
 
     def _on_category_changed(self, combo: Gtk.ComboBoxText) -> None:
@@ -328,8 +329,8 @@ class UnitConverterApplet(Applet):
                 '<span color="#ff6b6b">No units available</span>'
             )
             return
-        fi = max(0, min(self._from_idx, len(units) - 1))
-        ti = max(0, min(self._to_idx, len(units) - 1))
+        fi = clamp_index(self._from_idx, len(units))
+        ti = clamp_index(self._to_idx, len(units))
 
         try:
             value = float(text)

--- a/docking/applets/weather/state.py
+++ b/docking/applets/weather/state.py
@@ -32,6 +32,7 @@ from docking.applets.live_state import (
 )
 from docking.applets.tooltip import structured_tooltip
 from docking.applets.weather.api import AirQualityData, WeatherData
+from docking.core.math import clamp_index
 from docking.i18n import _
 
 DEFAULT_ICON_NAME = "weather-few-clouds"
@@ -85,7 +86,7 @@ def prefs_from_mapping(prefs: Mapping[str, Any] | None) -> WeatherPrefs:
             if isinstance(c, Mapping)
         )
         idx = int(prefs.get("active_index", 0))
-        idx = max(0, min(idx, len(cities) - 1)) if cities else 0
+        idx = clamp_index(idx, len(cities))
         return WeatherPrefs(
             cities=cities,
             active_index=idx,

--- a/docking/core/math.py
+++ b/docking/core/math.py
@@ -1,0 +1,33 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Small numeric helpers shared by rendering and state code."""
+
+from __future__ import annotations
+
+
+def clamp(value: float, minimum: float, maximum: float) -> float:
+    """Return value constrained to the inclusive minimum..maximum range."""
+    return max(minimum, min(maximum, value))
+
+
+def clamp_int(value: int, minimum: int, maximum: int) -> int:
+    """Return an integer value constrained to the inclusive range."""
+    return max(minimum, min(maximum, value))
+
+
+def clamp_index(index: int, length: int) -> int:
+    """Return an index constrained to the valid range for a sequence length."""
+    if length <= 0:
+        return 0
+    return clamp_int(index, 0, length - 1)

--- a/docking/platform/model.py
+++ b/docking/platform/model.py
@@ -163,6 +163,7 @@ from docking.core.items import (
     FOLDER_KIND,
     DockItem,
 )
+from docking.core.math import clamp
 from docking.log import get_logger, with_context
 from docking.platform.running import RunningAppInfo
 
@@ -343,7 +344,7 @@ class DockModel:
     ) -> None:
         item.badge_count = state.badge_count
         item.badge_visible = state.badge_visible
-        item.progress = max(0.0, min(1.0, state.progress))
+        item.progress = clamp(state.progress, 0.0, 1.0)
         item.progress_visible = state.progress_visible
         item.launcher_entry_urgent = state.urgent
         self._recompute_urgent(item=item)


### PR DESCRIPTION
Add shared clamp helpers for floats, integers, and sequence indexes, then replace repeated max/min clamping in applet state, rendering, and dock model code.