### PR TITLE
Fix System Monitor tooltip translations

### DIFF
--- a/docking/locale/af/LC_MESSAGES/docking.po
+++ b/docking/locale/af/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Volgende strek in {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/be/LC_MESSAGES/docking.po
+++ b/docking/locale/be/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Наступная разцяжка праз {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/bg/LC_MESSAGES/docking.po
+++ b/docking/locale/bg/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Следващо разтягане след {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/bn/LC_MESSAGES/docking.po
+++ b/docking/locale/bn/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "পরবর্তী স্ট্রেচ {time}-এ"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/bs/LC_MESSAGES/docking.po
+++ b/docking/locale/bs/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Sljedeće istezanje za {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/ca/LC_MESSAGES/docking.po
+++ b/docking/locale/ca/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Proper estirament en {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/cy/LC_MESSAGES/docking.po
+++ b/docking/locale/cy/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Ymestyniad nesaf mewn {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/da/LC_MESSAGES/docking.po
+++ b/docking/locale/da/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Næste stræk om {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/el/LC_MESSAGES/docking.po
+++ b/docking/locale/el/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Επόμενη διάταση σε {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/en_GB/LC_MESSAGES/docking.po
+++ b/docking/locale/en_GB/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Next stretch in {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/eo/LC_MESSAGES/docking.po
+++ b/docking/locale/eo/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "Sekva streĉado post {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/et/LC_MESSAGES/docking.po
+++ b/docking/locale/et/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Jargmine venitamine {time} parast"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/eu/LC_MESSAGES/docking.po
+++ b/docking/locale/eu/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Hurrengo luzaketa {time} barru"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/fa/LC_MESSAGES/docking.po
+++ b/docking/locale/fa/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "کشش بعدی در {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/fi/LC_MESSAGES/docking.po
+++ b/docking/locale/fi/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Seuraava venyttely {time} kuluttua"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/fil/LC_MESSAGES/docking.po
+++ b/docking/locale/fil/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Susunod na pag-inat sa {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/ga/LC_MESSAGES/docking.po
+++ b/docking/locale/ga/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "An chéad sineadh eile i {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/gl/LC_MESSAGES/docking.po
+++ b/docking/locale/gl/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Seguinte estiramento en {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/gu/LC_MESSAGES/docking.po
+++ b/docking/locale/gu/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "આગળનું ખેંચાણ {time} માં"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/he/LC_MESSAGES/docking.po
+++ b/docking/locale/he/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "מתיחה הבאה בעוד {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/hr/LC_MESSAGES/docking.po
+++ b/docking/locale/hr/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Sljedeće istezanje za {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/hu/LC_MESSAGES/docking.po
+++ b/docking/locale/hu/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Következő nyújtás: {time} múlva"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/id/LC_MESSAGES/docking.po
+++ b/docking/locale/id/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Peregangan berikutnya dalam {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/is/LC_MESSAGES/docking.po
+++ b/docking/locale/is/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Næsta teyging eftir {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/jv/LC_MESSAGES/docking.po
+++ b/docking/locale/jv/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "Peregangan sabanjure ing {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/kk/LC_MESSAGES/docking.po
+++ b/docking/locale/kk/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "Келесі созылу {time} кейін"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/km/LC_MESSAGES/docking.po
+++ b/docking/locale/km/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "ការលាតក្នុង {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/kn/LC_MESSAGES/docking.po
+++ b/docking/locale/kn/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "ಮುಂದಿನ ಸ್ಟ್ರೆಚ್ {time} ನಲ್ಲಿ"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/lt/LC_MESSAGES/docking.po
+++ b/docking/locale/lt/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Kitas tempimas po {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/lv/LC_MESSAGES/docking.po
+++ b/docking/locale/lv/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Nākamā stiepšanās pēc {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/mk/LC_MESSAGES/docking.po
+++ b/docking/locale/mk/LC_MESSAGES/docking.po
@@ -1659,7 +1659,7 @@ msgstr "Следно истегнување за {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/ml/LC_MESSAGES/docking.po
+++ b/docking/locale/ml/LC_MESSAGES/docking.po
@@ -1659,7 +1659,7 @@ msgstr "അടുത്ത സ്ട്രെച്ച് {time}-ല്‍"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/mn/LC_MESSAGES/docking.po
+++ b/docking/locale/mn/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "Дараагийн сунгалт {time}-д"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/mr/LC_MESSAGES/docking.po
+++ b/docking/locale/mr/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "पुढील स्ट्रेच {time} मध्ये"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/ms/LC_MESSAGES/docking.po
+++ b/docking/locale/ms/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Regangan seterusnya dalam {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/mt/LC_MESSAGES/docking.po
+++ b/docking/locale/mt/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Stretching li jmiss fi {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/nb/LC_MESSAGES/docking.po
+++ b/docking/locale/nb/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Neste tøyning om {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/ne/LC_MESSAGES/docking.po
+++ b/docking/locale/ne/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "अर्को स्ट्रेच {time} मा"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/nn/LC_MESSAGES/docking.po
+++ b/docking/locale/nn/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Neste tøying om {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/pa/LC_MESSAGES/docking.po
+++ b/docking/locale/pa/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "ਅਗਲੀ ਸਟ੍ਰੈਚ {time} ਵਿੱਚ"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/pt_PT/LC_MESSAGES/docking.po
+++ b/docking/locale/pt_PT/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Próximo alongamento em {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/ro/LC_MESSAGES/docking.po
+++ b/docking/locale/ro/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Urmatoarea intindere in {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/sl/LC_MESSAGES/docking.po
+++ b/docking/locale/sl/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Naslednja raztezna vaja čez {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/sq/LC_MESSAGES/docking.po
+++ b/docking/locale/sq/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Shtrirja tjetër në {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/sr/LC_MESSAGES/docking.po
+++ b/docking/locale/sr/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Следеће истезање за {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/sv/LC_MESSAGES/docking.po
+++ b/docking/locale/sv/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Nästa stretching om {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/sw/LC_MESSAGES/docking.po
+++ b/docking/locale/sw/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Kunyoosha kujayo katika {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/ta/LC_MESSAGES/docking.po
+++ b/docking/locale/ta/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "அடுத்த நீட்சி {time} இல்"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/te/LC_MESSAGES/docking.po
+++ b/docking/locale/te/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "తదుపరి స్ట్రెచ్ {time} లో"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/th/LC_MESSAGES/docking.po
+++ b/docking/locale/th/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "ยืดเส้นครั้งถัดไปใน {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/tr/LC_MESSAGES/docking.po
+++ b/docking/locale/tr/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "{time} sonra esneme"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/uk/LC_MESSAGES/docking.po
+++ b/docking/locale/uk/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Наступна розтяжка через {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/ur/LC_MESSAGES/docking.po
+++ b/docking/locale/ur/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "اگلی اسٹریچ {time} میں"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/uz/LC_MESSAGES/docking.po
+++ b/docking/locale/uz/LC_MESSAGES/docking.po
@@ -1655,7 +1655,7 @@ msgstr "Keyingi cho'zilish {time} da"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/vi/LC_MESSAGES/docking.po
+++ b/docking/locale/vi/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Lan gian co tiep theo trong {time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/xh/LC_MESSAGES/docking.po
+++ b/docking/locale/xh/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Ukoluleka okulandelayo kwi-{time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/docking/locale/zu/LC_MESSAGES/docking.po
+++ b/docking/locale/zu/LC_MESSAGES/docking.po
@@ -1635,7 +1635,7 @@ msgstr "Ukweluleka okulandelayo ngo-{time}"
 #: docking/applets/systemmonitor/applet.py:51
 #: docking/applets/systemmonitor/state.py:168
 msgid "System Monitor"
-msgstr "CPU Monitor"
+msgstr "System Monitor"
 
 #: docking/applets/systemmonitor/applet.py:85
 msgid "Show Disk Usage"

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import locale
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import docking.i18n as i18n_mod
@@ -26,3 +27,11 @@ def test_init_logs_locale_fallback_and_binds_domain(monkeypatch):
     warning.assert_called_once()
     bindtextdomain.assert_called_once_with(i18n_mod.DOMAIN, str(i18n_mod._LOCALE_DIR))
     textdomain.assert_called_once_with(i18n_mod.DOMAIN)
+
+
+def test_system_monitor_translation_does_not_regress_to_cpu_monitor():
+    for path in Path("docking/locale").glob("*/LC_MESSAGES/docking.po"):
+        text = path.read_text(encoding="utf-8")
+        assert 'msgid "System Monitor"\nmsgstr "CPU Monitor"' not in text, (
+            f"{path} still translates System Monitor as CPU Monitor"
+        )


### PR DESCRIPTION
## Summary
- correct locale entries that translated System Monitor as CPU Monitor
- add an i18n regression test for the System Monitor tooltip title
- validate catalogs after the translation update