### PR TITLE
Show Currency FX chart interval in tooltip

### DIFF
--- a/docking/applets/currencyfx/state.py
+++ b/docking/applets/currencyfx/state.py
@@ -736,11 +736,8 @@ def build_tooltip(
 ) -> str:
     """Build tooltip text."""
     pair = f"{base}/{quote}"
-    verb = (
-        _("Day samples")
-        if normalize_chart_interval(chart_interval) == ChartInterval.DAY
-        else None
-    )
+    interval = normalize_chart_interval(chart_interval)
+    verb = _("Day samples") if interval == ChartInterval.DAY else None
     state_error = error or (_("Unavailable") if fetch_failed else None)
     status = resolve_live_status(
         has_data=snapshot is not None,
@@ -767,7 +764,10 @@ def build_tooltip(
             rate=format_rate(snapshot.rate),
             quote=snapshot.quote,
         ),
-        details=(_("Change: {change}").format(change=format_change(snapshot.points)),),
+        details=(
+            _("Interval: {interval}").format(interval=interval.value.title()),
+            _("Change: {change}").format(change=format_change(snapshot.points)),
+        ),
         freshness=live_freshness_lines(
             status=status,
             updated_at=snapshot.fetched_at,

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-05-23 19:05+0200\n"
+"POT-Creation-Date: 2026-05-24 00:08+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -872,17 +872,22 @@ msgstr ""
 msgid "Quote"
 msgstr ""
 
-#: docking/applets/currencyfx/state.py:744 docking/applets/live_state.py:91
+#: docking/applets/currencyfx/state.py:741 docking/applets/live_state.py:91
 #: docking/applets/weather/state.py:180
 msgid "Unavailable"
 msgstr ""
 
-#: docking/applets/currencyfx/state.py:765
+#: docking/applets/currencyfx/state.py:762
 #, python-brace-format
 msgid "1 {base} = {rate} {quote}"
 msgstr ""
 
-#: docking/applets/currencyfx/state.py:770
+#: docking/applets/currencyfx/state.py:768
+#, python-brace-format
+msgid "Interval: {interval}"
+msgstr ""
+
+#: docking/applets/currencyfx/state.py:769
 #, python-brace-format
 msgid "Change: {change}"
 msgstr ""

--- a/tests/applets/test_currencyfx.py
+++ b/tests/applets/test_currencyfx.py
@@ -597,6 +597,8 @@ class TestCurrencyFxState:
         )
         assert "EUR/USD" in tooltip
         assert "1 EUR = 1.1 USD" in tooltip
+        assert "Interval: Week" in tooltip
+        assert "Change: +1.85%" in tooltip
         assert "Updated:" in tooltip
         assert "Updates every 15 minutes" in tooltip
 
@@ -611,6 +613,7 @@ class TestCurrencyFxState:
         )
 
         assert "Day samples every 15 minutes" in tooltip
+        assert "Interval: Day" in tooltip
 
     def test_build_tooltip_empty_and_error_states(self):
         text = build_tooltip(


### PR DESCRIPTION
## Summary
- add the selected chart interval to Currency FX tooltip details
- reuse the normalized interval for day-sample cadence wording
- update Currency FX tooltip tests