### PR TITLE
Route preview popup through preview service

### DIFF
--- a/docking/platform/backends/x11/previews.py
+++ b/docking/platform/backends/x11/previews.py
@@ -1,0 +1,239 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""X11 window preview capture service."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import gi
+
+gi.require_version("Gdk", "3.0")
+gi.require_version("GdkPixbuf", "2.0")
+gi.require_version("GdkX11", "3.0")
+gi.require_version("Gtk", "3.0")
+gi.require_version("Wnck", "3.0")
+from gi.repository import Gdk, GdkPixbuf, GdkX11, GLib, Gtk, Wnck
+
+from docking.log import get_logger
+from docking.platform.backends.base import PreviewImage, WindowId
+
+if TYPE_CHECKING:
+    from docking.platform.window_tracker import WindowTracker
+
+log = get_logger(name="x11_previews")
+
+THUMB_W = 200
+THUMB_H = 150
+ICON_FALLBACK_SIZE = 64
+CAPTURE_SAMPLE_GRID_MAX = 8
+CAPTURE_ALPHA_MIN = 8
+CAPTURE_MAX_CHANNEL_THRESHOLD = 10
+CAPTURE_AVERAGE_LUMA_THRESHOLD = 5
+
+
+class X11PreviewService:
+    """PreviewService implementation backed by X11 foreign-window capture."""
+
+    def __init__(self, window_tracker: WindowTracker) -> None:
+        self._tracker = window_tracker
+
+    def start(self) -> None:
+        """No runtime loop is needed for X11 preview capture."""
+
+    def stop(self) -> None:
+        """No persistent resources are held by the preview service."""
+
+    def capture(
+        self, window_id: WindowId, *, width: int, height: int
+    ) -> PreviewImage | None:
+        """Capture one X11 window preview by backend-neutral window ID."""
+        xid = _xid_from_window_id(window_id=window_id)
+        if xid is None:
+            return None
+
+        # Preserve the old PreviewPopup behavior exactly: preview thumbnails
+        # captured pixels directly from the XID and did not ask Wnck whether the
+        # window was minimized. Routing through capture_window() here would make
+        # minimized or transiently hidden windows immediately turn into fallback
+        # icons, which changes the visible popup behavior while the pointer moves
+        # from the dock toward the preview.
+        pixbuf = capture_xid(xid=xid, thumb_w=width, thumb_h=height)
+        if pixbuf is None:
+            return None
+        return PreviewImage(
+            image=pixbuf,
+            width=int(pixbuf.get_width()),
+            height=int(pixbuf.get_height()),
+        )
+
+    def fallback_icon_name(self, window_id: WindowId) -> str | None:
+        """Return no per-window icon override for the current X11 path."""
+        return None
+
+
+def capture_window(
+    wnck_window: Wnck.Window, thumb_w: int = THUMB_W, thumb_h: int = THUMB_H
+) -> GdkPixbuf.Pixbuf | None:
+    """Capture a window's content as a scaled thumbnail pixbuf."""
+    if wnck_window.is_minimized():
+        return _icon_fallback(thumb_w=thumb_w, thumb_h=thumb_h)
+
+    xid = wnck_window.get_xid()
+    pixbuf = capture_xid(xid=xid, thumb_w=thumb_w, thumb_h=thumb_h)
+    if pixbuf is None:
+        return _icon_fallback(thumb_w=thumb_w, thumb_h=thumb_h)
+    return pixbuf
+
+
+def capture_xid(
+    xid: int, thumb_w: int = THUMB_W, thumb_h: int = THUMB_H
+) -> GdkPixbuf.Pixbuf | None:
+    """Capture a window thumbnail by XID."""
+    display = GdkX11.X11Display.get_default()
+
+    try:
+        foreign = GdkX11.X11Window.foreign_new_for_display(display, xid)
+    except (TypeError, GLib.Error) as exc:
+        log.warning(f"Failed to create foreign X11 window for xid={xid}: {exc}")
+        foreign = None
+
+    if foreign:
+        try:
+            width = foreign.get_width()
+            height = foreign.get_height()
+            if width > 0 and height > 0:
+                display.error_trap_push()
+                pixbuf = Gdk.pixbuf_get_from_window(foreign, 0, 0, width, height)
+                x_error = display.error_trap_pop()
+                if x_error or not pixbuf:
+                    log.debug(f"X11 capture failed for xid={xid} (error={x_error})")
+                    return None
+                if _looks_unavailable_capture(pixbuf=pixbuf):
+                    log.debug(f"Capture looked unavailable (black) for xid={xid}")
+                    return None
+                scale = min(thumb_w / width, thumb_h / height)
+                new_width = max(int(width * scale), 1)
+                new_height = max(int(height * scale), 1)
+                return pixbuf.scale_simple(
+                    new_width, new_height, GdkPixbuf.InterpType.BILINEAR
+                )
+        except (TypeError, GLib.Error) as exc:
+            log.warning(f"Window preview capture failed for xid={xid}: {exc}")
+
+    return None
+
+
+def _looks_unavailable_capture(pixbuf: GdkPixbuf.Pixbuf) -> bool:
+    """Detect near-black captures that should fallback to app icon."""
+    try:
+        width = int(pixbuf.get_width())
+        height = int(pixbuf.get_height())
+        channels = int(pixbuf.get_n_channels())
+        rowstride = int(pixbuf.get_rowstride())
+        has_alpha = bool(pixbuf.get_has_alpha())
+        data = pixbuf.get_pixels()
+    except (AttributeError, TypeError, ValueError) as exc:
+        log.debug("Failed to inspect captured pixbuf: %s", exc)
+        return False
+
+    if width <= 0 or height <= 0 or channels < 3 or rowstride <= 0:
+        return False
+    if not isinstance(data, bytes | bytearray | memoryview):
+        return False
+
+    sample_x = max(1, min(CAPTURE_SAMPLE_GRID_MAX, width))
+    sample_y = max(1, min(CAPTURE_SAMPLE_GRID_MAX, height))
+    max_channel = 0
+    total_luma = 0
+    count = 0
+
+    for yi in range(sample_y):
+        y = int((yi + 0.5) * height / sample_y)
+        if y >= height:
+            y = height - 1
+        for xi in range(sample_x):
+            x = int((xi + 0.5) * width / sample_x)
+            if x >= width:
+                x = width - 1
+            p = y * rowstride + x * channels
+            r = data[p]
+            g = data[p + 1]
+            b = data[p + 2]
+            a = data[p + 3] if has_alpha and channels >= 4 else 255
+            if a < CAPTURE_ALPHA_MIN:
+                continue
+            max_channel = max(max_channel, r, g, b)
+            total_luma += (r + g + b) // 3
+            count += 1
+
+    if count == 0:
+        return True
+
+    avg_luma = total_luma / count
+    return (
+        max_channel < CAPTURE_MAX_CHANNEL_THRESHOLD
+        and avg_luma < CAPTURE_AVERAGE_LUMA_THRESHOLD
+    )
+
+
+def _icon_fallback(thumb_w: int, thumb_h: int) -> GdkPixbuf.Pixbuf | None:
+    """Create a dark placeholder pixbuf with the generic app icon centered."""
+    bg = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, True, 8, thumb_w, thumb_h)
+    bg.fill(0x1E1E1EFF)
+
+    icon_theme = Gtk.IconTheme.get_default()
+    if icon_theme is None:
+        return bg
+
+    icon_size = min(ICON_FALLBACK_SIZE, thumb_w, thumb_h)
+    try:
+        icon = icon_theme.load_icon("application-x-executable", icon_size, 0)
+    except GLib.Error as exc:
+        log.warning(f"Failed to load fallback preview icon: {exc}")
+        icon = None
+
+    if icon:
+        scaled_icon = icon.scale_simple(
+            icon_size, icon_size, GdkPixbuf.InterpType.BILINEAR
+        )
+    else:
+        scaled_icon = None
+
+    if scaled_icon is not None:
+        x = (thumb_w - icon_size) // 2
+        y = (thumb_h - icon_size) // 2
+        scaled_icon.composite(
+            bg,
+            x,
+            y,
+            icon_size,
+            icon_size,
+            x,
+            y,
+            1.0,
+            1.0,
+            GdkPixbuf.InterpType.BILINEAR,
+            255,
+        )
+    return bg
+
+
+def _xid_from_window_id(*, window_id: WindowId) -> int | None:
+    if window_id.backend != "x11":
+        return None
+    try:
+        return int(window_id.value)
+    except (TypeError, ValueError):
+        return None

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -204,6 +204,7 @@ from docking.core.items import FILE_KIND, FOLDER_KIND
 from docking.core.position import is_horizontal
 from docking.i18n import _
 from docking.log import get_logger
+from docking.platform.backends.base import PreviewService
 from docking.platform.environment import detect_desktop, log_runtime_snapshot
 from docking.platform.launcher import launch, launch_new_window, open_target
 from docking.platform.struts import (
@@ -343,6 +344,7 @@ class DockWindow(Gtk.Window):
         theme: Theme,
         window_tracker: WindowTracker,
         launcher: Launcher,
+        preview_service: PreviewService,
     ) -> None:
         super().__init__(type=Gtk.WindowType.TOPLEVEL)
         self.config = config
@@ -350,6 +352,7 @@ class DockWindow(Gtk.Window):
         self.renderer = renderer
         self.theme = theme
         self.window_tracker = window_tracker
+        self.preview_service = preview_service
         self.cursor_x: float = -1.0
         self.cursor_y: float = -1.0
         self.autohide: AutoHideController
@@ -510,7 +513,10 @@ class DockWindow(Gtk.Window):
             launcher=launcher,
         )
         self._menu.schedule_visible_folder_stack_prewarm(self.model.visible_items())
-        self.preview = PreviewPopup(window_tracker=self.window_tracker)
+        self.preview = PreviewPopup(
+            window_tracker=self.window_tracker,
+            preview_service=self.preview_service,
+        )
         self.preview.set_pointer_inside_dock_probe(self.is_pointer_inside_dock)
         self.preview.set_autohide(controller=self.autohide)
         self.hover.set_preview(preview=self.preview)

--- a/docking/ui/factory.py
+++ b/docking/ui/factory.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 from docking.core.config import Config
 from docking.core.theme import Theme
+from docking.platform.backends.x11.previews import X11PreviewService
 from docking.platform.dodge import ScreenRect, WindowDodgeMonitor
 from docking.platform.launcher import Launcher
 from docking.platform.model import DockModel
@@ -47,6 +48,7 @@ def build_dock_window(
         theme=theme,
         window_tracker=window_tracker,
         launcher=launcher,
+        preview_service=X11PreviewService(window_tracker=window_tracker),
     )
 
     def _get_dock_rect() -> ScreenRect | None:

--- a/docking/ui/preview.py
+++ b/docking/ui/preview.py
@@ -43,7 +43,6 @@ What this module owns
 This module owns:
 
 - preview popup creation and widget structure,
-- thumbnail capture and fallback logic,
 - delayed hide of the preview popup,
 - preview enter/leave tracking,
 - window activation from thumbnail clicks,
@@ -55,6 +54,7 @@ It does not own:
 - the decision to arm preview show,
 - dock-wide effective hover state,
 - autohide animation math.
+- platform-specific preview capture.
 
 Those belong to HoverManager and the interaction/autohide layers.
 
@@ -86,22 +86,11 @@ tooltip.
 
 Thumbnail capture model
 
-Preview thumbnails try to show real window contents, but X11 capture is not
-perfectly reliable. Windows can disappear mid-capture, minimized windows may
-have no usable pixels, and some captures come back effectively black.
-
-So the capture pipeline is:
-
-    Wnck.Window
-      |
-      +--> capture XID pixels if possible
-      |
-      +--> detect unavailable/black captures
-      |
-      +--> fall back to generic app icon on dark background
-
-That fallback is intentional. A stable generic preview is better than a broken
-or flashing thumbnail.
+Preview thumbnails try to show real window contents, but the way that happens
+is platform-owned. The popup asks a PreviewService for an image using a
+backend-neutral WindowId. On X11 that service can still do foreign-window
+capture internally; on a future native Wayland backend it may return an icon
+card or nothing if the compositor has no preview capability.
 
 Why CSS and widget structure live here
 
@@ -128,16 +117,15 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gdk", "3.0")
-gi.require_version("GdkX11", "3.0")
-gi.require_version("Wnck", "3.0")
-gi.require_version("GdkPixbuf", "2.0")
-from gi.repository import Gdk, GdkPixbuf, GdkX11, GLib, Gtk, Wnck
+from gi.repository import Gdk, GLib, Gtk
 
 from docking.core.position import Position, is_horizontal
 from docking.log import get_logger
+from docking.platform.backends.base import WindowId, WindowSnapshot
 from docking.ui.display import clamp_to_screen
 
 if TYPE_CHECKING:
+    from docking.platform.backends.base import PreviewService
     from docking.platform.window_tracker import WindowTracker
     from docking.ui.autohide import AutoHideController
 
@@ -151,10 +139,6 @@ LABEL_MAX_CHARS = 25
 PREVIEW_HIDE_DELAY_MS = 300
 ICON_FALLBACK_SIZE = 64
 PREVIEW_GAP_PX = 40
-CAPTURE_SAMPLE_GRID_MAX = 8
-CAPTURE_ALPHA_MIN = 8
-CAPTURE_MAX_CHANNEL_THRESHOLD = 10
-CAPTURE_AVERAGE_LUMA_THRESHOLD = 5
 
 _CSS = b"""
 .preview-popup {
@@ -199,178 +183,17 @@ def _ensure_css() -> None:
     _install_css()
 
 
-def capture_window(
-    wnck_window: Wnck.Window, thumb_w: int = THUMB_W, thumb_h: int = THUMB_H
-) -> GdkPixbuf.Pixbuf | None:
-    """Capture a window's content as a scaled thumbnail pixbuf.
-
-    Uses GdkX11.X11Window.foreign_new_for_display to create a GDK handle
-    for the target XID, then reads pixels via Gdk.pixbuf_get_from_window.
-    Falls back to _icon_fallback if the window is minimized (no pixel
-    content available) or if the foreign window handle fails (e.g. the
-    window was destroyed between detection and capture).
-    """
-    if wnck_window.is_minimized():
-        return _icon_fallback(thumb_w=thumb_w, thumb_h=thumb_h)
-
-    xid = wnck_window.get_xid()
-    pixbuf = capture_xid(xid=xid, thumb_w=thumb_w, thumb_h=thumb_h)
-    if pixbuf is None:
-        return _icon_fallback(thumb_w=thumb_w, thumb_h=thumb_h)
-    return pixbuf
-
-
-def capture_xid(
-    xid: int, thumb_w: int = THUMB_W, thumb_h: int = THUMB_H
-) -> GdkPixbuf.Pixbuf | None:
-    """Capture a window thumbnail by XID, avoiding direct Wnck object use."""
-    display = GdkX11.X11Display.get_default()
-
-    try:
-        foreign = GdkX11.X11Window.foreign_new_for_display(display, xid)
-    except (TypeError, GLib.Error) as exc:
-        log.warning(f"Failed to create foreign X11 window for xid={xid}: {exc}")
-        foreign = None
-
-    if foreign:
-        try:
-            width = foreign.get_width()
-            height = foreign.get_height()
-            if width > 0 and height > 0:
-                # Trap X11 errors: the window may be destroyed between
-                # foreign_new_for_display and pixbuf_get_from_window,
-                # causing a segfault in the C layer that Python can't catch.
-                display.error_trap_push()
-                pixbuf = Gdk.pixbuf_get_from_window(foreign, 0, 0, width, height)
-                x_error = display.error_trap_pop()
-                if x_error or not pixbuf:
-                    log.debug(f"X11 capture failed for xid={xid} (error={x_error})")
-                    return None
-                if _looks_unavailable_capture(pixbuf=pixbuf):
-                    log.debug(f"Capture looked unavailable (black) for xid={xid}")
-                    return None
-                # Scale preserving aspect ratio
-                scale = min(thumb_w / width, thumb_h / height)
-                new_width = max(int(width * scale), 1)
-                new_height = max(int(height * scale), 1)
-                return pixbuf.scale_simple(
-                    new_width, new_height, GdkPixbuf.InterpType.BILINEAR
-                )
-        except (TypeError, GLib.Error) as exc:
-            log.warning(f"Window preview capture failed for xid={xid}: {exc}")
-
-    return None
-
-
-def _looks_unavailable_capture(pixbuf: GdkPixbuf.Pixbuf) -> bool:
-    """Detect near-black captures that should fallback to app icon."""
-    try:
-        width = int(pixbuf.get_width())
-        height = int(pixbuf.get_height())
-        channels = int(pixbuf.get_n_channels())
-        rowstride = int(pixbuf.get_rowstride())
-        has_alpha = bool(pixbuf.get_has_alpha())
-        data = pixbuf.get_pixels()
-    except (AttributeError, TypeError, ValueError) as exc:
-        log.debug("Failed to inspect captured pixbuf: %s", exc)
-        return False
-
-    if width <= 0 or height <= 0 or channels < 3 or rowstride <= 0:
-        return False
-    if not isinstance(data, bytes | bytearray | memoryview):
-        return False
-
-    sample_x = max(1, min(CAPTURE_SAMPLE_GRID_MAX, width))
-    sample_y = max(1, min(CAPTURE_SAMPLE_GRID_MAX, height))
-    max_channel = 0
-    total_luma = 0
-    count = 0
-
-    for yi in range(sample_y):
-        y = int((yi + 0.5) * height / sample_y)
-        if y >= height:
-            y = height - 1
-        for xi in range(sample_x):
-            x = int((xi + 0.5) * width / sample_x)
-            if x >= width:
-                x = width - 1
-            p = y * rowstride + x * channels
-            r = data[p]
-            g = data[p + 1]
-            b = data[p + 2]
-            a = data[p + 3] if has_alpha and channels >= 4 else 255
-            if a < CAPTURE_ALPHA_MIN:
-                continue
-            max_channel = max(max_channel, r, g, b)
-            total_luma += (r + g + b) // 3
-            count += 1
-
-    if count == 0:
-        return True
-
-    avg_luma = total_luma / count
-    return (
-        max_channel < CAPTURE_MAX_CHANNEL_THRESHOLD
-        and avg_luma < CAPTURE_AVERAGE_LUMA_THRESHOLD
-    )
-
-
-def _icon_fallback(thumb_w: int, thumb_h: int) -> GdkPixbuf.Pixbuf | None:
-    """Create a dark placeholder pixbuf with the app icon centered.
-
-    Used when the window is minimized or pixel capture fails. Composites
-    a generic app icon (scaled to ICON_FALLBACK_SIZE) onto a dark background.
-    """
-    # Create dark background
-    bg = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, True, 8, thumb_w, thumb_h)
-    bg.fill(0x1E1E1EFF)
-
-    # Center a generic icon and avoid querying per-window class-group state.
-    icon_theme = Gtk.IconTheme.get_default()
-    if icon_theme is None:
-        return bg
-
-    icon_size = min(ICON_FALLBACK_SIZE, thumb_w, thumb_h)
-    try:
-        icon = icon_theme.load_icon("application-x-executable", icon_size, 0)
-    except GLib.Error as exc:
-        log.warning(f"Failed to load fallback preview icon: {exc}")
-        icon = None
-
-    if icon:
-        scaled_icon = icon.scale_simple(
-            icon_size, icon_size, GdkPixbuf.InterpType.BILINEAR
-        )
-    else:
-        scaled_icon = None
-
-    if scaled_icon is not None:
-        x = (thumb_w - icon_size) // 2
-        y = (thumb_h - icon_size) // 2
-        scaled_icon.composite(
-            bg,
-            x,
-            y,
-            icon_size,
-            icon_size,
-            x,
-            y,
-            1.0,
-            1.0,
-            GdkPixbuf.InterpType.BILINEAR,
-            255,
-        )
-    return bg
-
-
 class PreviewPopup(Gtk.Window):
     """Floating popup showing window thumbnails for a dock item."""
 
-    def __init__(self, window_tracker: WindowTracker) -> None:
+    def __init__(
+        self, window_tracker: WindowTracker, preview_service: PreviewService
+    ) -> None:
         super().__init__(type=Gtk.WindowType.POPUP)
         _ensure_css()
 
         self._tracker = window_tracker
+        self._preview_service = preview_service
         self._autohide: AutoHideController | None = None
         self._pointer_inside_dock: Callable[[], bool] | None = None
         self._hide_timer_id: int = 0
@@ -417,8 +240,8 @@ class PreviewPopup(Gtk.Window):
         The popup is centered on the icon along the main axis and offset
         away from the screen edge along the cross axis.
         """
-        xids = self._tracker.get_xids_for(desktop_id)
-        if not xids:
+        windows = list(self._tracker.list_windows(desktop_id))
+        if not windows:
             self.hide()
             return
         icon_name = self._tracker.icon_name_for_desktop(desktop_id)
@@ -441,9 +264,9 @@ class PreviewPopup(Gtk.Window):
         box.set_margin_top(POPUP_PADDING)
         box.set_margin_bottom(POPUP_PADDING)
 
-        for xid in xids:
-            thumb_widget = self._make_thumbnail_for_xid(
-                xid=xid, fallback_icon_name=icon_name
+        for window in windows:
+            thumb_widget = self._make_thumbnail_for_window(
+                window=window, fallback_icon_name=icon_name
             )
             box.pack_start(thumb_widget, False, False, 0)
 
@@ -478,30 +301,36 @@ class PreviewPopup(Gtk.Window):
         self.move(popup_pos.x, popup_pos.y)
         self.show_all()
 
-    def _make_thumbnail_for_xid(self, xid: int, fallback_icon_name: str) -> Gtk.Widget:
-        """Create a clickable thumbnail widget for a window XID."""
+    def _make_thumbnail_for_window(
+        self, window: WindowSnapshot, fallback_icon_name: str
+    ) -> Gtk.Widget:
+        """Create a clickable thumbnail widget for a window snapshot."""
         event_box = Gtk.EventBox()
         event_box.get_style_context().add_class("preview-thumb")
         event_box.set_events(
             Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.ENTER_NOTIFY_MASK
         )
-        event_box.connect("button-press-event", self._on_thumb_click, xid)
+        event_box.connect("button-press-event", self._on_thumb_click, window.id)
 
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
         # Thumbnail image
-        pixbuf = capture_xid(xid=xid)
-        if pixbuf:
-            image = Gtk.Image.new_from_pixbuf(pixbuf)
+        preview = self._preview_service.capture(
+            window.id, width=THUMB_W, height=THUMB_H
+        )
+        if preview is not None:
+            image = Gtk.Image.new_from_pixbuf(preview.image)
         else:
-            image = Gtk.Image.new_from_icon_name(
-                fallback_icon_name, Gtk.IconSize.DIALOG
+            icon_name = (
+                self._preview_service.fallback_icon_name(window.id)
+                or fallback_icon_name
             )
+            image = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.DIALOG)
         image.set_size_request(THUMB_W, THUMB_H)
         vbox.pack_start(image, False, False, 0)
 
         # Window title
-        title = self._tracker.get_window_title_for_xid(xid=xid)
+        title = window.title
         if len(title) > LABEL_MAX_CHARS:
             title = title[: LABEL_MAX_CHARS - 1] + "\u2026"
         label = Gtk.Label(label=title)
@@ -521,10 +350,10 @@ class PreviewPopup(Gtk.Window):
         return event_box
 
     def _on_thumb_click(
-        self, _widget: Gtk.EventBox, _event: Gdk.EventButton, xid: int
+        self, _widget: Gtk.EventBox, _event: Gdk.EventButton, window_id: WindowId
     ) -> bool:
         """Activate the clicked window."""
-        self._tracker.activate_xid(xid=xid)
+        self._tracker.activate(window_id)
         self.hide()
         self._release_dock_autohide_if_needed()
         return True

--- a/docs/WAYLAND.md
+++ b/docs/WAYLAND.md
@@ -3064,7 +3064,7 @@ The safest first moves are still X11-preserving refactors:
 1. Define `WindowId`, `WindowSnapshot`, `ActionResult`, and `WindowService`.
 2. Add an X11 adapter around the current `WindowTracker` without changing
    behavior, and add `window_ids` alongside existing XIDs in running-state
-   dataclasses. This is the combined PR 2 + PR 3 step currently under review.
+   dataclasses. This is the combined PR 2 + PR 3 step and is already merged.
 3. Wire the X11 window service into startup behind an X11-only backend/factory
    path while preserving a temporary legacy fallback if needed.
 4. Convert `MenuHandler` from Wnck windows/XIDs to `WindowSnapshot`.
@@ -3084,6 +3084,24 @@ from backend-neutral UI paths. After that, Docking should be able to run with a
 backend that intentionally lacks taskbar, preview, workspace, and overlap
 powers. That flushes out hidden X11 assumptions before compositor protocols are
 involved.
+
+### Behavior-Parity Tests
+
+Each migration PR that moves behavior behind a new service boundary must include
+a behavior-parity test at that boundary. The test should prove not only that the
+new API returns a plausible result, but that it preserves the important old
+mechanism and ownership split.
+
+For example, when moving preview capture out of `docking.ui.preview`, the test
+must encode that the old popup path captured directly from the XID, did not ask
+Wnck whether the window was minimized, and left app-icon fallback rendering to
+the UI after capture returned `None`. Without that kind of test, a refactor can
+look structurally correct while still changing visible behavior during pointer
+movement, hide transitions, or transient window-state changes.
+
+Before merging a service-boundary PR, explicitly identify the old call path that
+matters and add at least one regression test that would fail if the new service
+quietly switched to a different lower-level mechanism.
 
 ### X11 Window-Service Migration Shape
 
@@ -3137,14 +3155,14 @@ docking.app
                       close_xid(), cycle_windows(), close_all()
 ```
 
-The current PR is the combined PR 2 + PR 3 step: it introduces the X11 window
-facade and publishes neutral `WindowId` values alongside existing XIDs, but it
-does not switch production startup away from direct `WindowTracker` construction.
+The combined PR 2 + PR 3, PR 4, and PR 5 steps are already merged: Docking
+now has the X11 window facade, production X11 runtime wiring, neutral
+`WindowId` values alongside existing XIDs, and menu rows backed by
+`WindowSnapshot`.
 
-The next X11 migration PR should still be X11-only. It should prove that
-`X11WindowService` can replace direct `WindowTracker` construction without
-changing current X11 behavior, and it should not migrate menu or preview callers
-in the same step.
+The next active X11 migration PR is the preview service step. It should move
+preview capture behind `PreviewService` without changing current X11 behavior,
+and it should not complete the wider session-backend shape in the same step.
 
 An optional temporary fallback can make that step safer:
 
@@ -3174,7 +3192,7 @@ The PR sequence should keep every step reviewable and preserve the existing X11
 runtime after each merge. The first Wayland-specific PR should not appear until
 the app can run through explicit backend services on X11.
 
-#### PR 1: Backend Contracts Only
+#### [x] PR 1: Backend Contracts Only
 
 Add backend-neutral types and protocols without changing runtime wiring.
 
@@ -3209,7 +3227,7 @@ Exit criteria:
 - pure unit tests for dataclasses/capabilities pass
 - no runtime behavior changes
 
-#### PR 2 + PR 3: X11 Window Adapter Facade + Neutral Running IDs
+#### [x] PR 2 + PR 3: X11 Window Adapter Facade + Neutral Running IDs
 
 Wrap the current `WindowTracker` behavior behind an X11 `WindowService` while
 keeping compatibility methods alive. This combined PR also absorbs the neutral
@@ -3283,7 +3301,7 @@ Validation commands:
 - When the local environment has pytest installed:
   `.venv/bin/pytest tests/platform/test_backend_contracts.py tests/platform/test_window_tracker.py tests/platform/test_window_tracker_integration.py tests/platform/test_x11_window_service.py`
 
-#### PR 4: X11 Runtime Service Wiring
+#### [x] PR 4: X11 Runtime Service Wiring
 
 Switch production X11 construction from direct `WindowTracker` ownership to the
 new X11 service path, without moving any menu, preview, applet, visibility, or
@@ -3324,7 +3342,7 @@ Exit criteria:
 - current X11 UI tests still pass unchanged
 - no duplicate Wnck signal connection is possible
 
-#### PR 5: Menu Window Rows Use Snapshots
+#### [x] PR 5: Menu Window Rows Use Snapshots
 
 Remove Wnck/XID assumptions from open-window menu rows. This is the first
 planned UI consumer migration after the combined PR 2 + PR 3 and the X11 runtime
@@ -3369,7 +3387,7 @@ Exit criteria:
 - unsupported or empty `list_windows()` produces the current no-window menu
   behavior rather than a crash
 
-#### PR 6: Preview Popup Uses `PreviewService`
+#### [ ] PR 6: Preview Popup Uses `PreviewService`
 
 Remove direct `GdkX11`/`Wnck` usage from backend-neutral preview UI while
 keeping the X11 capture path internally unchanged.
@@ -3412,7 +3430,7 @@ Exit criteria:
 - preview behavior remains the same on X11
 - tests cover stale/not-found `WindowId` handling
 
-#### PR 7: Complete Session Backend Shape With X11 Only
+#### [ ] PR 7: Complete Session Backend Shape With X11 Only
 
 Complete the X11 `SessionBackend` shape after the first runtime service wiring
 and after menu/preview can consume services. Production still selects only the
@@ -3455,7 +3473,7 @@ Exit criteria:
 - tests can construct a fake/null session backend for UI wiring
 - `docking.app` no longer directly decides individual X11 services
 
-#### PR 8: Visibility Service
+#### [ ] PR 8: Visibility Service
 
 Move dodge monitor creation behind the session backend.
 
@@ -3491,7 +3509,7 @@ Exit criteria:
 - X11 dodge tests still pass
 - unsupported visibility service can run without crashing
 
-#### PR 9: Surface Service
+#### [ ] PR 9: Surface Service
 
 Move struts, barriers, blur hints, and platform surface hooks behind
 `SurfaceService`.
@@ -3528,7 +3546,7 @@ Exit criteria:
 - raw `GdkX11` checks are confined to X11 backend code or transitional shims
 - X11 placement, strut, barrier, and blur tests still pass
 
-#### PR 10: Applet Service Extraction
+#### [ ] PR 10: Applet Service Extraction
 
 Move Wnck/X11 applet dependencies behind applet-facing services.
 
@@ -3565,7 +3583,7 @@ Exit criteria:
 - backend-neutral applet loading can skip or disable unsupported actions
 - tests cover at least one unsupported-service path
 
-#### PR 11: Cleanup Transitional X11 APIs
+#### [ ] PR 11: Cleanup Transitional X11 APIs
 
 Remove compatibility methods only after all UI callers and tests use neutral
 backend APIs.
@@ -3593,7 +3611,7 @@ Exit criteria:
 - no backend-neutral UI module depends on Wnck windows or XIDs
 - X11 backend remains fully supported
 
-#### PR 12: Null / Reduced Backend
+#### [ ] PR 12: Null / Reduced Backend
 
 Add a backend with no taskbar powers to validate that X11 assumptions are no
 longer leaking through normal UI.
@@ -3632,7 +3650,7 @@ Exit criteria:
 - unsupported features degrade intentionally
 - reduced-backend tests prove no accidental X11 imports
 
-#### PR 13: Native Wayland Detection Stub
+#### [ ] PR 13: Native Wayland Detection Stub
 
 Only after the reduced backend works, add native Wayland detection that selects
 a reduced/no-op backend when unsupported.
@@ -3664,7 +3682,7 @@ Exit criteria:
 - X11 remains unchanged
 - logs and capability flags explain reduced mode
 
-#### PR 14: Layer-Shell Surface Backend
+#### [ ] PR 14: Layer-Shell Surface Backend
 
 Add native Wayland dock-surface placement for compositors that support
 layer-shell.
@@ -3702,7 +3720,7 @@ Exit criteria:
 - GNOME native Wayland remains reduced/unsupported with a clear log
 - X11 placement tests remain unchanged
 
-#### PR 15: Generic Foreign-Toplevel Window Service
+#### [ ] PR 15: Generic Foreign-Toplevel Window Service
 
 Add wlroots-style opened-app context.
 
@@ -3740,7 +3758,7 @@ Exit criteria:
   wlroots compositor
 - unsupported compositors continue reduced mode with clear logs
 
-#### PR 16: KWin / Plasma Backend
+#### [ ] PR 16: KWin / Plasma Backend
 
 Add the richest parity backend.
 
@@ -3771,7 +3789,7 @@ Exit criteria:
   workspace, and dodge features
 - non-Plasma Wayland backends are unaffected
 
-#### PR 17: COSMIC / Optional Compositor Extras
+#### [ ] PR 17: COSMIC / Optional Compositor Extras
 
 Add compositor-specific backends after the generic and KWin paths are stable.
 

--- a/tests/ui/test_factory.py
+++ b/tests/ui/test_factory.py
@@ -23,8 +23,14 @@ class TestBuildDockWindow:
         window = MagicMock()
         window.autohide = MagicMock()
         dodge_monitor = MagicMock()
+        preview_service = MagicMock()
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
+        monkeypatch.setattr(
+            factory_mod,
+            "X11PreviewService",
+            MagicMock(return_value=preview_service),
+        )
         monkeypatch.setattr(
             factory_mod,
             "WindowDodgeMonitor",
@@ -41,6 +47,7 @@ class TestBuildDockWindow:
         )
 
         assert result is window
+        factory_mod.X11PreviewService.assert_called_once_with(window_tracker=tracker)
         factory_mod.DockWindow.assert_called_once_with(
             config=config,
             model=model,
@@ -48,6 +55,7 @@ class TestBuildDockWindow:
             theme=theme,
             window_tracker=tracker,
             launcher=launcher,
+            preview_service=preview_service,
         )
         dodge_monitor.start.assert_called_once_with()
         assert window.dodge_monitor is dodge_monitor
@@ -76,6 +84,7 @@ class TestBuildDockWindow:
             return monitor
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
+        monkeypatch.setattr(factory_mod, "X11PreviewService", MagicMock())
         monkeypatch.setattr(factory_mod, "WindowDodgeMonitor", _make_dodge_monitor)
 
         factory_mod.build_dock_window(
@@ -111,6 +120,7 @@ class TestBuildDockWindow:
             return monitor
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
+        monkeypatch.setattr(factory_mod, "X11PreviewService", MagicMock())
         monkeypatch.setattr(factory_mod, "WindowDodgeMonitor", _make_dodge_monitor)
 
         factory_mod.build_dock_window(

--- a/tests/ui/test_preview.py
+++ b/tests/ui/test_preview.py
@@ -11,7 +11,9 @@ except ModuleNotFoundError:  # pragma: no cover
     sys.modules.setdefault("gi", gi_mock)
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
+import docking.platform.backends.x11.previews as x11_preview_mod
 import docking.ui.preview as preview_mod
+from docking.platform.backends.base import WindowId
 from docking.ui.preview import (
     ICON_FALLBACK_SIZE,
     POPUP_PADDING,
@@ -20,6 +22,57 @@ from docking.ui.preview import (
     THUMB_SPACING,
     THUMB_W,
 )
+
+
+class TestX11PreviewService:
+    def test_capture_uses_xid_without_live_window_state(self, monkeypatch):
+        # Given
+        tracker = MagicMock()
+        tracker._window_for_xid.side_effect = AssertionError(
+            "service should not consult Wnck minimized state for popup capture"
+        )
+        pixbuf = MagicMock()
+        pixbuf.get_width.return_value = 120
+        pixbuf.get_height.return_value = 80
+        monkeypatch.setattr(
+            x11_preview_mod,
+            "capture_xid",
+            MagicMock(return_value=pixbuf),
+        )
+        service = x11_preview_mod.X11PreviewService(window_tracker=tracker)
+
+        # When
+        result = service.capture(WindowId.x11(42), width=200, height=150)
+
+        # Then
+        assert result is not None
+        assert result.image is pixbuf
+        assert result.width == 120
+        assert result.height == 80
+        x11_preview_mod.capture_xid.assert_called_once_with(
+            xid=42, thumb_w=200, thumb_h=150
+        )
+        tracker._window_for_xid.assert_not_called()
+
+    def test_capture_returns_none_when_xid_capture_fails(self, monkeypatch):
+        # Given
+        tracker = MagicMock()
+        monkeypatch.setattr(
+            x11_preview_mod, "capture_xid", MagicMock(return_value=None)
+        )
+        monkeypatch.setattr(
+            x11_preview_mod,
+            "_icon_fallback",
+            MagicMock(side_effect=AssertionError("UI owns icon fallback")),
+        )
+        service = x11_preview_mod.X11PreviewService(window_tracker=tracker)
+
+        # When
+        result = service.capture(WindowId.x11(42), width=200, height=150)
+
+        # Then
+        assert result is None
+        x11_preview_mod._icon_fallback.assert_not_called()
 
 
 class TestPreviewConstants:
@@ -64,15 +117,17 @@ class TestIconFallback:
         bg = MagicMock()
         pixbuf_cls = MagicMock()
         pixbuf_cls.new.return_value = bg
-        monkeypatch.setattr(preview_mod.GdkPixbuf, "Pixbuf", pixbuf_cls, raising=False)
         monkeypatch.setattr(
-            preview_mod.Gtk.IconTheme,
+            x11_preview_mod.GdkPixbuf, "Pixbuf", pixbuf_cls, raising=False
+        )
+        monkeypatch.setattr(
+            x11_preview_mod.Gtk.IconTheme,
             "get_default",
             lambda: None,
             raising=False,
         )
         # When
-        result = preview_mod._icon_fallback(thumb_w=120, thumb_h=80)
+        result = x11_preview_mod._icon_fallback(thumb_w=120, thumb_h=80)
         # Then
         assert result is bg
         bg.fill.assert_called_once()
@@ -86,18 +141,20 @@ class TestIconFallback:
 
         pixbuf_cls = MagicMock()
         pixbuf_cls.new.return_value = bg
-        monkeypatch.setattr(preview_mod.GdkPixbuf, "Pixbuf", pixbuf_cls, raising=False)
+        monkeypatch.setattr(
+            x11_preview_mod.GdkPixbuf, "Pixbuf", pixbuf_cls, raising=False
+        )
 
         theme = MagicMock()
         theme.load_icon.return_value = icon
         monkeypatch.setattr(
-            preview_mod.Gtk.IconTheme,
+            x11_preview_mod.Gtk.IconTheme,
             "get_default",
             lambda: theme,
             raising=False,
         )
         # When
-        result = preview_mod._icon_fallback(thumb_w=200, thumb_h=150)
+        result = x11_preview_mod._icon_fallback(thumb_w=200, thumb_h=150)
         # Then
         assert result is bg
         scaled_icon.composite.assert_called_once()
@@ -109,9 +166,9 @@ class TestCaptureWindow:
         window = MagicMock()
         window.is_minimized.return_value = True
         fallback = MagicMock()
-        monkeypatch.setattr(preview_mod, "_icon_fallback", lambda **_k: fallback)
+        monkeypatch.setattr(x11_preview_mod, "_icon_fallback", lambda **_k: fallback)
         # When
-        result = preview_mod.capture_window(window)
+        result = x11_preview_mod.capture_window(window)
         # Then
         assert result is fallback
 
@@ -132,25 +189,25 @@ class TestCaptureWindow:
         display = MagicMock()
         display.error_trap_pop.return_value = 0
         monkeypatch.setattr(
-            preview_mod.GdkX11.X11Display,
+            x11_preview_mod.GdkX11.X11Display,
             "get_default",
             lambda: display,
             raising=False,
         )
         monkeypatch.setattr(
-            preview_mod.GdkX11.X11Window,
+            x11_preview_mod.GdkX11.X11Window,
             "foreign_new_for_display",
             lambda _display, _xid: foreign,
             raising=False,
         )
         monkeypatch.setattr(
-            preview_mod.Gdk,
+            x11_preview_mod.Gdk,
             "pixbuf_get_from_window",
             lambda *_a, **_k: pixbuf,
             raising=False,
         )
         # When
-        result = preview_mod.capture_window(window, thumb_w=200, thumb_h=150)
+        result = x11_preview_mod.capture_window(window, thumb_w=200, thumb_h=150)
         # Then
         assert result is scaled
         pixbuf.scale_simple.assert_called_once()
@@ -162,22 +219,22 @@ class TestCaptureWindow:
         window.get_xid.return_value = 100
 
         fallback = MagicMock()
-        monkeypatch.setattr(preview_mod, "_icon_fallback", lambda **_k: fallback)
-        monkeypatch.setattr(preview_mod.GLib, "Error", RuntimeError, raising=False)
+        monkeypatch.setattr(x11_preview_mod, "_icon_fallback", lambda **_k: fallback)
+        monkeypatch.setattr(x11_preview_mod.GLib, "Error", RuntimeError, raising=False)
         monkeypatch.setattr(
-            preview_mod.GdkX11.X11Display,
+            x11_preview_mod.GdkX11.X11Display,
             "get_default",
             lambda: MagicMock(),
             raising=False,
         )
         monkeypatch.setattr(
-            preview_mod.GdkX11.X11Window,
+            x11_preview_mod.GdkX11.X11Window,
             "foreign_new_for_display",
             MagicMock(side_effect=TypeError("bad foreign window")),
             raising=False,
         )
         # When
-        result = preview_mod.capture_window(window, thumb_w=180, thumb_h=120)
+        result = x11_preview_mod.capture_window(window, thumb_w=180, thumb_h=120)
         # Then
         assert result is fallback
 
@@ -199,24 +256,24 @@ class TestCaptureWindow:
         display = MagicMock()
         display.error_trap_pop.return_value = 0
         monkeypatch.setattr(
-            preview_mod.GdkX11.X11Display,
+            x11_preview_mod.GdkX11.X11Display,
             "get_default",
             lambda: display,
             raising=False,
         )
         monkeypatch.setattr(
-            preview_mod.GdkX11.X11Window,
+            x11_preview_mod.GdkX11.X11Window,
             "foreign_new_for_display",
             lambda _display, _xid: foreign,
             raising=False,
         )
         monkeypatch.setattr(
-            preview_mod.Gdk,
+            x11_preview_mod.Gdk,
             "pixbuf_get_from_window",
             lambda *_a, **_k: pixbuf,
             raising=False,
         )
         # When
-        result = preview_mod.capture_xid(42, thumb_w=200, thumb_h=150)
+        result = x11_preview_mod.capture_xid(42, thumb_w=200, thumb_h=150)
         # Then
         assert result is None

--- a/tests/ui/test_preview_popup_integration.py
+++ b/tests/ui/test_preview_popup_integration.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from docking.core.position import Position
+from docking.platform.backends.base import WindowId, WindowSnapshot
 
 
 def _load_preview_module():
@@ -46,35 +47,20 @@ def _load_preview_module():
         NotifyType=SimpleNamespace(INFERIOR=1),
         CrossingMode=SimpleNamespace(NORMAL=1),
     )
-    fake_gdkpixbuf = types.SimpleNamespace(
-        Pixbuf=type("Pixbuf", (), {}),
-        InterpType=SimpleNamespace(BILINEAR=1),
-        Colorspace=SimpleNamespace(RGB=1),
-    )
-    fake_gdkx11 = types.SimpleNamespace(
-        X11Display=SimpleNamespace(get_default=lambda: MagicMock()),
-        X11Window=SimpleNamespace(
-            foreign_new_for_display=lambda _display, _xid: MagicMock()
-        ),
-    )
     fake_glib = types.SimpleNamespace(
         Error=Exception,
         timeout_add=lambda *_args, **_kwargs: 1,
         source_remove=lambda *_args, **_kwargs: None,
     )
     fake_pango = types.SimpleNamespace(EllipsizeMode=SimpleNamespace(END=1))
-    fake_wnck = types.SimpleNamespace(Window=type("Window", (), {}))
 
     gi_module = types.ModuleType("gi")
     gi_module.require_version = lambda *_args, **_kwargs: None
     repo_module = types.ModuleType("gi.repository")
     repo_module.Gtk = fake_gtk
     repo_module.Gdk = fake_gdk
-    repo_module.GdkPixbuf = fake_gdkpixbuf
-    repo_module.GdkX11 = fake_gdkx11
     repo_module.GLib = fake_glib
     repo_module.Pango = fake_pango
-    repo_module.Wnck = fake_wnck
     gi_module.repository = repo_module
     sys.modules["gi"] = gi_module
     sys.modules["gi.repository"] = repo_module
@@ -203,9 +189,26 @@ class FakeLabel:
         return
 
 
+class FakePreviewService:
+    def __init__(self) -> None:
+        self.capture = MagicMock(return_value=None)
+        self.fallback_icon_name = MagicMock(return_value=None)
+
+
+def _snapshot(value: int, title: str = "Window") -> WindowSnapshot:
+    return WindowSnapshot(
+        id=WindowId.x11(value),
+        desktop_id="firefox.desktop",
+        title=title,
+        can_activate=True,
+        can_preview=True,
+    )
+
+
 def _make_popup():
     popup = object.__new__(preview_mod.PreviewPopup)
     popup._tracker = MagicMock()
+    popup._preview_service = FakePreviewService()
     popup._autohide = None
     popup._pointer_inside_dock = None
     popup._hide_timer_id = 0
@@ -217,7 +220,7 @@ class TestPreviewPopupIntegration:
     def test_show_for_item_hides_when_no_windows(self):
         # Given
         popup = _make_popup()
-        popup._tracker.get_xids_for.return_value = []
+        popup._tracker.list_windows.return_value = []
         popup.hide = MagicMock()
 
         # When
@@ -236,10 +239,10 @@ class TestPreviewPopupIntegration:
     def test_show_for_item_builds_content_and_moves(self, monkeypatch):
         # Given
         popup = _make_popup()
-        popup._tracker.get_xids_for.return_value = [1, 2]
+        popup._tracker.list_windows.return_value = [_snapshot(1), _snapshot(2)]
         popup._tracker.icon_name_for_desktop.return_value = "firefox"
         popup._cancel_hide_timer = MagicMock()
-        popup._make_thumbnail_for_xid = MagicMock(return_value=object())
+        popup._make_thumbnail_for_window = MagicMock(return_value=object())
         popup.get_child = MagicMock(return_value=None)
         popup.remove = MagicMock()
         popup.add = MagicMock()
@@ -275,8 +278,7 @@ class TestPreviewPopupIntegration:
     def test_make_thumbnail_truncates_label(self, monkeypatch):
         # Given
         popup = _make_popup()
-        popup._tracker.get_window_title_for_xid.return_value = "A" * 40
-        monkeypatch.setattr(preview_mod, "capture_xid", lambda **_kwargs: None)
+        popup._preview_service.capture.return_value = None
         monkeypatch.setattr(
             preview_mod,
             "Gtk",
@@ -300,8 +302,8 @@ class TestPreviewPopupIntegration:
             ),
         )
         # When
-        widget = preview_mod.PreviewPopup._make_thumbnail_for_xid(
-            popup, xid=42, fallback_icon_name="app"
+        widget = preview_mod.PreviewPopup._make_thumbnail_for_window(
+            popup, window=_snapshot(42, title="A" * 40), fallback_icon_name="app"
         )
 
         # Then
@@ -364,10 +366,10 @@ class TestPreviewPopupIntegration:
         popup.hide = MagicMock()
 
         handled = preview_mod.PreviewPopup._on_thumb_click(
-            popup, MagicMock(), MagicMock(), xid=42
+            popup, MagicMock(), MagicMock(), window_id=WindowId.x11(42)
         )
 
         assert handled is True
-        popup._tracker.activate_xid.assert_called_once_with(xid=42)
+        popup._tracker.activate.assert_called_once_with(WindowId.x11(42))
         popup.hide.assert_called_once()
         popup._autohide.on_mouse_leave.assert_called_once()

--- a/tests/visual/render_cases.py
+++ b/tests/visual/render_cases.py
@@ -16,6 +16,7 @@ from gi.repository import Gdk, GdkPixbuf, Gtk
 from docking.core.items import FOLDER_KIND, DockItem
 from docking.core.position import Position
 from docking.core.theme import Theme
+from docking.platform.backends.base import PreviewImage, WindowId, WindowSnapshot
 from docking.ui.autohide import HideState
 from docking.ui.geometry import build_geometry_frame
 from docking.ui.menu import MenuHandler
@@ -361,28 +362,46 @@ def _draw_tooltip_case() -> cairo.ImageSurface:
 
 def _draw_preview_case() -> cairo.ImageSurface:
     tracker = MagicMock()
-    tracker.get_xids_for.return_value = [101, 102]
-    tracker.icon_name_for_desktop.return_value = "firefox"
-    tracker.get_window_title_for_xid.side_effect = [
-        "Firefox - Docking Visual Regression",
-        "Docs - Feature Review",
+    tracker.list_windows.return_value = [
+        WindowSnapshot(
+            id=WindowId.x11(101),
+            desktop_id="firefox.desktop",
+            title="Firefox - Docking Visual Regression",
+            can_activate=True,
+            can_preview=True,
+        ),
+        WindowSnapshot(
+            id=WindowId.x11(102),
+            desktop_id="firefox.desktop",
+            title="Docs - Feature Review",
+            can_activate=True,
+            can_preview=True,
+        ),
     ]
-    popup = PreviewPopup(window_tracker=tracker)
+    tracker.icon_name_for_desktop.return_value = "firefox"
+    preview_service = MagicMock()
+    preview_service.capture.side_effect = [
+        PreviewImage(
+            image=_pixbuf(max(THUMB_W, THUMB_H), red=235, green=94, blue=55),
+            width=THUMB_W,
+            height=THUMB_H,
+        ),
+        PreviewImage(
+            image=_pixbuf(max(THUMB_W, THUMB_H), red=60, green=132, blue=241),
+            width=THUMB_W,
+            height=THUMB_H,
+        ),
+    ]
+    preview_service.fallback_icon_name.return_value = None
+    popup = PreviewPopup(window_tracker=tracker, preview_service=preview_service)
     try:
-        with patch(
-            "docking.ui.preview.capture_xid",
-            side_effect=[
-                _pixbuf(max(THUMB_W, THUMB_H), red=235, green=94, blue=55),
-                _pixbuf(max(THUMB_W, THUMB_H), red=60, green=132, blue=241),
-            ],
-        ):
-            popup.show_for_item(
-                desktop_id="firefox.desktop",
-                anchor_x=140.0,
-                icon_w=48.0,
-                anchor_y=320.0,
-                position=Position.BOTTOM,
-            )
+        popup.show_for_item(
+            desktop_id="firefox.desktop",
+            anchor_x=140.0,
+            icon_w=48.0,
+            anchor_y=320.0,
+            position=Position.BOTTOM,
+        )
         return _capture_window_surface(popup)
     finally:
         popup.destroy()


### PR DESCRIPTION
## Summary
- move X11 preview capture and fallback helpers into `docking.platform.backends.x11.previews`
- make `PreviewPopup` consume `WindowSnapshot` and `PreviewService` instead of raw XIDs, Wnck, and GdkX11
- mark the merged Wayland/X11 migration document PRs as completed and update stale sequence wording

## Checks
- commit hook: ruff format, ruff check, ty, i18n/package checks, and 3348 tests passed
- focused preview/factory tests passed
- changed-file ruff and ty passed

Note: local full visual run still reports existing GTK-rendered popup size mismatches for folder stack, tooltip, and preview surfaces in this environment, so I did not update baselines.