### PR TITLE
Fix autohide when pointer leaves from dock edge

### DIFF
--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -1007,21 +1007,23 @@ class DockWindow(Gtk.Window):
             event.x,
             event.y,
         )
-        if event.detail == Gdk.NotifyType.INFERIOR:
-            return False
-
         # Spurious leave filter: when the tooltip popup appears, GTK
         # generates a NONLINEAR leave even though the cursor is still
-        # inside the dock's current cursor region. Query the live pointer
-        # position instead of trusting event.x/event.y: for top/bottom exits,
-        # GTK can report the last in-window point, which would make a real
-        # leave look like it was still inside the dock and block autohide.
+        # inside the dock's current cursor region. Tooltip hover can also arrive
+        # as INFERIOR even though the pointer has left the shelf. Query the live
+        # pointer position instead of trusting event detail or event.x/event.y:
+        # for top/bottom exits, GTK can report the last in-window point, which
+        # would make a real leave look like it was still inside the dock and
+        # block autohide.
         current_entry = self._cache.geometry_frame
         frame = (
             current_entry.frame if current_entry is not None else None
         ) or self._cache.applied_input_frame
         input_rect = current_input_rect(frame)
-        if input_rect is not None and self.interaction.pointer_inside_input_rect():
+        pointer_inside = (
+            input_rect is not None and self.interaction.pointer_inside_input_rect()
+        )
+        if pointer_inside:
             return False
 
         if not self.dock_hovered:

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -1012,17 +1012,16 @@ class DockWindow(Gtk.Window):
 
         # Spurious leave filter: when the tooltip popup appears, GTK
         # generates a NONLINEAR leave even though the cursor is still
-        # inside the dock's current cursor region. Ignore those leaves
-        # using the same half-open region semantics as the rest of the
-        # shared geometry layer.
+        # inside the dock's current cursor region. Query the live pointer
+        # position instead of trusting event.x/event.y: for top/bottom exits,
+        # GTK can report the last in-window point, which would make a real
+        # leave look like it was still inside the dock and block autohide.
         current_entry = self._cache.geometry_frame
         frame = (
             current_entry.frame if current_entry is not None else None
         ) or self._cache.applied_input_frame
         input_rect = current_input_rect(frame)
-        if input_rect is not None and self.interaction.point_inside_event_frame(
-            x=event.x, y=event.y
-        ):
+        if input_rect is not None and self.interaction.pointer_inside_input_rect():
             return False
 
         if not self.dock_hovered:

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -131,6 +131,7 @@ def _make_stub(item: DockItem | None = None):
     stub.interaction = MagicMock()
     stub.interaction.on_effective_enter = MagicMock()
     stub.interaction.on_effective_leave = MagicMock()
+    stub.interaction.pointer_inside_input_rect = MagicMock(return_value=False)
     _bind_geometry_signature(stub)
     return stub, item
 
@@ -555,7 +556,7 @@ class TestLeaveEnterFlow:
         # Then
         assert handled is False
 
-    def test_leave_inside_input_rect_is_ignored(self):
+    def test_leave_with_live_pointer_inside_input_rect_is_ignored(self):
         # Given
         stub, _item = _make_stub()
         stub._cache.geometry_frame.frame = SimpleNamespace(
@@ -567,15 +568,39 @@ class TestLeaveEnterFlow:
             x=20.0,
             y=20.0,
         )
+        stub.interaction.pointer_inside_input_rect.return_value = True
 
         # When
         handled = dock_window_mod.DockWindow._on_leave(stub, MagicMock(), event)
         # Then
         assert handled is False
-        stub.interaction.point_inside_event_frame.assert_called_once_with(
-            x=20.0, y=20.0
-        )
+        stub.interaction.pointer_inside_input_rect.assert_called_once_with()
         stub.hover.cancel.assert_not_called()
+
+    def test_leave_with_stale_inside_event_coords_but_pointer_outside_hides(self):
+        # Given
+        stub, _item = _make_stub()
+        widget = MagicMock()
+        stub.autohide = _autohide(enabled=True)
+        stub.preview = MagicMock()
+        stub.preview.get_visible.return_value = False
+        stub._cache.geometry_frame.frame = SimpleNamespace(
+            cursor_rect=Rect(0, 0, 100, 100)
+        )
+        event = SimpleNamespace(
+            detail=dock_window_mod.Gdk.NotifyType.NONLINEAR,
+            mode=dock_window_mod.Gdk.CrossingMode.NORMAL,
+            x=20.0,
+            y=20.0,
+        )
+        stub.interaction.pointer_inside_input_rect.return_value = False
+
+        # When
+        handled = dock_window_mod.DockWindow._on_leave(stub, widget, event)
+        # Then
+        assert handled is True
+        stub.interaction.pointer_inside_input_rect.assert_called_once_with()
+        stub.interaction.on_effective_leave.assert_called_once_with(widget)
 
     def test_leave_clears_hover_and_resets_cursor_without_preview_or_autohide(self):
         # Given

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -545,6 +545,7 @@ class TestLeaveEnterFlow:
     def test_leave_ignores_inferior_notify(self):
         # Given
         stub, _item = _make_stub()
+        stub.interaction.pointer_inside_input_rect.return_value = True
         event = SimpleNamespace(
             detail=dock_window_mod.Gdk.NotifyType.INFERIOR,
             mode=dock_window_mod.Gdk.CrossingMode.NORMAL,
@@ -555,6 +556,27 @@ class TestLeaveEnterFlow:
         handled = dock_window_mod.DockWindow._on_leave(stub, MagicMock(), event)
         # Then
         assert handled is False
+        stub.interaction.pointer_inside_input_rect.assert_called_once_with()
+
+    def test_leave_to_tooltip_outside_shelf_triggers_effective_leave(self):
+        # Given
+        stub, _item = _make_stub()
+        widget = MagicMock()
+        stub.autohide = _autohide(enabled=True)
+        event = SimpleNamespace(
+            detail=dock_window_mod.Gdk.NotifyType.INFERIOR,
+            mode=dock_window_mod.Gdk.CrossingMode.NORMAL,
+            x=20.0,
+            y=20.0,
+        )
+        stub.interaction.pointer_inside_input_rect.return_value = False
+
+        # When
+        handled = dock_window_mod.DockWindow._on_leave(stub, widget, event)
+        # Then
+        assert handled is True
+        stub.interaction.pointer_inside_input_rect.assert_called_once_with()
+        stub.interaction.on_effective_leave.assert_called_once_with(widget)
 
     def test_leave_with_live_pointer_inside_input_rect_is_ignored(self):
         # Given


### PR DESCRIPTION
## Summary
- fix leave-event filtering so autohide uses the live pointer position instead of stale event coordinates
- preserve the tooltip/spurious-leave guard when the pointer is actually still inside the dock input region
- add a regression test for top/bottom exits where GTK reports the last in-window event coordinates

## Investigation
The merged backend-contracts PR did not touch autohide, dock leave handling, dodge, or config, and no runtime code imports the new backend contracts. The observed symptom matches the existing leave filter: upward exits can arrive with event.x/event.y still inside cursor_rect, so the dock ignored the leave and never called autohide.on_mouse_leave(). Side exits often report x outside the rect, so those still hid correctly.

## Verification
- .venv/bin/ruff check docking/ui/dock_window.py tests/ui/test_dock_window_integration.py
- python3 -m compileall -q docking/ui/dock_window.py tests/ui/test_dock_window_integration.py
- git diff --check

## Not run
- .venv/bin/pytest tests/ui/test_dock_window_integration.py -k leave: the venv pytest entrypoint fails with ModuleNotFoundError: No module named 'pytest'