### PR TITLE
Add shared applet text and HTTP helpers

### DIFF
--- a/docking/applets/hackernews/state.py
+++ b/docking/applets/hackernews/state.py
@@ -24,7 +24,6 @@ test without a desktop session.
 from __future__ import annotations
 
 import datetime as dt
-import html
 import json
 import urllib.request
 from collections.abc import Callable, Mapping, Sequence
@@ -38,6 +37,7 @@ from docking.applets.live_state import (
     refresh_recovery_label,
     resolve_live_status,
 )
+from docking.applets.text import normalize_text
 from docking.applets.tooltip import structured_tooltip
 from docking.i18n import _
 from docking.log import get_logger
@@ -94,12 +94,6 @@ class HackerNewsPage:
     stories: tuple[HackerNewsStory, ...]
     next_offset: int
     has_more: bool
-
-
-def normalize_text(value: object) -> str:
-    """Normalize API text fields for compact tooltip/menu display."""
-    text = html.unescape(str(value or ""))
-    return " ".join(text.replace("\n", " ").replace("\r", " ").split()).strip()
 
 
 def story_rank(*, index: int, count: int) -> str:

--- a/docking/applets/http.py
+++ b/docking/applets/http.py
@@ -1,0 +1,55 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""HTTP helpers for applets that use the Python standard library."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.request import Request, urlopen
+
+DEFAULT_USER_AGENT = "DockingApplet/1.0 (+https://github.com/edumucelli/docking)"
+
+
+def http_get_bytes(
+    url: str,
+    *,
+    timeout: float = 8.0,
+    user_agent: str = DEFAULT_USER_AGENT,
+) -> bytes:
+    """Fetch a URL and return the raw response body."""
+    request = Request(url, headers={"User-Agent": user_agent})
+    with urlopen(request, timeout=timeout) as response:
+        return response.read()
+
+
+def http_get_text(
+    url: str,
+    *,
+    timeout: float = 8.0,
+    user_agent: str = DEFAULT_USER_AGENT,
+    encoding: str = "utf-8",
+) -> str:
+    """Fetch a URL and decode the response body as text."""
+    return http_get_bytes(url, timeout=timeout, user_agent=user_agent).decode(encoding)
+
+
+def http_get_json(
+    url: str,
+    *,
+    timeout: float = 8.0,
+    user_agent: str = DEFAULT_USER_AGENT,
+) -> Any:
+    """Fetch a URL and decode the response body as JSON."""
+    return json.loads(http_get_text(url, timeout=timeout, user_agent=user_agent))

--- a/docking/applets/text.py
+++ b/docking/applets/text.py
@@ -1,0 +1,24 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Small text helpers shared by applets."""
+
+from __future__ import annotations
+
+import html
+
+
+def normalize_text(value: object) -> str:
+    """Decode HTML entities and collapse whitespace for compact UI text."""
+    text = html.unescape(str(value or ""))
+    return " ".join(text.replace("\n", " ").replace("\r", " ").split()).strip()

--- a/docking/applets/todayinhistory/state.py
+++ b/docking/applets/todayinhistory/state.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import html
 import json
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -23,6 +22,7 @@ from importlib import resources
 from typing import Any
 from urllib.request import Request, urlopen
 
+from docking.applets.text import normalize_text
 from docking.applets.todayinhistory import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -48,11 +48,6 @@ class HistoryEvent:
     article_title: str = ""
     article_url: str = ""
     source_label: str = _WIKIPEDIA_SOURCE
-
-
-def normalize_text(text: str) -> str:
-    clean = html.unescape(text).replace("\n", " ").replace("\r", " ").strip()
-    return " ".join(clean.split())
 
 
 def format_history_event(event: HistoryEvent) -> str:

--- a/docking/applets/trivia/state.py
+++ b/docking/applets/trivia/state.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import html
 import json
 import random
 from collections.abc import Callable
@@ -23,6 +22,7 @@ from dataclasses import dataclass, replace
 from typing import Any
 from urllib.request import Request, urlopen
 
+from docking.applets.text import normalize_text
 from docking.applets.trivia import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -89,11 +89,6 @@ FALLBACK_TRIVIA: tuple[TriviaEntry, ...] = (
         correct_answer="George Orwell",
     ),
 )
-
-
-def normalize_text(text: str) -> str:
-    clean = html.unescape(text).replace("\n", " ").replace("\r", " ").strip()
-    return " ".join(clean.split())
 
 
 def format_difficulty(difficulty: str) -> str:


### PR DESCRIPTION
Add shared applet helpers for compact text normalization and standard-library HTTP requests, then move Hacker News, Today in History, and Trivia onto the shared text normalization helper.