### PR TITLE
Complete X11 session backend shape

### DIFF
--- a/docking/app.py
+++ b/docking/app.py
@@ -77,7 +77,7 @@ from gi.repository import GLib, Gtk
 from docking.core.config import Config
 from docking.core.theme import Theme
 from docking.ipc import DockItemsService
-from docking.platform.backends.x11.session import build_x11_window_tracker
+from docking.platform.backends.selection import create_session_backend
 from docking.platform.environment import apply_tweaks, detect_desktop
 from docking.platform.launcher import Launcher
 from docking.platform.model import DockModel
@@ -98,7 +98,7 @@ def main() -> None:
     launcher = Launcher()
     model = DockModel(config=config, launcher=launcher)
     renderer = DockRenderer()
-    tracker = build_x11_window_tracker(model=model, launcher=launcher, config=config)
+    backend = create_session_backend(config=config, launcher=launcher, model=model)
     unity = UnityLauncherListener(model=model)
 
     window = build_dock_window(
@@ -106,7 +106,8 @@ def main() -> None:
         model=model,
         renderer=renderer,
         theme=theme,
-        window_tracker=tracker,
+        window_tracker=backend.windows,
+        preview_service=backend.previews,
         launcher=launcher,
     )
     items_service = DockItemsService(model=model, window=window)
@@ -121,23 +122,24 @@ def main() -> None:
         window.show_all()
         new_year.start()
         window.start_update_checks()
-        GLib.idle_add(_start_runtime, items_service, model, tracker)
+        GLib.idle_add(_start_runtime, items_service, model, backend)
         Gtk.main()
     finally:
         items_service.stop()
         window.stop_update_checks()
         new_year.stop()
         unity.stop()
+        backend.stop()
         model.stop_applets()
 
 
 def _start_runtime(
-    items_service: DockItemsService, model: DockModel, window_tracker: object
+    items_service: DockItemsService, model: DockModel, backend: object
 ) -> bool:
     """Start background runtime pieces after the window has been shown."""
-    tracker_start = getattr(window_tracker, "start", None)
-    if callable(tracker_start):
-        tracker_start()
+    backend_start = getattr(backend, "start", None)
+    if callable(backend_start):
+        backend_start()
     items_service.start()
     model.start_applets()
     return False

--- a/docking/platform/backends/selection.py
+++ b/docking/platform/backends/selection.py
@@ -1,0 +1,54 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Session backend selection.
+
+This module is intentionally small while production still selects only the X11
+backend. Keeping the selection point explicit now gives later native Wayland and
+reduced-backend work a single place to add detection without threading display
+checks through app startup or UI modules.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from docking.log import get_logger
+
+if TYPE_CHECKING:
+    from docking.core.config import Config
+    from docking.platform.backends.x11.session import X11SessionBackend
+    from docking.platform.launcher import Launcher
+    from docking.platform.model import DockModel
+
+log = get_logger(name="backend_selection")
+
+
+def create_session_backend(
+    *, config: Config, launcher: Launcher, model: DockModel
+) -> X11SessionBackend:
+    """Create the production session backend for the current runtime.
+
+    Native Wayland and reduced backends are not selected yet. Import the X11
+    backend lazily so future native Wayland startup can avoid importing X11-only
+    modules before selection.
+    """
+    from docking.platform.backends.x11.session import build_x11_session_backend
+
+    backend = build_x11_session_backend(
+        model=model,
+        launcher=launcher,
+        config=config,
+    )
+    log.info("Selected session backend: %s", backend.name)
+    return backend

--- a/docking/platform/backends/x11/__init__.py
+++ b/docking/platform/backends/x11/__init__.py
@@ -13,7 +13,16 @@
 
 """X11 backend services."""
 
-from docking.platform.backends.x11.session import build_x11_window_tracker
+from docking.platform.backends.x11.session import (
+    X11SessionBackend,
+    build_x11_session_backend,
+    build_x11_window_tracker,
+)
 from docking.platform.backends.x11.windows import X11WindowService
 
-__all__ = ["X11WindowService", "build_x11_window_tracker"]
+__all__ = [
+    "X11SessionBackend",
+    "X11WindowService",
+    "build_x11_session_backend",
+    "build_x11_window_tracker",
+]

--- a/docking/platform/backends/x11/session.py
+++ b/docking/platform/backends/x11/session.py
@@ -16,9 +16,19 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from docking.log import get_logger
+from docking.platform.backends.base import (
+    DisplayServer,
+    PlacementRequest,
+    PlatformCapabilities,
+    Rect,
+    ReservationRequest,
+    VisibilityMonitor,
+)
+from docking.platform.backends.x11.previews import X11PreviewService
 from docking.platform.backends.x11.windows import X11WindowService
 from docking.platform.window_tracker import WindowTracker
 
@@ -57,3 +67,179 @@ def _window_service_mode() -> str:
         X11_WINDOW_SERVICE_SERVICE,
     )
     return X11_WINDOW_SERVICE_SERVICE
+
+
+def build_x11_session_backend(
+    *, model: DockModel, launcher: Launcher, config: Config | None = None
+) -> X11SessionBackend:
+    """Build the X11-only session backend used by production startup."""
+    return X11SessionBackend(model=model, launcher=launcher, config=config)
+
+
+class X11SessionBackend:
+    """SessionBackend implementation for the current X11 runtime.
+
+    This backend intentionally remains X11-only. It groups the already-migrated
+    window and preview services so application startup can depend on a session
+    backend shape before native Wayland services exist. Surface and visibility
+    stay transitional until their dedicated migration PRs.
+    """
+
+    def __init__(
+        self, *, model: DockModel, launcher: Launcher, config: Config | None = None
+    ) -> None:
+        self._windows = build_x11_window_tracker(
+            model=model, launcher=launcher, config=config
+        )
+        self._previews = X11PreviewService(window_tracker=self._windows)
+        self._surface = _TransitionalSurfaceService()
+        self._visibility = _TransitionalVisibilityService()
+
+    @property
+    def name(self) -> str:
+        return "x11"
+
+    @property
+    def display_server(self) -> DisplayServer:
+        return DisplayServer.X11
+
+    @property
+    def capabilities(self) -> PlatformCapabilities:
+        return PlatformCapabilities(
+            tracks_windows=True,
+            tracks_active_window=True,
+            tracks_attention=True,
+            tracks_minimized=True,
+            tracks_maximized=True,
+            tracks_fullscreen=True,
+            tracks_stacking_order=True,
+            supports_activate=True,
+            supports_minimize=True,
+            supports_close=True,
+            supports_window_menu=True,
+            tracks_window_geometry=True,
+            tracks_window_workspace=True,
+            supports_current_workspace_filter=True,
+            supports_workspace_list=True,
+            supports_workspace_switch=True,
+            supports_show_desktop=True,
+            supports_screen_reservation=True,
+            supports_input_region=True,
+            supports_pointer_barrier=True,
+            supports_background_blur_hint=True,
+            supports_overlap_active=True,
+            supports_overlap_any=True,
+            supports_overlap_maximized=True,
+            supports_screen_color_pick=True,
+            supports_screenshot=True,
+            supports_idle_time=True,
+            supports_window_pick=True,
+            supports_window_pid=True,
+            supports_process_kill=True,
+        )
+
+    @property
+    def windows(self) -> WindowTracker:
+        return self._windows
+
+    @property
+    def surface(self) -> _TransitionalSurfaceService:
+        return self._surface
+
+    @property
+    def visibility(self) -> _TransitionalVisibilityService:
+        return self._visibility
+
+    @property
+    def previews(self) -> X11PreviewService:
+        return self._previews
+
+    @property
+    def workspaces(self) -> None:
+        return None
+
+    @property
+    def desktop_actions(self) -> None:
+        return None
+
+    @property
+    def screen_capture(self) -> None:
+        return None
+
+    @property
+    def idle(self) -> None:
+        return None
+
+    @property
+    def window_picker(self) -> None:
+        return None
+
+    def start(self) -> None:
+        self._call_service_method(self._windows, "start")
+        self._previews.start()
+        self._surface.start()
+        self._visibility.start()
+
+    def stop(self) -> None:
+        self._visibility.stop()
+        self._surface.stop()
+        self._previews.stop()
+        self._call_service_method(self._windows, "stop")
+
+    @staticmethod
+    def _call_service_method(service: object, method_name: str) -> None:
+        method = getattr(service, method_name, None)
+        if callable(method):
+            method()
+
+
+class _TransitionalSurfaceService:
+    """No-op surface service until X11 surface ownership moves in PR 9."""
+
+    def start(self) -> None:
+        return
+
+    def stop(self) -> None:
+        return
+
+    def configure_before_realize(self, window: object) -> None:
+        return
+
+    def on_realize(self, window: object) -> None:
+        return
+
+    def position_or_anchor(self, request: PlacementRequest) -> None:
+        return
+
+    def set_reservation(self, request: ReservationRequest) -> None:
+        return
+
+    def clear_reservation(self) -> None:
+        return
+
+    def update_input_region(self, rect: Rect) -> None:
+        return
+
+    def set_blur_region(self, rect: Rect | None) -> None:
+        return
+
+
+class _TransitionalVisibilityService:
+    """Unsupported visibility service until dodge ownership moves in PR 8."""
+
+    def start(self) -> None:
+        return
+
+    def stop(self) -> None:
+        return
+
+    def supports_hide_mode(self, mode: object) -> bool:
+        return False
+
+    def create_monitor(
+        self,
+        *,
+        get_dock_rect: Callable[[], Rect | None],
+        on_change: Callable[[bool], None],
+    ) -> VisibilityMonitor | None:
+        return None

--- a/docking/ui/factory.py
+++ b/docking/ui/factory.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from docking.core.config import Config
 from docking.core.theme import Theme
-from docking.platform.backends.x11.previews import X11PreviewService
+from docking.platform.backends.base import PreviewService
 from docking.platform.dodge import ScreenRect, WindowDodgeMonitor
 from docking.platform.launcher import Launcher
 from docking.platform.model import DockModel
@@ -38,6 +38,7 @@ def build_dock_window(
     renderer: DockRenderer,
     theme: Theme,
     window_tracker: WindowTracker,
+    preview_service: PreviewService,
     launcher: Launcher,
 ) -> DockWindow:
     """Build a fully wired dock window and its UI collaborators."""
@@ -48,7 +49,7 @@ def build_dock_window(
         theme=theme,
         window_tracker=window_tracker,
         launcher=launcher,
-        preview_service=X11PreviewService(window_tracker=window_tracker),
+        preview_service=preview_service,
     )
 
     def _get_dock_rect() -> ScreenRect | None:

--- a/docs/WAYLAND.md
+++ b/docs/WAYLAND.md
@@ -3160,9 +3160,10 @@ now has the X11 window facade, production X11 runtime wiring, neutral
 `WindowId` values alongside existing XIDs, and menu rows backed by
 `WindowSnapshot`.
 
-The next active X11 migration PR is the preview service step. It should move
-preview capture behind `PreviewService` without changing current X11 behavior,
-and it should not complete the wider session-backend shape in the same step.
+The next active X11 migration PR is the X11-only session backend shape. It
+should group the already-migrated window and preview services behind an explicit
+session backend without changing current X11 behavior, and it should leave
+visibility and surface ownership to their dedicated later PRs.
 
 An optional temporary fallback can make that step safer:
 
@@ -3387,7 +3388,7 @@ Exit criteria:
 - unsupported or empty `list_windows()` produces the current no-window menu
   behavior rather than a crash
 
-#### [ ] PR 6: Preview Popup Uses `PreviewService`
+#### [x] PR 6: Preview Popup Uses `PreviewService`
 
 Remove direct `GdkX11`/`Wnck` usage from backend-neutral preview UI while
 keeping the X11 capture path internally unchanged.

--- a/tests/platform/test_backend_selection.py
+++ b/tests/platform/test_backend_selection.py
@@ -1,0 +1,33 @@
+"""Tests for session backend selection."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from docking.platform.backends import selection
+
+
+def test_create_session_backend_selects_x11_backend(monkeypatch):
+    backend = MagicMock()
+    builder = MagicMock(return_value=backend)
+    x11_session = MagicMock(build_x11_session_backend=builder)
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "docking.platform.backends.x11.session":
+            return x11_session
+        return real_import(name, globals, locals, fromlist, level)
+
+    real_import = __import__
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    config = MagicMock()
+    launcher = MagicMock()
+    model = MagicMock()
+    result = selection.create_session_backend(
+        config=config,
+        launcher=launcher,
+        model=model,
+    )
+
+    assert result is backend
+    builder.assert_called_once_with(model=model, launcher=launcher, config=config)

--- a/tests/platform/test_x11_session.py
+++ b/tests/platform/test_x11_session.py
@@ -56,3 +56,68 @@ def test_build_x11_window_tracker_ignores_invalid_mode(monkeypatch):
     assert result is service
     service_cls.assert_called_once()
     legacy_cls.assert_not_called()
+
+
+def test_build_x11_session_backend_groups_x11_services(monkeypatch):
+    windows = MagicMock()
+    previews = MagicMock()
+    monkeypatch.setattr(
+        session, "build_x11_window_tracker", MagicMock(return_value=windows)
+    )
+    monkeypatch.setattr(session, "X11PreviewService", MagicMock(return_value=previews))
+
+    backend = session.build_x11_session_backend(
+        model=MagicMock(), launcher=MagicMock(), config=MagicMock()
+    )
+
+    assert backend.name == "x11"
+    assert backend.display_server is session.DisplayServer.X11
+    assert backend.windows is windows
+    assert backend.previews is previews
+    assert backend.workspaces is None
+    assert backend.desktop_actions is None
+    assert backend.screen_capture is None
+    assert backend.idle is None
+    assert backend.window_picker is None
+    assert backend.capabilities.tracks_windows is True
+    assert backend.capabilities.supports_window_menu is True
+    assert backend.capabilities.supports_screen_reservation is True
+    session.X11PreviewService.assert_called_once_with(window_tracker=windows)
+
+
+def test_x11_session_backend_lifecycle_starts_and_stops_services(monkeypatch):
+    windows = MagicMock()
+    previews = MagicMock()
+    monkeypatch.setattr(
+        session, "build_x11_window_tracker", MagicMock(return_value=windows)
+    )
+    monkeypatch.setattr(session, "X11PreviewService", MagicMock(return_value=previews))
+    backend = session.X11SessionBackend(
+        model=MagicMock(), launcher=MagicMock(), config=MagicMock()
+    )
+
+    backend.start()
+    backend.stop()
+
+    windows.start.assert_called_once_with()
+    previews.start.assert_called_once_with()
+    previews.stop.assert_called_once_with()
+    windows.stop.assert_called_once_with()
+
+
+def test_x11_session_backend_allows_legacy_tracker_without_lifecycle(monkeypatch):
+    windows = object()
+    previews = MagicMock()
+    monkeypatch.setattr(
+        session, "build_x11_window_tracker", MagicMock(return_value=windows)
+    )
+    monkeypatch.setattr(session, "X11PreviewService", MagicMock(return_value=previews))
+    backend = session.X11SessionBackend(
+        model=MagicMock(), launcher=MagicMock(), config=MagicMock()
+    )
+
+    backend.start()
+    backend.stop()
+
+    previews.start.assert_called_once_with()
+    previews.stop.assert_called_once_with()

--- a/tests/smoke/test_python314_smoke.py
+++ b/tests/smoke/test_python314_smoke.py
@@ -69,6 +69,9 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
         "docking.platform.model": {
             "DockModel": type("DockModel", (), {}),
         },
+        "docking.platform.backends.selection": {
+            "create_session_backend": lambda **_kwargs: None,
+        },
         "docking.platform.backends.x11.session": {
             "build_x11_window_tracker": lambda **_kwargs: None,
         },
@@ -244,6 +247,10 @@ def test_app_main_smoke(monkeypatch):
     model = MagicMock()
     renderer = MagicMock()
     tracker = MagicMock()
+    preview_service = MagicMock()
+    backend = MagicMock()
+    backend.windows = tracker
+    backend.previews = preview_service
     unity = MagicMock()
     new_year = MagicMock()
     window = MagicMock()
@@ -262,8 +269,8 @@ def test_app_main_smoke(monkeypatch):
     monkeypatch.setattr(app_mod, "DockRenderer", MagicMock(return_value=renderer))
     monkeypatch.setattr(
         app_mod,
-        "build_x11_window_tracker",
-        MagicMock(return_value=tracker),
+        "create_session_backend",
+        MagicMock(return_value=backend),
     )
     monkeypatch.setattr(app_mod, "UnityLauncherListener", MagicMock(return_value=unity))
     monkeypatch.setattr(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -54,6 +54,9 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
         "docking.platform.model": {
             "DockModel": type("DockModel", (), {}),
         },
+        "docking.platform.backends.selection": {
+            "create_session_backend": lambda **_kwargs: None,
+        },
         "docking.platform.backends.x11.session": {
             "build_x11_window_tracker": lambda **_kwargs: None,
         },
@@ -122,6 +125,10 @@ class TestAppMain:
         model = MagicMock()
         renderer = MagicMock()
         tracker = MagicMock()
+        preview_service = MagicMock()
+        backend = MagicMock()
+        backend.windows = tracker
+        backend.previews = preview_service
         unity = MagicMock()
         new_year = MagicMock()
         window = MagicMock()
@@ -156,8 +163,8 @@ class TestAppMain:
         monkeypatch.setattr(app_mod, "DockRenderer", MagicMock(return_value=renderer))
         monkeypatch.setattr(
             app_mod,
-            "build_x11_window_tracker",
-            MagicMock(return_value=tracker),
+            "create_session_backend",
+            MagicMock(return_value=backend),
         )
         monkeypatch.setattr(
             app_mod,
@@ -187,9 +194,11 @@ class TestAppMain:
             renderer=renderer,
             theme=applied_theme,
             window_tracker=tracker,
+            preview_service=preview_service,
             launcher=launcher,
         )
-        tracker.start.assert_called_once()
+        backend.start.assert_called_once()
+        backend.stop.assert_called_once()
         model.start_applets.assert_called_once()
         model.stop_applets.assert_called_once()
         items_service.start.assert_called_once()
@@ -204,7 +213,7 @@ class TestAppMain:
             app_mod._start_runtime,
             items_service,
             model,
-            tracker,
+            backend,
         )
         fake_gtk.main.assert_called_once()
         assert call_order == [
@@ -250,6 +259,10 @@ class TestAppMain:
         model = MagicMock()
         renderer = MagicMock()
         tracker = MagicMock()
+        preview_service = MagicMock()
+        backend = MagicMock()
+        backend.windows = tracker
+        backend.previews = preview_service
         unity = MagicMock()
         new_year = MagicMock()
         window = MagicMock()
@@ -278,7 +291,7 @@ class TestAppMain:
         launcher_cls = MagicMock(return_value=launcher)
         model_cls = MagicMock(return_value=model)
         renderer_cls = MagicMock(return_value=renderer)
-        tracker_cls = MagicMock(return_value=tracker)
+        backend_cls = MagicMock(return_value=backend)
         unity_cls = MagicMock(return_value=unity)
         new_year_cls = MagicMock(return_value=new_year)
         factory = MagicMock(return_value=window)
@@ -296,9 +309,9 @@ class TestAppMain:
             sys.modules["docking.ui.renderer"], "DockRenderer", renderer_cls
         )
         monkeypatch.setattr(
-            sys.modules["docking.platform.backends.x11.session"],
-            "build_x11_window_tracker",
-            tracker_cls,
+            sys.modules["docking.platform.backends.selection"],
+            "create_session_backend",
+            backend_cls,
         )
         monkeypatch.setattr(
             sys.modules["docking.platform.unity"], "UnityLauncherListener", unity_cls
@@ -327,7 +340,8 @@ class TestAppMain:
         factory.assert_called_once()
         items_service_cls.assert_called_once_with(model=model, window=window)
         fake_gtk.main.assert_called_once()
-        tracker.start.assert_called_once()
+        backend.start.assert_called_once()
+        backend.stop.assert_called_once()
         unity.start.assert_called_once()
         unity.stop.assert_called_once()
         new_year.start.assert_called_once()

--- a/tests/ui/test_factory.py
+++ b/tests/ui/test_factory.py
@@ -19,18 +19,13 @@ class TestBuildDockWindow:
         theme = MagicMock()
         tracker = MagicMock()
         launcher = MagicMock()
+        preview_service = MagicMock()
 
         window = MagicMock()
         window.autohide = MagicMock()
         dodge_monitor = MagicMock()
-        preview_service = MagicMock()
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
-        monkeypatch.setattr(
-            factory_mod,
-            "X11PreviewService",
-            MagicMock(return_value=preview_service),
-        )
         monkeypatch.setattr(
             factory_mod,
             "WindowDodgeMonitor",
@@ -43,11 +38,11 @@ class TestBuildDockWindow:
             renderer=renderer,
             theme=theme,
             window_tracker=tracker,
+            preview_service=preview_service,
             launcher=launcher,
         )
 
         assert result is window
-        factory_mod.X11PreviewService.assert_called_once_with(window_tracker=tracker)
         factory_mod.DockWindow.assert_called_once_with(
             config=config,
             model=model,
@@ -69,6 +64,7 @@ class TestBuildDockWindow:
         theme = MagicMock()
         tracker = MagicMock()
         launcher = MagicMock()
+        preview_service = MagicMock()
 
         window = MagicMock()
         window.autohide = MagicMock()
@@ -84,7 +80,6 @@ class TestBuildDockWindow:
             return monitor
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
-        monkeypatch.setattr(factory_mod, "X11PreviewService", MagicMock())
         monkeypatch.setattr(factory_mod, "WindowDodgeMonitor", _make_dodge_monitor)
 
         factory_mod.build_dock_window(
@@ -93,6 +88,7 @@ class TestBuildDockWindow:
             renderer=renderer,
             theme=theme,
             window_tracker=tracker,
+            preview_service=preview_service,
             launcher=launcher,
         )
 
@@ -107,6 +103,7 @@ class TestBuildDockWindow:
         theme = MagicMock()
         tracker = MagicMock()
         launcher = MagicMock()
+        preview_service = MagicMock()
 
         window = MagicMock()
         window.autohide = MagicMock()
@@ -120,7 +117,6 @@ class TestBuildDockWindow:
             return monitor
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
-        monkeypatch.setattr(factory_mod, "X11PreviewService", MagicMock())
         monkeypatch.setattr(factory_mod, "WindowDodgeMonitor", _make_dodge_monitor)
 
         factory_mod.build_dock_window(
@@ -129,6 +125,7 @@ class TestBuildDockWindow:
             renderer=renderer,
             theme=theme,
             window_tracker=tracker,
+            preview_service=preview_service,
             launcher=launcher,
         )
 


### PR DESCRIPTION
## Summary
- add an explicit backend selection entry point that currently selects the X11 session backend lazily
- add `X11SessionBackend` to group the current X11 window service and X11 preview service, with transitional surface/visibility services for later PRs
- pass window and preview services from the selected backend through app startup into the dock window factory
- mark PR 6 as merged in `docs/WAYLAND.md` and update the active migration note for PR 7