### PR TITLE
Use lazy formatting for debug logs

### DIFF
--- a/docking/applets/ambient/applet.py
+++ b/docking/applets/ambient/applet.py
@@ -208,7 +208,7 @@ class AmbientApplet(Applet):
 
     def _stop_playback(self) -> None:
         if self._pipeline:
-            log.debug(f"Stopping pipeline: {self._state.current}")
+            log.debug("Stopping pipeline: %s", self._state.current)
             if self._bus_watching:
                 bus = self._pipeline.get_bus()
                 if bus:

--- a/docking/ui/autohide.py
+++ b/docking/ui/autohide.py
@@ -264,7 +264,7 @@ def _source_exists(source_id: int) -> bool:
         ctx = GLib.MainContext.default()
         return bool(ctx and ctx.find_source_by_id(source_id))
     except Exception as exc:
-        log.debug(f"Could not query GLib source id {source_id}: {exc}")
+        log.debug("Could not query GLib source id %s: %s", source_id, exc)
         # If runtime doesn't expose the check, fall back to best effort.
         return True
 

--- a/docking/ui/dnd.py
+++ b/docking/ui/dnd.py
@@ -320,7 +320,7 @@ class DnDHandler:
                         Gtk.drag_set_icon_pixbuf(
                             context, scaled, icon_size // 2, icon_size // 2
                         )
-                log.debug(f"  -> dragging item {i}: {item.name}")
+                log.debug("  -> dragging item %d: %s", i, item.name)
                 return
         log.debug("  -> no item matched")
 
@@ -396,7 +396,7 @@ class DnDHandler:
             new_index = -1
 
         if new_index != self.drag_index:
-            log.debug(f"drag-motion: reorder {self.drag_index} -> {new_index}")
+            log.debug("drag-motion: reorder %d -> %d", self.drag_index, new_index)
             self._model.reorder_visible(self.drag_index, new_index)
             self.drag_index = new_index
 
@@ -461,7 +461,7 @@ class DnDHandler:
 
         # External drop -- process URIs
         insert_at = max(0, self.drop_insert_index)
-        log.debug(f"drag-data-received: external drop, insert_at={insert_at}")
+        log.debug("drag-data-received: external drop, insert_at=%d", insert_at)
         uris = selection.get_uris()
         if not uris:
             text = selection.get_text()

--- a/docking/ui/preview.py
+++ b/docking/ui/preview.py
@@ -244,10 +244,10 @@ def capture_xid(
                 pixbuf = Gdk.pixbuf_get_from_window(foreign, 0, 0, width, height)
                 x_error = display.error_trap_pop()
                 if x_error or not pixbuf:
-                    log.debug(f"X11 capture failed for xid={xid} (error={x_error})")
+                    log.debug("X11 capture failed for xid=%s (error=%s)", xid, x_error)
                     return None
                 if _looks_unavailable_capture(pixbuf=pixbuf):
-                    log.debug(f"Capture looked unavailable (black) for xid={xid}")
+                    log.debug("Capture looked unavailable (black) for xid=%s", xid)
                     return None
                 # Scale preserving aspect ratio
                 scale = min(thumb_w / width, thumb_h / height)
@@ -531,7 +531,7 @@ class PreviewPopup(Gtk.Window):
 
     def _on_enter(self, _widget: Gtk.Widget, event: Gdk.EventCrossing) -> bool:
         """Keep popup and dock visible while mouse is inside preview."""
-        log.debug(f"preview enter: detail={event.detail} mode={event.mode}")
+        log.debug("preview enter: detail=%s mode=%s", event.detail, event.mode)
         self._cancel_hide_timer()
         if self._autohide:
             self._autohide.on_mouse_enter()
@@ -561,7 +561,7 @@ class PreviewPopup(Gtk.Window):
         if event.detail == Gdk.NotifyType.INFERIOR:
             log.debug("preview leave: INFERIOR (ignored)")
             return False
-        log.debug(f"preview leave: detail={event.detail} mode={event.mode}")
+        log.debug("preview leave: detail=%s mode=%s", event.detail, event.mode)
         self._schedule_hide()
         return False
 
@@ -573,7 +573,7 @@ class PreviewPopup(Gtk.Window):
     def _schedule_hide(self, delay_ms: int = PREVIEW_HIDE_DELAY_MS) -> None:
         """Hide after a grace period (lets user move mouse to popup)."""
         self._cancel_hide_timer()
-        log.debug(f"preview: scheduling hide in {delay_ms}ms")
+        log.debug("preview: scheduling hide in %dms", delay_ms)
         self._hide_timer_id = GLib.timeout_add(delay_ms, self._do_hide)
 
     def _do_hide(self) -> bool:

--- a/docking/ui/tooltip.py
+++ b/docking/ui/tooltip.py
@@ -276,7 +276,7 @@ class TooltipManager:
         # crossing events) vs just repositioning (cheap: move only).
         content_changed = not (item is self._last_item and item.name == self._last_name)
         if content_changed:
-            log.debug(f"content changed: {item.name}")
+            log.debug("content changed: %s", item.name)
 
         item_geometry = geometry.geometry_for_item(item)
         if item_geometry is None:


### PR DESCRIPTION
Convert selected debug logging calls from eager f-strings to logger argument formatting in applet and UI hot paths.