### PR TITLE
Add safe JSON loading helper

### DIFF
--- a/docking/applets/aiusage/store.py
+++ b/docking/applets/aiusage/store.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 from docking.applets.aiusage import state as aiusage_state
 from docking.core.paths import ensure_parent_dir
+from docking.core.serialization import safe_json_load
 from docking.log import get_logger
 from docking.platform.environment import docking_config_dir
 
@@ -37,11 +38,8 @@ def config_path() -> Path:
 
 def read_prefs_from_disk() -> dict | None:
     """Read aiusage prefs directly from dock.json on disk."""
-    path = config_path()
-    try:
-        config = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        log.debug("Failed to read AI usage prefs from %s: %s", path, exc)
+    config = safe_json_load(config_path(), default=None)
+    if not isinstance(config, dict):
         return None
     prefs = config.get("applet_prefs", {})
     return prefs.get(PREFS_KEY) or prefs.get(PREFS_KEY_LEGACY)

--- a/docking/applets/camshield/helper.py
+++ b/docking/applets/camshield/helper.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from docking.core.paths import ensure_dir
+from docking.core.serialization import safe_json_load
 
 STATE_DIR = Path("/var/lib/docking/camshield")
 STATE_FILE = STATE_DIR / "devices.json"
@@ -198,12 +199,9 @@ def _restore_acl(*, snapshot: DeviceSnapshot) -> bool:
 
 def _read_state(*, state_dir: Path) -> dict[str, DeviceSnapshot]:
     path = state_dir / STATE_FILE.name
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {}
+    raw = safe_json_load(path, default={})
 
-    if raw.get("version") != _STATE_VERSION:
+    if not isinstance(raw, dict) or raw.get("version") != _STATE_VERSION:
         return {}
 
     result: dict[str, DeviceSnapshot] = {}

--- a/docking/core/serialization.py
+++ b/docking/core/serialization.py
@@ -1,0 +1,30 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Serialization helpers for small local data files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
+
+
+def safe_json_load(path: Path | str, *, default: _T) -> Any | _T:
+    """Read a JSON file, returning default when it is absent or invalid."""
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return default


### PR DESCRIPTION
Add a shared JSON file loader for optional local state and use it in AI usage preferences and Cam Shield state restoration. This PR is stacked on the environment path helper branch because the patch depends on those shared path helpers.