### PR TITLE
Add pressure reveal support

### DIFF
--- a/docking/core/config.py
+++ b/docking/core/config.py
@@ -280,6 +280,10 @@ MAX_TRANSPARENCY = 1.0
 DEFAULT_ADDITIONAL_DISTANCE_FROM_EDGE = 0
 MIN_ADDITIONAL_DISTANCE_FROM_EDGE = 0
 MAX_ADDITIONAL_DISTANCE_FROM_EDGE = 100
+DEFAULT_PRESSURE_REVEAL_ENABLED = False
+DEFAULT_PRESSURE_THRESHOLD = 50
+MIN_PRESSURE_THRESHOLD = 5
+MAX_PRESSURE_THRESHOLD = 500
 
 logger = get_logger("config")
 _SAVE_LOCK = threading.RLock()
@@ -738,6 +742,13 @@ class Config:
     # Extra pixels added to the theme's distance_from_edge_px. The on-screen
     # gap between the dock and the screen edge is the sum of the two.
     additional_distance_from_edge: int = DEFAULT_ADDITIONAL_DISTANCE_FROM_EDGE
+    # When True, the hidden dock only reveals after the cursor has pushed
+    # against the screen edge enough to accumulate ``pressure_threshold``
+    # pixels of resisted motion (X11 pointer-barrier "pressure"). Prevents
+    # accidental reveals on multi-monitor setups where the dock edge sits
+    # between two screens.
+    pressure_reveal_enabled: bool = DEFAULT_PRESSURE_REVEAL_ENABLED
+    pressure_threshold: int = DEFAULT_PRESSURE_THRESHOLD
     # Typed pinned entries in display order.
     pinned: list[PinnedEntry] = field(default_factory=lambda: list(DEFAULT_PINNED))
     # Per-applet preferences keyed by applet id (e.g. "clock")
@@ -865,6 +876,16 @@ class Config:
             default=DEFAULT_ADDITIONAL_DISTANCE_FROM_EDGE,
             minimum=MIN_ADDITIONAL_DISTANCE_FROM_EDGE,
             maximum=MAX_ADDITIONAL_DISTANCE_FROM_EDGE,
+        )
+        self.pressure_reveal_enabled = _normalize_bool(
+            self.pressure_reveal_enabled,
+            default=DEFAULT_PRESSURE_REVEAL_ENABLED,
+        )
+        self.pressure_threshold = _normalize_int(
+            self.pressure_threshold,
+            default=DEFAULT_PRESSURE_THRESHOLD,
+            minimum=MIN_PRESSURE_THRESHOLD,
+            maximum=MAX_PRESSURE_THRESHOLD,
         )
         self.pinned = normalize_pinned_entries(list(self.pinned))
         self.applet_prefs = _normalize_pref_map(self.applet_prefs)

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-05-22 20:30+0200\n"
+"POT-Creation-Date: 2026-05-22 20:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1057,7 +1057,7 @@ msgid "{verb} every {interval}"
 msgstr ""
 
 #: docking/applets/freshness.py:42 docking/applets/freshness.py:49
-#: docking/ui/settings.py:212
+#: docking/ui/settings.py:216
 msgid "Updates"
 msgstr ""
 
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:605 docking/ui/settings.py:185
+#: docking/ui/menu.py:605 docking/ui/settings.py:189
 msgid "Preferences"
 msgstr ""
 
@@ -2371,258 +2371,272 @@ msgstr ""
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-#: docking/ui/settings.py:209
+#: docking/ui/settings.py:213
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:210 docking/ui/settings.py:431
+#: docking/ui/settings.py:214 docking/ui/settings.py:469
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:211
+#: docking/ui/settings.py:215
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:230
+#: docking/ui/settings.py:234
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:231
+#: docking/ui/settings.py:235
 msgid "Always on Top"
 msgstr ""
 
-#: docking/ui/settings.py:232
+#: docking/ui/settings.py:236
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:233
+#: docking/ui/settings.py:237
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:234
+#: docking/ui/settings.py:238
 msgid "Dodge Active Window"
 msgstr ""
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:239
 msgid "Dodge All Windows"
 msgstr ""
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:240
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:253
+#: docking/ui/settings.py:257
 msgid "Toggle Focus"
 msgstr ""
 
-#: docking/ui/settings.py:254
+#: docking/ui/settings.py:258
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:255
+#: docking/ui/settings.py:259
 msgid "Most Recent Window"
 msgstr ""
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:266
 msgid "New Window"
 msgstr ""
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:267
 msgid "Minimize Windows"
 msgstr ""
 
-#: docking/ui/settings.py:264
+#: docking/ui/settings.py:268
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:271
+#: docking/ui/settings.py:275
 msgid "Click"
 msgstr ""
 
-#: docking/ui/settings.py:272
+#: docking/ui/settings.py:276
 msgid "Hover"
 msgstr ""
 
-#: docking/ui/settings.py:289
+#: docking/ui/settings.py:293
 msgid "Daily"
 msgstr ""
 
-#: docking/ui/settings.py:290
+#: docking/ui/settings.py:294
 msgid "Weekly"
 msgstr ""
 
-#: docking/ui/settings.py:340
+#: docking/ui/settings.py:344
 msgid "Added on top of the theme's own distance from the edge."
 msgstr ""
 
-#: docking/ui/settings.py:373
+#: docking/ui/settings.py:389
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:375
+#: docking/ui/settings.py:391
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:376
+#: docking/ui/settings.py:392
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:377
+#: docking/ui/settings.py:393
 msgid "Transparency"
 msgstr ""
 
-#: docking/ui/settings.py:378
+#: docking/ui/settings.py:394
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:379
+#: docking/ui/settings.py:395
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:380
+#: docking/ui/settings.py:396
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:381
+#: docking/ui/settings.py:397
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:387
+#: docking/ui/settings.py:403
 msgid "Placement"
 msgstr ""
 
-#: docking/ui/settings.py:389
+#: docking/ui/settings.py:405
 msgid "Position"
 msgstr ""
 
-#: docking/ui/settings.py:390
+#: docking/ui/settings.py:406
 msgid "Extra Distance from Edge"
 msgstr ""
 
-#: docking/ui/settings.py:391
+#: docking/ui/settings.py:407
 msgid "Follow Cursor"
 msgstr ""
 
-#: docking/ui/settings.py:392
+#: docking/ui/settings.py:408
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:397
+#: docking/ui/settings.py:413
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:399
+#: docking/ui/settings.py:415
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:400
+#: docking/ui/settings.py:416
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:401
+#: docking/ui/settings.py:417
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:423
+#: docking/ui/settings.py:439
+msgid ""
+"Pixels of cursor pressure against the edge required to reveal a hidden dock. "
+"Higher values mean the dock will not reveal as easily."
+msgstr ""
+
+#: docking/ui/settings.py:461
 msgid "Mouse"
 msgstr ""
 
-#: docking/ui/settings.py:425
+#: docking/ui/settings.py:463
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:426
+#: docking/ui/settings.py:464
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:433
+#: docking/ui/settings.py:471
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:434
+#: docking/ui/settings.py:472
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:435
+#: docking/ui/settings.py:473
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:440
+#: docking/ui/settings.py:474
+msgid "Pressure Reveal"
+msgstr ""
+
+#: docking/ui/settings.py:475
+msgid "Pressure Threshold"
+msgstr ""
+
+#: docking/ui/settings.py:480
 msgid "Folder Stacks"
 msgstr ""
 
-#: docking/ui/settings.py:442
+#: docking/ui/settings.py:482
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:467
+#: docking/ui/settings.py:507
 msgid "Check Now"
 msgstr ""
 
-#: docking/ui/settings.py:469
+#: docking/ui/settings.py:509
 msgid "View Releases"
 msgstr ""
 
-#: docking/ui/settings.py:481
+#: docking/ui/settings.py:521
 msgid "Update Checks"
 msgstr ""
 
-#: docking/ui/settings.py:483
+#: docking/ui/settings.py:523
 msgid "Check Automatically"
 msgstr ""
 
-#: docking/ui/settings.py:484
+#: docking/ui/settings.py:524
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:485
+#: docking/ui/settings.py:525
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:486
+#: docking/ui/settings.py:526
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:907
+#: docking/ui/settings.py:957
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:911
+#: docking/ui/settings.py:961
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:913
+#: docking/ui/settings.py:963
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:952
+#: docking/ui/settings.py:1006
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:954
+#: docking/ui/settings.py:1008
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:957
+#: docking/ui/settings.py:1011
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:959
+#: docking/ui/settings.py:1013
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:961
+#: docking/ui/settings.py:1015
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:963
+#: docking/ui/settings.py:1017
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:966
+#: docking/ui/settings.py:1020
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/platform/barriers.py
+++ b/docking/platform/barriers.py
@@ -99,6 +99,7 @@ provides the platform primitive.
 from __future__ import annotations
 
 import ctypes
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from docking.core.position import Position
@@ -108,6 +109,81 @@ if TYPE_CHECKING:
     from gi.repository import GdkX11
 
 log = get_logger(name="barriers")
+
+
+# X11 / XInput2 constants used to decode barrier events.
+# See /usr/include/X11/X.h and X11/extensions/XInput2.h.
+_X_GENERIC_EVENT = 35
+_XI_BARRIER_HIT = 25
+_XI_BARRIER_LEAVE = 26
+_XI_ALL_MASTER_DEVICES = 1
+_XI_BARRIER_POINTER_RELEASED = 1
+_GDK_FILTER_CONTINUE = 0  # Gdk.FilterReturn.CONTINUE
+
+# Per-event accumulation cap. A single fast cursor jab can carry a large dx/dy;
+# clamping prevents one event from blowing through the pressure threshold and
+# matches Plank's empirically-tuned behaviour.
+_PER_EVENT_PRESSURE_CAP = 15.0
+
+# Default pressure threshold (accumulated motion across barrier events). Plank
+# converged on 50 after two rounds of tuning (0.11.127, 0.11.157).
+DEFAULT_PRESSURE_THRESHOLD = 50
+
+
+class _XGenericEventCookie(ctypes.Structure):
+    """Mirrors X11's ``XGenericEventCookie`` struct."""
+
+    _fields_ = [
+        ("type", ctypes.c_int),
+        ("serial", ctypes.c_ulong),
+        ("send_event", ctypes.c_int),
+        ("display", ctypes.c_void_p),
+        ("extension", ctypes.c_int),
+        ("evtype", ctypes.c_int),
+        ("cookie", ctypes.c_uint),
+        ("data", ctypes.c_void_p),
+    ]
+
+
+class _XIBarrierEvent(ctypes.Structure):
+    """Mirrors X11's ``XIBarrierEvent`` (XInput2)."""
+
+    _fields_ = [
+        ("type", ctypes.c_int),
+        ("serial", ctypes.c_ulong),
+        ("send_event", ctypes.c_int),
+        ("display", ctypes.c_void_p),
+        ("extension", ctypes.c_int),
+        ("evtype", ctypes.c_int),
+        ("time", ctypes.c_ulong),
+        ("deviceid", ctypes.c_int),
+        ("sourceid", ctypes.c_int),
+        ("event", ctypes.c_ulong),
+        ("root", ctypes.c_ulong),
+        ("root_x", ctypes.c_double),
+        ("root_y", ctypes.c_double),
+        ("dx", ctypes.c_double),
+        ("dy", ctypes.c_double),
+        ("dtime", ctypes.c_int),
+        ("flags", ctypes.c_int),
+        ("barrier", ctypes.c_ulong),
+        ("eventid", ctypes.c_uint),
+    ]
+
+
+class _XIEventMask(ctypes.Structure):
+    """Mirrors X11's ``XIEventMask`` (XInput2 event selection)."""
+
+    _fields_ = [
+        ("deviceid", ctypes.c_int),
+        ("mask_len", ctypes.c_int),
+        ("mask", ctypes.POINTER(ctypes.c_ubyte)),
+    ]
+
+
+def _xi_set_event_mask(byte_index: int) -> int:
+    """Return a XI event-mask byte with the given XI event bit set."""
+    return 1 << (byte_index & 7)
 
 
 def _load_libs() -> tuple[ctypes.CDLL, ctypes.CDLL, ctypes.CDLL] | None:
@@ -120,6 +196,25 @@ def _load_libs() -> tuple[ctypes.CDLL, ctypes.CDLL, ctypes.CDLL] | None:
     except OSError as e:
         log.debug("barrier libs unavailable: %s", e)
         return None
+
+
+def _load_gdk_lib() -> ctypes.CDLL | None:
+    """Load libgdk-3 so we can register an X event filter (PyGI does not expose it)."""
+    for name in ("libgdk-3.so.0", "libgdk-3.so"):
+        try:
+            return ctypes.cdll.LoadLibrary(name)
+        except OSError:
+            continue
+    log.debug("libgdk-3 unavailable; pressure-reveal disabled")
+    return None
+
+
+_GDK_FILTER_FUNC = ctypes.CFUNCTYPE(
+    ctypes.c_int,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+)
 
 
 class PointerBarrier:
@@ -145,10 +240,42 @@ class PointerBarrier:
         self._xdisplay: ctypes.c_void_p | None = None
         self._libs: tuple[ctypes.CDLL, ctypes.CDLL, ctypes.CDLL] | None = None
         self._supported: bool = False
+        # Pressure accumulator state.
+        self._xi_opcode: int = 0
+        self._position: Position = Position.BOTTOM
+        self._pressure_threshold: float = float(DEFAULT_PRESSURE_THRESHOLD)
+        self._pressure_callback: Callable[[], None] | None = None
+        self._accumulated_pressure: float = 0.0
+        self._gdk_display = None  # GdkX11.X11Display when filter installed
+        self._filter_installed: bool = False
+        self._gdk_lib: ctypes.CDLL | None = None
+        # CFUNCTYPE objects must be kept alive while libgdk holds a pointer.
+        self._gdk_filter_ref: object | None = None
 
     @property
     def supported(self) -> bool:
         return self._supported
+
+    def set_pressure_handler(
+        self,
+        *,
+        callback: Callable[[], None] | None,
+        threshold: int,
+    ) -> None:
+        """Register a callback fired when pressure exceeds ``threshold``.
+
+        Pass ``callback=None`` to disable pressure-based reveal; events are
+        still received (so the barrier blocks) but never trigger a reveal,
+        leaving the normal trigger-strip enter path in charge.
+        """
+        self._pressure_callback = callback
+        self._pressure_threshold = float(max(1, threshold))
+        self._accumulated_pressure = 0.0
+        # Lazily install the GDK X event filter the first time pressure is
+        # actually wanted: until then there's no reason to pay the ctypes
+        # filter overhead.
+        if callback is not None:
+            self._install_gdk_filter()
 
     def initialize(self, gdk_display: GdkX11.X11Display) -> bool:
         """Check XInput 2.3+ support. Returns True if barriers work."""
@@ -180,6 +307,8 @@ class PointerBarrier:
         ):
             log.debug("XInput extension not available")
             return False
+        self._xi_opcode = opcode.value
+        self._gdk_display = gdk_display
 
         # Verify XInput >= 2.3
         xi.XIQueryVersion.restype = ctypes.c_int
@@ -231,6 +360,8 @@ class PointerBarrier:
             return
 
         self.destroy()
+        self._position = position
+        self._accumulated_pressure = 0.0
 
         xlib, xfixes, _ = self._libs
         mx, my = monitor_x * scale, monitor_y * scale
@@ -287,6 +418,7 @@ class PointerBarrier:
                 y2,
                 self._barrier_id,
             )
+            self._subscribe_to_barrier_events(root=root)
         else:
             log.warning("failed to create pointer barrier")
 
@@ -301,3 +433,168 @@ class PointerBarrier:
             xfixes.XFixesDestroyPointerBarrier(self._xdisplay, self._barrier_id)
             log.debug("barrier destroyed: id=%d", self._barrier_id)
             self._barrier_id = 0
+        self._accumulated_pressure = 0.0
+
+    def shutdown(self) -> None:
+        """Tear down the barrier and remove the global event filter."""
+        self.destroy()
+        if self._filter_installed and self._gdk_lib is not None:
+            self._gdk_lib.gdk_window_remove_filter.argtypes = [
+                ctypes.c_void_p,
+                _GDK_FILTER_FUNC,
+                ctypes.c_void_p,
+            ]
+            self._gdk_lib.gdk_window_remove_filter.restype = None
+            try:
+                self._gdk_lib.gdk_window_remove_filter(None, self._gdk_filter_ref, None)
+            except Exception as exc:
+                log.warning("failed to remove barrier filter: %s", exc)
+            self._filter_installed = False
+            self._gdk_filter_ref = None
+
+    def _subscribe_to_barrier_events(self, *, root: int) -> None:
+        """Register for XI_BarrierHit/Leave and install the GDK filter."""
+        if self._libs is None:
+            return
+        _, _, xi = self._libs
+
+        # Build XIEventMask with BarrierHit + BarrierLeave bits set. The mask
+        # needs to be long enough to cover the highest XI event id we care
+        # about; one byte per 8 events is the X11 convention.
+        mask_len = (max(_XI_BARRIER_HIT, _XI_BARRIER_LEAVE) // 8) + 1
+        mask = (ctypes.c_ubyte * mask_len)()
+        mask[_XI_BARRIER_HIT // 8] |= _xi_set_event_mask(_XI_BARRIER_HIT)
+        mask[_XI_BARRIER_LEAVE // 8] |= _xi_set_event_mask(_XI_BARRIER_LEAVE)
+
+        event_mask = _XIEventMask(
+            deviceid=_XI_ALL_MASTER_DEVICES,
+            mask_len=mask_len,
+            mask=ctypes.cast(mask, ctypes.POINTER(ctypes.c_ubyte)),
+        )
+
+        xi.XISelectEvents.restype = ctypes.c_int
+        xi.XISelectEvents.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_ulong,
+            ctypes.POINTER(_XIEventMask),
+            ctypes.c_int,
+        ]
+        status = xi.XISelectEvents(self._xdisplay, root, ctypes.byref(event_mask), 1)
+        if status != 0:
+            log.warning("XISelectEvents failed for barrier events: %d", status)
+
+    def _install_gdk_filter(self) -> None:
+        """Install a GDK X event filter via ctypes (PyGI does not expose it).
+
+        ``gdk_window_add_filter`` takes a callback receiving the raw
+        ``XEvent*``. The callback signature is not introspectable through
+        GObject Introspection (``GdkXEvent`` is opaque), so PyGObject hides
+        the function. We call libgdk-3 directly via ctypes.
+        """
+        if self._filter_installed:
+            return
+        self._gdk_lib = _load_gdk_lib()
+        if self._gdk_lib is None:
+            return
+
+        gdk_lib = self._gdk_lib
+        gdk_lib.gdk_window_add_filter.argtypes = [
+            ctypes.c_void_p,
+            _GDK_FILTER_FUNC,
+            ctypes.c_void_p,
+        ]
+        gdk_lib.gdk_window_add_filter.restype = None
+        self._gdk_filter_ref = _GDK_FILTER_FUNC(self._gdk_filter_callback)
+        # window=NULL means "all toplevel windows" -- exactly Plank's pattern.
+        gdk_lib.gdk_window_add_filter(None, self._gdk_filter_ref, None)
+        self._filter_installed = True
+
+    def _gdk_filter_callback(self, xevent_ptr, _gdk_event_ptr, _user_data):
+        """C-callable filter; delegates to the safe Python handler."""
+        try:
+            return self._handle_x_event(xevent_ptr)
+        except Exception as exc:
+            log.warning("barrier filter callback raised: %s", exc)
+            return _GDK_FILTER_CONTINUE
+
+    def _handle_x_event(self, xevent_ptr_int) -> int:
+        """Read the XEvent at ``xevent_ptr_int``; consume barrier events for our id."""
+        if self._libs is None or self._barrier_id == 0 or not xevent_ptr_int:
+            return _GDK_FILTER_CONTINUE
+
+        cookie_ptr = ctypes.cast(
+            ctypes.c_void_p(xevent_ptr_int),
+            ctypes.POINTER(_XGenericEventCookie),
+        )
+        cookie = cookie_ptr.contents
+        if cookie.type != _X_GENERIC_EVENT:
+            return _GDK_FILTER_CONTINUE
+        if cookie.extension != self._xi_opcode:
+            return _GDK_FILTER_CONTINUE
+        if cookie.evtype not in (_XI_BARRIER_HIT, _XI_BARRIER_LEAVE):
+            return _GDK_FILTER_CONTINUE
+
+        xlib, _, _ = self._libs
+        xlib.XGetEventData.restype = ctypes.c_int
+        xlib.XGetEventData.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(_XGenericEventCookie),
+        ]
+        xlib.XFreeEventData.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(_XGenericEventCookie),
+        ]
+        if not xlib.XGetEventData(self._xdisplay, cookie_ptr):
+            return _GDK_FILTER_CONTINUE
+        try:
+            barrier_event = ctypes.cast(
+                cookie.data, ctypes.POINTER(_XIBarrierEvent)
+            ).contents
+            if barrier_event.barrier != self._barrier_id:
+                return _GDK_FILTER_CONTINUE
+            if cookie.evtype == _XI_BARRIER_LEAVE:
+                self._accumulated_pressure = 0.0
+                return _GDK_FILTER_CONTINUE
+            self._handle_barrier_hit(
+                dx=float(barrier_event.dx), dy=float(barrier_event.dy)
+            )
+        finally:
+            xlib.XFreeEventData(self._xdisplay, cookie_ptr)
+        return _GDK_FILTER_CONTINUE
+
+    def _handle_barrier_hit(self, *, dx: float, dy: float) -> None:
+        """Accumulate barrier pressure; fire the callback past threshold."""
+        if self._pressure_callback is None:
+            return
+
+        # The barrier event reports motion the barrier resisted. Split that
+        # motion into a perpendicular component (into the barrier, what we
+        # want to count as "pressure") and a parallel component ("slide").
+        # Only accumulate when the user is genuinely pushing into the edge,
+        # not skating along it.
+        if self._position in (Position.BOTTOM, Position.TOP):
+            distance = abs(dy)
+            slide = abs(dx)
+        else:
+            distance = abs(dx)
+            slide = abs(dy)
+
+        if slide >= distance:
+            return
+
+        # Per-event clamp: a single fast jab shouldn't blow past the
+        # threshold instantly.
+        delta = min(_PER_EVENT_PRESSURE_CAP, distance)
+        self._accumulated_pressure += delta
+
+        if self._accumulated_pressure >= self._pressure_threshold:
+            log.debug(
+                "barrier pressure threshold reached: %.1f >= %.1f",
+                self._accumulated_pressure,
+                self._pressure_threshold,
+            )
+            self._accumulated_pressure = 0.0
+            try:
+                self._pressure_callback()
+            except Exception as exc:
+                log.warning("pressure callback raised: %s", exc)

--- a/docking/ui/placement.py
+++ b/docking/ui/placement.py
@@ -435,6 +435,25 @@ class DockPlacementController:
             monitor_h=geom.height,
             scale=self._window.get_scale_factor(),
         )
+        self.refresh_pressure_handler()
+
+    def refresh_pressure_handler(self) -> None:
+        """Wire the barrier's pressure callback to autohide reveal, if enabled."""
+        config = self._window.config
+        if config.pressure_reveal_enabled:
+            self._barrier.set_pressure_handler(
+                callback=self._on_barrier_pressure,
+                threshold=config.pressure_threshold,
+            )
+        else:
+            self._barrier.set_pressure_handler(callback=None, threshold=1)
+
+    def _on_barrier_pressure(self) -> None:
+        """Reveal the dock when accumulated barrier pressure exceeds threshold."""
+        autohide = getattr(self._window, "autohide", None)
+        if autohide is None:
+            return
+        autohide.on_mouse_enter()
 
     def clear_struts(self) -> None:
         """Remove strut reservation by setting all struts to zero."""

--- a/docking/ui/runtime.py
+++ b/docking/ui/runtime.py
@@ -62,6 +62,9 @@ class DockRuntime:
         else:
             self._window.placement.stop_active_display()
 
+    def refresh_pressure_handler(self) -> None:
+        self._window.placement.refresh_pressure_handler()
+
     def set_icons_locked(self, locked: bool) -> None:
         self._window.dnd.set_locked(locked)
 

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -58,10 +58,12 @@ from docking.applets.separator import meta as _separator_meta
 from docking.core.config import (
     MAX_ADDITIONAL_DISTANCE_FROM_EDGE,
     MAX_ICON_SIZE,
+    MAX_PRESSURE_THRESHOLD,
     MAX_TRANSPARENCY,
     MAX_ZOOM_PERCENT,
     MIN_ADDITIONAL_DISTANCE_FROM_EDGE,
     MIN_ICON_SIZE,
+    MIN_PRESSURE_THRESHOLD,
     MIN_TRANSPARENCY,
     MIN_ZOOM_PERCENT,
     FolderStackUnfold,
@@ -161,6 +163,8 @@ class SettingsWindowController:
         self._transparency_scale: Any = None
         self._additional_distance_scale: Any = None
         self._additional_distance_desc: Any = None
+        self._pressure_reveal_switch: Any = None
+        self._pressure_threshold_scale: Any = None
         self._zoom_percent_spin: Any = None
         self._hide_delay_spin: Any = None
         self._unhide_delay_spin: Any = None
@@ -365,6 +369,16 @@ class SettingsWindowController:
             maximum=HIDE_DELAY_MAX_MS,
             step=HIDE_DELAY_STEP_MS,
         )
+        self._pressure_reveal_switch = self._new_switch()
+        self._pressure_threshold_scale = Gtk.Scale.new_with_range(
+            Gtk.Orientation.HORIZONTAL,
+            MIN_PRESSURE_THRESHOLD,
+            MAX_PRESSURE_THRESHOLD,
+            1,
+        )
+        self._pressure_threshold_scale.set_digits(0)
+        self._pressure_threshold_scale.set_draw_value(True)
+        self._pressure_threshold_scale.set_size_request(TRANSPARENCY_SCALE_WIDTH_PX, -1)
 
         self._register_bindings()
 
@@ -418,6 +432,28 @@ class SettingsWindowController:
         hide_mode_box.pack_start(self._hide_mode_combo, False, False, 0)
         hide_mode_box.pack_start(self._hide_mode_desc, False, False, 0)
 
+        pressure_threshold_desc = Gtk.Label(
+            label=_(
+                "Pixels of cursor pressure against the edge required to "
+                "reveal a hidden dock. Higher values mean the dock will not "
+                "reveal as easily."
+            ),
+        )
+        pressure_threshold_desc.set_xalign(0.0)
+        pressure_threshold_desc.set_line_wrap(True)
+        pressure_threshold_desc.set_line_wrap_mode(2)
+        pressure_threshold_desc.set_max_width_chars(HIDE_MODE_DESC_MAX_CHARS)
+        pressure_threshold_desc.get_style_context().add_class("dim-label")
+        pressure_threshold_box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=HIDE_MODE_BOX_SPACING_PX,
+        )
+        pressure_threshold_box.set_size_request(TRANSPARENCY_SCALE_WIDTH_PX, -1)
+        pressure_threshold_box.pack_start(
+            self._pressure_threshold_scale, False, False, 0
+        )
+        pressure_threshold_box.pack_start(pressure_threshold_desc, False, False, 0)
+
         self._append_section(
             outer=outer,
             title=_("Mouse"),
@@ -433,6 +469,8 @@ class SettingsWindowController:
                 (_("Hide Mode"), hide_mode_box),
                 (_("Hide Delay"), self._hide_delay_spin),
                 (_("Unhide Delay"), self._unhide_delay_spin),
+                (_("Pressure Reveal"), self._pressure_reveal_switch),
+                (_("Pressure Threshold"), pressure_threshold_box),
             ],
         )
         self._append_section(
@@ -690,6 +728,16 @@ class SettingsWindowController:
                 config_attr="unhide_delay_ms",
                 widget=self._unhide_delay_spin,
             ),
+            self._register_switch_binding(
+                config_attr="pressure_reveal_enabled",
+                widget=self._pressure_reveal_switch,
+                on_change=self._after_pressure_reveal_changed,
+            ),
+            self._register_int_binding(
+                config_attr="pressure_threshold",
+                widget=self._pressure_threshold_scale,
+                on_change=self._after_pressure_reveal_changed,
+            ),
         ]
 
     def _register_switch_binding(
@@ -943,6 +991,10 @@ class SettingsWindowController:
         self._runtime.reposition()
         self._runtime.queue_draw()
 
+    def _after_pressure_reveal_changed(self, _value) -> None:
+        self._runtime.refresh_pressure_handler()
+        self._update_dependent_sensitivity()
+
     def _after_hide_mode_changed(self, mode: str) -> None:
         self._runtime.on_hide_mode_changed()
         self._update_hide_mode_description()
@@ -998,6 +1050,10 @@ class SettingsWindowController:
             self._hide_delay_spin.set_sensitive(hide_controls_sensitive)
         if self._unhide_delay_spin is not None:
             self._unhide_delay_spin.set_sensitive(hide_controls_sensitive)
+        if self._pressure_threshold_scale is not None:
+            self._pressure_threshold_scale.set_sensitive(
+                bool(self._config.pressure_reveal_enabled)
+            )
 
     def _on_applet_toggled(
         self,

--- a/tests/platform/test_barriers.py
+++ b/tests/platform/test_barriers.py
@@ -161,3 +161,80 @@ class TestPointerBarrierCoordinates:
 
         coords = xfixes.XFixesCreatePointerBarrier.call_args.args[2:6]
         assert coords == expected
+
+
+class TestPressureHandler:
+    """Pressure accumulation, threshold gating, and slide-vs-distance filter."""
+
+    @staticmethod
+    def _make_barrier_with_pressure(position=Position.BOTTOM, threshold=50):
+        xlib = MagicMock()
+        xlib.XDefaultRootWindow.return_value = 1
+        xfixes = MagicMock()
+        xfixes.XFixesCreatePointerBarrier.return_value = 42
+        barrier = PointerBarrier()
+        barrier._supported = True
+        barrier._libs = (xlib, xfixes, MagicMock())
+        barrier._xdisplay = ctypes.c_void_p(99)
+        barrier._barrier_id = 42
+        barrier._position = position
+        callback = MagicMock()
+        barrier.set_pressure_handler(callback=callback, threshold=threshold)
+        return barrier, callback
+
+    def test_no_callback_means_pressure_is_ignored(self):
+        barrier = PointerBarrier()
+        barrier._position = Position.BOTTOM
+        barrier.set_pressure_handler(callback=None, threshold=1)
+        # Should not raise; should not accumulate visibly.
+        barrier._handle_barrier_hit(dx=0.0, dy=100.0)
+        assert barrier._accumulated_pressure == 0.0
+
+    def test_perpendicular_motion_accumulates_until_threshold(self):
+        barrier, callback = self._make_barrier_with_pressure(threshold=31)
+        # 2 hits of dy=15 sum to 30, still below 31.
+        barrier._handle_barrier_hit(dx=0.0, dy=15.0)
+        barrier._handle_barrier_hit(dx=0.0, dy=15.0)
+        assert callback.call_count == 0
+        # 3rd hit pushes total to 45, crossing 31.
+        barrier._handle_barrier_hit(dx=0.0, dy=15.0)
+        assert callback.call_count == 1
+
+    def test_slide_along_edge_does_not_accumulate(self):
+        barrier, callback = self._make_barrier_with_pressure(threshold=10)
+        # For BOTTOM, dx is slide, dy is distance. slide >= distance -> skip.
+        for _ in range(20):
+            barrier._handle_barrier_hit(dx=100.0, dy=5.0)
+        assert callback.call_count == 0
+        assert barrier._accumulated_pressure == 0.0
+
+    def test_per_event_cap_prevents_single_jab_from_blowing_through(self):
+        barrier, callback = self._make_barrier_with_pressure(threshold=50)
+        # One event with huge dy gets clamped to 15 per the per-event cap.
+        barrier._handle_barrier_hit(dx=0.0, dy=1000.0)
+        assert callback.call_count == 0
+        assert barrier._accumulated_pressure == 15.0
+
+    def test_threshold_reset_after_firing(self):
+        barrier, callback = self._make_barrier_with_pressure(threshold=15)
+        barrier._handle_barrier_hit(dx=0.0, dy=15.0)
+        assert callback.call_count == 1
+        assert barrier._accumulated_pressure == 0.0
+        # A second push has to accumulate from zero again.
+        barrier._handle_barrier_hit(dx=0.0, dy=10.0)
+        assert callback.call_count == 1
+
+    def test_vertical_dock_uses_dx_as_distance(self):
+        barrier, callback = self._make_barrier_with_pressure(
+            position=Position.LEFT, threshold=15
+        )
+        # For LEFT/RIGHT, dx is distance, dy is slide.
+        barrier._handle_barrier_hit(dx=15.0, dy=0.0)
+        assert callback.call_count == 1
+
+    def test_callback_exception_is_swallowed(self):
+        barrier, callback = self._make_barrier_with_pressure(threshold=5)
+        callback.side_effect = RuntimeError("boom")
+        # Must not propagate, otherwise the X event filter would crash GDK.
+        barrier._handle_barrier_hit(dx=0.0, dy=15.0)
+        assert callback.call_count == 1

--- a/tests/ui/test_placement.py
+++ b/tests/ui/test_placement.py
@@ -22,6 +22,8 @@ def _make_window(**overrides):
             hide_mode="none",
             monitor_index=-1,
             additional_distance_from_edge=0,
+            pressure_reveal_enabled=False,
+            pressure_threshold=50,
         ),
         theme=SimpleNamespace(
             top_padding=4,
@@ -63,7 +65,11 @@ class TestPlacementControllerLifecycle:
         window = _make_window(
             get_display=lambda: display,
             get_screen=lambda: screen,
-            config=SimpleNamespace(active_display=True),
+            config=SimpleNamespace(
+                active_display=True,
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
+            ),
         )
         barrier = MagicMock()
         controller = placement_mod.DockPlacementController(window, barrier=barrier)
@@ -191,7 +197,9 @@ class TestPlacementControllerGeometry:
         zero_display = SimpleNamespace(get_n_monitors=lambda: 0)
         window = _make_window(
             get_display=lambda: zero_display,
-            config=SimpleNamespace(monitor_index=-1),
+            config=SimpleNamespace(
+                monitor_index=-1, pressure_reveal_enabled=False, pressure_threshold=50
+            ),
         )
         controller = placement_mod.DockPlacementController(window)
         assert controller.current_monitor_choice() == -1
@@ -203,7 +211,9 @@ class TestPlacementControllerGeometry:
         )
         window = _make_window(
             get_display=lambda: display,
-            config=SimpleNamespace(monitor_index=99),
+            config=SimpleNamespace(
+                monitor_index=99, pressure_reveal_enabled=False, pressure_threshold=50
+            ),
         )
         controller = placement_mod.DockPlacementController(window)
         assert controller.current_monitor_choice() == 0
@@ -216,7 +226,9 @@ class TestPlacementControllerGeometry:
         )
         window = _make_window(
             get_display=lambda: display,
-            config=SimpleNamespace(monitor_index=2),
+            config=SimpleNamespace(
+                monitor_index=2, pressure_reveal_enabled=False, pressure_threshold=50
+            ),
         )
         controller = placement_mod.DockPlacementController(window)
 
@@ -312,6 +324,8 @@ class TestPlacementControllerGeometry:
                 hide_mode="none",
                 monitor_index=-1,
                 additional_distance_from_edge=0,
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
             ),
             theme=SimpleNamespace(
                 top_padding=4,
@@ -347,6 +361,8 @@ class TestPlacementControllerGeometry:
                 hide_mode="none",
                 monitor_index=-1,
                 additional_distance_from_edge=0,
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
             ),
             theme=SimpleNamespace(
                 top_padding=4,
@@ -389,6 +405,8 @@ class TestPlacementControllerGeometry:
                 hide_mode="none",
                 monitor_index=1,
                 additional_distance_from_edge=0,
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
             ),
         )
         controller = placement_mod.DockPlacementController(window)
@@ -444,7 +462,13 @@ class TestPlacementControllerGeometry:
 
 class TestPlacementControllerStruts:
     def test_set_struts_clears_when_autohide_enabled(self):
-        window = _make_window(config=SimpleNamespace(hide_mode="autohide"))
+        window = _make_window(
+            config=SimpleNamespace(
+                hide_mode="autohide",
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
+            )
+        )
         controller = placement_mod.DockPlacementController(window)
         controller.clear_struts = MagicMock()
 
@@ -454,7 +478,9 @@ class TestPlacementControllerStruts:
 
     def test_set_struts_returns_when_no_window(self):
         window = _make_window(
-            config=SimpleNamespace(hide_mode="none"),
+            config=SimpleNamespace(
+                hide_mode="none", pressure_reveal_enabled=False, pressure_threshold=50
+            ),
             get_window=lambda: None,
         )
         controller = placement_mod.DockPlacementController(window)
@@ -481,6 +507,8 @@ class TestPlacementControllerStruts:
                 active_display=False,
                 monitor_index=-1,
                 additional_distance_from_edge=0,
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
             ),
             get_window=lambda: FakeX11Window(),
             get_display=lambda: MagicMock(),
@@ -520,6 +548,8 @@ class TestPlacementControllerStruts:
                 active_display=False,
                 monitor_index=-1,
                 additional_distance_from_edge=0,
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
             ),
             theme=SimpleNamespace(bottom_padding=8, distance_from_edge=0),
             get_window=lambda: gdk_window,
@@ -561,6 +591,8 @@ class TestPlacementControllerStruts:
                 active_display=True,
                 monitor_index=-1,
                 additional_distance_from_edge=0,
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
             ),
             theme=SimpleNamespace(bottom_padding=8, distance_from_edge=0),
             get_window=lambda: gdk_window,
@@ -607,7 +639,11 @@ class TestPlacementControllerStruts:
         barrier.update.assert_not_called()
 
         barrier = MagicMock(supported=True)
-        window = _make_window(config=SimpleNamespace(hide_mode="none"))
+        window = _make_window(
+            config=SimpleNamespace(
+                hide_mode="none", pressure_reveal_enabled=False, pressure_threshold=50
+            )
+        )
         controller = placement_mod.DockPlacementController(window, barrier=barrier)
         controller.update_barrier()
         barrier.destroy.assert_called_once()
@@ -615,7 +651,12 @@ class TestPlacementControllerStruts:
     def test_update_barrier_destroys_when_monitor_missing(self):
         barrier = MagicMock(supported=True)
         window = _make_window(
-            config=SimpleNamespace(hide_mode="autohide", pos=Position.BOTTOM)
+            config=SimpleNamespace(
+                hide_mode="autohide",
+                pos=Position.BOTTOM,
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
+            )
         )
         controller = placement_mod.DockPlacementController(window, barrier=barrier)
         controller._resolve_target_monitor = MagicMock(return_value=None)
@@ -629,7 +670,12 @@ class TestPlacementControllerStruts:
         geom = SimpleNamespace(x=100, y=50, width=1280, height=720)
         monitor = SimpleNamespace(get_geometry=lambda: geom)
         window = _make_window(
-            config=SimpleNamespace(hide_mode="autohide", pos=Position.RIGHT),
+            config=SimpleNamespace(
+                hide_mode="autohide",
+                pos=Position.RIGHT,
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
+            ),
             get_scale_factor=lambda: 1,
         )
         controller = placement_mod.DockPlacementController(window, barrier=barrier)
@@ -674,7 +720,12 @@ class TestPlacementControllerStruts:
         geom = SimpleNamespace(x=0, y=0, width=1920, height=1080)
         monitor = SimpleNamespace(get_geometry=lambda: geom)
         window = _make_window(
-            config=SimpleNamespace(hide_mode="autohide", pos=Position.BOTTOM),
+            config=SimpleNamespace(
+                hide_mode="autohide",
+                pos=Position.BOTTOM,
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
+            ),
             get_scale_factor=lambda: 2,
         )
         controller = placement_mod.DockPlacementController(window, barrier=real_barrier)
@@ -722,7 +773,12 @@ class TestPlacementControllerStruts:
         geom = SimpleNamespace(x=0, y=0, width=1920, height=1080)
         monitor = SimpleNamespace(get_geometry=lambda: geom)
         window = _make_window(
-            config=SimpleNamespace(hide_mode="autohide", pos=Position.BOTTOM),
+            config=SimpleNamespace(
+                hide_mode="autohide",
+                pos=Position.BOTTOM,
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
+            ),
             get_scale_factor=lambda: scale,
         )
         controller = placement_mod.DockPlacementController(window, barrier=real_barrier)
@@ -811,7 +867,14 @@ class TestPlacementControllerStruts:
 
     def test_resolve_target_monitor_uses_active_display_and_fallbacks(self):
         controller = placement_mod.DockPlacementController(
-            _make_window(config=SimpleNamespace(active_display=True, monitor_index=-1))
+            _make_window(
+                config=SimpleNamespace(
+                    active_display=True,
+                    monitor_index=-1,
+                    pressure_reveal_enabled=False,
+                    pressure_threshold=50,
+                )
+            )
         )
         active_monitor = object()
         controller._active_monitor = active_monitor
@@ -824,7 +887,14 @@ class TestPlacementControllerStruts:
             get_monitor=lambda idx: primary if idx == 0 else None,
         )
         controller = placement_mod.DockPlacementController(
-            _make_window(config=SimpleNamespace(active_display=False, monitor_index=-1))
+            _make_window(
+                config=SimpleNamespace(
+                    active_display=False,
+                    monitor_index=-1,
+                    pressure_reveal_enabled=False,
+                    pressure_threshold=50,
+                )
+            )
         )
         assert controller._resolve_target_monitor(display=no_get_n) is primary
 
@@ -838,7 +908,14 @@ class TestPlacementControllerStruts:
             get_primary_monitor=lambda: None,
         )
         controller = placement_mod.DockPlacementController(
-            _make_window(config=SimpleNamespace(active_display=False, monitor_index=1))
+            _make_window(
+                config=SimpleNamespace(
+                    active_display=False,
+                    monitor_index=1,
+                    pressure_reveal_enabled=False,
+                    pressure_threshold=50,
+                )
+            )
         )
         assert controller._resolve_target_monitor(display=display) is selected
 
@@ -849,7 +926,14 @@ class TestPlacementControllerStruts:
             get_primary_monitor=lambda: None,
         )
         controller = placement_mod.DockPlacementController(
-            _make_window(config=SimpleNamespace(active_display=False, monitor_index=9))
+            _make_window(
+                config=SimpleNamespace(
+                    active_display=False,
+                    monitor_index=9,
+                    pressure_reveal_enabled=False,
+                    pressure_threshold=50,
+                )
+            )
         )
         assert controller._resolve_target_monitor(display=display) is fallback
 

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -494,6 +494,8 @@ def _config():
         update_check_enabled=True,
         update_check_interval_hours=24,
         additional_distance_from_edge=0,
+        pressure_reveal_enabled=False,
+        pressure_threshold=50,
         save=MagicMock(),
     )
 


### PR DESCRIPTION
Add pressure-based reveal support for pointer barriers, expose pressure reveal settings, and cover the barrier, placement, and settings behavior. This PR is stacked on the extra distance-from-edge branch because the patch depends on that settings and placement shape.