### PR TITLE
Wire X11 runtime through window service

### DIFF
--- a/docking/app.py
+++ b/docking/app.py
@@ -77,11 +77,11 @@ from gi.repository import GLib, Gtk
 from docking.core.config import Config
 from docking.core.theme import Theme
 from docking.ipc import DockItemsService
+from docking.platform.backends.x11.session import build_x11_window_tracker
 from docking.platform.environment import apply_tweaks, detect_desktop
 from docking.platform.launcher import Launcher
 from docking.platform.model import DockModel
 from docking.platform.unity import UnityLauncherListener
-from docking.platform.window_tracker import WindowTracker
 from docking.ui.factory import build_dock_window
 from docking.ui.new_year import NewYearGreetingController
 from docking.ui.renderer import DockRenderer
@@ -98,7 +98,7 @@ def main() -> None:
     launcher = Launcher()
     model = DockModel(config=config, launcher=launcher)
     renderer = DockRenderer()
-    tracker = WindowTracker(model=model, launcher=launcher, config=config)
+    tracker = build_x11_window_tracker(model=model, launcher=launcher, config=config)
     unity = UnityLauncherListener(model=model)
 
     window = build_dock_window(
@@ -121,7 +121,7 @@ def main() -> None:
         window.show_all()
         new_year.start()
         window.start_update_checks()
-        GLib.idle_add(_start_runtime, items_service, model)
+        GLib.idle_add(_start_runtime, items_service, model, tracker)
         Gtk.main()
     finally:
         items_service.stop()
@@ -131,8 +131,13 @@ def main() -> None:
         model.stop_applets()
 
 
-def _start_runtime(items_service: DockItemsService, model: DockModel) -> bool:
+def _start_runtime(
+    items_service: DockItemsService, model: DockModel, window_tracker: object
+) -> bool:
     """Start background runtime pieces after the window has been shown."""
+    tracker_start = getattr(window_tracker, "start", None)
+    if callable(tracker_start):
+        tracker_start()
     items_service.start()
     model.start_applets()
     return False

--- a/docking/platform/backends/x11/__init__.py
+++ b/docking/platform/backends/x11/__init__.py
@@ -13,6 +13,7 @@
 
 """X11 backend services."""
 
+from docking.platform.backends.x11.session import build_x11_window_tracker
 from docking.platform.backends.x11.windows import X11WindowService
 
-__all__ = ["X11WindowService"]
+__all__ = ["X11WindowService", "build_x11_window_tracker"]

--- a/docking/platform/backends/x11/session.py
+++ b/docking/platform/backends/x11/session.py
@@ -1,0 +1,59 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""X11 runtime construction helpers."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from docking.log import get_logger
+from docking.platform.backends.x11.windows import X11WindowService
+from docking.platform.window_tracker import WindowTracker
+
+if TYPE_CHECKING:
+    from docking.core.config import Config
+    from docking.platform.launcher import Launcher
+    from docking.platform.model import DockModel
+
+
+X11_WINDOW_SERVICE_ENV = "DOCKING_X11_WINDOW_SERVICE"
+X11_WINDOW_SERVICE_LEGACY = "legacy"
+X11_WINDOW_SERVICE_SERVICE = "service"
+
+log = get_logger(name="x11_session")
+
+
+def build_x11_window_tracker(
+    *, model: DockModel, launcher: Launcher, config: Config | None = None
+) -> WindowTracker:
+    """Build the X11 window runtime used by current UI compatibility callers."""
+    mode = _window_service_mode()
+    if mode == X11_WINDOW_SERVICE_LEGACY:
+        return WindowTracker(model=model, launcher=launcher, config=config)
+    return X11WindowService(model=model, launcher=launcher, config=config)
+
+
+def _window_service_mode() -> str:
+    raw_mode = os.environ.get(X11_WINDOW_SERVICE_ENV, X11_WINDOW_SERVICE_SERVICE)
+    mode = raw_mode.strip().lower()
+    if mode in {X11_WINDOW_SERVICE_LEGACY, X11_WINDOW_SERVICE_SERVICE}:
+        return mode
+    log.warning(
+        "Ignoring invalid %s=%r; using %s",
+        X11_WINDOW_SERVICE_ENV,
+        raw_mode,
+        X11_WINDOW_SERVICE_SERVICE,
+    )
+    return X11_WINDOW_SERVICE_SERVICE

--- a/docking/platform/window_tracker.py
+++ b/docking/platform/window_tracker.py
@@ -381,6 +381,9 @@ class WindowTracker:
 
     def _init_screen(self) -> bool:
         """Initialize Wnck screen and connect signals."""
+        if self._screen is not None:
+            return False
+
         self._screen = Wnck.Screen.get_default()
         if self._screen is None:
             return False

--- a/docs/WAYLAND.md
+++ b/docs/WAYLAND.md
@@ -3072,11 +3072,15 @@ The safest first moves are still X11-preserving refactors:
    `PreviewService`.
 6. Move dodge creation behind `VisibilityService`.
 7. Move struts/barriers/blur/input-region ownership behind `SurfaceService`.
-8. Add a `NullSessionBackend` or reduced backend and verify Docking can run
+8. Remove transitional X11 compatibility APIs after all X11 UI callers use
+   backend-neutral services.
+9. Add a `NullSessionBackend` or reduced backend and verify Docking can run
    without Wnck task powers.
-9. Only after that, start layer-shell and Wayland toplevel implementation.
+10. Only after that, start layer-shell and Wayland toplevel implementation.
 
-The key test before real Wayland code is: Docking should be able to run with a
+The key test before real Wayland code is: X11 should first run entirely through
+backend-neutral services, with transitional XID/Wnck compatibility APIs removed
+from backend-neutral UI paths. After that, Docking should be able to run with a
 backend that intentionally lacks taskbar, preview, workspace, and overlap
 powers. That flushes out hidden X11 assumptions before compositor protocols are
 involved.
@@ -3193,6 +3197,13 @@ Do not:
 - add Wayland code
 - change menu or preview behavior
 
+Manual visual checks:
+
+- Launch the dock once on X11 and confirm there is no visible behavior change.
+- Open a few pinned and unpinned apps and confirm running indicators still update.
+- Hover an app with windows and confirm previews still appear.
+- Right-click an app and confirm the existing menu still opens normally.
+
 Exit criteria:
 
 - pure unit tests for dataclasses/capabilities pass
@@ -3231,6 +3242,13 @@ Do not:
 - change `DockModel.update_running()` semantics
 - change `docking.app` startup wiring
 - add Wayland or reduced-backend selection
+
+Manual visual checks:
+
+- Launch the dock on X11 and confirm startup, running indicators, previews, and menus look unchanged.
+- Open multiple windows for one app and confirm the window count and indicator state still match the old behavior.
+- Trigger an urgent window and confirm the same attention animation or highlight appears.
+- Close and reopen apps and confirm transient unpinned app icons appear and disappear normally.
 
 Exit criteria:
 
@@ -3289,6 +3307,14 @@ Do not:
 - change `DockModel.update_running()` semantics
 - thread environment checks beyond the construction point
 
+Manual visual checks:
+
+- Run the default service path and compare it with `DOCKING_X11_WINDOW_SERVICE=legacy`.
+- Watch for duplicate updates: flickering indicators, duplicated menu rows, repeated preview refreshes, or doubled close and activate behavior.
+- Test left-click actions for running apps: focus, cycle, most-recent, minimize, and close-focused.
+- Right-click running apps and confirm open-window rows, close, and close-all still affect the correct windows.
+- Hover apps with one and multiple windows and confirm previews still map to the correct windows.
+
 Exit criteria:
 
 - X11 startup uses `X11WindowService` by default, or can be forced to it with the
@@ -3328,6 +3354,14 @@ Do not:
 - change app startup/backend selection
 - add native Wayland-specific menu behavior
 
+Manual visual checks:
+
+- Right-click apps with zero, one, and multiple windows and confirm menu layout and separators are unchanged.
+- Confirm open-window rows show the right titles, sorted in the expected order.
+- Activate each listed window from the menu and confirm the correct window is focused.
+- Use per-window close buttons and Close or Close All, including with stale or just-closed windows.
+- Check long window titles for truncation, spacing, and menu width regressions.
+
 Exit criteria:
 
 - menu tests no longer need live/fake Wnck windows for open-window rows
@@ -3363,6 +3397,14 @@ Do not:
 - change thumbnail sizing or timing policy unless required by the service
   boundary
 - delete `get_xids_for()` until no callers remain
+
+Manual visual checks:
+
+- Hover apps with one, two, and many windows and confirm preview thumbnails still appear in the right order.
+- Click a preview and confirm it activates the intended window.
+- Close a window while the preview is open and confirm the popup degrades without crashing or stale thumbnails.
+- Check preview sizing, title labels, icon fallback, hover timing, and dismissal behavior.
+- Test minimized windows and windows on other workspaces if the current X11 behavior supports them.
 
 Exit criteria:
 
@@ -3400,6 +3442,13 @@ Do not:
 - change applets yet
 - make `GDK_BACKEND=wayland` claim support
 
+Manual visual checks:
+
+- Launch the dock on X11 and confirm startup order feels unchanged: dock appears, applets start, updates run, and window state populates.
+- Confirm all already-migrated menu and preview flows still work through the session backend.
+- Toggle the temporary X11 fallback if still present and compare behavior.
+- Check logs for backend selection clarity without noisy warnings during normal X11 startup.
+
 Exit criteria:
 
 - startup behavior is unchanged on X11
@@ -3427,6 +3476,14 @@ Do not:
 - change dodge math
 - add Wayland overlap protocols
 - change surface placement or struts
+
+Manual visual checks:
+
+- Test every hide mode, especially dodge-active, dodge-any, dodge-maximized, autohide, and always-visible.
+- Move, maximize, minimize, and close windows near the dock edge and confirm reveal and hide timing is unchanged.
+- Move the dock between screen edges and monitors and confirm overlap detection still follows the correct edge.
+- Check pressure reveal, pointer barriers, and hover reveal if enabled.
+- Confirm unsupported or reduced visibility paths do not leave the dock stuck hidden or stuck visible.
 
 Exit criteria:
 
@@ -3458,6 +3515,14 @@ Do not:
 - rewrite placement math unless required to preserve behavior
 - change always-visible/autohide semantics
 
+Manual visual checks:
+
+- Check dock placement on bottom, top, left, and right positions.
+- Verify edge distance, additional distance, strut reservation, blur hint, keep-above behavior, and rounded-edge rendering.
+- Maximize windows near the dock and confirm reserved space is still correct.
+- Test multi-monitor placement and monitor switching.
+- Check autohide and reveal geometry after changing icon size, zoom, distance, and position settings.
+
 Exit criteria:
 
 - raw `GdkX11` checks are confined to X11 backend code or transitional shims
@@ -3486,13 +3551,49 @@ Do not:
 - make applet UI depend on compositor names directly
 - remove X11 helper paths until each applet has tests
 
+Manual visual checks:
+
+- Review each migrated applet menu, tooltip, icon state, and click behavior on X11.
+- For Desktop, Workspaces, Window Killer, Desk Presence, Color Picker, Screenshot, and Caffeine, confirm the platform-specific action still works.
+- Confirm unsupported-service states are clear and do not crash the applet popup or menu.
+- Check applet ordering, anchoring, and startup behavior after enabling or disabling migrated applets.
+- Verify translated and long labels still fit in applet menus and dialogs.
+
 Exit criteria:
 
 - applets keep current X11 behavior
 - backend-neutral applet loading can skip or disable unsupported actions
 - tests cover at least one unsupported-service path
 
-#### PR 11: Null / Reduced Backend
+#### PR 11: Cleanup Transitional X11 APIs
+
+Remove compatibility methods only after all UI callers and tests use neutral
+backend APIs.
+
+Start here:
+
+- remove or deprecate `get_xids_for`, `activate_xid`, `close_xid` from
+  backend-neutral call paths
+- keep XID internals inside X11 backend where still useful
+- update documentation and support language
+- search the repo for `get_xids_for`, `get_windows_for`, `activate_xid`,
+  `close_xid`, raw `Wnck.Window`, and raw XID usage before deleting anything
+- preserve any X11-only internals that the X11 backend still needs for previews
+  or diagnostics
+
+Manual visual checks:
+
+- Run a full X11 smoke pass: startup, running indicators, click actions, menus, previews, hide modes, and applets.
+- Open and close multiple app windows quickly and confirm no stale XID or window assumptions remain visible.
+- Compare the cleaned path against behavior from before cleanup for menu rows, previews, and click actions.
+- Confirm no unsupported Wayland or reduced backend UI regresses after compatibility methods are removed.
+
+Exit criteria:
+
+- no backend-neutral UI module depends on Wnck windows or XIDs
+- X11 backend remains fully supported
+
+#### PR 12: Null / Reduced Backend
 
 Add a backend with no taskbar powers to validate that X11 assumptions are no
 longer leaking through normal UI.
@@ -3517,13 +3618,21 @@ Do not:
 - import X11 modules from the null backend
 - silently pretend taskbar/window actions succeeded
 
+Manual visual checks:
+
+- Force the reduced backend and confirm the dock starts with pinned launchers and backend-neutral applets.
+- Confirm running indicators, window rows, previews, dodge modes, and unsupported actions disappear or disable cleanly.
+- Check right-click menus for pinned apps: launch, pin, and remove actions should still be usable where applicable.
+- Confirm no X11-only errors leak into the UI and logs explain the reduced capabilities.
+- Switch back to X11 and confirm full behavior returns.
+
 Exit criteria:
 
 - Docking can start without Wnck task powers
 - unsupported features degrade intentionally
 - reduced-backend tests prove no accidental X11 imports
 
-#### PR 12: Native Wayland Detection Stub
+#### PR 13: Native Wayland Detection Stub
 
 Only after the reduced backend works, add native Wayland detection that selects
 a reduced/no-op backend when unsupported.
@@ -3542,13 +3651,20 @@ Do not:
 - run X11 fallback code in native Wayland unless explicitly under XWayland
 - claim current-open-app support on compositors without a toplevel protocol
 
+Manual visual checks:
+
+- Start under native Wayland and confirm Docking enters reduced mode instead of crashing.
+- Start under X11 or XWayland and confirm the X11 backend is still selected and behavior is unchanged.
+- Confirm unsupported taskbar and window features are hidden, disabled, or clearly unavailable on native Wayland.
+- Check logs for a concise backend and capability explanation without noisy repeated warnings.
+
 Exit criteria:
 
 - Docking does not crash on native Wayland startup
 - X11 remains unchanged
 - logs and capability flags explain reduced mode
 
-#### PR 13: Layer-Shell Surface Backend
+#### PR 14: Layer-Shell Surface Backend
 
 Add native Wayland dock-surface placement for compositors that support
 layer-shell.
@@ -3571,6 +3687,14 @@ Do not:
 - make layer-shell a hard dependency
 - import layer-shell modules in X11 sessions
 
+Manual visual checks:
+
+- On a layer-shell compositor, check dock anchoring on all four edges and all configured monitors.
+- Maximize windows and confirm exclusive zones reserve space correctly.
+- Toggle autohide and always-visible modes and confirm reveal or hide geometry stays aligned to the layer-shell edge.
+- Check fallback behavior when layer-shell is missing, especially on GNOME or Mutter native Wayland.
+- Verify X11 placement, struts, and blur behavior are unchanged.
+
 Exit criteria:
 
 - native Wayland dock can reserve edge space on a supported layer-shell
@@ -3578,7 +3702,7 @@ Exit criteria:
 - GNOME native Wayland remains reduced/unsupported with a clear log
 - X11 placement tests remain unchanged
 
-#### PR 14: Generic Foreign-Toplevel Window Service
+#### PR 15: Generic Foreign-Toplevel Window Service
 
 Add wlroots-style opened-app context.
 
@@ -3602,13 +3726,21 @@ Do not:
 - add compositor-specific Plasma or COSMIC code here
 - change X11 matching behavior
 
+Manual visual checks:
+
+- On a supported wlroots compositor, open apps and confirm running indicators appear and clear correctly.
+- Open multiple windows for one app and confirm counts, active state, and basic actions match compositor capability.
+- Test activate, close, and minimize where supported; unsupported actions should be disabled or no-op visibly safely.
+- Check app matching for common desktop IDs, Flatpak apps, and apps with unusual app IDs.
+- Confirm X11 behavior is unchanged after the generic Wayland service lands.
+
 Exit criteria:
 
 - running indicators and basic window actions work on at least one supported
   wlroots compositor
 - unsupported compositors continue reduced mode with clear logs
 
-#### PR 15: KWin / Plasma Backend
+#### PR 16: KWin / Plasma Backend
 
 Add the richest parity backend.
 
@@ -3625,13 +3757,21 @@ Start here:
   present
 - keep protocol selection deterministic and logged
 
+Manual visual checks:
+
+- On Plasma Wayland, check running indicators, active windows, attention state, window actions, and workspace filtering.
+- Move windows across virtual desktops and monitors and confirm Docking tracks the expected workspace state.
+- Test show-desktop, workspace switching, close, minimize, activate, and dodge modes backed by geometry.
+- Confirm Plasma-specific behavior wins over generic foreign-toplevel behavior when both are present.
+- Re-test non-Plasma Wayland and X11 to confirm they are unaffected.
+
 Exit criteria:
 
 - KWin Wayland reaches closest behavior to current X11 for taskbar, actions,
   workspace, and dodge features
 - non-Plasma Wayland backends are unaffected
 
-#### PR 16: COSMIC / Optional Compositor Extras
+#### PR 17: COSMIC / Optional Compositor Extras
 
 Add compositor-specific backends after the generic and KWin paths are stable.
 
@@ -3645,31 +3785,18 @@ Start here:
 - keep each optional backend isolated so a missing dependency or unsupported
   compositor cannot affect X11, generic wlroots, or Plasma
 
+Manual visual checks:
+
+- On each supported optional compositor, confirm only that compositor-specific path activates.
+- Check running indicators, workspace behavior, overlap or dodge behavior, and supported actions against that compositor capability.
+- Start on unsupported compositors and confirm the app falls back to generic or reduced behavior cleanly.
+- Confirm missing optional dependencies produce clear logs and no visible startup breakage.
+- Re-test X11, wlroots generic, and Plasma paths after each optional backend is added.
+
 Exit criteria:
 
 - each compositor extension is capability-gated and does not affect X11 or
   other Wayland backends
-
-#### PR 17: Cleanup Transitional X11 APIs
-
-Remove compatibility methods only after all UI callers and tests use neutral
-backend APIs.
-
-Start here:
-
-- remove or deprecate `get_xids_for`, `activate_xid`, `close_xid` from
-  backend-neutral call paths
-- keep XID internals inside X11 backend where still useful
-- update documentation and support language
-- search the repo for `get_xids_for`, `get_windows_for`, `activate_xid`,
-  `close_xid`, raw `Wnck.Window`, and raw XID usage before deleting anything
-- preserve any X11-only internals that the X11 backend still needs for previews
-  or diagnostics
-
-Exit criteria:
-
-- no backend-neutral UI module depends on Wnck windows or XIDs
-- X11 backend remains fully supported
 
 ### Cairo-Dock Parity Checklist
 

--- a/tests/platform/test_window_tracker_integration.py
+++ b/tests/platform/test_window_tracker_integration.py
@@ -177,6 +177,31 @@ class TestWindowTrackerInit:
         ]
         tracker._update_running.assert_called_once()
 
+    def test_init_screen_is_idempotent(self, tracker_env, monkeypatch):
+        # Given
+        tracker, _model, _launcher = tracker_env
+        screen = FakeScreen(windows=[], active_window=None)
+        monkeypatch.setattr(
+            window_tracker_mod.Wnck.Screen,
+            "get_default",
+            lambda: screen,
+            raising=False,
+        )
+        tracker._update_running = MagicMock()
+
+        # When
+        assert tracker._init_screen() is False
+        assert tracker._init_screen() is False
+
+        # Then
+        assert screen.force_update_called == 1
+        assert screen.connections == [
+            "window-opened",
+            "window-closed",
+            "active-window-changed",
+        ]
+        tracker._update_running.assert_called_once()
+
 
 class TestWindowTrackerRunningAggregation:
     def test_update_running_aggregates_windows(self, tracker_env):

--- a/tests/platform/test_x11_session.py
+++ b/tests/platform/test_x11_session.py
@@ -1,0 +1,58 @@
+"""Tests for X11 runtime construction helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from docking.platform.backends.x11 import session
+
+
+def test_build_x11_window_tracker_defaults_to_service(monkeypatch):
+    service = MagicMock()
+    service_cls = MagicMock(return_value=service)
+    legacy_cls = MagicMock()
+    monkeypatch.delenv(session.X11_WINDOW_SERVICE_ENV, raising=False)
+    monkeypatch.setattr(session, "X11WindowService", service_cls)
+    monkeypatch.setattr(session, "WindowTracker", legacy_cls)
+
+    result = session.build_x11_window_tracker(
+        model=MagicMock(), launcher=MagicMock(), config=MagicMock()
+    )
+
+    assert result is service
+    service_cls.assert_called_once()
+    legacy_cls.assert_not_called()
+
+
+def test_build_x11_window_tracker_allows_legacy_fallback(monkeypatch):
+    legacy = MagicMock()
+    service_cls = MagicMock()
+    legacy_cls = MagicMock(return_value=legacy)
+    monkeypatch.setenv(session.X11_WINDOW_SERVICE_ENV, "legacy")
+    monkeypatch.setattr(session, "X11WindowService", service_cls)
+    monkeypatch.setattr(session, "WindowTracker", legacy_cls)
+
+    result = session.build_x11_window_tracker(
+        model=MagicMock(), launcher=MagicMock(), config=MagicMock()
+    )
+
+    assert result is legacy
+    legacy_cls.assert_called_once()
+    service_cls.assert_not_called()
+
+
+def test_build_x11_window_tracker_ignores_invalid_mode(monkeypatch):
+    service = MagicMock()
+    service_cls = MagicMock(return_value=service)
+    legacy_cls = MagicMock()
+    monkeypatch.setenv(session.X11_WINDOW_SERVICE_ENV, "invalid")
+    monkeypatch.setattr(session, "X11WindowService", service_cls)
+    monkeypatch.setattr(session, "WindowTracker", legacy_cls)
+
+    result = session.build_x11_window_tracker(
+        model=MagicMock(), launcher=MagicMock(), config=MagicMock()
+    )
+
+    assert result is service
+    service_cls.assert_called_once()
+    legacy_cls.assert_not_called()

--- a/tests/smoke/test_python314_smoke.py
+++ b/tests/smoke/test_python314_smoke.py
@@ -46,6 +46,14 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
     platform_pkg.__path__ = []
     monkeypatch.setitem(sys.modules, "docking.platform", platform_pkg)
 
+    backends_pkg = types.ModuleType("docking.platform.backends")
+    backends_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "docking.platform.backends", backends_pkg)
+
+    x11_pkg = types.ModuleType("docking.platform.backends.x11")
+    x11_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "docking.platform.backends.x11", x11_pkg)
+
     ui_pkg = types.ModuleType("docking.ui")
     ui_pkg.__path__ = []
     monkeypatch.setitem(sys.modules, "docking.ui", ui_pkg)
@@ -60,6 +68,9 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
         },
         "docking.platform.model": {
             "DockModel": type("DockModel", (), {}),
+        },
+        "docking.platform.backends.x11.session": {
+            "build_x11_window_tracker": lambda **_kwargs: None,
         },
         "docking.platform.window_tracker": {
             "WindowTracker": type("WindowTracker", (), {}),
@@ -249,7 +260,11 @@ def test_app_main_smoke(monkeypatch):
     monkeypatch.setattr(app_mod, "Launcher", MagicMock(return_value=launcher))
     monkeypatch.setattr(app_mod, "DockModel", MagicMock(return_value=model))
     monkeypatch.setattr(app_mod, "DockRenderer", MagicMock(return_value=renderer))
-    monkeypatch.setattr(app_mod, "WindowTracker", MagicMock(return_value=tracker))
+    monkeypatch.setattr(
+        app_mod,
+        "build_x11_window_tracker",
+        MagicMock(return_value=tracker),
+    )
     monkeypatch.setattr(app_mod, "UnityLauncherListener", MagicMock(return_value=unity))
     monkeypatch.setattr(
         app_mod,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -31,6 +31,14 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
     platform_pkg.__path__ = []
     monkeypatch.setitem(sys.modules, "docking.platform", platform_pkg)
 
+    backends_pkg = types.ModuleType("docking.platform.backends")
+    backends_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "docking.platform.backends", backends_pkg)
+
+    x11_pkg = types.ModuleType("docking.platform.backends.x11")
+    x11_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "docking.platform.backends.x11", x11_pkg)
+
     ui_pkg = types.ModuleType("docking.ui")
     ui_pkg.__path__ = []
     monkeypatch.setitem(sys.modules, "docking.ui", ui_pkg)
@@ -45,6 +53,9 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
         },
         "docking.platform.model": {
             "DockModel": type("DockModel", (), {}),
+        },
+        "docking.platform.backends.x11.session": {
+            "build_x11_window_tracker": lambda **_kwargs: None,
         },
         "docking.platform.window_tracker": {
             "WindowTracker": type("WindowTracker", (), {}),
@@ -143,7 +154,11 @@ class TestAppMain:
         monkeypatch.setattr(app_mod, "Launcher", MagicMock(return_value=launcher))
         monkeypatch.setattr(app_mod, "DockModel", MagicMock(return_value=model))
         monkeypatch.setattr(app_mod, "DockRenderer", MagicMock(return_value=renderer))
-        monkeypatch.setattr(app_mod, "WindowTracker", MagicMock(return_value=tracker))
+        monkeypatch.setattr(
+            app_mod,
+            "build_x11_window_tracker",
+            MagicMock(return_value=tracker),
+        )
         monkeypatch.setattr(
             app_mod,
             "UnityLauncherListener",
@@ -174,6 +189,7 @@ class TestAppMain:
             window_tracker=tracker,
             launcher=launcher,
         )
+        tracker.start.assert_called_once()
         model.start_applets.assert_called_once()
         model.stop_applets.assert_called_once()
         items_service.start.assert_called_once()
@@ -188,6 +204,7 @@ class TestAppMain:
             app_mod._start_runtime,
             items_service,
             model,
+            tracker,
         )
         fake_gtk.main.assert_called_once()
         assert call_order == [
@@ -206,6 +223,20 @@ class TestAppMain:
         assert signal.SIGTERM in sig_calls
         for call in fake_glib.unix_signal_add.call_args_list:
             assert call.args[2] is app_mod._quit
+
+    def test_start_runtime_allows_legacy_tracker_without_start(self, monkeypatch):
+        # Given
+        app_mod, _fake_glib, _fake_gtk = _load_app_module(monkeypatch)
+        items_service = MagicMock()
+        model = MagicMock()
+
+        # When
+        result = app_mod._start_runtime(items_service, model, object())
+
+        # Then
+        assert result is False
+        items_service.start.assert_called_once()
+        model.start_applets.assert_called_once()
 
     def test_module_entrypoint_invokes_main(self, monkeypatch):
         # Given
@@ -265,7 +296,9 @@ class TestAppMain:
             sys.modules["docking.ui.renderer"], "DockRenderer", renderer_cls
         )
         monkeypatch.setattr(
-            sys.modules["docking.platform.window_tracker"], "WindowTracker", tracker_cls
+            sys.modules["docking.platform.backends.x11.session"],
+            "build_x11_window_tracker",
+            tracker_cls,
         )
         monkeypatch.setattr(
             sys.modules["docking.platform.unity"], "UnityLauncherListener", unity_cls
@@ -294,6 +327,7 @@ class TestAppMain:
         factory.assert_called_once()
         items_service_cls.assert_called_once_with(model=model, window=window)
         fake_gtk.main.assert_called_once()
+        tracker.start.assert_called_once()
         unity.start.assert_called_once()
         unity.stop.assert_called_once()
         new_year.start.assert_called_once()


### PR DESCRIPTION
## Summary
- Add an X11 runtime construction helper that uses X11WindowService by default with a temporary DOCKING_X11_WINDOW_SERVICE=legacy fallback.
- Switch app startup to build the X11 window runtime through that helper and start service-style trackers after the dock is shown.
- Make WindowTracker screen initialization idempotent so explicit service startup cannot double-connect Wnck signals.
- Cover service/legacy construction, invalid env fallback, startup wiring, legacy no-start runtime, and idempotent Wnck setup in tests.

Pre-commit completed successfully: ruff format, ruff check, ty, i18n checks, package-data checks, translation packaging checks, and 3345 tests.