### PR TITLE
Add UV index to weather applet

### DIFF
--- a/docking/applets/weather/api.py
+++ b/docking/applets/weather/api.py
@@ -215,6 +215,7 @@ class AirQualityData(NamedTuple):
     pm2_5: float  # Fine particulate (μg/m³)
     pm10: float  # Particulate (μg/m³)
     label: str  # Human-readable level
+    uv_index: float | None = None  # Current UV index
 
 
 def aqi_label(aqi: int) -> str:
@@ -244,17 +245,31 @@ def fetch_air_quality(lat: float, lng: float) -> AirQualityData | None:
             params={
                 "latitude": lat,
                 "longitude": lng,
-                "current": ["european_aqi", "pm10", "pm2_5"],
+                "current": ["european_aqi", "pm10", "pm2_5", "uv_index"],
             },
         )
         current = responses[0].Current()
         aqi = int(current.Variables(0).Value())
         pm10 = round(current.Variables(1).Value(), 1)
         pm2_5 = round(current.Variables(2).Value(), 1)
-        return AirQualityData(aqi=aqi, pm2_5=pm2_5, pm10=pm10, label=aqi_label(aqi=aqi))
+        uv_index = _optional_current_value(current, index=3)
+        return AirQualityData(
+            aqi=aqi,
+            pm2_5=pm2_5,
+            pm10=pm10,
+            label=aqi_label(aqi=aqi),
+            uv_index=uv_index,
+        )
     except Exception:
         log.bind(action="fetch_air_quality").warning(
             "Failed to fetch air quality",
             exc_info=True,
         )
+        return None
+
+
+def _optional_current_value(current: Any, *, index: int) -> float | None:
+    try:
+        return round(float(current.Variables(index).Value()), 1)
+    except (AttributeError, IndexError, TypeError, ValueError):
         return None

--- a/docking/applets/weather/applet.py
+++ b/docking/applets/weather/applet.py
@@ -508,6 +508,14 @@ class WeatherApplet(Applet):
             )
             aqi_lbl.override_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(1, 1, 1, 0.7))
             box.pack_start(aqi_lbl, False, False, 0)
+            if self._air_quality.uv_index is not None:
+                uv_lbl = Gtk.Label(
+                    label=_("UV Index: {value}").format(
+                        value=f"{self._air_quality.uv_index:.1f}"
+                    )
+                )
+                uv_lbl.override_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(1, 1, 1, 0.7))
+                box.pack_start(uv_lbl, False, False, 0)
 
         for day in weather.daily:
             row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)

--- a/docking/applets/weather/state.py
+++ b/docking/applets/weather/state.py
@@ -200,6 +200,10 @@ def build_tooltip(
     details = []
     if air_quality:
         details.append(_("Air: {label}").format(label=air_quality.label))
+        if air_quality.uv_index is not None:
+            details.append(
+                _("UV Index: {value}").format(value=f"{air_quality.uv_index:.1f}")
+            )
     for day in weather.daily:
         temp = format_temperature_range(
             low_celsius=day.temp_min,

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-05-22 20:32+0200\n"
+"POT-Creation-Date: 2026-05-23 19:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -314,7 +314,7 @@ msgstr ""
 #: docking/applets/hackernews/applet.py:188
 #: docking/applets/speedtest/applet.py:116
 #: docking/applets/thermals/applet.py:147 docking/applets/tooltip.py:46
-#: docking/applets/weather/applet.py:181 docking/applets/weather/applet.py:538
+#: docking/applets/weather/applet.py:181 docking/applets/weather/applet.py:546
 #, python-brace-format
 msgid "Error: {msg}"
 msgstr ""
@@ -1090,18 +1090,18 @@ msgid "{count} days"
 msgstr ""
 
 #: docking/applets/hackernews/applet.py:68
-#: docking/applets/hackernews/state.py:158
+#: docking/applets/hackernews/state.py:157
 msgid "Hacker News"
 msgstr ""
 
 #: docking/applets/hackernews/applet.py:160
-#: docking/applets/hackernews/state.py:164
-#: docking/applets/hackernews/state.py:197
+#: docking/applets/hackernews/state.py:163
+#: docking/applets/hackernews/state.py:196
 msgid "Refreshes"
 msgstr ""
 
 #: docking/applets/hackernews/applet.py:172
-#: docking/applets/hackernews/state.py:179
+#: docking/applets/hackernews/state.py:178
 #, python-brace-format
 msgid "{score} points, {comments} comments"
 msgstr ""
@@ -1122,31 +1122,31 @@ msgstr ""
 msgid "No Hacker News stories"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:115
+#: docking/applets/hackernews/state.py:114
 msgid "now"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:118
+#: docking/applets/hackernews/state.py:117
 #, python-brace-format
 msgid "{minutes}m ago"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:121
+#: docking/applets/hackernews/state.py:120
 #, python-brace-format
 msgid "{hours}h ago"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:123
+#: docking/applets/hackernews/state.py:122
 #, python-brace-format
 msgid "{days}d ago"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:172
+#: docking/applets/hackernews/state.py:171
 #, python-brace-format
 msgid "{source} {rank}"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:188
+#: docking/applets/hackernews/state.py:187
 msgid "Loading next stories..."
 msgstr ""
 
@@ -1385,89 +1385,89 @@ msgstr ""
 msgid "Stopped"
 msgstr ""
 
-#: docking/applets/network/applet.py:77 docking/applets/network/state.py:227
-#: docking/applets/network/state.py:238
+#: docking/applets/network/applet.py:79 docking/applets/network/state.py:246
+#: docking/applets/network/state.py:257
 msgid "Network"
 msgstr ""
 
-#: docking/applets/network/applet.py:131
+#: docking/applets/network/applet.py:127
 #, python-brace-format
 msgid "WiFi: {ssid} ({pct}%)"
 msgstr ""
 
-#: docking/applets/network/applet.py:140
+#: docking/applets/network/applet.py:136
 #, python-brace-format
 msgid "Ethernet: {iface}"
 msgstr ""
 
-#: docking/applets/network/applet.py:145 docking/applets/network/state.py:228
+#: docking/applets/network/applet.py:141 docking/applets/network/state.py:247
 msgid "Not connected"
 msgstr ""
 
-#: docking/applets/network/applet.py:149
+#: docking/applets/network/applet.py:145
 #, python-brace-format
 msgid "IP: {ip}"
 msgstr ""
 
-#: docking/applets/network/applet.py:160
+#: docking/applets/network/applet.py:156
 msgid "Connection Information"
 msgstr ""
 
-#: docking/applets/network/applet.py:166
+#: docking/applets/network/applet.py:162
 msgid "Edit Connections..."
 msgstr ""
 
-#: docking/applets/network/applet.py:176
+#: docking/applets/network/applet.py:172
 msgid "Connect to Hidden Wi-Fi Network..."
 msgstr ""
 
-#: docking/applets/network/applet.py:183
+#: docking/applets/network/applet.py:179
 msgid "Create New Wi-Fi Network..."
 msgstr ""
 
-#: docking/applets/network/applet.py:187
+#: docking/applets/network/applet.py:183
 msgid "Enable Networking"
 msgstr ""
 
-#: docking/applets/network/applet.py:198
+#: docking/applets/network/applet.py:194
 msgid "Enable Wi-Fi"
 msgstr ""
 
-#: docking/applets/network/applet.py:215
+#: docking/applets/network/applet.py:211
 msgid "Show Download"
 msgstr ""
 
-#: docking/applets/network/applet.py:216
+#: docking/applets/network/applet.py:212
 msgid "Show Upload"
 msgstr ""
 
-#: docking/applets/network/applet.py:217
+#: docking/applets/network/applet.py:213
 msgid "Hide Speeds"
 msgstr ""
 
-#: docking/applets/network/applet.py:268
+#: docking/applets/network/applet.py:262
 msgid "Available Networks"
 msgstr ""
 
-#: docking/applets/network/applet.py:272
+#: docking/applets/network/applet.py:266
 #, python-brace-format
 msgid "{ssid} ({pct}%)"
 msgstr ""
 
-#: docking/applets/network/applet.py:274
+#: docking/applets/network/applet.py:268
 #, python-brace-format
 msgid "Connected: {label}"
 msgstr ""
 
-#: docking/applets/network/applet.py:283
+#: docking/applets/network/applet.py:277
 msgid "No networks found"
 msgstr ""
 
-#: docking/applets/network/applet.py:295
+#: docking/applets/network/applet.py:289
 msgid "VPN Connections"
 msgstr ""
 
-#: docking/applets/network/applet.py:298
+#: docking/applets/network/applet.py:292
 msgid "Unnamed VPN"
 msgstr ""
 
@@ -2072,17 +2072,17 @@ msgstr[1] ""
 msgid "Random Trivia"
 msgstr ""
 
-#: docking/applets/trivia/applet.py:90 docking/applets/trivia/state.py:110
+#: docking/applets/trivia/applet.py:90 docking/applets/trivia/state.py:109
 #, python-brace-format
 msgid "{category} / {difficulty}"
 msgstr ""
 
-#: docking/applets/trivia/applet.py:109 docking/applets/trivia/state.py:121
+#: docking/applets/trivia/applet.py:109 docking/applets/trivia/state.py:120
 #, python-brace-format
 msgid "Correct answer: {answer}"
 msgstr ""
 
-#: docking/applets/trivia/applet.py:118 docking/applets/trivia/state.py:120
+#: docking/applets/trivia/applet.py:118 docking/applets/trivia/state.py:119
 #, python-brace-format
 msgid "Your answer: {answer}"
 msgstr ""
@@ -2095,19 +2095,19 @@ msgstr ""
 msgid "Trivia: loading..."
 msgstr ""
 
-#: docking/applets/trivia/state.py:96
+#: docking/applets/trivia/state.py:95
 msgid "Easy"
 msgstr ""
 
-#: docking/applets/trivia/state.py:97
+#: docking/applets/trivia/state.py:96
 msgid "Medium"
 msgstr ""
 
-#: docking/applets/trivia/state.py:98
+#: docking/applets/trivia/state.py:97
 msgid "Hard"
 msgstr ""
 
-#: docking/applets/trivia/state.py:118
+#: docking/applets/trivia/state.py:117
 #, python-brace-format
 msgid "Correct: {answer}"
 msgstr ""
@@ -2201,7 +2201,7 @@ msgstr ""
 msgid "No weather data"
 msgstr ""
 
-#: docking/applets/weather/applet.py:494 docking/applets/weather/state.py:212
+#: docking/applets/weather/applet.py:494 docking/applets/weather/state.py:216
 #, python-brace-format
 msgid "{temp}, {desc}"
 msgstr ""
@@ -2211,7 +2211,12 @@ msgstr ""
 msgid "Air: {label}"
 msgstr ""
 
-#: docking/applets/weather/applet.py:519
+#: docking/applets/weather/applet.py:513 docking/applets/weather/state.py:205
+#, python-brace-format
+msgid "UV Index: {value}"
+msgstr ""
+
+#: docking/applets/weather/applet.py:527
 #, python-brace-format
 msgid "{date}: {temp_range}"
 msgstr ""
@@ -2237,7 +2242,7 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: docking/ui/dock_window.py:392
+#: docking/ui/dock_window.py:393
 msgid "Docking"
 msgstr ""
 
@@ -2375,7 +2380,7 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:214 docking/ui/settings.py:469
+#: docking/ui/settings.py:214 docking/ui/settings.py:467
 msgid "Behavior"
 msgstr ""
 
@@ -2455,188 +2460,188 @@ msgstr ""
 msgid "Added on top of the theme's own distance from the edge."
 msgstr ""
 
-#: docking/ui/settings.py:389
+#: docking/ui/settings.py:387
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:391
+#: docking/ui/settings.py:389
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:392
+#: docking/ui/settings.py:390
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:393
+#: docking/ui/settings.py:391
 msgid "Transparency"
 msgstr ""
 
-#: docking/ui/settings.py:394
+#: docking/ui/settings.py:392
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:395
+#: docking/ui/settings.py:393
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:396
+#: docking/ui/settings.py:394
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:397
+#: docking/ui/settings.py:395
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:403
+#: docking/ui/settings.py:401
 msgid "Placement"
 msgstr ""
 
-#: docking/ui/settings.py:405
+#: docking/ui/settings.py:403
 msgid "Position"
 msgstr ""
 
-#: docking/ui/settings.py:406
+#: docking/ui/settings.py:404
 msgid "Extra Distance from Edge"
 msgstr ""
 
-#: docking/ui/settings.py:407
+#: docking/ui/settings.py:405
 msgid "Follow Cursor"
 msgstr ""
 
-#: docking/ui/settings.py:408
+#: docking/ui/settings.py:406
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:413
+#: docking/ui/settings.py:411
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:415
+#: docking/ui/settings.py:413
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:416
+#: docking/ui/settings.py:414
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:417
+#: docking/ui/settings.py:415
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:439
+#: docking/ui/settings.py:437
 msgid ""
 "Pixels of cursor pressure against the edge required to reveal a hidden dock. "
 "Higher values mean the dock will not reveal as easily."
 msgstr ""
 
-#: docking/ui/settings.py:461
+#: docking/ui/settings.py:459
 msgid "Mouse"
 msgstr ""
 
-#: docking/ui/settings.py:463
+#: docking/ui/settings.py:461
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:464
+#: docking/ui/settings.py:462
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:471
+#: docking/ui/settings.py:469
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:472
+#: docking/ui/settings.py:470
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:473
+#: docking/ui/settings.py:471
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:474
+#: docking/ui/settings.py:472
 msgid "Pressure Reveal"
 msgstr ""
 
-#: docking/ui/settings.py:475
+#: docking/ui/settings.py:473
 msgid "Pressure Threshold"
 msgstr ""
 
-#: docking/ui/settings.py:480
+#: docking/ui/settings.py:478
 msgid "Folder Stacks"
 msgstr ""
 
-#: docking/ui/settings.py:482
+#: docking/ui/settings.py:480
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:507
+#: docking/ui/settings.py:505
 msgid "Check Now"
 msgstr ""
 
-#: docking/ui/settings.py:509
+#: docking/ui/settings.py:507
 msgid "View Releases"
 msgstr ""
 
-#: docking/ui/settings.py:521
+#: docking/ui/settings.py:519
 msgid "Update Checks"
 msgstr ""
 
-#: docking/ui/settings.py:523
+#: docking/ui/settings.py:521
 msgid "Check Automatically"
 msgstr ""
 
-#: docking/ui/settings.py:524
+#: docking/ui/settings.py:522
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:525
+#: docking/ui/settings.py:523
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:526
+#: docking/ui/settings.py:524
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:957
+#: docking/ui/settings.py:955
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:961
+#: docking/ui/settings.py:959
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:963
+#: docking/ui/settings.py:961
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:1006
+#: docking/ui/settings.py:1004
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1008
+#: docking/ui/settings.py:1006
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1011
+#: docking/ui/settings.py:1009
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:1013
+#: docking/ui/settings.py:1011
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1015
+#: docking/ui/settings.py:1013
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1017
+#: docking/ui/settings.py:1015
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1020
+#: docking/ui/settings.py:1018
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/tests/applets/test_weather.py
+++ b/tests/applets/test_weather.py
@@ -341,7 +341,13 @@ class TestWeatherMenu:
         assert not any("Remove" in label for label in labels)
 
 
-_SAMPLE_AQI = AirQualityData(aqi=28, pm2_5=8.1, pm10=9.1, label="Fair")
+_SAMPLE_AQI = AirQualityData(
+    aqi=28,
+    pm2_5=8.1,
+    pm10=9.1,
+    label="Fair",
+    uv_index=5.7,
+)
 
 
 class TestAqiLabel:
@@ -379,6 +385,7 @@ class TestAirQualityInTooltip:
         applet._air_quality = _SAMPLE_AQI
         applet.refresh_tooltip()
         assert "Air: Fair" in applet.item.name
+        assert "UV Index: 5.7" in applet.item.name
 
     def test_tooltip_no_aqi_when_unavailable(self):
         applet = _make_applet()
@@ -1024,5 +1031,10 @@ class TestWeatherDialogAndWidget:
         box = applet._build_tooltip_widget()
 
         # Then
-        # city + current + air + 2 daily rows
-        assert len(box.get_children()) >= 5
+        labels = [
+            child._label
+            for child in box.get_children()
+            if isinstance(child, _FakeLabel)
+        ]
+        assert "Air: Fair" in labels
+        assert "UV Index: 5.7" in labels

--- a/tests/applets/test_weather_api.py
+++ b/tests/applets/test_weather_api.py
@@ -126,7 +126,7 @@ class _WeatherResp:
 
 class _AqiResp:
     def __init__(self):
-        self._current = _Current([_Var(37), _Var(15.44), _Var(9.93)])
+        self._current = _Current([_Var(37), _Var(15.44), _Var(9.93), _Var(6.32)])
 
     def Current(self):
         return self._current
@@ -164,9 +164,12 @@ class TestWeatherApiFetch:
         assert aqi_label(120) == "Extremely Poor"
 
     def test_fetch_air_quality_success(self, monkeypatch):
+        calls: list[dict[str, object]] = []
+
         class _Client:
             def weather_api(self, url, params):
-                _ = (url, params)
+                _ = url
+                calls.append(params)
                 return [_AqiResp()]
 
         monkeypatch.setattr(weather_api_mod, "_get_client", lambda: _Client())
@@ -175,7 +178,15 @@ class TestWeatherApiFetch:
         assert data.aqi == 37
         assert data.pm10 == 15.4
         assert data.pm2_5 == 9.9
+        assert data.uv_index == 6.3
         assert data.label == "Fair"
+        assert calls == [
+            {
+                "latitude": 1.0,
+                "longitude": 2.0,
+                "current": ["european_aqi", "pm10", "pm2_5", "uv_index"],
+            }
+        ]
 
     def test_fetch_air_quality_error_returns_none(self, monkeypatch):
         class _Client:


### PR DESCRIPTION
## Summary
- request Open-Meteo uv_index with the weather applet air-quality data
- show UV Index as a separate line under Air in text and rich tooltips
- cover the new payload and tooltip output with tests