### PR TITLE
Move pressure threshold help to info tooltip

### DIFF
--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-05-28 19:50+0200\n"
+"POT-Creation-Date: 2026-05-28 20:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2593,7 +2593,7 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:218 docking/ui/settings.py:475
+#: docking/ui/settings.py:218 docking/ui/settings.py:477
 msgid "Behavior"
 msgstr ""
 
@@ -2681,192 +2681,192 @@ msgstr ""
 msgid "Added on top of the theme's own distance from the edge."
 msgstr ""
 
-#: docking/ui/settings.py:393
-msgid "Look"
-msgstr ""
-
 #: docking/ui/settings.py:395
-msgid "Theme"
-msgstr ""
-
-#: docking/ui/settings.py:396
-msgid "Icon Size"
-msgstr ""
-
-#: docking/ui/settings.py:397
-msgid "Transparency"
-msgstr ""
-
-#: docking/ui/settings.py:398
-msgid "Zoom"
-msgstr ""
-
-#: docking/ui/settings.py:399
-msgid "Zoom Percent"
-msgstr ""
-
-#: docking/ui/settings.py:400
-msgid "Show Tooltips"
-msgstr ""
-
-#: docking/ui/settings.py:401
-msgid "Window Previews"
-msgstr ""
-
-#: docking/ui/settings.py:407
-msgid "Placement"
-msgstr ""
-
-#: docking/ui/settings.py:409
-msgid "Position"
-msgstr ""
-
-#: docking/ui/settings.py:410
-msgid "Extra Distance from Edge"
-msgstr ""
-
-#: docking/ui/settings.py:411
-msgid "Follow Cursor"
-msgstr ""
-
-#: docking/ui/settings.py:412
-msgid "Current Workspace Only"
-msgstr ""
-
-#: docking/ui/settings.py:417
-msgid "Layout"
-msgstr ""
-
-#: docking/ui/settings.py:419
-msgid "Lock Positions"
-msgstr ""
-
-#: docking/ui/settings.py:420
-msgid "Anchor Applets to End"
-msgstr ""
-
-#: docking/ui/settings.py:421
-msgid "Anchor Files to End"
-msgstr ""
-
-#: docking/ui/settings.py:444
 msgid ""
 "Pixels of cursor pressure against the edge required to reveal a hidden dock. "
 "Higher values mean the dock will not reveal as easily."
 msgstr ""
 
-#: docking/ui/settings.py:466
-msgid "Mouse"
+#: docking/ui/settings.py:405
+msgid "Look"
+msgstr ""
+
+#: docking/ui/settings.py:407
+msgid "Theme"
+msgstr ""
+
+#: docking/ui/settings.py:408
+msgid "Icon Size"
+msgstr ""
+
+#: docking/ui/settings.py:409
+msgid "Transparency"
+msgstr ""
+
+#: docking/ui/settings.py:410
+msgid "Zoom"
+msgstr ""
+
+#: docking/ui/settings.py:411
+msgid "Zoom Percent"
+msgstr ""
+
+#: docking/ui/settings.py:412
+msgid "Show Tooltips"
+msgstr ""
+
+#: docking/ui/settings.py:413
+msgid "Window Previews"
+msgstr ""
+
+#: docking/ui/settings.py:419
+msgid "Placement"
+msgstr ""
+
+#: docking/ui/settings.py:421
+msgid "Position"
+msgstr ""
+
+#: docking/ui/settings.py:422
+msgid "Extra Distance from Edge"
+msgstr ""
+
+#: docking/ui/settings.py:423
+msgid "Follow Cursor"
+msgstr ""
+
+#: docking/ui/settings.py:424
+msgid "Current Workspace Only"
+msgstr ""
+
+#: docking/ui/settings.py:429
+msgid "Layout"
+msgstr ""
+
+#: docking/ui/settings.py:431
+msgid "Lock Positions"
+msgstr ""
+
+#: docking/ui/settings.py:432
+msgid "Anchor Applets to End"
+msgstr ""
+
+#: docking/ui/settings.py:433
+msgid "Anchor Files to End"
 msgstr ""
 
 #: docking/ui/settings.py:468
-msgid "Left Click"
-msgstr ""
-
-#: docking/ui/settings.py:469
-msgid "Middle Click"
+msgid "Mouse"
 msgstr ""
 
 #: docking/ui/settings.py:470
+msgid "Left Click"
+msgstr ""
+
+#: docking/ui/settings.py:471
+msgid "Middle Click"
+msgstr ""
+
+#: docking/ui/settings.py:472
 msgid "Window List Sort"
 msgstr ""
 
-#: docking/ui/settings.py:477
+#: docking/ui/settings.py:479
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:478
+#: docking/ui/settings.py:480
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:479
+#: docking/ui/settings.py:481
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:480
+#: docking/ui/settings.py:482
 msgid "Pressure Reveal"
 msgstr ""
 
-#: docking/ui/settings.py:481
+#: docking/ui/settings.py:483
 msgid "Pressure Threshold"
 msgstr ""
 
-#: docking/ui/settings.py:486
+#: docking/ui/settings.py:488
 msgid "Folder Stacks"
 msgstr ""
 
-#: docking/ui/settings.py:488
+#: docking/ui/settings.py:490
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:527
+#: docking/ui/settings.py:529
 msgid "Check Now"
 msgstr ""
 
-#: docking/ui/settings.py:529
+#: docking/ui/settings.py:531
 msgid "View Releases"
 msgstr ""
 
-#: docking/ui/settings.py:541
+#: docking/ui/settings.py:543
 msgid "Update Checks"
 msgstr ""
 
-#: docking/ui/settings.py:543
+#: docking/ui/settings.py:545
 msgid "Check Automatically"
 msgstr ""
 
-#: docking/ui/settings.py:544
+#: docking/ui/settings.py:546
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:545
+#: docking/ui/settings.py:547
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:546
+#: docking/ui/settings.py:548
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:981
+#: docking/ui/settings.py:983
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:985
+#: docking/ui/settings.py:987
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:987
+#: docking/ui/settings.py:989
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:1030
+#: docking/ui/settings.py:1032
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1032
+#: docking/ui/settings.py:1034
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1035
+#: docking/ui/settings.py:1037
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:1037
+#: docking/ui/settings.py:1039
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1039
+#: docking/ui/settings.py:1041
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1041
+#: docking/ui/settings.py:1043
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1044
+#: docking/ui/settings.py:1046
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -103,7 +103,6 @@ ROW_SPACING_PX = 12
 HIDE_MODE_COMBO_WIDTH_PX = 180
 HIDE_MODE_INFO_ICON_WIDTH_PX = 14
 TRANSPARENCY_SCALE_WIDTH_PX = 132
-DESCRIPTION_MAX_CHARS = 28
 HIDE_MODE_BOX_SPACING_PX = 4
 APPLET_GRID_COLUMN_SPACING_PX = 16
 APPLET_GRID_ROW_SPACING_PX = 8
@@ -169,6 +168,7 @@ class SettingsWindowController:
         self._additional_distance_info: Any = None
         self._pressure_reveal_switch: Any = None
         self._pressure_threshold_scale: Any = None
+        self._pressure_threshold_info: Any = None
         self._zoom_percent_spin: Any = None
         self._hide_delay_spin: Any = None
         self._unhide_delay_spin: Any = None
@@ -384,7 +384,19 @@ class SettingsWindowController:
         )
         self._pressure_threshold_scale.set_digits(0)
         self._pressure_threshold_scale.set_draw_value(True)
-        self._pressure_threshold_scale.set_size_request(TRANSPARENCY_SCALE_WIDTH_PX, -1)
+        self._pressure_threshold_scale.set_size_request(
+            TRANSPARENCY_SCALE_WIDTH_PX
+            - HIDE_MODE_INFO_ICON_WIDTH_PX
+            - HIDE_MODE_BOX_SPACING_PX,
+            -1,
+        )
+        self._pressure_threshold_info = self._new_info_icon(
+            _(
+                "Pixels of cursor pressure against the edge required to "
+                "reveal a hidden dock. Higher values mean the dock will not "
+                "reveal as easily."
+            )
+        )
 
         self._register_bindings()
 
@@ -439,27 +451,17 @@ class SettingsWindowController:
         hide_mode_box.pack_start(self._hide_mode_combo, True, True, 0)
         hide_mode_box.pack_start(self._hide_mode_info, False, False, 0)
 
-        pressure_threshold_desc = Gtk.Label(
-            label=_(
-                "Pixels of cursor pressure against the edge required to "
-                "reveal a hidden dock. Higher values mean the dock will not "
-                "reveal as easily."
-            ),
-        )
-        pressure_threshold_desc.set_xalign(0.0)
-        pressure_threshold_desc.set_line_wrap(True)
-        pressure_threshold_desc.set_line_wrap_mode(2)
-        pressure_threshold_desc.set_max_width_chars(DESCRIPTION_MAX_CHARS)
-        pressure_threshold_desc.get_style_context().add_class("dim-label")
         pressure_threshold_box = Gtk.Box(
-            orientation=Gtk.Orientation.VERTICAL,
+            orientation=Gtk.Orientation.HORIZONTAL,
             spacing=HIDE_MODE_BOX_SPACING_PX,
         )
         pressure_threshold_box.set_size_request(TRANSPARENCY_SCALE_WIDTH_PX, -1)
         pressure_threshold_box.pack_start(
             self._pressure_threshold_scale, False, False, 0
         )
-        pressure_threshold_box.pack_start(pressure_threshold_desc, False, False, 0)
+        pressure_threshold_box.pack_start(
+            self._pressure_threshold_info, False, False, 0
+        )
 
         self._append_section(
             outer=outer,

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -674,6 +674,50 @@ class TestSettingsWindowController:
         assert "Unhide Delay" in behavior_rows
         assert "Open On" in behavior_rows
 
+    def test_pressure_threshold_uses_info_icon_tooltip(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        controller = settings_mod.SettingsWindowController(
+            parent=object(),
+            runtime=MagicMock(),
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=_config(),
+        )
+
+        controller.show()
+        stack = controller._window.child.children[1]
+        behavior_box = stack.pages[1][0]
+
+        pressure_row = None
+        for section in behavior_box.get_children():
+            if not isinstance(section, FakeBox):
+                continue
+            children = section.get_children()
+            if len(children) < 2 or not isinstance(children[1], FakeBox):
+                continue
+            for row in children[1].get_children():
+                if not isinstance(row, FakeBox) or not row.get_children():
+                    continue
+                title = row.get_children()[0]
+                if isinstance(title, FakeLabel) and title.get_label() == (
+                    "Pressure Threshold"
+                ):
+                    pressure_row = row
+                    break
+
+        assert pressure_row is not None
+        pressure_box = pressure_row.get_children()[1]
+        assert isinstance(pressure_box, FakeBox)
+        assert pressure_box.get_children() == [
+            controller._pressure_threshold_scale,
+            controller._pressure_threshold_info,
+        ]
+        assert isinstance(controller._pressure_threshold_info, FakeEventBox)
+        assert "cursor pressure" in controller._pressure_threshold_info.tooltip_text
+
     def test_theme_change_updates_config_and_runtime(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Replace the visible Pressure Threshold helper text with an info icon tooltip.
- Keep the tooltip text aligned with the existing explanation.
- Add settings coverage for the info icon layout.