### PR TITLE
Add battery power and peripheral details

### DIFF
--- a/docking/applets/battery/applet.py
+++ b/docking/applets/battery/applet.py
@@ -26,23 +26,38 @@ from gi.repository import GdkPixbuf, GLib, Gtk
 
 from docking.applets.base import Applet
 from docking.applets.battery import meta
+from docking.applets.battery.peripherals import (
+    PeripheralBattery,
+    read_peripheral_batteries,
+    tooltip_lines,
+)
 from docking.applets.battery.render import render_icon
 from docking.applets.battery.state import (
+    OVERLAY_NONE,
+    OVERLAY_PERCENT,
+    OVERLAY_POWER,
     BatteryState,
     open_power_settings,
+    overlay_from_prefs,
     power_settings_command,
     read_battery,
+    read_power_watts,
     tooltip_text,
 )
-from docking.applets.menu import menu_sections
+from docking.applets.menu import menu_sections, radio_menu_items
 from docking.i18n import _
 
 if TYPE_CHECKING:
     from docking.core.config import Config
 
+# Battery charge/status changes slowly; power draw changes by the second, so the
+# live power overlay refreshes on a separate, faster sysfs-only timer.
+_FULL_POLL_SECONDS = 60
+_POWER_POLL_SECONDS = 5
+
 
 class BatteryApplet(Applet):
-    """Shows battery charge icon from sysfs, polled every 60 seconds."""
+    """Shows a battery icon from sysfs, with an optional percent/power overlay."""
 
     id = meta.id
     name = _("Battery")
@@ -50,41 +65,55 @@ class BatteryApplet(Applet):
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
         self._timer_id: int = 0
-        self._show_percent = False
+        self._power_timer_id: int = 0
+        self._overlay = OVERLAY_NONE
         if config:
             prefs = config.applet_prefs.get(meta.id, {})
-            self._show_percent = bool(prefs.get("show_percent", False))
+            self._overlay = overlay_from_prefs(prefs)
         self._state: BatteryState | None = read_battery()
+        self._peripherals: list[PeripheralBattery] = read_peripheral_batteries()
         super().__init__(icon_size=icon_size, config=config)
         self.present()
 
     def create_icon(self, size: int) -> GdkPixbuf.Pixbuf | None:
         """Load battery theme icon matching current state."""
-        return render_icon(
-            size=size,
-            state=self._state,
-            show_percent=self._show_percent,
-        )
+        return render_icon(size=size, state=self._state, overlay=self._overlay)
 
     def refresh_tooltip(self) -> None:
-        self.item.name = tooltip_text(state=self._state)
+        self.item.name = tooltip_lines(
+            battery_line=tooltip_text(state=self._state),
+            peripherals=self._peripherals,
+        )
 
     def start(self, notify: Callable[[], None]) -> None:
-        """Start 60-second polling timer (battery changes slowly)."""
+        """Start the slow full-state poll plus the power overlay poll if needed."""
         super().start(notify=notify)
-        self._timer_id = GLib.timeout_add_seconds(60, self._tick)
+        self._peripherals = read_peripheral_batteries()
+        self._timer_id = GLib.timeout_add_seconds(_FULL_POLL_SECONDS, self._tick)
+        self._sync_power_timer()
+        self.present()
 
     def stop(self) -> None:
-        """Stop the polling timer."""
+        """Stop the polling timers."""
         if self._timer_id:
             GLib.source_remove(self._timer_id)
             self._timer_id = 0
+        if self._power_timer_id:
+            GLib.source_remove(self._power_timer_id)
+            self._power_timer_id = 0
         super().stop()
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
-        show = Gtk.CheckMenuItem(label=_("Show Percent"))
-        show.set_active(self._show_percent)
-        show.connect("toggled", self._on_toggle_percent)
+        overlay = radio_menu_items(
+            choices=(
+                (_("No overlay"), OVERLAY_NONE),
+                (_("Percentage"), OVERLAY_PERCENT),
+                (_("Power (W)"), OVERLAY_POWER),
+            ),
+            active_value=self._overlay,
+            on_selected=lambda _widget, value: self._set_overlay(mode=value),
+            gtk=Gtk,
+        )
 
         settings: list[Gtk.MenuItem] = []
         cmd = power_settings_command()
@@ -92,15 +121,36 @@ class BatteryApplet(Applet):
             power_settings = Gtk.MenuItem(label=_("Power Settings"))
             power_settings.connect("activate", lambda _widget: open_power_settings())
             settings.append(power_settings)
-        return menu_sections(display=[show], settings=settings, gtk=Gtk)
+        return menu_sections(display=overlay, settings=settings, gtk=Gtk)
 
-    def _on_toggle_percent(self, widget: Gtk.CheckMenuItem) -> None:
-        self._show_percent = widget.get_active()
-        self.save_prefs(prefs={"show_percent": self._show_percent})
+    def _set_overlay(self, mode: str) -> None:
+        self._overlay = mode
+        self.save_prefs(prefs={"overlay": mode})
+        self._sync_power_timer()
         self.present()
+
+    def _sync_power_timer(self) -> None:
+        """Run the fast power poll only while the power overlay is selected."""
+        if self._notify is None:
+            return
+        if self._overlay == OVERLAY_POWER and not self._power_timer_id:
+            self._power_timer_id = GLib.timeout_add_seconds(
+                _POWER_POLL_SECONDS, self._power_tick
+            )
+        elif self._overlay != OVERLAY_POWER and self._power_timer_id:
+            GLib.source_remove(self._power_timer_id)
+            self._power_timer_id = 0
 
     def _tick(self) -> bool:
-        """Re-read sysfs and refresh icon."""
+        """Re-read sysfs + peripherals and refresh icon."""
         self._state = read_battery()
+        self._peripherals = read_peripheral_batteries()
         self.present()
+        return True
+
+    def _power_tick(self) -> bool:
+        """Cheap sysfs-only refresh of the live power reading."""
+        if self._state is not None:
+            self._state = self._state._replace(power_watts=read_power_watts())
+            self.present()
         return True

--- a/docking/applets/battery/peripherals.py
+++ b/docking/applets/battery/peripherals.py
@@ -1,0 +1,175 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Peripheral battery discovery via UPower (mouse, keyboard, headset, ...).
+
+UPower exposes wireless peripherals on the system bus alongside the laptop
+battery. We enumerate devices and keep the ones that are *not* a power supply
+(``PowerSupply == false``) and whose ``Type`` is an actual accessory, then read
+each device's charge. The laptop battery, UPS, line power, monitors and the
+aggregate ``DisplayDevice`` are filtered out.
+
+Parsing/formatting is split from the DBus access so it can be unit-tested with
+plain property dicts; the Gio call returns ``[]`` on any failure (e.g. a
+headless session with no system bus).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, NamedTuple
+
+from gi.repository import Gio, GLib
+
+from docking.i18n import _
+from docking.log import get_logger
+
+log = get_logger("battery.peripherals")
+
+_UPOWER = "org.freedesktop.UPower"
+_UPOWER_PATH = "/org/freedesktop/UPower"
+_UPOWER_DEVICE = "org.freedesktop.UPower.Device"
+_DBUS_TIMEOUT_MS = 2000
+
+# UPower device Type enum -> human label, restricted to real accessories.
+_TYPE_NAMES: dict[int, str] = {
+    5: _("Mouse"),
+    6: _("Keyboard"),
+    8: _("Phone"),
+    9: _("Media Player"),
+    10: _("Tablet"),
+    12: _("Controller"),
+    13: _("Pen"),
+    14: _("Touchpad"),
+    17: _("Headset"),
+    18: _("Speakers"),
+    19: _("Headphones"),
+    21: _("Audio"),
+    22: _("Remote"),
+    26: _("Wearable"),
+}
+# Types that are never peripherals: unknown, line-power, battery, ups, monitor,
+# computer, network.
+_EXCLUDED_TYPES = frozenset({0, 1, 2, 3, 4, 11, 16})
+
+# UPower State enum value for charging.
+_STATE_CHARGING = 1
+# UPower BatteryLevel enum -> coarse word (for devices without an exact percent).
+_LEVEL_NAMES: dict[int, str] = {
+    3: _("Low"),
+    4: _("Critical"),
+    6: _("Normal"),
+    7: _("High"),
+    8: _("Full"),
+}
+
+
+class PeripheralBattery(NamedTuple):
+    """Charge info for one wireless accessory."""
+
+    model: str
+    kind: str  # Human-readable device type, e.g. "Keyboard"
+    percent: float | None
+    charging: bool
+    level: str  # Coarse level word when no exact percent, else ""
+
+
+def _peripheral_from_props(props: dict[str, Any]) -> PeripheralBattery | None:
+    """Build a PeripheralBattery from UPower device properties, or None."""
+    if props.get("PowerSupply", True):
+        return None
+    device_type = int(props.get("Type", 0))
+    if device_type in _EXCLUDED_TYPES:
+        return None
+
+    percent = props.get("Percentage")
+    state = int(props.get("State", 0))
+    return PeripheralBattery(
+        model=str(props.get("Model", "") or ""),
+        kind=_TYPE_NAMES.get(device_type, _("Device")),
+        percent=float(percent) if percent is not None else None,
+        charging=state == _STATE_CHARGING,
+        level=_LEVEL_NAMES.get(int(props.get("BatteryLevel", 0)), ""),
+    )
+
+
+def peripheral_label(peripheral: PeripheralBattery) -> str:
+    """Menu/tooltip row text, e.g. ``Keychron K8: 96%``."""
+    name = peripheral.model or peripheral.kind
+    charge = _charge_text(peripheral=peripheral)
+    return f"{name}: {charge}" if charge else name
+
+
+def tooltip_lines(
+    *, battery_line: str, peripherals: Iterable[PeripheralBattery]
+) -> str:
+    """Compose the battery tooltip with one peripheral row per line beneath it."""
+    lines = [battery_line]
+    lines.extend(peripheral_label(peripheral=peripheral) for peripheral in peripherals)
+    return "\n".join(lines)
+
+
+def _charge_text(*, peripheral: PeripheralBattery) -> str:
+    if peripheral.percent is not None and peripheral.percent > 0:
+        text = f"{peripheral.percent:.0f}%"
+    elif peripheral.level:
+        text = peripheral.level
+    else:
+        return ""
+    if peripheral.charging:
+        text = _("{charge} (charging)").format(charge=text)
+    return text
+
+
+def read_peripheral_batteries() -> list[PeripheralBattery]:
+    """Enumerate accessory batteries via UPower, sorted lowest charge first."""
+    try:
+        bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+        paths = bus.call_sync(
+            _UPOWER,
+            _UPOWER_PATH,
+            _UPOWER,
+            "EnumerateDevices",
+            None,
+            GLib.VariantType("(ao)"),
+            Gio.DBusCallFlags.NONE,
+            _DBUS_TIMEOUT_MS,
+            None,
+        ).unpack()[0]
+    except GLib.Error as exc:
+        log.debug("UPower enumerate failed: %s", exc)
+        return []
+
+    peripherals: list[PeripheralBattery] = []
+    for path in paths:
+        try:
+            props = bus.call_sync(
+                _UPOWER,
+                path,
+                "org.freedesktop.DBus.Properties",
+                "GetAll",
+                GLib.Variant("(s)", (_UPOWER_DEVICE,)),
+                GLib.VariantType("(a{sv})"),
+                Gio.DBusCallFlags.NONE,
+                _DBUS_TIMEOUT_MS,
+                None,
+            ).unpack()[0]
+        except GLib.Error as exc:
+            log.debug("UPower properties failed for %s: %s", path, exc)
+            continue
+        peripheral = _peripheral_from_props(props=props)
+        if peripheral is not None:
+            peripherals.append(peripheral)
+
+    peripherals.sort(key=lambda p: p.percent if p.percent is not None else 999.0)
+    return peripherals

--- a/docking/applets/battery/render.py
+++ b/docking/applets/battery/render.py
@@ -23,7 +23,13 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import Gdk, GdkPixbuf
 
 from docking.applets.base import draw_icon_label
-from docking.applets.battery.state import BatteryState
+from docking.applets.battery.state import (
+    OVERLAY_NONE,
+    OVERLAY_PERCENT,
+    OVERLAY_POWER,
+    BatteryState,
+    format_power,
+)
 from docking.applets.draw import rounded_rect
 from docking.core.math import clamp
 
@@ -126,10 +132,19 @@ def _draw_battery(
         cr.fill()
 
 
+def _overlay_label(*, state: BatteryState, overlay: str) -> str | None:
+    """Bottom-center overlay text for the selected mode, or None."""
+    if overlay == OVERLAY_PERCENT:
+        return f"{state.capacity}%"
+    if overlay == OVERLAY_POWER and state.power_watts is not None:
+        return format_power(state.power_watts, compact=True)
+    return None
+
+
 def render_icon(
     size: int,
     state: BatteryState | None,
-    show_percent: bool = False,
+    overlay: str = OVERLAY_NONE,
 ) -> GdkPixbuf.Pixbuf | None:
     """Render standardized battery icon independent from system theme."""
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, size, size)
@@ -146,7 +161,8 @@ def render_icon(
             capacity=state.capacity,
             charging=state.icon_name.endswith("-charging"),
         )
-        if show_percent:
-            draw_icon_label(cr=cr, text=f"{state.capacity}%", size=size)
+        label = _overlay_label(state=state, overlay=overlay)
+        if label is not None:
+            draw_icon_label(cr=cr, text=label, size=size)
 
     return Gdk.pixbuf_get_from_surface(surface, 0, 0, size, size)

--- a/docking/applets/battery/state.py
+++ b/docking/applets/battery/state.py
@@ -27,6 +27,12 @@ from docking.log import get_logger, with_context
 BAT_BASE = Path("/sys/class/power_supply")
 log = with_context(get_logger("battery.state"))
 
+# Bottom-center overlay modes (mutually exclusive, mirroring the network applet).
+OVERLAY_NONE = "none"
+OVERLAY_PERCENT = "percent"
+OVERLAY_POWER = "power"
+OVERLAY_MODES = (OVERLAY_NONE, OVERLAY_PERCENT, OVERLAY_POWER)
+
 
 class BatteryState(NamedTuple):
     """Resolved battery info from sysfs."""
@@ -35,6 +41,7 @@ class BatteryState(NamedTuple):
     capacity: int  # 0-100 percent
     status: str  # Kernel battery status (e.g. Charging / Discharging / Full)
     seconds_remaining: int | None  # Time estimate until empty/full when known
+    power_watts: float | None = None  # Instantaneous battery power draw/input
 
 
 # Kernel capacity_level values -> FDO icon base names
@@ -79,6 +86,7 @@ def read_battery(bat_name: str = "BAT0", base: Path = BAT_BASE) -> BatteryState 
                 bat_dir=bat_dir,
                 status=status,
             )
+        power_watts = _read_power_watts(bat_dir=bat_dir)
     except (OSError, ValueError) as exc:
         log.debug("Failed to read battery state from %s: %s", bat_dir, exc)
         return None
@@ -87,7 +95,52 @@ def read_battery(bat_name: str = "BAT0", base: Path = BAT_BASE) -> BatteryState 
         capacity=capacity,
         status=status,
         seconds_remaining=seconds_remaining,
+        power_watts=power_watts,
     )
+
+
+def read_power_watts(bat_name: str = "BAT0", base: Path = BAT_BASE) -> float | None:
+    """Read just the instantaneous battery power in watts (no subprocess).
+
+    Cheap sysfs-only read used for the live power overlay's fast refresh, kept
+    separate from ``read_battery`` so the frequent poll never spawns ``upower``.
+    """
+    bat_dir = base / bat_name
+    if not bat_dir.exists():
+        return None
+    return _read_power_watts(bat_dir=bat_dir)
+
+
+def _read_power_watts(*, bat_dir: Path) -> float | None:
+    """Resolve battery power in watts from sysfs.
+
+    Prefers ``power_now`` (microwatts); falls back to ``current_now`` (microamps)
+    times ``voltage_now`` (microvolts) for charge-based batteries. The value is a
+    magnitude; direction (draw vs input) comes from ``status``.
+    """
+    power_now = _read_int(path=bat_dir / "power_now")
+    if power_now is not None:
+        return power_now / 1_000_000 if power_now >= 0 else None
+
+    current_now = _read_int(path=bat_dir / "current_now")
+    voltage_now = _read_int(path=bat_dir / "voltage_now")
+    if current_now is not None and voltage_now is not None:
+        return (current_now * voltage_now) / 1e12
+    return None
+
+
+def overlay_from_prefs(prefs: dict[str, object]) -> str:
+    """Resolve the overlay mode, migrating the legacy ``show_percent`` flag."""
+    mode = prefs.get("overlay")
+    if mode in OVERLAY_MODES:
+        return str(mode)
+    return OVERLAY_PERCENT if prefs.get("show_percent") else OVERLAY_NONE
+
+
+def format_power(watts: float, *, compact: bool = False) -> str:
+    """Format watts as e.g. ``7.6 W`` (or ``7.6W`` for the compact overlay)."""
+    digits = f"{watts:.1f}" if watts < 10 else f"{watts:.0f}"
+    return f"{digits}W" if compact else f"{digits} W"
 
 
 def power_settings_command() -> list[str] | None:
@@ -115,11 +168,20 @@ def tooltip_text(state: BatteryState | None) -> str:
     """Build tooltip string from current state."""
     if state is None:
         return _("No battery")
-    base = _("Battery: {pct}%").format(pct=state.capacity)
+    parts = [_("Battery: {pct}%").format(pct=state.capacity)]
     estimate = _estimate_suffix(state=state)
-    if estimate is None:
-        return base
-    return f"{base} • {estimate}"
+    if estimate is not None:
+        parts.append(estimate)
+    power = _power_suffix(state=state)
+    if power is not None:
+        parts.append(power)
+    return " • ".join(parts)
+
+
+def _power_suffix(state: BatteryState) -> str | None:
+    if state.power_watts is None or state.power_watts <= 0:
+        return None
+    return format_power(state.power_watts)
 
 
 def _estimate_suffix(state: BatteryState) -> str | None:

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-05-30 00:13+0200\n"
+"POT-Creation-Date: 2026-05-30 00:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -178,7 +178,7 @@ msgid "{hours}h"
 msgstr ""
 
 #: docking/applets/alarm/state.py:228 docking/applets/alarm/state.py:307
-#: docking/applets/battery/state.py:144 docking/applets/sunrise/state.py:418
+#: docking/applets/battery/state.py:206 docking/applets/sunrise/state.py:418
 #, python-brace-format
 msgid "{minutes}m"
 msgstr ""
@@ -356,38 +356,133 @@ msgstr ""
 msgid "Search applications..."
 msgstr ""
 
-#: docking/applets/battery/applet.py:48
+#: docking/applets/battery/applet.py:63
 msgid "Battery"
 msgstr ""
 
-#: docking/applets/battery/applet.py:85
-msgid "Show Percent"
+#: docking/applets/battery/applet.py:109
+msgid "No overlay"
 msgstr ""
 
-#: docking/applets/battery/applet.py:92
+#: docking/applets/battery/applet.py:110
+msgid "Percentage"
+msgstr ""
+
+#: docking/applets/battery/applet.py:111
+msgid "Power (W)"
+msgstr ""
+
+#: docking/applets/battery/applet.py:121
 msgid "Power Settings"
 msgstr ""
 
-#: docking/applets/battery/state.py:117
+#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:468
+msgid "Mouse"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:47
+msgid "Keyboard"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:48
+msgid "Phone"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:49
+msgid "Media Player"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:50
+msgid "Tablet"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:51
+msgid "Controller"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:52
+msgid "Pen"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:53
+msgid "Touchpad"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:54
+msgid "Headset"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:55
+msgid "Speakers"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:56
+msgid "Headphones"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:57
+msgid "Audio"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:58
+msgid "Remote"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:59
+msgid "Wearable"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:69
+msgid "Low"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:70
+#: docking/applets/certwatch/state.py:248
+msgid "Critical"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:71
+msgid "Normal"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:72
+msgid "High"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:73
+#: docking/applets/moon/offline.py:231 docking/applets/moon/state.py:145
+msgid "Full"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:99
+msgid "Device"
+msgstr ""
+
+#: docking/applets/battery/peripherals.py:130
+#, python-brace-format
+msgid "{charge} (charging)"
+msgstr ""
+
+#: docking/applets/battery/state.py:170
 msgid "No battery"
 msgstr ""
 
-#: docking/applets/battery/state.py:118
+#: docking/applets/battery/state.py:171
 #, python-brace-format
 msgid "Battery: {pct}%"
 msgstr ""
 
-#: docking/applets/battery/state.py:131
+#: docking/applets/battery/state.py:193
 #, python-brace-format
 msgid "{time} left"
 msgstr ""
 
-#: docking/applets/battery/state.py:133
+#: docking/applets/battery/state.py:195
 #, python-brace-format
 msgid "{time} until full"
 msgstr ""
 
-#: docking/applets/battery/state.py:143
+#: docking/applets/battery/state.py:205
 #, python-brace-format
 msgid "{hours}h {minutes:02d}m"
 msgstr ""
@@ -745,10 +840,6 @@ msgstr ""
 
 #: docking/applets/certwatch/state.py:247
 msgid "Warn"
-msgstr ""
-
-#: docking/applets/certwatch/state.py:248
-msgid "Critical"
 msgstr ""
 
 #: docking/applets/certwatch/state.py:249
@@ -1533,10 +1624,6 @@ msgstr ""
 
 #: docking/applets/moon/offline.py:229 docking/applets/moon/state.py:143
 msgid "New"
-msgstr ""
-
-#: docking/applets/moon/offline.py:231 docking/applets/moon/state.py:145
-msgid "Full"
 msgstr ""
 
 #: docking/applets/moon/offline.py:233
@@ -2789,10 +2876,6 @@ msgstr ""
 
 #: docking/ui/settings.py:433
 msgid "Anchor Files to End"
-msgstr ""
-
-#: docking/ui/settings.py:468
-msgid "Mouse"
 msgstr ""
 
 #: docking/ui/settings.py:470

--- a/tests/applets/test_battery.py
+++ b/tests/applets/test_battery.py
@@ -9,11 +9,22 @@ import pytest
 import docking.applets.battery.applet as battery_applet_mod
 import docking.applets.battery.state as battery_state_mod
 from docking.applets.battery.applet import BatteryApplet
+from docking.applets.battery.peripherals import (
+    PeripheralBattery,
+    _peripheral_from_props,
+    peripheral_label,
+)
 from docking.applets.battery.state import (
+    OVERLAY_NONE,
+    OVERLAY_PERCENT,
+    OVERLAY_POWER,
     BatteryState,
+    format_power,
     open_power_settings,
+    overlay_from_prefs,
     power_settings_command,
     read_battery,
+    read_power_watts,
     resolve_battery_icon,
     tooltip_text,
 )
@@ -341,6 +352,167 @@ class TestTooltipText:
         assert tooltip_text(state) == "Battery: 100%"
 
 
+class TestPowerWatts:
+    def test_reads_power_now_microwatts(self, tmp_path):
+        bat = tmp_path / "BAT0"
+        bat.mkdir()
+        (bat / "power_now").write_text("7600000\n")  # 7.6 W
+        assert read_power_watts(base=tmp_path) == pytest.approx(7.6)
+
+    def test_falls_back_to_current_times_voltage(self, tmp_path):
+        bat = tmp_path / "BAT0"
+        bat.mkdir()
+        (bat / "current_now").write_text("500000\n")  # 0.5 A
+        (bat / "voltage_now").write_text("12000000\n")  # 12 V
+        assert read_power_watts(base=tmp_path) == pytest.approx(6.0)
+
+    def test_negative_power_now_is_none(self, tmp_path):
+        bat = tmp_path / "BAT0"
+        bat.mkdir()
+        (bat / "power_now").write_text("-1\n")
+        assert read_power_watts(base=tmp_path) is None
+
+    def test_missing_battery_is_none(self, tmp_path):
+        assert read_power_watts(base=tmp_path) is None
+
+
+class TestFormatPower:
+    def test_one_decimal_below_ten(self):
+        assert format_power(7.64) == "7.6 W"
+
+    def test_no_decimal_at_or_above_ten(self):
+        assert format_power(24.1) == "24 W"
+
+    def test_compact_drops_space(self):
+        assert format_power(7.64, compact=True) == "7.6W"
+
+
+class TestOverlayFromPrefs:
+    def test_explicit_mode_wins(self):
+        assert overlay_from_prefs({"overlay": OVERLAY_POWER}) == OVERLAY_POWER
+
+    def test_migrates_legacy_show_percent(self):
+        assert overlay_from_prefs({"show_percent": True}) == OVERLAY_PERCENT
+
+    def test_defaults_to_none(self):
+        assert overlay_from_prefs({}) == OVERLAY_NONE
+
+
+class TestTooltipPower:
+    def test_appends_power_when_known(self):
+        state = BatteryState(
+            icon_name="battery-good",
+            capacity=67,
+            status="Discharging",
+            seconds_remaining=8040,
+            power_watts=7.6,
+        )
+        assert tooltip_text(state) == "Battery: 67% • 2h 14m left • 7.6 W"
+
+    def test_omits_power_when_zero(self):
+        state = BatteryState(
+            icon_name="battery-good",
+            capacity=100,
+            status="Not charging",
+            seconds_remaining=None,
+            power_watts=0.0,
+        )
+        assert tooltip_text(state) == "Battery: 100%"
+
+
+class TestPeripheralParsing:
+    def _keyboard_props(self, **overrides):
+        props = {
+            "PowerSupply": False,
+            "Type": 6,
+            "Model": "Keychron K8",
+            "Percentage": 96.0,
+            "State": 2,
+            "BatteryLevel": 1,
+        }
+        props.update(overrides)
+        return props
+
+    def test_parses_keyboard(self):
+        p = _peripheral_from_props(self._keyboard_props())
+        assert p == PeripheralBattery(
+            model="Keychron K8",
+            kind="Keyboard",
+            percent=96.0,
+            charging=False,
+            level="",
+        )
+
+    def test_skips_power_supply_devices(self):
+        assert _peripheral_from_props(self._keyboard_props(PowerSupply=True)) is None
+
+    def test_skips_excluded_types(self):
+        # Type 4 == monitor, 1 == line-power.
+        assert _peripheral_from_props(self._keyboard_props(Type=4)) is None
+        assert _peripheral_from_props(self._keyboard_props(Type=1)) is None
+
+    def test_charging_flag_and_coarse_level(self):
+        p = _peripheral_from_props(
+            self._keyboard_props(Type=5, Percentage=0.0, State=1, BatteryLevel=3)
+        )
+        assert p.kind == "Mouse"
+        assert p.charging is True
+        assert p.level == "Low"
+
+
+class TestPeripheralLabel:
+    def test_percent(self):
+        p = PeripheralBattery("Keychron K8", "Keyboard", 96.0, False, "")
+        assert peripheral_label(p) == "Keychron K8: 96%"
+
+    def test_charging_suffix(self):
+        p = PeripheralBattery("MX Master", "Mouse", 40.0, True, "")
+        assert peripheral_label(p) == "MX Master: 40% (charging)"
+
+    def test_coarse_level_when_no_percent(self):
+        p = PeripheralBattery("Headset", "Headset", None, False, "Low")
+        assert peripheral_label(p) == "Headset: Low"
+
+    def test_model_fallback_to_kind(self):
+        p = PeripheralBattery("", "Mouse", None, False, "")
+        assert peripheral_label(p) == "Mouse"
+
+
+class TestPeripheralTooltip:
+    def test_tooltip_lists_peripherals_under_battery(self):
+        applet = BatteryApplet(48)
+        applet._state = BatteryState(
+            icon_name="battery-good",
+            capacity=80,
+            status="Discharging",
+            seconds_remaining=None,
+        )
+        applet._peripherals = [
+            PeripheralBattery("Keychron K8", "Keyboard", 96.0, False, ""),
+            PeripheralBattery("MX Master", "Mouse", 40.0, True, ""),
+        ]
+
+        applet.refresh_tooltip()
+
+        assert applet.item.name == (
+            "Battery: 80%\nKeychron K8: 96%\nMX Master: 40% (charging)"
+        )
+
+    def test_tooltip_battery_only_when_no_peripherals(self):
+        applet = BatteryApplet(48)
+        applet._state = BatteryState(
+            icon_name="battery-good",
+            capacity=80,
+            status="Discharging",
+            seconds_remaining=None,
+        )
+        applet._peripherals = []
+
+        applet.refresh_tooltip()
+
+        assert applet.item.name == "Battery: 80%"
+
+
 class TestPowerSettingsLauncher:
     def test_prefers_first_available_power_settings_command(self, monkeypatch):
         monkeypatch.setattr(
@@ -399,22 +571,23 @@ class TestBatteryAppletRendering:
         pixbuf = applet.create_icon(48)
         assert pixbuf is not None
 
-    def test_renders_with_percent_label_enabled(self):
+    def test_renders_with_power_overlay_enabled(self):
         state = BatteryState(
             icon_name="battery-good",
             capacity=72,
             status="Discharging",
             seconds_remaining=None,
+            power_watts=7.6,
         )
         applet = BatteryApplet(48, config=Config(applet_prefs={"battery": {}}))
         applet._state = state
-        applet._show_percent = True
+        applet._overlay = OVERLAY_POWER
 
         pixbuf = applet.create_icon(48)
 
         assert pixbuf is not None
 
-    def test_menu_shows_power_settings_when_available(self, monkeypatch):
+    def test_menu_shows_overlay_choices_and_power_settings(self, monkeypatch):
         opened: list[str] = []
         monkeypatch.setattr(
             battery_applet_mod,
@@ -431,37 +604,43 @@ class TestBatteryAppletRendering:
         items = applet.get_menu_items()
 
         assert [item.get_label() for item in items] == [
-            "Show Percent",
+            "No overlay",
+            "Percentage",
+            "Power (W)",
             "",
             "Power Settings",
         ]
-        callback, args = items[2]._signals["activate"][0]
+        callback, args = items[4]._signals["activate"][0]
         callback(None, *args)
         assert opened == ["opened"]
 
-    def test_menu_keeps_show_percent_without_power_settings_tool(self, monkeypatch):
+    def test_menu_overlay_only_without_power_settings_tool(self, monkeypatch):
         monkeypatch.setattr(battery_applet_mod, "power_settings_command", lambda: None)
 
         applet = BatteryApplet(48)
         assert [item.get_label() for item in applet.get_menu_items()] == [
-            "Show Percent"
+            "No overlay",
+            "Percentage",
+            "Power (W)",
         ]
 
-    def test_loads_and_saves_show_percent_pref(self, tmp_path):
+    def test_migrates_legacy_show_percent_pref(self, tmp_path):
         path = tmp_path / "dock.json"
         config = Config(applet_prefs={"battery": {"show_percent": True}})
         config.save(path)
         config = Config.load(path)
         applet = BatteryApplet(48, config=config)
 
-        assert applet._show_percent is True
+        assert applet._overlay == OVERLAY_PERCENT
+
+    def test_set_overlay_saves_pref(self, tmp_path):
+        config = Config(applet_prefs={"battery": {}})
+        applet = BatteryApplet(48, config=config)
 
         applet.present = MagicMock()
-        widget = MagicMock()
-        widget.get_active.return_value = False
-        applet._on_toggle_percent(widget)
+        applet._set_overlay(mode=OVERLAY_POWER)
 
-        assert config.applet_prefs["battery"] == {"show_percent": False}
+        assert config.applet_prefs["battery"] == {"overlay": OVERLAY_POWER}
         applet.present.assert_called_once()
 
     def test_tooltip_shows_percentage(self, tmp_path, monkeypatch):
@@ -475,6 +654,7 @@ class TestBatteryAppletRendering:
             "_upower_seconds_remaining",
             lambda **_kwargs: None,
         )
+        monkeypatch.setattr(battery_applet_mod, "read_peripheral_batteries", list)
         with patch(
             "docking.applets.battery.applet.read_battery",
             return_value=read_battery("BAT0", base=tmp_path),
@@ -482,7 +662,8 @@ class TestBatteryAppletRendering:
             applet = BatteryApplet(48)
         assert applet.item.name == "Battery: 72%"
 
-    def test_tooltip_no_battery(self):
+    def test_tooltip_no_battery(self, monkeypatch):
+        monkeypatch.setattr(battery_applet_mod, "read_peripheral_batteries", list)
         with patch("docking.applets.battery.applet.read_battery", return_value=None):
             applet = BatteryApplet(48)
         assert applet.item.name == "No battery"


### PR DESCRIPTION
## Summary
- Add battery power draw support and a power overlay option.
- Show peripheral battery details from UPower in the Battery applet tooltip.
- Add power settings menu integration and expanded battery tests.