### PR TITLE
Group renderer state inputs

### DIFF
--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -227,6 +227,7 @@ from docking.ui.interaction import DockInteractionCoordinator
 from docking.ui.menu import MenuHandler
 from docking.ui.placement import DockPlacementController
 from docking.ui.preview import PreviewPopup
+from docking.ui.renderer import RenderState
 from docking.ui.runtime import DockRuntime
 from docking.ui.settings import SettingsWindowController
 from docking.ui.tooltip import TooltipManager
@@ -699,18 +700,21 @@ class DockWindow(Gtk.Window):
         cursor_main_axis = (
             self.cursor_x if is_horizontal(pos=self.config.pos) else self.cursor_y
         )
+        render_state = RenderState(
+            hide_offset=hide_offset,
+            drag_index=drag_index,
+            drop_insert_index=drop_insert,
+            hovered_id=hovered_id,
+            drop_target_id=drop_target,
+            cursor_main=cursor_main_axis,
+        )
         self.renderer.draw(
             cr,
             widget,
             frame,
             self.config,
             self.theme,
-            hide_offset,
-            drag_index,
-            drop_insert,
-            hovered_id,
-            drop_target_id=drop_target,
-            cursor_main=cursor_main_axis,
+            render_state,
         )
         # Update input region as hide state changes (shrink when hidden)
         self.update_input_region(frame=frame)

--- a/docking/ui/renderer.py
+++ b/docking/ui/renderer.py
@@ -213,6 +213,22 @@ URGENT_GLOW_OUTER_ALPHA = 0.33
 
 
 @dataclass(frozen=True)
+class RenderState:
+    """Transient per-frame view state consumed by :meth:`DockRenderer.draw`.
+
+    Frozen so the renderer (and any future caller wanting "did anything
+    change?") can rely on value equality.
+    """
+
+    hide_offset: float = 0.0
+    drag_index: int = -1
+    drop_insert_index: int = -1
+    hovered_id: str = ""
+    drop_target_id: str = ""
+    cursor_main: float = -1.0
+
+
+@dataclass(frozen=True)
 class _IconSurfaceCacheKey:
     """Identity for a rendered icon source surface.
 
@@ -636,12 +652,7 @@ class DockRenderer:
         frame: DockGeometryFrame,
         config: Config,
         theme: Theme,
-        hide_offset: float = 0.0,
-        drag_index: int = -1,
-        drop_insert_index: int = -1,
-        hovered_id: str = "",
-        drop_target_id: str = "",
-        cursor_main: float = -1.0,
+        state: RenderState,
     ) -> None:
         """Main draw entry point -- called on every 'draw' signal.
 
@@ -672,12 +683,7 @@ class DockRenderer:
             frame=frame,
             config=config,
             theme=theme,
-            hide_offset=hide_offset,
-            drag_index=drag_index,
-            drop_insert_index=drop_insert_index,
-            hovered_id=hovered_id,
-            drop_target_id=drop_target_id,
-            cursor_main=cursor_main,
+            state=state,
         )
         cr.set_operator(cairo.OPERATOR_SOURCE)
         cr.set_source_surface(offscreen, 0, 0)
@@ -689,14 +695,17 @@ class DockRenderer:
         frame: DockGeometryFrame,
         config: Config,
         theme: Theme,
-        hide_offset: float,
-        drag_index: int,
-        drop_insert_index: int,
-        hovered_id: str,
-        drop_target_id: str = "",
-        cursor_main: float = -1.0,
+        state: RenderState,
     ) -> None:
         """Render all dock content to a Cairo context."""
+        # Unpack once so the rest of this method (and helpers) reads naturally.
+        hide_offset = state.hide_offset
+        drag_index = state.drag_index
+        drop_insert_index = state.drop_insert_index
+        hovered_id = state.hovered_id
+        drop_target_id = state.drop_target_id
+        cursor_main = state.cursor_main
+
         pos = config.pos
         width = frame.window_rect.w
         height = frame.window_rect.h

--- a/tests/ui/test_renderer_integration.py
+++ b/tests/ui/test_renderer_integration.py
@@ -20,6 +20,7 @@ from docking.ui.geometry import (
     Rect,
     build_geometry_frame,
 )
+from docking.ui.renderer import RenderState
 
 
 def _surface_context(width: int = 420, height: int = 90):
@@ -90,6 +91,7 @@ class TestRendererDrawEntry:
             frame=frame,
             config=config,
             theme=theme,
+            state=renderer_mod.RenderState(),
         )
         # Then
         renderer._draw_content.assert_called_once()
@@ -108,6 +110,7 @@ class TestRendererDrawEntry:
             frame=frame,
             config=SimpleNamespace(),
             theme=MagicMock(),
+            state=renderer_mod.RenderState(),
         )
         first_surface = renderer._cache.offscreen_surface
 
@@ -117,6 +120,7 @@ class TestRendererDrawEntry:
             frame=frame,
             config=SimpleNamespace(),
             theme=MagicMock(),
+            state=renderer_mod.RenderState(),
         )
 
         assert first_surface is not None
@@ -137,6 +141,7 @@ class TestRendererDrawEntry:
             frame=frame,
             config=SimpleNamespace(),
             theme=MagicMock(),
+            state=renderer_mod.RenderState(),
         )
         first_surface = renderer._cache.offscreen_surface
 
@@ -147,6 +152,7 @@ class TestRendererDrawEntry:
             frame=frame,
             config=SimpleNamespace(),
             theme=MagicMock(),
+            state=renderer_mod.RenderState(),
         )
 
         assert first_surface is not None
@@ -202,10 +208,12 @@ class TestRendererContentFlow:
             frame=_frame([i1, i2], layout),
             config=config,
             theme=theme,
-            hide_offset=1.0,
-            drag_index=-1,
-            drop_insert_index=1,
-            hovered_id="firefox.desktop",
+            state=RenderState(
+                hide_offset=1.0,
+                drag_index=-1,
+                drop_insert_index=1,
+                hovered_id="firefox.desktop",
+            ),
         )
 
         # Then
@@ -263,10 +271,12 @@ class TestRendererContentFlow:
             frame=frame,
             config=config,
             theme=theme,
-            hide_offset=0.0,
-            drag_index=-1,
-            drop_insert_index=-1,
-            hovered_id="",
+            state=RenderState(
+                hide_offset=0.0,
+                drag_index=-1,
+                drop_insert_index=-1,
+                hovered_id="",
+            ),
         )
 
         assert shelf_calls
@@ -304,10 +314,12 @@ class TestRendererContentFlow:
             frame=_frame([item], layout),
             config=config,
             theme=theme,
-            hide_offset=0.0,
-            drag_index=-1,
-            drop_insert_index=-1,
-            hovered_id="",
+            state=RenderState(
+                hide_offset=0.0,
+                drag_index=-1,
+                drop_insert_index=-1,
+                hovered_id="",
+            ),
         )
 
         renderer._draw_badge.assert_called_once()
@@ -351,10 +363,12 @@ class TestRendererContentFlow:
             frame=frame,
             config=config,
             theme=theme,
-            hide_offset=1.0,
-            drag_index=-1,
-            drop_insert_index=-1,
-            hovered_id="",
+            state=RenderState(
+                hide_offset=1.0,
+                drag_index=-1,
+                drop_insert_index=-1,
+                hovered_id="",
+            ),
         )
 
         assert shelf_calls
@@ -392,10 +406,12 @@ class TestRendererContentFlow:
             frame=_frame([item], layout),
             config=config,
             theme=theme,
-            hide_offset=0.0,
-            drag_index=-1,
-            drop_insert_index=-1,
-            hovered_id="",
+            state=RenderState(
+                hide_offset=0.0,
+                drag_index=-1,
+                drop_insert_index=-1,
+                hovered_id="",
+            ),
         )
 
         renderer._draw_icon.assert_not_called()
@@ -417,10 +433,12 @@ class TestRendererContentFlow:
             frame=_frame([], []),
             config=config,
             theme=theme,
-            hide_offset=0.0,
-            drag_index=-1,
-            drop_insert_index=-1,
-            hovered_id="",
+            state=RenderState(
+                hide_offset=0.0,
+                drag_index=-1,
+                drop_insert_index=-1,
+                hovered_id="",
+            ),
         )
         # Then
         # When

--- a/tests/visual/render_cases.py
+++ b/tests/visual/render_cases.py
@@ -20,7 +20,7 @@ from docking.ui.autohide import HideState
 from docking.ui.geometry import build_geometry_frame
 from docking.ui.menu import MenuHandler
 from docking.ui.preview import THUMB_H, THUMB_W, PreviewPopup
-from docking.ui.renderer import DockRenderer
+from docking.ui.renderer import DockRenderer, RenderState
 from docking.ui.tooltip import TooltipManager
 
 DOCK_CASES = (
@@ -159,6 +159,12 @@ def _draw_renderer_case(case_name: str) -> cairo.ImageSurface:
         assert case_name == "dock-bottom-idle"
 
     cursor_main = 210.0 if hovered_id else -1_000_000.0
+    render_state = RenderState(
+        hide_offset=hide_offset,
+        drop_insert_index=drop_insert_index,
+        hovered_id=hovered_id,
+        cursor_main=cursor_main,
+    )
     frame = build_geometry_frame(
         items=items,
         config=config,
@@ -183,9 +189,7 @@ def _draw_renderer_case(case_name: str) -> cairo.ImageSurface:
             frame=frame,
             config=config,
             theme=theme,
-            hide_offset=hide_offset,
-            drop_insert_index=drop_insert_index,
-            hovered_id=hovered_id,
+            state=render_state,
         )
         return surface
 


### PR DESCRIPTION
Introduce a RenderState value object for the dock renderer draw path and update integration coverage to build and vary that state explicitly.