### PR TITLE
Add optional alphabetical sorting for context menu window list

### DIFF
--- a/docking/core/config.py
+++ b/docking/core/config.py
@@ -459,9 +459,23 @@ class FolderStackUnfold(str, Enum):
     HOVER = "hover"
 
 
+class WindowListSort(str, Enum):
+    """Sort order for open windows in the right-click context menu.
+
+    Mode           Behavior
+    ─────────────  ──────────────────────────────────────────────────────
+    DEFAULT        Windows appear in scan order (the order they were discovered).
+    ALPHABETICAL   Windows are sorted alphabetically by title.
+    """
+
+    DEFAULT = "default"
+    ALPHABETICAL = "alphabetical"
+
+
 DEFAULT_LEFT_CLICK_ACTION = LeftClickAction.TOGGLE.value
 DEFAULT_MIDDLE_CLICK_ACTION = MiddleClickAction.NEW_WINDOW.value
 DEFAULT_FOLDER_STACK_UNFOLD = FolderStackUnfold.HOVER.value
+DEFAULT_WINDOW_LIST_SORT = WindowListSort.DEFAULT.value
 DEFAULT_SHOW_WINDOW_COUNT_NUMBERS = False
 
 
@@ -505,6 +519,20 @@ def _normalize_folder_stack_unfold(value: object) -> str:
                 exc,
             )
     return DEFAULT_FOLDER_STACK_UNFOLD
+
+
+def _normalize_window_list_sort(value: object) -> str:
+    if isinstance(value, str):
+        try:
+            return WindowListSort(value=value).value
+        except ValueError as exc:
+            logger.warning(
+                "Invalid window list sort %r; using default %r (%s)",
+                value,
+                DEFAULT_WINDOW_LIST_SORT,
+                exc,
+            )
+    return DEFAULT_WINDOW_LIST_SORT
 
 
 @dataclass
@@ -733,6 +761,8 @@ class Config:
     middle_click_action: str = DEFAULT_MIDDLE_CLICK_ACTION
     # How pinned folder stacks open from the dock
     folder_stack_unfold: str = DEFAULT_FOLDER_STACK_UNFOLD
+    # Sort order for open windows in the right-click context menu
+    window_list_sort: str = DEFAULT_WINDOW_LIST_SORT
     # Whether running application indicators show a numeric window count
     show_window_count_numbers: bool = DEFAULT_SHOW_WINDOW_COUNT_NUMBERS
     # Theme name (loads from assets/themes/{name}.json)
@@ -864,6 +894,9 @@ class Config:
         )
         self.folder_stack_unfold = _normalize_folder_stack_unfold(
             self.folder_stack_unfold,
+        )
+        self.window_list_sort = _normalize_window_list_sort(
+            self.window_list_sort,
         )
         self.show_window_count_numbers = _normalize_bool(
             self.show_window_count_numbers,

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-05-26 09:05+0200\n"
+"POT-Creation-Date: 2026-05-27 09:19-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1207,7 +1207,7 @@ msgid "{verb} every {interval}"
 msgstr ""
 
 #: docking/applets/freshness.py:42 docking/applets/freshness.py:49
-#: docking/ui/settings.py:218
+#: docking/ui/settings.py:220
 msgid "Updates"
 msgstr ""
 
@@ -2435,76 +2435,76 @@ msgstr ""
 msgid "%d More in Folder"
 msgstr ""
 
-#: docking/ui/menu.py:390
+#: docking/ui/menu.py:391
 msgid "Icon"
 msgstr ""
 
-#: docking/ui/menu.py:392
+#: docking/ui/menu.py:393
 msgid "Docking Icon"
 msgstr ""
 
-#: docking/ui/menu.py:393
+#: docking/ui/menu.py:394
 msgid "System Icon"
 msgstr ""
 
-#: docking/ui/menu.py:436 docking/ui/menu.py:456 docking/ui/menu.py:472
-#: docking/ui/menu.py:520
+#: docking/ui/menu.py:437 docking/ui/menu.py:457 docking/ui/menu.py:473
+#: docking/ui/menu.py:521
 msgid "Remove from Dock"
 msgstr ""
 
-#: docking/ui/menu.py:449
+#: docking/ui/menu.py:450
 msgid "Open"
 msgstr ""
 
-#: docking/ui/menu.py:479
+#: docking/ui/menu.py:480
 msgid "Keep in Dock"
 msgstr ""
 
-#: docking/ui/menu.py:488
+#: docking/ui/menu.py:489
 msgid "Close All"
 msgstr ""
 
-#: docking/ui/menu.py:488
+#: docking/ui/menu.py:489
 msgid "Close"
 msgstr ""
 
-#: docking/ui/menu.py:505
+#: docking/ui/menu.py:506
 msgid "Sort By"
 msgstr ""
 
-#: docking/ui/menu.py:513
+#: docking/ui/menu.py:514
 msgid "Show Hidden Files"
 msgstr ""
 
-#: docking/ui/menu.py:550
+#: docking/ui/menu.py:551
 msgid "Add Applet"
 msgstr ""
 
-#: docking/ui/menu.py:588
+#: docking/ui/menu.py:589
 msgid "No Applets Available"
 msgstr ""
 
-#: docking/ui/menu.py:595
+#: docking/ui/menu.py:596
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:605 docking/ui/settings.py:191
+#: docking/ui/menu.py:606 docking/ui/settings.py:193
 msgid "Preferences"
 msgstr ""
 
-#: docking/ui/menu.py:610
+#: docking/ui/menu.py:611
 msgid "About"
 msgstr ""
 
-#: docking/ui/menu.py:615
+#: docking/ui/menu.py:616
 msgid "Get Support"
 msgstr ""
 
-#: docking/ui/menu.py:622
+#: docking/ui/menu.py:623
 msgid "Quit"
 msgstr ""
 
-#: docking/ui/menu.py:659
+#: docking/ui/menu.py:667
 msgid "Window"
 msgstr ""
 
@@ -2518,272 +2518,284 @@ msgstr ""
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-#: docking/ui/settings.py:215
+#: docking/ui/settings.py:217
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:216 docking/ui/settings.py:464
+#: docking/ui/settings.py:218 docking/ui/settings.py:475
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:217
+#: docking/ui/settings.py:219
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:241
+#: docking/ui/settings.py:243
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:242
+#: docking/ui/settings.py:244
 msgid "Always on Top"
 msgstr ""
 
-#: docking/ui/settings.py:243
+#: docking/ui/settings.py:245
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:244
+#: docking/ui/settings.py:246
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:245
+#: docking/ui/settings.py:247
 msgid "Dodge Active"
 msgstr ""
 
-#: docking/ui/settings.py:246
+#: docking/ui/settings.py:248
 msgid "Dodge Windows"
 msgstr ""
 
-#: docking/ui/settings.py:247
+#: docking/ui/settings.py:249
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:260
 msgid "Toggle Focus"
 msgstr ""
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:261
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:262
 msgid "Most Recent Window"
 msgstr ""
 
-#: docking/ui/settings.py:267
+#: docking/ui/settings.py:269
 msgid "New Window"
 msgstr ""
 
-#: docking/ui/settings.py:268
+#: docking/ui/settings.py:270
 msgid "Minimize Windows"
 msgstr ""
 
-#: docking/ui/settings.py:269
+#: docking/ui/settings.py:271
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:276
+#: docking/ui/settings.py:278
 msgid "Click"
 msgstr ""
 
-#: docking/ui/settings.py:277
+#: docking/ui/settings.py:279
 msgid "Hover"
 msgstr ""
 
-#: docking/ui/settings.py:294
+#: docking/ui/settings.py:286
+msgid "Default"
+msgstr ""
+
+#: docking/ui/settings.py:287
+msgid "Alphabetical"
+msgstr ""
+
+#: docking/ui/settings.py:304
 msgid "Daily"
 msgstr ""
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:305
 msgid "Weekly"
 msgstr ""
 
-#: docking/ui/settings.py:345
+#: docking/ui/settings.py:355
 msgid "Added on top of the theme's own distance from the edge."
 msgstr ""
 
-#: docking/ui/settings.py:383
+#: docking/ui/settings.py:393
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:385
+#: docking/ui/settings.py:395
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:386
+#: docking/ui/settings.py:396
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:387
+#: docking/ui/settings.py:397
 msgid "Transparency"
 msgstr ""
 
-#: docking/ui/settings.py:388
+#: docking/ui/settings.py:398
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:389
+#: docking/ui/settings.py:399
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:390
+#: docking/ui/settings.py:400
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:391
+#: docking/ui/settings.py:401
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:397
+#: docking/ui/settings.py:407
 msgid "Placement"
 msgstr ""
 
-#: docking/ui/settings.py:399
+#: docking/ui/settings.py:409
 msgid "Position"
 msgstr ""
 
-#: docking/ui/settings.py:400
+#: docking/ui/settings.py:410
 msgid "Extra Distance from Edge"
 msgstr ""
 
-#: docking/ui/settings.py:401
+#: docking/ui/settings.py:411
 msgid "Follow Cursor"
 msgstr ""
 
-#: docking/ui/settings.py:402
+#: docking/ui/settings.py:412
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:407
+#: docking/ui/settings.py:417
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:409
+#: docking/ui/settings.py:419
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:410
+#: docking/ui/settings.py:420
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:411
+#: docking/ui/settings.py:421
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:434
+#: docking/ui/settings.py:444
 msgid ""
 "Pixels of cursor pressure against the edge required to reveal a hidden dock. "
 "Higher values mean the dock will not reveal as easily."
 msgstr ""
 
-#: docking/ui/settings.py:456
+#: docking/ui/settings.py:466
 msgid "Mouse"
 msgstr ""
 
-#: docking/ui/settings.py:458
+#: docking/ui/settings.py:468
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:459
+#: docking/ui/settings.py:469
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:466
-msgid "Hide Mode"
-msgstr ""
-
-#: docking/ui/settings.py:467
-msgid "Hide Delay"
-msgstr ""
-
-#: docking/ui/settings.py:468
-msgid "Unhide Delay"
-msgstr ""
-
-#: docking/ui/settings.py:469
-msgid "Pressure Reveal"
-msgstr ""
-
 #: docking/ui/settings.py:470
-msgid "Pressure Threshold"
-msgstr ""
-
-#: docking/ui/settings.py:475
-msgid "Folder Stacks"
+msgid "Window List Sort"
 msgstr ""
 
 #: docking/ui/settings.py:477
+msgid "Hide Mode"
+msgstr ""
+
+#: docking/ui/settings.py:478
+msgid "Hide Delay"
+msgstr ""
+
+#: docking/ui/settings.py:479
+msgid "Unhide Delay"
+msgstr ""
+
+#: docking/ui/settings.py:480
+msgid "Pressure Reveal"
+msgstr ""
+
+#: docking/ui/settings.py:481
+msgid "Pressure Threshold"
+msgstr ""
+
+#: docking/ui/settings.py:486
+msgid "Folder Stacks"
+msgstr ""
+
+#: docking/ui/settings.py:488
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:516
+#: docking/ui/settings.py:527
 msgid "Check Now"
 msgstr ""
 
-#: docking/ui/settings.py:518
+#: docking/ui/settings.py:529
 msgid "View Releases"
 msgstr ""
 
-#: docking/ui/settings.py:530
+#: docking/ui/settings.py:541
 msgid "Update Checks"
 msgstr ""
 
-#: docking/ui/settings.py:532
+#: docking/ui/settings.py:543
 msgid "Check Automatically"
 msgstr ""
 
-#: docking/ui/settings.py:533
+#: docking/ui/settings.py:544
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:534
+#: docking/ui/settings.py:545
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:535
+#: docking/ui/settings.py:546
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:966
+#: docking/ui/settings.py:981
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:970
+#: docking/ui/settings.py:985
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:972
+#: docking/ui/settings.py:987
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:1015
+#: docking/ui/settings.py:1030
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1017
+#: docking/ui/settings.py:1032
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1020
+#: docking/ui/settings.py:1035
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:1022
+#: docking/ui/settings.py:1037
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1024
+#: docking/ui/settings.py:1039
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1026
+#: docking/ui/settings.py:1041
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1029
+#: docking/ui/settings.py:1044
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -177,6 +177,7 @@ from docking.applets.identity import (
 )
 from docking.applets.identity import is_applet_desktop_id as is_applet
 from docking.applets.separator import meta as _separator_meta
+from docking.core.config import WindowListSort
 from docking.core.items import FILE_KIND, FOLDER_KIND
 from docking.i18n import _
 from docking.log import get_logger
@@ -648,6 +649,13 @@ class MenuHandler:
         windows = self._tracker.get_windows_for(desktop_id=desktop_id)
         if not windows:
             return
+        if self._config.window_list_sort == WindowListSort.ALPHABETICAL.value:
+            windows = sorted(
+                windows,
+                key=lambda w: (
+                    self._tracker.get_window_title_for_xid(w.get_xid()) or ""
+                ).lower(),
+            )
         for window in windows:
             menu.append(self._build_window_menu_row(window=window))
         separator = Gtk.SeparatorMenuItem()

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -69,6 +69,7 @@ from docking.core.config import (
     FolderStackUnfold,
     LeftClickAction,
     MiddleClickAction,
+    WindowListSort,
 )
 from docking.core.position import Position
 from docking.core.theme import Theme, list_theme_names
@@ -150,6 +151,7 @@ class SettingsWindowController:
         self._left_click_combo: Any = None
         self._middle_click_combo: Any = None
         self._folder_stack_unfold_combo: Any = None
+        self._window_list_sort_combo: Any = None
         self._window_count_numbers_switch: Any = None
         self._previews_switch: Any = None
         self._tooltips_switch: Any = None
@@ -277,6 +279,14 @@ class SettingsWindowController:
             (FolderStackUnfold.HOVER.value, _("Hover")),
         ]:
             self._folder_stack_unfold_combo.append(mode_value, mode_label)
+
+        self._window_list_sort_combo = Gtk.ComboBoxText()
+        self._window_list_sort_combo.set_size_request(HIDE_MODE_COMBO_WIDTH_PX, -1)
+        for sort_value, sort_label in [
+            (WindowListSort.DEFAULT.value, _("Default")),
+            (WindowListSort.ALPHABETICAL.value, _("Alphabetical")),
+        ]:
+            self._window_list_sort_combo.append(sort_value, sort_label)
 
         self._previews_switch = self._new_switch()
         self._tooltips_switch = self._new_switch()
@@ -457,6 +467,7 @@ class SettingsWindowController:
             rows=[
                 (_("Left Click"), self._left_click_combo),
                 (_("Middle Click"), self._middle_click_combo),
+                (_("Window List Sort"), self._window_list_sort_combo),
             ],
         )
         self._append_section(
@@ -623,6 +634,10 @@ class SettingsWindowController:
             self._register_choice_binding(
                 config_attr="folder_stack_unfold",
                 widget=self._folder_stack_unfold_combo,
+            ),
+            self._register_choice_binding(
+                config_attr="window_list_sort",
+                widget=self._window_list_sort_combo,
             ),
             self._register_switch_binding(
                 config_attr="show_window_count_numbers",

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -38,6 +38,7 @@ class TestConfigDefaults:
         assert c.left_click_action == "toggle"
         assert c.middle_click_action == "new-window"
         assert c.folder_stack_unfold == "hover"
+        assert c.window_list_sort == "default"
         assert c.show_window_count_numbers is False
         assert c.theme == "default"
         assert c.transparency == 1.0
@@ -261,6 +262,7 @@ class TestConfigLoad:
                     "left_click_action": "cycle",
                     "middle_click_action": "minimize",
                     "folder_stack_unfold": "hover",
+                    "window_list_sort": "alphabetical",
                     "show_window_count_numbers": "true",
                 }
             )
@@ -275,6 +277,7 @@ class TestConfigLoad:
         assert config.left_click_action == "cycle"
         assert config.middle_click_action == "minimize"
         assert config.folder_stack_unfold == "hover"
+        assert config.window_list_sort == "alphabetical"
         assert config.show_window_count_numbers is True
 
     def test_load_clamps_transparency_to_minimum(self, tmp_path):
@@ -293,6 +296,7 @@ class TestConfigLoad:
                     "left_click_action": "explode",
                     "middle_click_action": "quit-all",
                     "folder_stack_unfold": "peek",
+                    "window_list_sort": "reverse",
                 }
             )
         )
@@ -302,6 +306,7 @@ class TestConfigLoad:
         assert config.left_click_action == "toggle"
         assert config.middle_click_action == "new-window"
         assert config.folder_stack_unfold == "hover"
+        assert config.window_list_sort == "default"
 
     def test_load_ignores_legacy_autohide_key(self, tmp_path):
         path = tmp_path / "dock.json"
@@ -494,6 +499,15 @@ class TestConfigSave:
 
         saved = json.loads(path.read_text())
         assert saved["folder_stack_unfold"] == "hover"
+
+    def test_save_persists_window_list_sort(self, tmp_path):
+        path = tmp_path / "dock.json"
+        config = Config(window_list_sort="alphabetical")
+
+        config.save(path)
+
+        saved = json.loads(path.read_text())
+        assert saved["window_list_sort"] == "alphabetical"
 
     def test_save_persists_show_window_count_numbers(self, tmp_path):
         path = tmp_path / "dock.json"

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -1133,9 +1133,7 @@ class TestItemMenus:
         row.activate()
         handler._tracker.activate_xid.assert_called_once_with(7)
 
-    def test_window_list_default_preserves_tracker_order(
-        self, handler, monkeypatch
-    ):
+    def test_window_list_default_preserves_tracker_order(self, handler, monkeypatch):
         menu = FakeMenu()
         item = DockItem(
             desktop_id="code.desktop",
@@ -1162,9 +1160,7 @@ class TestItemMenus:
         labels = [r.get_child().children[1].label for r in rows]
         assert labels == ["Charlie", "Alpha", "Bravo"]
 
-    def test_window_list_alphabetical_sorts_by_title(
-        self, handler, monkeypatch
-    ):
+    def test_window_list_alphabetical_sorts_by_title(self, handler, monkeypatch):
         menu = FakeMenu()
         item = DockItem(
             desktop_id="code.desktop",

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -735,6 +735,7 @@ def handler(monkeypatch):
         pos="bottom",
         position="bottom",
         item_prefs={},
+        window_list_sort="default",
         save=MagicMock(),
     )
     tracker = MagicMock()
@@ -1131,6 +1132,64 @@ class TestItemMenus:
 
         row.activate()
         handler._tracker.activate_xid.assert_called_once_with(7)
+
+    def test_window_list_default_preserves_tracker_order(
+        self, handler, monkeypatch
+    ):
+        menu = FakeMenu()
+        item = DockItem(
+            desktop_id="code.desktop",
+            is_running=True,
+            instance_count=3,
+        )
+        w1, w2, w3 = MagicMock(), MagicMock(), MagicMock()
+        w1.get_xid.return_value = 1
+        w2.get_xid.return_value = 2
+        w3.get_xid.return_value = 3
+        handler._tracker.get_windows_for.return_value = [w1, w2, w3]
+        handler._tracker.get_window_title_for_xid.side_effect = {
+            1: "Charlie",
+            2: "Alpha",
+            3: "Bravo",
+        }.get
+        handler._config.window_list_sort = "default"
+        monkeypatch.setattr(menu_mod, "capture_window", lambda **_kwargs: None)
+        monkeypatch.setattr(menu_mod.launcher_mod, "get_actions", lambda **_kwargs: [])
+
+        handler._build_item_menu(menu=menu, item=item)
+
+        rows = [c for c in menu.children if getattr(c, "_window_row", False)]
+        labels = [r.get_child().children[1].label for r in rows]
+        assert labels == ["Charlie", "Alpha", "Bravo"]
+
+    def test_window_list_alphabetical_sorts_by_title(
+        self, handler, monkeypatch
+    ):
+        menu = FakeMenu()
+        item = DockItem(
+            desktop_id="code.desktop",
+            is_running=True,
+            instance_count=3,
+        )
+        w1, w2, w3 = MagicMock(), MagicMock(), MagicMock()
+        w1.get_xid.return_value = 1
+        w2.get_xid.return_value = 2
+        w3.get_xid.return_value = 3
+        handler._tracker.get_windows_for.return_value = [w1, w2, w3]
+        handler._tracker.get_window_title_for_xid.side_effect = {
+            1: "Charlie",
+            2: "Alpha",
+            3: "Bravo",
+        }.get
+        handler._config.window_list_sort = "alphabetical"
+        monkeypatch.setattr(menu_mod, "capture_window", lambda **_kwargs: None)
+        monkeypatch.setattr(menu_mod.launcher_mod, "get_actions", lambda **_kwargs: [])
+
+        handler._build_item_menu(menu=menu, item=item)
+
+        rows = [c for c in menu.children if getattr(c, "_window_row", False)]
+        labels = [r.get_child().children[1].label for r in rows]
+        assert labels == ["Alpha", "Bravo", "Charlie"]
 
 
 class TestDockMenu:

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -511,6 +511,7 @@ def _config():
         left_click_action="toggle",
         middle_click_action="new-window",
         folder_stack_unfold="click",
+        window_list_sort="default",
         show_window_count_numbers=False,
         lock_icons=False,
         current_workspace_only=False,
@@ -782,6 +783,28 @@ class TestSettingsWindowController:
         assert config.folder_stack_unfold == "hover"
         config.save.assert_called_once()
         runtime.assert_not_called()
+
+    def test_window_list_sort_binding_updates_config(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        runtime = MagicMock()
+        config = _config()
+        controller = settings_mod.SettingsWindowController(
+            parent=object(),
+            runtime=runtime,
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=config,
+        )
+
+        controller.show()
+        controller._window_list_sort_combo.set_active_id("alphabetical")
+        controller._window_list_sort_combo.emit_changed()
+
+        assert config.window_list_sort == "alphabetical"
+        config.save.assert_called_once()
 
     def test_show_window_count_numbers_binding_updates_config_and_redraws(
         self, monkeypatch


### PR DESCRIPTION
When apps have many open windows, the right-click window list is hard to scan because windows appear in discovery order. This adds a "Window List Sort" option (Preferences > Behavior > Mouse) that lets users sort the list alphabetically by title.

Default behavior is unchanged: the option defaults to "default" (scan order). Setting it to "alphabetical" sorts window entries by title, case-insensitive. The left-click action
(toggle/cycle/most-recent) is a separate code path and is not affected.

- New WindowListSort enum in config with "default" and "alphabetical"
- Config plumbing: default constant, normalizer, dataclass field, __post_init__ normalization (same pattern as LeftClickAction)
- Sorting in MenuHandler._append_open_windows: only the right-click menu, not preview thumbnails
- ComboBox in Preferences > Behavior > Mouse section with binding
- POT regenerated with 3 new translatable strings
- Backward compatible: missing key gets default; unknown key on older builds is silently ignored

Screenshot showing the results (Sorry for the filter, but you get the idea!)

<img width="804" height="1490" alt="image" src="https://github.com/user-attachments/assets/1e6bc558-fd0d-4dc4-9103-c00b6662de49" />
