### PR TITLE
Tighten settings control widths

### DIFF
--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-05-24 00:08+0200\n"
+"POT-Creation-Date: 2026-05-24 00:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1062,7 +1062,7 @@ msgid "{verb} every {interval}"
 msgstr ""
 
 #: docking/applets/freshness.py:42 docking/applets/freshness.py:49
-#: docking/ui/settings.py:216
+#: docking/ui/settings.py:218
 msgid "Updates"
 msgstr ""
 
@@ -2351,7 +2351,7 @@ msgstr ""
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:605 docking/ui/settings.py:189
+#: docking/ui/menu.py:605 docking/ui/settings.py:191
 msgid "Preferences"
 msgstr ""
 
@@ -2381,272 +2381,272 @@ msgstr ""
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-#: docking/ui/settings.py:213
+#: docking/ui/settings.py:215
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:214 docking/ui/settings.py:467
+#: docking/ui/settings.py:216 docking/ui/settings.py:464
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:215
+#: docking/ui/settings.py:217
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:234
+#: docking/ui/settings.py:241
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:235
+#: docking/ui/settings.py:242
 msgid "Always on Top"
 msgstr ""
 
-#: docking/ui/settings.py:236
+#: docking/ui/settings.py:243
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:237
+#: docking/ui/settings.py:244
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:238
-msgid "Dodge Active Window"
+#: docking/ui/settings.py:245
+msgid "Dodge Active"
 msgstr ""
 
-#: docking/ui/settings.py:239
-msgid "Dodge All Windows"
+#: docking/ui/settings.py:246
+msgid "Dodge Windows"
 msgstr ""
 
-#: docking/ui/settings.py:240
+#: docking/ui/settings.py:247
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:257
+#: docking/ui/settings.py:258
 msgid "Toggle Focus"
 msgstr ""
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:259
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:260
 msgid "Most Recent Window"
 msgstr ""
 
-#: docking/ui/settings.py:266
+#: docking/ui/settings.py:267
 msgid "New Window"
 msgstr ""
 
-#: docking/ui/settings.py:267
+#: docking/ui/settings.py:268
 msgid "Minimize Windows"
 msgstr ""
 
-#: docking/ui/settings.py:268
+#: docking/ui/settings.py:269
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:276
 msgid "Click"
 msgstr ""
 
-#: docking/ui/settings.py:276
+#: docking/ui/settings.py:277
 msgid "Hover"
 msgstr ""
 
-#: docking/ui/settings.py:293
+#: docking/ui/settings.py:294
 msgid "Daily"
 msgstr ""
 
-#: docking/ui/settings.py:294
+#: docking/ui/settings.py:295
 msgid "Weekly"
 msgstr ""
 
-#: docking/ui/settings.py:344
+#: docking/ui/settings.py:345
 msgid "Added on top of the theme's own distance from the edge."
 msgstr ""
 
-#: docking/ui/settings.py:387
+#: docking/ui/settings.py:383
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:389
+#: docking/ui/settings.py:385
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:390
+#: docking/ui/settings.py:386
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:391
+#: docking/ui/settings.py:387
 msgid "Transparency"
 msgstr ""
 
-#: docking/ui/settings.py:392
+#: docking/ui/settings.py:388
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:393
+#: docking/ui/settings.py:389
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:394
+#: docking/ui/settings.py:390
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:395
+#: docking/ui/settings.py:391
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:401
+#: docking/ui/settings.py:397
 msgid "Placement"
 msgstr ""
 
-#: docking/ui/settings.py:403
+#: docking/ui/settings.py:399
 msgid "Position"
 msgstr ""
 
-#: docking/ui/settings.py:404
+#: docking/ui/settings.py:400
 msgid "Extra Distance from Edge"
 msgstr ""
 
-#: docking/ui/settings.py:405
+#: docking/ui/settings.py:401
 msgid "Follow Cursor"
 msgstr ""
 
-#: docking/ui/settings.py:406
+#: docking/ui/settings.py:402
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:411
+#: docking/ui/settings.py:407
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:413
+#: docking/ui/settings.py:409
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:414
+#: docking/ui/settings.py:410
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:415
+#: docking/ui/settings.py:411
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:437
+#: docking/ui/settings.py:434
 msgid ""
 "Pixels of cursor pressure against the edge required to reveal a hidden dock. "
 "Higher values mean the dock will not reveal as easily."
 msgstr ""
 
-#: docking/ui/settings.py:459
+#: docking/ui/settings.py:456
 msgid "Mouse"
 msgstr ""
 
-#: docking/ui/settings.py:461
+#: docking/ui/settings.py:458
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:462
+#: docking/ui/settings.py:459
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:469
+#: docking/ui/settings.py:466
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:470
+#: docking/ui/settings.py:467
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:471
+#: docking/ui/settings.py:468
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:472
+#: docking/ui/settings.py:469
 msgid "Pressure Reveal"
 msgstr ""
 
-#: docking/ui/settings.py:473
+#: docking/ui/settings.py:470
 msgid "Pressure Threshold"
 msgstr ""
 
-#: docking/ui/settings.py:478
+#: docking/ui/settings.py:475
 msgid "Folder Stacks"
 msgstr ""
 
-#: docking/ui/settings.py:480
+#: docking/ui/settings.py:477
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:505
+#: docking/ui/settings.py:516
 msgid "Check Now"
 msgstr ""
 
-#: docking/ui/settings.py:507
+#: docking/ui/settings.py:518
 msgid "View Releases"
 msgstr ""
 
-#: docking/ui/settings.py:519
+#: docking/ui/settings.py:530
 msgid "Update Checks"
 msgstr ""
 
-#: docking/ui/settings.py:521
+#: docking/ui/settings.py:532
 msgid "Check Automatically"
 msgstr ""
 
-#: docking/ui/settings.py:522
+#: docking/ui/settings.py:533
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:523
+#: docking/ui/settings.py:534
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:524
+#: docking/ui/settings.py:535
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:955
+#: docking/ui/settings.py:966
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:959
+#: docking/ui/settings.py:970
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:961
+#: docking/ui/settings.py:972
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:1004
+#: docking/ui/settings.py:1015
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1006
+#: docking/ui/settings.py:1017
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1009
+#: docking/ui/settings.py:1020
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:1011
+#: docking/ui/settings.py:1022
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1013
+#: docking/ui/settings.py:1024
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1015
+#: docking/ui/settings.py:1026
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1018
+#: docking/ui/settings.py:1029
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -100,8 +100,9 @@ SECTION_HEADER_TOP_MARGIN_PX = 6
 SECTION_HEADER_BOTTOM_MARGIN_PX = 2
 ROW_SPACING_PX = 12
 HIDE_MODE_COMBO_WIDTH_PX = 180
+HIDE_MODE_INFO_ICON_WIDTH_PX = 14
 TRANSPARENCY_SCALE_WIDTH_PX = 132
-HIDE_MODE_DESC_MAX_CHARS = 28
+DESCRIPTION_MAX_CHARS = 28
 HIDE_MODE_BOX_SPACING_PX = 4
 APPLET_GRID_COLUMN_SPACING_PX = 16
 APPLET_GRID_ROW_SPACING_PX = 8
@@ -145,6 +146,7 @@ class SettingsWindowController:
         self._syncing_widgets = False
 
         self._hide_mode_combo: Any = None
+        self._hide_mode_info: Any = None
         self._left_click_combo: Any = None
         self._middle_click_combo: Any = None
         self._folder_stack_unfold_combo: Any = None
@@ -162,7 +164,7 @@ class SettingsWindowController:
         self._icon_size_spin: Any = None
         self._transparency_scale: Any = None
         self._additional_distance_scale: Any = None
-        self._additional_distance_desc: Any = None
+        self._additional_distance_info: Any = None
         self._pressure_reveal_switch: Any = None
         self._pressure_threshold_scale: Any = None
         self._zoom_percent_spin: Any = None
@@ -229,25 +231,24 @@ class SettingsWindowController:
         self._bindings.clear()
 
         self._hide_mode_combo = Gtk.ComboBoxText()
-        self._hide_mode_combo.set_size_request(HIDE_MODE_COMBO_WIDTH_PX, -1)
+        self._hide_mode_combo.set_size_request(
+            HIDE_MODE_COMBO_WIDTH_PX
+            - HIDE_MODE_INFO_ICON_WIDTH_PX
+            - HIDE_MODE_BOX_SPACING_PX,
+            -1,
+        )
         for mode_value, mode_label in [
             ("none", _("Don't Hide")),
             ("always-on-top", _("Always on Top")),
             ("autohide", _("Auto-hide")),
             ("intelligent", _("Intelligent")),
-            ("dodge-active", _("Dodge Active Window")),
-            ("window-dodge", _("Dodge All Windows")),
+            ("dodge-active", _("Dodge Active")),
+            ("window-dodge", _("Dodge Windows")),
             ("dodge-maximized", _("Dodge Maximized")),
         ]:
             self._hide_mode_combo.append(mode_value, mode_label)
 
-        self._hide_mode_desc = Gtk.Label()
-        self._hide_mode_desc.set_xalign(0.0)
-        self._hide_mode_desc.set_line_wrap(True)
-        self._hide_mode_desc.set_line_wrap_mode(2)  # Pango.WrapMode.WORD_CHAR
-        self._hide_mode_desc.set_max_width_chars(HIDE_MODE_DESC_MAX_CHARS)
-        ctx = self._hide_mode_desc.get_style_context()
-        ctx.add_class("dim-label")
+        self._hide_mode_info = self._new_info_icon()
         self._hide_mode_combo.connect("changed", self._on_hide_mode_combo_changed)
         self._update_hide_mode_description()
 
@@ -340,16 +341,11 @@ class SettingsWindowController:
         self._additional_distance_scale.set_size_request(
             TRANSPARENCY_SCALE_WIDTH_PX, -1
         )
-        self._additional_distance_desc = Gtk.Label(
-            label=_("Added on top of the theme's own distance from the edge."),
+        self._additional_distance_info = self._new_info_icon(
+            _("Added on top of the theme's own distance from the edge.")
         )
-        self._additional_distance_desc.set_xalign(0.0)
-        self._additional_distance_desc.set_line_wrap(True)
-        self._additional_distance_desc.set_line_wrap_mode(2)  # Pango.WrapMode.WORD_CHAR
-        self._additional_distance_desc.set_max_width_chars(HIDE_MODE_DESC_MAX_CHARS)
-        self._additional_distance_desc.get_style_context().add_class("dim-label")
         additional_distance_box = Gtk.Box(
-            orientation=Gtk.Orientation.VERTICAL,
+            orientation=Gtk.Orientation.HORIZONTAL,
             spacing=HIDE_MODE_BOX_SPACING_PX,
         )
         additional_distance_box.set_size_request(TRANSPARENCY_SCALE_WIDTH_PX, -1)
@@ -357,7 +353,7 @@ class SettingsWindowController:
             self._additional_distance_scale, False, False, 0
         )
         additional_distance_box.pack_start(
-            self._additional_distance_desc, False, False, 0
+            self._additional_distance_info, False, False, 0
         )
         self._hide_delay_spin = self._new_numeric_spin_button(
             minimum=0,
@@ -426,11 +422,12 @@ class SettingsWindowController:
         outer.set_border_width(APPEARANCE_TAB_BORDER_PX)
 
         hide_mode_box = Gtk.Box(
-            orientation=Gtk.Orientation.VERTICAL,
+            orientation=Gtk.Orientation.HORIZONTAL,
             spacing=HIDE_MODE_BOX_SPACING_PX,
         )
-        hide_mode_box.pack_start(self._hide_mode_combo, False, False, 0)
-        hide_mode_box.pack_start(self._hide_mode_desc, False, False, 0)
+        hide_mode_box.set_size_request(HIDE_MODE_COMBO_WIDTH_PX, -1)
+        hide_mode_box.pack_start(self._hide_mode_combo, True, True, 0)
+        hide_mode_box.pack_start(self._hide_mode_info, False, False, 0)
 
         pressure_threshold_desc = Gtk.Label(
             label=_(
@@ -442,7 +439,7 @@ class SettingsWindowController:
         pressure_threshold_desc.set_xalign(0.0)
         pressure_threshold_desc.set_line_wrap(True)
         pressure_threshold_desc.set_line_wrap_mode(2)
-        pressure_threshold_desc.set_max_width_chars(HIDE_MODE_DESC_MAX_CHARS)
+        pressure_threshold_desc.set_max_width_chars(DESCRIPTION_MAX_CHARS)
         pressure_threshold_desc.get_style_context().add_class("dim-label")
         pressure_threshold_box = Gtk.Box(
             orientation=Gtk.Orientation.VERTICAL,
@@ -482,6 +479,20 @@ class SettingsWindowController:
         )
 
         return outer
+
+    def _new_info_icon(self, tooltip: str = "") -> Gtk.EventBox:
+        icon = Gtk.EventBox()
+        icon.set_visible_window(False)
+        icon.set_size_request(HIDE_MODE_INFO_ICON_WIDTH_PX, -1)
+        if tooltip:
+            icon.set_tooltip_text(tooltip)
+        icon.add(
+            Gtk.Image.new_from_icon_name(
+                "dialog-information-symbolic",
+                Gtk.IconSize.MENU,
+            )
+        )
+        return icon
 
     def _build_applets_tab(self) -> Gtk.Widget:
         scroller = Gtk.ScrolledWindow()
@@ -1023,13 +1034,11 @@ class SettingsWindowController:
         self._update_hide_mode_description()
 
     def _update_hide_mode_description(self) -> None:
-        if not self._hide_mode_combo or not self._hide_mode_desc:
+        if not self._hide_mode_combo or not self._hide_mode_info:
             return
         mode = self._hide_mode_combo.get_active_id() or "none"
         desc = self._HIDE_MODE_DESCRIPTIONS.get(mode, "")
-        self._hide_mode_desc.set_markup(
-            f"<small>{GLib.markup_escape_text(desc)}</small>"
-        )
+        self._hide_mode_info.set_tooltip_text(desc)
 
     def _after_tooltips_changed(self, active: bool) -> None:
         if not active:

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -41,6 +41,7 @@ class FakeLabel:
         self.margin_bottom = 0
         self.line_wrap = False
         self.max_width_chars = -1
+        self.tooltip_text = None
 
     def get_label(self) -> str:
         return self._label
@@ -71,6 +72,9 @@ class FakeLabel:
 
     def set_line_wrap_mode(self, mode: int) -> None:
         pass
+
+    def set_tooltip_text(self, value: str) -> None:
+        self.tooltip_text = value
 
     def get_style_context(self) -> FakeStyleContext:
         return FakeStyleContext()
@@ -360,6 +364,10 @@ class FakeImage:
         self.pixel_size = None
 
     @classmethod
+    def new_from_icon_name(cls, icon_name: str, icon_size):
+        return cls(("icon", icon_name, icon_size))
+
+    @classmethod
     def new_from_pixbuf(cls, pixbuf):
         return cls(("pixbuf", pixbuf))
 
@@ -392,6 +400,26 @@ class FakePixbuf:
         )
 
 
+class FakeEventBox:
+    def __init__(self) -> None:
+        self.child = None
+        self.visible_window = True
+        self.size_request = None
+        self.tooltip_text = None
+
+    def set_visible_window(self, value: bool) -> None:
+        self.visible_window = value
+
+    def set_size_request(self, width: int, height: int) -> None:
+        self.size_request = (width, height)
+
+    def set_tooltip_text(self, value: str) -> None:
+        self.tooltip_text = value
+
+    def add(self, child) -> None:
+        self.child = child
+
+
 class FakeScrolledWindow:
     def __init__(self) -> None:
         self.child = None
@@ -421,6 +449,10 @@ class FakePolicyType:
 
 class FakeAlign:
     CENTER = 0
+
+
+class FakeIconSize:
+    MENU = 0
 
 
 class FakeWindowPosition:
@@ -461,10 +493,12 @@ class FakeGtk:
     CheckButton = FakeCheckButton
     Button = FakeButton
     Image = FakeImage
+    EventBox = FakeEventBox
     ScrolledWindow = FakeScrolledWindow
     Orientation = FakeOrientation
     PolicyType = FakePolicyType
     Align = FakeAlign
+    IconSize = FakeIconSize
     WindowPosition = FakeWindowPosition
     Settings = FakeGtkSettings
 


### PR DESCRIPTION
## Summary
- constrain the Hide Mode control group so its subtitle does not widen the row
- make Extra Distance from Edge use the same compact control and subtitle width as Hide Mode