### PR TITLE
Adopt shared applet HTTP helpers

### DIFF
--- a/docking/applets/apod/api.py
+++ b/docking/applets/apod/api.py
@@ -20,12 +20,12 @@ one image download per day.
 
 from __future__ import annotations
 
-import json
 import urllib.request
 from typing import NamedTuple
 
 from docking.applets.apod import meta
 from docking.applets.apod.state import ApodResult, build_page_url
+from docking.applets.http import http_get_json
 from docking.core.paths import ensure_dir
 from docking.log import get_logger, with_context
 from docking.platform.environment import docking_cache_dir
@@ -100,13 +100,11 @@ def _pick_image_url(*, payload: dict) -> str:
 
 
 def _fetch_json(*, api_key: str) -> dict:
-    req = urllib.request.Request(
+    return http_get_json(
         f"{API_URL}?api_key={api_key}&thumbs=true",
-        headers={"User-Agent": USER_AGENT},
+        timeout=REQUEST_TIMEOUT_S,
+        user_agent=USER_AGENT,
     )
-    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_S) as resp:
-        raw = resp.read().decode("utf-8", errors="replace")
-    return json.loads(raw)
 
 
 def _download_image(*, url: str, date_iso: str) -> str:

--- a/docking/applets/hackernews/state.py
+++ b/docking/applets/hackernews/state.py
@@ -24,12 +24,11 @@ test without a desktop session.
 from __future__ import annotations
 
 import datetime as dt
-import json
-import urllib.request
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
 
+from docking.applets.http import http_get_json
 from docking.applets.live_state import (
     live_freshness_lines,
     live_state_error,
@@ -435,37 +434,19 @@ def prefs_payload(
     }
 
 
-def _get_json(url: str, *, timeout: float = FETCH_TIMEOUT_S) -> object:
-    request = urllib.request.Request(
-        url=url,
-        headers={
-            "Accept": "application/json",
-            "User-Agent": "DockingHackerNewsApplet/1.0",
-        },
-    )
-    with urllib.request.urlopen(request, timeout=timeout) as response:
-        return json.loads(response.read())
-
-
 def fetch_hn_stories(
     *,
     limit: int = DEFAULT_FETCH_LIMIT,
     offset: int = 0,
-    get_json: Callable[[str], object] | None = None,
 ) -> tuple[HackerNewsStory, ...]:
     """Fetch HN top stories using the official Firebase API."""
-    return fetch_hn_story_page(
-        limit=limit,
-        offset=offset,
-        get_json=get_json,
-    ).stories
+    return fetch_hn_story_page(limit=limit, offset=offset).stories
 
 
 def fetch_hn_story_page(
     *,
     limit: int = DEFAULT_FETCH_LIMIT,
     offset: int = 0,
-    get_json: Callable[[str], object] | None = None,
 ) -> HackerNewsPage:
     """Fetch one cursor page using HN topstories ids.
 
@@ -473,9 +454,10 @@ def fetch_hn_story_page(
     stories. That lets paging continue even when a fetched id is dead/deleted
     or otherwise filtered out.
     """
-    fetch = get_json or _get_json
     try:
-        raw_ids = fetch(f"{HN_BASE_URL}/topstories.json")
+        raw_ids = http_get_json(
+            f"{HN_BASE_URL}/topstories.json", timeout=FETCH_TIMEOUT_S
+        )
         ids, next_offset, has_more = parse_top_story_id_page(
             raw_ids,
             limit=limit,
@@ -483,7 +465,9 @@ def fetch_hn_story_page(
         )
         stories: list[HackerNewsStory] = []
         for story_id in ids:
-            raw_story = fetch(f"{HN_BASE_URL}/item/{story_id}.json")
+            raw_story = http_get_json(
+                f"{HN_BASE_URL}/item/{story_id}.json", timeout=FETCH_TIMEOUT_S
+            )
             story = parse_story_payload(raw_story)
             if story is not None:
                 stories.append(story)

--- a/docking/applets/quote/state.py
+++ b/docking/applets/quote/state.py
@@ -16,12 +16,10 @@
 from __future__ import annotations
 
 import html
-import json
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
-from urllib.request import Request, urlopen
 
+from docking.applets.http import http_get_json
 from docking.applets.quote import meta
 from docking.log import get_logger, with_context
 
@@ -100,16 +98,6 @@ def format_quote(entry: QuoteEntry) -> str:
     return entry.text
 
 
-def _http_get_json(url: str, timeout: float = 8.0) -> Any:
-    request = Request(
-        url=url,
-        headers={"User-Agent": "DockingQuoteApplet/1.0 (+https://github.com/)"},
-    )
-    with urlopen(request, timeout=timeout) as response:
-        payload = response.read().decode("utf-8", errors="replace")
-    return json.loads(payload)
-
-
 def _parse_zenquotes(data: Any, limit: int) -> list[QuoteEntry]:
     quotes: list[QuoteEntry] = []
     if not isinstance(data, list):
@@ -164,21 +152,18 @@ def _parse_chuck(data: Any) -> list[QuoteEntry]:
     return [QuoteEntry(text=text)]
 
 
-def fetch_quotes(
-    source: str,
-    limit: int = DEFAULT_FETCH_LIMIT,
-    http_get_json: Callable[[str], Any] | None = None,
-) -> list[QuoteEntry]:
+def fetch_quotes(source: str, limit: int = DEFAULT_FETCH_LIMIT) -> list[QuoteEntry]:
     """Fetch quotes for a source. Returns empty list on any failure."""
-    getter = http_get_json or _http_get_json
     try:
         if source == "quotationspage":
-            data = getter("https://zenquotes.io/api/quotes")
+            data = http_get_json("https://zenquotes.io/api/quotes")
             return _parse_zenquotes(data=data, limit=limit)
         if source == "chucknorrisfactsfr":
-            data = getter("https://api.chucknorris.io/jokes/random")
+            data = http_get_json("https://api.chucknorris.io/jokes/random")
             return _parse_chuck(data=data)
-        data = getter(f"https://v2.jokeapi.dev/joke/Any?type=single&amount={limit}")
+        data = http_get_json(
+            f"https://v2.jokeapi.dev/joke/Any?type=single&amount={limit}"
+        )
         return _parse_jokeapi(data=data, limit=limit)
     except Exception as exc:
         log.bind(action="fetch_quotes").debug(

--- a/docking/applets/todayinhistory/state.py
+++ b/docking/applets/todayinhistory/state.py
@@ -16,12 +16,12 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from importlib import resources
 from typing import Any
-from urllib.request import Request, urlopen
 
+from docking.applets.http import http_get_json
 from docking.applets.text import normalize_text
 from docking.applets.todayinhistory import meta
 from docking.i18n import _
@@ -55,21 +55,6 @@ def format_history_event(event: HistoryEvent) -> str:
     if event.summary:
         return "\n".join((header, event.summary))
     return header
-
-
-def _http_get_json(url: str, timeout: float = 8.0) -> Any:
-    request = Request(
-        url=url,
-        headers={
-            "User-Agent": (
-                "DockingTodayInHistoryApplet/1.0 "
-                "(+https://github.com/edumucelli/docking)"
-            )
-        },
-    )
-    with urlopen(request, timeout=timeout) as response:
-        payload = response.read().decode("utf-8", errors="replace")
-    return json.loads(payload)
 
 
 def _date_key(*, month: int, day: int) -> str:
@@ -225,11 +210,9 @@ def fetch_today_in_history(
     month: int,
     day: int,
     limit: int = DEFAULT_FETCH_LIMIT,
-    http_get_json: Callable[[str], Any] | None = None,
 ) -> list[HistoryEvent]:
-    getter = http_get_json or _http_get_json
     try:
-        data = getter(_WIKIPEDIA_ENDPOINT.format(month=month, day=day))
+        data = http_get_json(_WIKIPEDIA_ENDPOINT.format(month=month, day=day))
         return _parse_wikipedia_events(data=data, limit=limit)
     except Exception as exc:
         log.bind(action="fetch_today_in_history").debug(

--- a/docking/applets/trivia/state.py
+++ b/docking/applets/trivia/state.py
@@ -15,13 +15,12 @@
 
 from __future__ import annotations
 
-import json
 import random
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import Any
-from urllib.request import Request, urlopen
 
+from docking.applets.http import http_get_json
 from docking.applets.text import normalize_text
 from docking.applets.trivia import meta
 from docking.i18n import _
@@ -122,16 +121,6 @@ def format_trivia(entry: TriviaEntry) -> str:
     return "\n".join(lines)
 
 
-def _http_get_json(url: str, timeout: float = 8.0) -> Any:
-    request = Request(
-        url=url,
-        headers={"User-Agent": "DockingTriviaApplet/1.0 (+https://github.com/)"},
-    )
-    with urlopen(request, timeout=timeout) as response:
-        payload = response.read().decode("utf-8", errors="replace")
-    return json.loads(payload)
-
-
 def _shuffle_answers(
     answers: list[str],
     shuffle: Callable[[list[str]], None] | None = None,
@@ -202,12 +191,10 @@ def _parse_results(
 
 def fetch_trivia(
     limit: int = DEFAULT_FETCH_LIMIT,
-    http_get_json: Callable[[str], Any] | None = None,
     shuffle_answers: Callable[[list[str]], None] | None = None,
 ) -> list[TriviaEntry]:
-    getter = http_get_json or _http_get_json
     try:
-        data = getter(_TRIVIA_ENDPOINT.format(limit=limit))
+        data = http_get_json(_TRIVIA_ENDPOINT.format(limit=limit))
         return _parse_results(
             data=data,
             limit=limit,

--- a/tests/applets/test_apod.py
+++ b/tests/applets/test_apod.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
@@ -138,17 +137,10 @@ class TestPrefsRoundTrip:
 
 
 class TestFetchToday:
-    def test_parses_successful_response(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("docking.applets.apod.api.CACHE_DIR", tmp_path / "apod")
-
-        def fake_urlopen(req, timeout=None):
+    def _patch_image_download(self, monkeypatch, payload_bytes):
+        def fake_urlopen(_req, timeout=None):
             mock = MagicMock()
-            url = req.full_url if hasattr(req, "full_url") else str(req)
-            if url.startswith("https://api.nasa.gov/"):
-                mock.read.return_value = json.dumps(_SAMPLE_PAYLOAD).encode()
-            else:
-                # JPEG magic bytes are enough for the download path.
-                mock.read.side_effect = [b"\xff\xd8\xff\xe0" + b"\x00" * 512, b""]
+            mock.read.side_effect = [payload_bytes, b""]
             mock.__enter__ = lambda self: self
             mock.__exit__ = lambda self, *a: None
             return mock
@@ -156,6 +148,14 @@ class TestFetchToday:
         monkeypatch.setattr(
             "docking.applets.apod.api.urllib.request.urlopen", fake_urlopen
         )
+
+    def test_parses_successful_response(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("docking.applets.apod.api.CACHE_DIR", tmp_path / "apod")
+        monkeypatch.setattr(
+            "docking.applets.apod.api.http_get_json",
+            lambda url, **_kwargs: _SAMPLE_PAYLOAD,
+        )
+        self._patch_image_download(monkeypatch, b"\xff\xd8\xff\xe0" + b"\x00" * 512)
 
         got = fetch_today()
         assert isinstance(got, ApodResult)
@@ -171,20 +171,10 @@ class TestFetchToday:
         payload["url"] = "https://youtube.com/watch?v=abc"
         payload["thumbnail_url"] = "https://example/thumb.jpg"
 
-        def fake_urlopen(req, timeout=None):
-            mock = MagicMock()
-            url = req.full_url if hasattr(req, "full_url") else str(req)
-            if url.startswith("https://api.nasa.gov/"):
-                mock.read.return_value = json.dumps(payload).encode()
-            else:
-                mock.read.side_effect = [b"\xff\xd8\xff\xe0" + b"\x00" * 64, b""]
-            mock.__enter__ = lambda self: self
-            mock.__exit__ = lambda self, *a: None
-            return mock
-
         monkeypatch.setattr(
-            "docking.applets.apod.api.urllib.request.urlopen", fake_urlopen
+            "docking.applets.apod.api.http_get_json", lambda url, **_kwargs: payload
         )
+        self._patch_image_download(monkeypatch, b"\xff\xd8\xff\xe0" + b"\x00" * 64)
 
         got = fetch_today()
         assert isinstance(got, ApodResult)
@@ -192,24 +182,17 @@ class TestFetchToday:
         assert got.image_url == "https://example/thumb.jpg"
 
     def test_network_failure_returns_error(self, monkeypatch):
-        def boom(req, timeout=None):
+        def boom(*_args, **_kwargs):
             raise OSError("network down")
 
-        monkeypatch.setattr("docking.applets.apod.api.urllib.request.urlopen", boom)
+        monkeypatch.setattr("docking.applets.apod.api.http_get_json", boom)
         got = fetch_today()
         assert isinstance(got, ApodError)
         assert "network down" in got.message
 
     def test_unexpected_payload_returns_error(self, monkeypatch):
-        def fake_urlopen(req, timeout=None):
-            mock = MagicMock()
-            mock.read.return_value = b"[]"
-            mock.__enter__ = lambda self: self
-            mock.__exit__ = lambda self, *a: None
-            return mock
-
         monkeypatch.setattr(
-            "docking.applets.apod.api.urllib.request.urlopen", fake_urlopen
+            "docking.applets.apod.api.http_get_json", lambda url, **_kwargs: []
         )
         got = fetch_today()
         assert isinstance(got, ApodError)

--- a/tests/applets/test_hackernews.py
+++ b/tests/applets/test_hackernews.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime as dt
-import json
 from unittest.mock import MagicMock, patch
 
 import docking.applets.hackernews.applet as hackernews_applet_mod
@@ -313,10 +312,12 @@ class TestHackerNewsState:
 
 
 class TestFetchHnStories:
-    def test_fetches_top_stories(self):
+    def test_fetches_top_stories(self, monkeypatch):
+        import docking.applets.hackernews.state as hn_state
+
         seen = []
 
-        def get_json(url: str):
+        def get_json(url, *, timeout=None):
             seen.append(url)
             if url == f"{HN_BASE_URL}/topstories.json":
                 return [111, 222, 123, 456]
@@ -334,7 +335,8 @@ class TestFetchHnStories:
                 "score": 20,
             }
 
-        stories = fetch_hn_stories(limit=2, offset=2, get_json=get_json)
+        monkeypatch.setattr(hn_state, "http_get_json", get_json)
+        stories = fetch_hn_stories(limit=2, offset=2)
 
         assert [story.title for story in stories] == ["First", "Second"]
         assert seen == [
@@ -343,8 +345,10 @@ class TestFetchHnStories:
             f"{HN_BASE_URL}/item/456.json",
         ]
 
-    def test_fetch_story_page_tracks_cursor_past_filtered_items(self):
-        def get_json(url: str):
+    def test_fetch_story_page_tracks_cursor_past_filtered_items(self, monkeypatch):
+        import docking.applets.hackernews.state as hn_state
+
+        def get_json(url, *, timeout=None):
             if url == f"{HN_BASE_URL}/topstories.json":
                 return [1, 2, 3]
             if url == f"{HN_BASE_URL}/item/1.json":
@@ -353,41 +357,21 @@ class TestFetchHnStories:
                 return {"id": 2, "type": "comment", "title": "Ignored"}
             return {"id": 3, "type": "story", "title": "Third"}
 
-        page = fetch_hn_story_page(limit=2, offset=0, get_json=get_json)
+        monkeypatch.setattr(hn_state, "http_get_json", get_json)
+        page = fetch_hn_story_page(limit=2, offset=0)
 
         assert [story.id for story in page.stories] == [1]
         assert page.next_offset == 2
         assert page.has_more is True
 
-    def test_fetch_failure_returns_empty(self):
-        assert (
-            fetch_hn_stories(get_json=lambda _url: (_ for _ in ()).throw(OSError()))
-            == ()
-        )
-
-    def test_get_json_uses_request_headers(self, monkeypatch):
+    def test_fetch_failure_returns_empty(self, monkeypatch):
         import docking.applets.hackernews.state as hn_state
 
-        seen = []
+        def raising(_url, *, timeout=None):
+            raise OSError("boom")
 
-        class _Response:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_args):
-                return None
-
-            def read(self):
-                return json.dumps([1, 2]).encode()
-
-        monkeypatch.setattr(
-            hn_state.urllib.request,
-            "urlopen",
-            lambda req, timeout: seen.append((req.full_url, timeout)) or _Response(),
-        )
-
-        assert hn_state._get_json("https://example.test") == [1, 2]
-        assert seen == [("https://example.test", 5)]
+        monkeypatch.setattr(hn_state, "http_get_json", raising)
+        assert fetch_hn_stories() == ()
 
 
 class TestHackerNewsRender:

--- a/tests/applets/test_quote.py
+++ b/tests/applets/test_quote.py
@@ -25,7 +25,7 @@ class TestFormatQuote:
 
 
 class TestFetchQuotes:
-    @patch("docking.applets.quote.state._http_get_json")
+    @patch("docking.applets.quote.state.http_get_json")
     def test_fetches_quotations_source(self, mock_get):
         mock_get.return_value = [
             {"q": "Alpha quote", "a": "Alice"},
@@ -35,7 +35,7 @@ class TestFetchQuotes:
         assert len(quotes) == 2
         assert quotes[0] == QuoteEntry(text="Alpha quote", author="Alice")
 
-    @patch("docking.applets.quote.state._http_get_json")
+    @patch("docking.applets.quote.state.http_get_json")
     def test_fetches_joke_sources(self, mock_get):
         mock_get.return_value = {
             "jokes": [
@@ -47,14 +47,14 @@ class TestFetchQuotes:
         assert len(quotes) == 2
         assert quotes[0] == QuoteEntry(text="First joke")
 
-    @patch("docking.applets.quote.state._http_get_json")
+    @patch("docking.applets.quote.state.http_get_json")
     def test_fetches_chuck_source(self, mock_get):
         mock_get.return_value = {"value": "Chuck quote"}
         quotes = fetch_quotes(source="chucknorrisfactsfr", limit=1)
         assert quotes == [QuoteEntry(text="Chuck quote")]
 
     @patch(
-        "docking.applets.quote.state._http_get_json", side_effect=RuntimeError("boom")
+        "docking.applets.quote.state.http_get_json", side_effect=RuntimeError("boom")
     )
     def test_fetch_failure_returns_empty(self, _mock_get):
         assert fetch_quotes(source="quotationspage") == []

--- a/tests/applets/test_todayinhistory.py
+++ b/tests/applets/test_todayinhistory.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -48,7 +47,7 @@ class TestHistoryHelpers:
         assert "Apollo 11" in text
         assert "Sea of Tranquility" in text
 
-    @patch("docking.applets.todayinhistory.state._http_get_json")
+    @patch("docking.applets.todayinhistory.state.http_get_json")
     def test_fetch_today_in_history_parses_wikipedia_response(self, mock_get):
         mock_get.return_value = {
             "events": [
@@ -78,7 +77,7 @@ class TestHistoryHelpers:
         assert entries[0].article_url.endswith("/Apollo_11")
 
     @patch(
-        "docking.applets.todayinhistory.state._http_get_json",
+        "docking.applets.todayinhistory.state.http_get_json",
         side_effect=RuntimeError,
     )
     def test_fetch_failure_returns_empty(self, _mock_get):
@@ -165,29 +164,6 @@ class TestHistoryHelpers:
         ]
         assert today_state_mod._parse_wikipedia_events(data=[], limit=3) == []
         assert today_state_mod._parse_wikipedia_events(data={}, limit=3) == []
-
-    def test_http_get_json_uses_urlopen(self, monkeypatch):
-        class _Response:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *_args):
-                return False
-
-            def read(self):
-                return json.dumps({"ok": True}).encode()
-
-        seen = []
-        monkeypatch.setattr(
-            today_state_mod,
-            "urlopen",
-            lambda request, timeout: (
-                seen.append((request.full_url, timeout)) or _Response()
-            ),
-        )
-
-        assert today_state_mod._http_get_json("https://example.test") == {"ok": True}
-        assert seen == [("https://example.test", 8.0)]
 
     def test_fallback_catalog_exact_pool_and_empty(self):
         catalog = {

--- a/tests/applets/test_trivia.py
+++ b/tests/applets/test_trivia.py
@@ -56,7 +56,7 @@ class TestTriviaHelpers:
 
 
 class TestFetchTrivia:
-    @patch("docking.applets.trivia.state._http_get_json")
+    @patch("docking.applets.trivia.state.http_get_json")
     def test_fetches_entries_from_api(self, mock_get):
         mock_get.return_value = {
             "response_code": 0,
@@ -82,7 +82,7 @@ class TestFetchTrivia:
         assert entries[0].answers[0] == "Mercury"
 
     @patch(
-        "docking.applets.trivia.state._http_get_json",
+        "docking.applets.trivia.state.http_get_json",
         side_effect=RuntimeError("boom"),
     )
     def test_fetch_failure_returns_empty(self, _mock_get):


### PR DESCRIPTION
Move APOD, Hacker News, Quote, Today in History, and Trivia network fetches onto the shared applet HTTP helpers while keeping their existing parsing and error handling behavior.