### PR TITLE
Use window snapshots for menu window rows

### DIFF
--- a/docking/platform/window_tracker.py
+++ b/docking/platform/window_tracker.py
@@ -764,6 +764,17 @@ class WindowTracker:
             )
             return
 
+    def activate(self, window_id: WindowId) -> ActionResult:
+        """Activate one X11 window by backend-neutral window ID."""
+        xid = self._xid_from_window_id(window_id)
+        if xid is None:
+            return ActionResult.UNSUPPORTED
+        window = self._window_for_xid(xid=xid)
+        if window is None:
+            return ActionResult.NOT_FOUND
+        self.activate_window(window=window)
+        return ActionResult.OK
+
     def activate_xid(self, xid: int) -> None:
         """Activate a window by XID, if still present."""
         window = self._window_for_xid(xid=xid)
@@ -909,6 +920,16 @@ class WindowTracker:
                 result = ActionResult.FAILED
         return result
 
+    def close(self, window_id: WindowId) -> ActionResult:
+        """Close one X11 window by backend-neutral window ID."""
+        xid = self._xid_from_window_id(window_id)
+        if xid is None:
+            return ActionResult.UNSUPPORTED
+        if self._window_for_xid(xid=xid) is None:
+            return ActionResult.NOT_FOUND
+        self.close_xid(xid=xid)
+        return ActionResult.OK
+
     def close_xid(self, xid: int) -> None:
         """Close a specific window by XID, if still present."""
         window = self._window_for_xid(xid=xid)
@@ -963,6 +984,15 @@ class WindowTracker:
                 f"Failed to read window xid: {exc}"
             )
             return 0
+
+    @staticmethod
+    def _xid_from_window_id(window_id: WindowId) -> int | None:
+        if window_id.backend != "x11":
+            return None
+        try:
+            return int(window_id.value)
+        except (TypeError, ValueError):
+            return None
 
     def _get_windows_for(self, desktop_id: str) -> list[Wnck.Window]:
         """Get windows for desktop_id using cached XIDs from last scan.

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -44,7 +44,7 @@ MenuHandler owns:
 - building item-specific and dock-specific actions,
 - applet submenu organization,
 - folder item menus,
-- live window menu entries with thumbnails,
+- live window menu entries with backend-neutral window actions,
 - popup creation and lifecycle hookup.
 
 It does not own:
@@ -120,12 +120,11 @@ Kinds of menus built here
 Left-click folder stacks are coordinated through `FolderStackController`; this
 module only exposes the facade methods used by dock input handling.
 
-Window thumbnails in menus
+Window entries in menus
 
-For running applications, the menu may include live window entries. Those use
-the same preview capture machinery as the preview popup, but at smaller sizes.
-That gives the user recognition value directly inside the menu without having to
-switch to the larger preview surface.
+For running applications, the menu may include live window entries. Those rows
+use backend-neutral window snapshots so activation and close actions do not need
+raw Wnck windows or XIDs in the menu layer.
 
 Popup lifecycle
 
@@ -184,13 +183,13 @@ from docking.log import get_logger
 from docking.ui.about import AboutDialogController
 from docking.ui.folder.stack import FolderStackController
 from docking.ui.geometry import DockGeometryBuilder, DockGeometryFrame
-from docking.ui.preview import capture_window
 from docking.ui.runtime import DockRuntime
 from docking.ui.settings import SettingsWindowController
 
 if TYPE_CHECKING:
     from docking.core.config import Config
     from docking.core.items import DockItem
+    from docking.platform.backends.base import WindowId, WindowSnapshot
     from docking.platform.launcher import Launcher
     from docking.platform.model import DockModel
     from docking.platform.window_tracker import WindowTracker
@@ -646,36 +645,27 @@ class MenuHandler:
 
     def _append_open_windows(self, menu: Gtk.Menu, desktop_id: str) -> None:
         """Append running windows as rich menu rows with activate/close."""
-        windows = self._tracker.get_windows_for(desktop_id=desktop_id)
+        windows = list(self._tracker.list_windows(desktop_id=desktop_id))
         if not windows:
             return
         if self._config.window_list_sort == WindowListSort.ALPHABETICAL.value:
-            windows = sorted(
-                windows,
-                key=lambda w: (
-                    self._tracker.get_window_title_for_xid(w.get_xid()) or ""
-                ).lower(),
-            )
+            windows = sorted(windows, key=lambda window: window.title.lower())
         for window in windows:
             menu.append(self._build_window_menu_row(window=window))
         separator = Gtk.SeparatorMenuItem()
         separator._window_rows_separator = True
         menu.append(separator)
 
-    def _build_window_menu_row(self, window: Any) -> Gtk.MenuItem:
-        xid = window.get_xid()
-        title = self._tracker.get_window_title_for_xid(xid) or _("Window")
+    def _build_window_menu_row(self, window: WindowSnapshot) -> Gtk.MenuItem:
+        title = window.title or _("Window")
         row = Gtk.MenuItem()
         row.set_label(title)
-        thumb = capture_window(
-            wnck_window=window, thumb_w=WINDOW_MENU_THUMB_W, thumb_h=WINDOW_MENU_THUMB_H
-        )
 
         box = Gtk.Box(
             orientation=Gtk.Orientation.HORIZONTAL,
             spacing=MENU_ROW_SPACING_PX,
         )
-        image = Gtk.Image.new_from_pixbuf(thumb) if thumb is not None else Gtk.Image()
+        image = Gtk.Image()
         image.set_pixel_size(WINDOW_MENU_THUMB_H)
         box.pack_start(image, False, False, 0)
 
@@ -697,9 +687,11 @@ class MenuHandler:
             row.remove(child)
         row.add(box)
         row._window_row = True
-        row.connect("button-press-event", self._on_window_row_button_press, xid)
-        row.connect("button-release-event", self._on_window_row_button_release, xid)
-        row.connect("activate", lambda *_a: self._tracker.activate_xid(xid))
+        row.connect("button-press-event", self._on_window_row_button_press, window.id)
+        row.connect(
+            "button-release-event", self._on_window_row_button_release, window.id
+        )
+        row.connect("activate", lambda *_a: self._tracker.activate(window.id))
         return row
 
     def _window_close_zone_hit(
@@ -713,16 +705,16 @@ class MenuHandler:
         return width > 0 and x >= max(0.0, width - WINDOW_MENU_CLOSE_HIT_W)
 
     def _on_window_row_button_press(
-        self, widget: Gtk.Widget, event: Gdk.EventButton, xid: int
+        self, widget: Gtk.Widget, event: Gdk.EventButton, window_id: WindowId
     ) -> bool:
         return self._window_close_zone_hit(widget=widget, event=event)
 
     def _on_window_row_button_release(
-        self, widget: Gtk.Widget, event: Gdk.EventButton, xid: int
+        self, widget: Gtk.Widget, event: Gdk.EventButton, window_id: WindowId
     ) -> bool:
         if not self._window_close_zone_hit(widget=widget, event=event):
             return False
-        self._tracker.close_xid(xid)
+        self._tracker.close(window_id)
         self._remove_window_row(widget=widget, event=event)
         self._runtime.hide_hover_ui()
         return True

--- a/tests/platform/test_window_tracker_integration.py
+++ b/tests/platform/test_window_tracker_integration.py
@@ -17,7 +17,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for non-GI environmen
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
 import docking.platform.window_tracker as window_tracker_mod
-from docking.platform.backends.base import WindowId
+from docking.platform.backends.base import ActionResult, WindowId
 from docking.platform.launcher import DesktopInfo
 from docking.platform.model import DockItem
 
@@ -458,6 +458,37 @@ class TestWindowActions:
 
         tracker.close_xid(2)
 
+        assert w1.closed_with == []
+        assert w2.closed_with == [123]
+
+    def test_activate_uses_window_id(self, tracker_env):
+        tracker, _model, _launcher = tracker_env
+        w1 = FakeWindow(1)
+        w2 = FakeWindow(2)
+        tracker._screen = FakeScreen(windows=[w1, w2], active_window=None)
+
+        result = tracker.activate(WindowId.x11(2))
+
+        assert result is ActionResult.OK
+        assert w1.activated_with == []
+        assert w2.activated_with == [123]
+
+    def test_activate_rejects_non_x11_window_id(self, tracker_env):
+        tracker, _model, _launcher = tracker_env
+
+        result = tracker.activate(WindowId(backend="wayland", value="1"))
+
+        assert result is ActionResult.UNSUPPORTED
+
+    def test_close_uses_window_id(self, tracker_env):
+        tracker, _model, _launcher = tracker_env
+        w1 = FakeWindow(1)
+        w2 = FakeWindow(2)
+        tracker._screen = FakeScreen(windows=[w1, w2], active_window=None)
+
+        result = tracker.close(WindowId.x11(2))
+
+        assert result is ActionResult.OK
         assert w1.closed_with == []
         assert w2.closed_with == [123]
 

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -20,6 +20,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for non-GI environmen
 import docking.ui.folder.stack as folder_stack_mod
 import docking.ui.menu as menu_mod
 from docking.core.items import FILE_KIND, FOLDER_KIND
+from docking.platform.backends.base import WindowId, WindowSnapshot
 from docking.platform.model import DockItem
 
 
@@ -739,8 +740,7 @@ def handler(monkeypatch):
         save=MagicMock(),
     )
     tracker = MagicMock()
-    tracker.get_windows_for.return_value = []
-    tracker.get_window_title_for_xid.side_effect = lambda xid: f"Window {xid}"
+    tracker.list_windows.return_value = []
     launcher = MagicMock()
     launcher.default_directory_app_name.return_value = None
     return menu_mod.MenuHandler(
@@ -1092,11 +1092,14 @@ class TestItemMenus:
             is_running=True,
             instance_count=1,
         )
-        window = MagicMock()
-        window.get_xid.return_value = 7
-        handler._tracker.get_windows_for.return_value = [window]
-        handler._tracker.get_window_title_for_xid.return_value = "A" * 80
-        monkeypatch.setattr(menu_mod, "capture_window", lambda **_kwargs: "thumb")
+        window_id = WindowId.x11(7)
+        handler._tracker.list_windows.return_value = [
+            WindowSnapshot(
+                id=window_id,
+                desktop_id="firefox.desktop",
+                title="A" * 80,
+            )
+        ]
         monkeypatch.setattr(menu_mod.launcher_mod, "get_actions", lambda **_kwargs: [])
 
         handler._build_item_menu(menu=menu, item=item)
@@ -1115,7 +1118,7 @@ class TestItemMenus:
         close_event = SimpleNamespace(x=170.0)
         assert row.emit("button-press-event", close_event) is True
         assert row.emit("button-release-event", close_event) is True
-        handler._tracker.close_xid.assert_called_once_with(7)
+        handler._tracker.close.assert_called_once_with(window_id)
         handler._runtime.hide_hover_ui.assert_called_once()
         assert row.hidden is True
         assert row.destroyed is True
@@ -1131,7 +1134,7 @@ class TestItemMenus:
         assert menu.popup_event is close_event
 
         row.activate()
-        handler._tracker.activate_xid.assert_called_once_with(7)
+        handler._tracker.activate.assert_called_once_with(window_id)
 
     def test_window_list_default_preserves_tracker_order(self, handler, monkeypatch):
         menu = FakeMenu()
@@ -1140,18 +1143,18 @@ class TestItemMenus:
             is_running=True,
             instance_count=3,
         )
-        w1, w2, w3 = MagicMock(), MagicMock(), MagicMock()
-        w1.get_xid.return_value = 1
-        w2.get_xid.return_value = 2
-        w3.get_xid.return_value = 3
-        handler._tracker.get_windows_for.return_value = [w1, w2, w3]
-        handler._tracker.get_window_title_for_xid.side_effect = {
-            1: "Charlie",
-            2: "Alpha",
-            3: "Bravo",
-        }.get
+        handler._tracker.list_windows.return_value = [
+            WindowSnapshot(
+                id=WindowId.x11(1), desktop_id="code.desktop", title="Charlie"
+            ),
+            WindowSnapshot(
+                id=WindowId.x11(2), desktop_id="code.desktop", title="Alpha"
+            ),
+            WindowSnapshot(
+                id=WindowId.x11(3), desktop_id="code.desktop", title="Bravo"
+            ),
+        ]
         handler._config.window_list_sort = "default"
-        monkeypatch.setattr(menu_mod, "capture_window", lambda **_kwargs: None)
         monkeypatch.setattr(menu_mod.launcher_mod, "get_actions", lambda **_kwargs: [])
 
         handler._build_item_menu(menu=menu, item=item)
@@ -1167,18 +1170,18 @@ class TestItemMenus:
             is_running=True,
             instance_count=3,
         )
-        w1, w2, w3 = MagicMock(), MagicMock(), MagicMock()
-        w1.get_xid.return_value = 1
-        w2.get_xid.return_value = 2
-        w3.get_xid.return_value = 3
-        handler._tracker.get_windows_for.return_value = [w1, w2, w3]
-        handler._tracker.get_window_title_for_xid.side_effect = {
-            1: "Charlie",
-            2: "Alpha",
-            3: "Bravo",
-        }.get
+        handler._tracker.list_windows.return_value = [
+            WindowSnapshot(
+                id=WindowId.x11(1), desktop_id="code.desktop", title="Charlie"
+            ),
+            WindowSnapshot(
+                id=WindowId.x11(2), desktop_id="code.desktop", title="Alpha"
+            ),
+            WindowSnapshot(
+                id=WindowId.x11(3), desktop_id="code.desktop", title="Bravo"
+            ),
+        ]
         handler._config.window_list_sort = "alphabetical"
-        monkeypatch.setattr(menu_mod, "capture_window", lambda **_kwargs: None)
         monkeypatch.setattr(menu_mod.launcher_mod, "get_actions", lambda **_kwargs: [])
 
         handler._build_item_menu(menu=menu, item=item)


### PR DESCRIPTION
## Summary
- Migrate app menu window rows from raw Wnck windows/XIDs to WindowSnapshot rows and WindowId actions.
- Add neutral activate/close methods to WindowTracker so the temporary legacy X11 fallback supports the new menu path.
- Update menu and tracker tests for snapshot ordering, activate, close, and non-X11 rejection.

Pre-commit completed successfully: ruff format, ruff check, ty, i18n checks, package-data checks, translation packaging checks, and 3348 tests.