### PR TITLE
Move X11 dodge monitor behind visibility service

### DIFF
--- a/docking/app.py
+++ b/docking/app.py
@@ -108,6 +108,7 @@ def main() -> None:
         theme=theme,
         window_tracker=backend.windows,
         preview_service=backend.previews,
+        visibility_service=backend.visibility,
         launcher=launcher,
     )
     items_service = DockItemsService(model=model, window=window)

--- a/docking/platform/backends/x11/__init__.py
+++ b/docking/platform/backends/x11/__init__.py
@@ -18,10 +18,12 @@ from docking.platform.backends.x11.session import (
     build_x11_session_backend,
     build_x11_window_tracker,
 )
+from docking.platform.backends.x11.visibility import X11VisibilityService
 from docking.platform.backends.x11.windows import X11WindowService
 
 __all__ = [
     "X11SessionBackend",
+    "X11VisibilityService",
     "X11WindowService",
     "build_x11_session_backend",
     "build_x11_window_tracker",

--- a/docking/platform/backends/x11/session.py
+++ b/docking/platform/backends/x11/session.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from docking.log import get_logger
@@ -26,9 +25,9 @@ from docking.platform.backends.base import (
     PlatformCapabilities,
     Rect,
     ReservationRequest,
-    VisibilityMonitor,
 )
 from docking.platform.backends.x11.previews import X11PreviewService
+from docking.platform.backends.x11.visibility import X11VisibilityService
 from docking.platform.backends.x11.windows import X11WindowService
 from docking.platform.window_tracker import WindowTracker
 
@@ -80,9 +79,9 @@ class X11SessionBackend:
     """SessionBackend implementation for the current X11 runtime.
 
     This backend intentionally remains X11-only. It groups the already-migrated
-    window and preview services so application startup can depend on a session
-    backend shape before native Wayland services exist. Surface and visibility
-    stay transitional until their dedicated migration PRs.
+    window, preview, and visibility services so application startup can depend
+    on a session backend shape before native Wayland services exist. Surface
+    stays transitional until its dedicated migration PR.
     """
 
     def __init__(
@@ -93,7 +92,7 @@ class X11SessionBackend:
         )
         self._previews = X11PreviewService(window_tracker=self._windows)
         self._surface = _TransitionalSurfaceService()
-        self._visibility = _TransitionalVisibilityService()
+        self._visibility = X11VisibilityService(config=config)
 
     @property
     def name(self) -> str:
@@ -147,7 +146,7 @@ class X11SessionBackend:
         return self._surface
 
     @property
-    def visibility(self) -> _TransitionalVisibilityService:
+    def visibility(self) -> X11VisibilityService:
         return self._visibility
 
     @property
@@ -222,24 +221,3 @@ class _TransitionalSurfaceService:
 
     def set_blur_region(self, rect: Rect | None) -> None:
         return
-
-
-class _TransitionalVisibilityService:
-    """Unsupported visibility service until dodge ownership moves in PR 8."""
-
-    def start(self) -> None:
-        return
-
-    def stop(self) -> None:
-        return
-
-    def supports_hide_mode(self, mode: object) -> bool:
-        return False
-
-    def create_monitor(
-        self,
-        *,
-        get_dock_rect: Callable[[], Rect | None],
-        on_change: Callable[[bool], None],
-    ) -> VisibilityMonitor | None:
-        return None

--- a/docking/platform/backends/x11/visibility.py
+++ b/docking/platform/backends/x11/visibility.py
@@ -1,0 +1,75 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""X11 overlap/dodge visibility service."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from docking.core.config import HideMode
+from docking.platform.backends.base import Rect, VisibilityMonitor
+from docking.platform.dodge import ScreenRect, WindowDodgeMonitor
+
+if TYPE_CHECKING:
+    from docking.core.config import Config
+
+
+_SUPPORTED_HIDE_MODES = frozenset(
+    {
+        HideMode.INTELLIGENT,
+        HideMode.DODGE_ACTIVE,
+        HideMode.WINDOW_DODGE,
+        HideMode.DODGE_MAXIMIZED,
+    }
+)
+
+
+class X11VisibilityService:
+    """VisibilityService backed by the existing Wnck WindowDodgeMonitor."""
+
+    def __init__(self, *, config: Config | None) -> None:
+        self._config = config
+
+    def start(self) -> None:
+        """No service-level runtime loop is needed."""
+
+    def stop(self) -> None:
+        """No service-level resources are held."""
+
+    def supports_hide_mode(self, mode: object) -> bool:
+        """Return whether X11 can monitor foreign-window overlap for a mode."""
+        return mode in _SUPPORTED_HIDE_MODES
+
+    def create_monitor(
+        self,
+        *,
+        get_dock_rect: Callable[[], Rect | None],
+        on_change: Callable[[bool], None],
+    ) -> VisibilityMonitor | None:
+        """Create the current X11 dodge monitor, preserving old factory wiring."""
+        if self._config is None:
+            return None
+
+        return WindowDodgeMonitor(
+            config=self._config,
+            get_dock_rect=lambda: _to_screen_rect(get_dock_rect()),
+            on_change=on_change,
+        )
+
+
+def _to_screen_rect(rect: Rect | None) -> ScreenRect | None:
+    if rect is None:
+        return None
+    return ScreenRect(x=rect.x, y=rect.y, width=rect.width, height=rect.height)

--- a/docking/platform/backends/x11/visibility.py
+++ b/docking/platform/backends/x11/visibility.py
@@ -25,8 +25,10 @@ from docking.platform.dodge import ScreenRect, WindowDodgeMonitor
 if TYPE_CHECKING:
     from docking.core.config import Config
 
-
-_SUPPORTED_HIDE_MODES = frozenset(
+# These are only the hide modes that depend on foreign-window overlap state.
+# The simpler modes such as NONE, ALWAYS_ON_TOP, and AUTOHIDE are handled by
+# dock autohide/surface behavior and do not need an X11 dodge monitor.
+_OVERLAP_HIDE_MODES = frozenset(
     {
         HideMode.INTELLIGENT,
         HideMode.DODGE_ACTIVE,
@@ -50,7 +52,7 @@ class X11VisibilityService:
 
     def supports_hide_mode(self, mode: object) -> bool:
         """Return whether X11 can monitor foreign-window overlap for a mode."""
-        return mode in _SUPPORTED_HIDE_MODES
+        return mode in _OVERLAP_HIDE_MODES
 
     def create_monitor(
         self,

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -245,7 +245,7 @@ if TYPE_CHECKING:
     from docking.core.config import Config
     from docking.core.items import DockItem
     from docking.core.theme import Theme
-    from docking.platform.dodge import WindowDodgeMonitor
+    from docking.platform.backends.base import VisibilityMonitor
     from docking.platform.launcher import Launcher
     from docking.platform.model import DockModel
     from docking.platform.window_tracker import WindowTracker
@@ -379,7 +379,7 @@ class DockWindow(Gtk.Window):
         self._redraw_source_id: int | None = None
         self.dock_hovered: bool = False
         self._last_autohide_state: HideState | None = None
-        self.dodge_monitor: WindowDodgeMonitor | None = None
+        self.dodge_monitor: VisibilityMonitor | None = None
 
         self._setup_window()
         self._setup_drawing_area()

--- a/docking/ui/factory.py
+++ b/docking/ui/factory.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 
 from docking.core.config import Config
 from docking.core.theme import Theme
-from docking.platform.backends.base import PreviewService
-from docking.platform.dodge import ScreenRect, WindowDodgeMonitor
+from docking.platform.backends.base import PreviewService, Rect, VisibilityService
 from docking.platform.launcher import Launcher
 from docking.platform.model import DockModel
 from docking.platform.window_tracker import WindowTracker
@@ -39,6 +38,7 @@ def build_dock_window(
     theme: Theme,
     window_tracker: WindowTracker,
     preview_service: PreviewService,
+    visibility_service: VisibilityService,
     launcher: Launcher,
 ) -> DockWindow:
     """Build a fully wired dock window and its UI collaborators."""
@@ -52,18 +52,18 @@ def build_dock_window(
         preview_service=preview_service,
     )
 
-    def _get_dock_rect() -> ScreenRect | None:
+    def _get_dock_rect() -> Rect | None:
         if not window.get_realized():
             return None
         wx, wy = window.get_position()
         ww, wh = window.get_size()
-        return ScreenRect(x=wx, y=wy, width=ww, height=wh)
+        return Rect(x=wx, y=wy, width=ww, height=wh)
 
-    dodge_monitor = WindowDodgeMonitor(
-        config=config,
+    dodge_monitor = visibility_service.create_monitor(
         get_dock_rect=_get_dock_rect,
         on_change=window.autohide.set_window_should_hide,
     )
     window.dodge_monitor = dodge_monitor
-    dodge_monitor.start()
+    if dodge_monitor is not None:
+        dodge_monitor.start()
     return window

--- a/docs/WAYLAND.md
+++ b/docs/WAYLAND.md
@@ -3160,10 +3160,10 @@ now has the X11 window facade, production X11 runtime wiring, neutral
 `WindowId` values alongside existing XIDs, and menu rows backed by
 `WindowSnapshot`.
 
-The next active X11 migration PR is the X11-only session backend shape. It
-should group the already-migrated window and preview services behind an explicit
-session backend without changing current X11 behavior, and it should leave
-visibility and surface ownership to their dedicated later PRs.
+The next active X11 migration PR is the visibility service step. It should move
+X11 dodge monitor ownership behind `VisibilityService` without changing current
+overlap or hide-mode behavior, and it should leave surface ownership to its
+dedicated later PR.
 
 An optional temporary fallback can make that step safer:
 
@@ -3431,7 +3431,7 @@ Exit criteria:
 - preview behavior remains the same on X11
 - tests cover stale/not-found `WindowId` handling
 
-#### [ ] PR 7: Complete Session Backend Shape With X11 Only
+#### [x] PR 7: Complete Session Backend Shape With X11 Only
 
 Complete the X11 `SessionBackend` shape after the first runtime service wiring
 and after menu/preview can consume services. Production still selects only the

--- a/tests/platform/test_x11_session.py
+++ b/tests/platform/test_x11_session.py
@@ -61,19 +61,25 @@ def test_build_x11_window_tracker_ignores_invalid_mode(monkeypatch):
 def test_build_x11_session_backend_groups_x11_services(monkeypatch):
     windows = MagicMock()
     previews = MagicMock()
+    visibility = MagicMock()
+    config = MagicMock()
     monkeypatch.setattr(
         session, "build_x11_window_tracker", MagicMock(return_value=windows)
     )
     monkeypatch.setattr(session, "X11PreviewService", MagicMock(return_value=previews))
+    monkeypatch.setattr(
+        session, "X11VisibilityService", MagicMock(return_value=visibility)
+    )
 
     backend = session.build_x11_session_backend(
-        model=MagicMock(), launcher=MagicMock(), config=MagicMock()
+        model=MagicMock(), launcher=MagicMock(), config=config
     )
 
     assert backend.name == "x11"
     assert backend.display_server is session.DisplayServer.X11
     assert backend.windows is windows
     assert backend.previews is previews
+    assert backend.visibility is visibility
     assert backend.workspaces is None
     assert backend.desktop_actions is None
     assert backend.screen_capture is None
@@ -82,16 +88,22 @@ def test_build_x11_session_backend_groups_x11_services(monkeypatch):
     assert backend.capabilities.tracks_windows is True
     assert backend.capabilities.supports_window_menu is True
     assert backend.capabilities.supports_screen_reservation is True
+    assert backend.capabilities.supports_overlap_active is True
     session.X11PreviewService.assert_called_once_with(window_tracker=windows)
+    session.X11VisibilityService.assert_called_once_with(config=config)
 
 
 def test_x11_session_backend_lifecycle_starts_and_stops_services(monkeypatch):
     windows = MagicMock()
     previews = MagicMock()
+    visibility = MagicMock()
     monkeypatch.setattr(
         session, "build_x11_window_tracker", MagicMock(return_value=windows)
     )
     monkeypatch.setattr(session, "X11PreviewService", MagicMock(return_value=previews))
+    monkeypatch.setattr(
+        session, "X11VisibilityService", MagicMock(return_value=visibility)
+    )
     backend = session.X11SessionBackend(
         model=MagicMock(), launcher=MagicMock(), config=MagicMock()
     )
@@ -101,6 +113,8 @@ def test_x11_session_backend_lifecycle_starts_and_stops_services(monkeypatch):
 
     windows.start.assert_called_once_with()
     previews.start.assert_called_once_with()
+    visibility.start.assert_called_once_with()
+    visibility.stop.assert_called_once_with()
     previews.stop.assert_called_once_with()
     windows.stop.assert_called_once_with()
 
@@ -108,10 +122,14 @@ def test_x11_session_backend_lifecycle_starts_and_stops_services(monkeypatch):
 def test_x11_session_backend_allows_legacy_tracker_without_lifecycle(monkeypatch):
     windows = object()
     previews = MagicMock()
+    visibility = MagicMock()
     monkeypatch.setattr(
         session, "build_x11_window_tracker", MagicMock(return_value=windows)
     )
     monkeypatch.setattr(session, "X11PreviewService", MagicMock(return_value=previews))
+    monkeypatch.setattr(
+        session, "X11VisibilityService", MagicMock(return_value=visibility)
+    )
     backend = session.X11SessionBackend(
         model=MagicMock(), launcher=MagicMock(), config=MagicMock()
     )
@@ -119,5 +137,7 @@ def test_x11_session_backend_allows_legacy_tracker_without_lifecycle(monkeypatch
     backend.start()
     backend.stop()
 
+    visibility.start.assert_called_once_with()
+    visibility.stop.assert_called_once_with()
     previews.start.assert_called_once_with()
     previews.stop.assert_called_once_with()

--- a/tests/platform/test_x11_visibility.py
+++ b/tests/platform/test_x11_visibility.py
@@ -1,0 +1,68 @@
+"""Tests for X11 visibility service wiring."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from docking.core.config import HideMode
+from docking.platform.backends.base import Rect
+from docking.platform.backends.x11 import visibility
+from docking.platform.dodge import ScreenRect
+
+
+def test_create_monitor_preserves_window_dodge_monitor_arguments(monkeypatch):
+    config = MagicMock()
+    monitor = MagicMock()
+    monitor_cls = MagicMock(return_value=monitor)
+    monkeypatch.setattr(visibility, "WindowDodgeMonitor", monitor_cls)
+    get_dock_rect = MagicMock(return_value=Rect(x=10, y=20, width=300, height=40))
+    on_change = MagicMock()
+    service = visibility.X11VisibilityService(config=config)
+
+    result = service.create_monitor(
+        get_dock_rect=get_dock_rect,
+        on_change=on_change,
+    )
+
+    assert result is monitor
+    monitor_cls.assert_called_once()
+    kwargs = monitor_cls.call_args.kwargs
+    assert kwargs["config"] is config
+    assert kwargs["on_change"] is on_change
+    assert kwargs["get_dock_rect"]() == ScreenRect(
+        x=10,
+        y=20,
+        width=300,
+        height=40,
+    )
+
+
+def test_create_monitor_preserves_unrealized_none_rect(monkeypatch):
+    config = MagicMock()
+    monitor_cls = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(visibility, "WindowDodgeMonitor", monitor_cls)
+    service = visibility.X11VisibilityService(config=config)
+
+    service.create_monitor(get_dock_rect=lambda: None, on_change=MagicMock())
+
+    assert monitor_cls.call_args.kwargs["get_dock_rect"]() is None
+
+
+def test_create_monitor_returns_none_without_config():
+    service = visibility.X11VisibilityService(config=None)
+
+    result = service.create_monitor(get_dock_rect=MagicMock(), on_change=MagicMock())
+
+    assert result is None
+
+
+def test_supports_only_overlap_hide_modes():
+    service = visibility.X11VisibilityService(config=MagicMock())
+
+    assert service.supports_hide_mode(HideMode.INTELLIGENT) is True
+    assert service.supports_hide_mode(HideMode.DODGE_ACTIVE) is True
+    assert service.supports_hide_mode(HideMode.WINDOW_DODGE) is True
+    assert service.supports_hide_mode(HideMode.DODGE_MAXIMIZED) is True
+    assert service.supports_hide_mode(HideMode.NONE) is False
+    assert service.supports_hide_mode(HideMode.AUTOHIDE) is False
+    assert service.supports_hide_mode(object()) is False

--- a/tests/smoke/test_python314_smoke.py
+++ b/tests/smoke/test_python314_smoke.py
@@ -250,7 +250,9 @@ def test_app_main_smoke(monkeypatch):
     preview_service = MagicMock()
     backend = MagicMock()
     backend.windows = tracker
+    visibility_service = MagicMock()
     backend.previews = preview_service
+    backend.visibility = visibility_service
     unity = MagicMock()
     new_year = MagicMock()
     window = MagicMock()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -128,7 +128,9 @@ class TestAppMain:
         preview_service = MagicMock()
         backend = MagicMock()
         backend.windows = tracker
+        visibility_service = MagicMock()
         backend.previews = preview_service
+        backend.visibility = visibility_service
         unity = MagicMock()
         new_year = MagicMock()
         window = MagicMock()
@@ -195,6 +197,7 @@ class TestAppMain:
             theme=applied_theme,
             window_tracker=tracker,
             preview_service=preview_service,
+            visibility_service=visibility_service,
             launcher=launcher,
         )
         backend.start.assert_called_once()
@@ -262,7 +265,9 @@ class TestAppMain:
         preview_service = MagicMock()
         backend = MagicMock()
         backend.windows = tracker
+        visibility_service = MagicMock()
         backend.previews = preview_service
+        backend.visibility = visibility_service
         unity = MagicMock()
         new_year = MagicMock()
         window = MagicMock()

--- a/tests/ui/test_factory.py
+++ b/tests/ui/test_factory.py
@@ -20,17 +20,14 @@ class TestBuildDockWindow:
         tracker = MagicMock()
         launcher = MagicMock()
         preview_service = MagicMock()
+        visibility_service = MagicMock()
 
         window = MagicMock()
         window.autohide = MagicMock()
         dodge_monitor = MagicMock()
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
-        monkeypatch.setattr(
-            factory_mod,
-            "WindowDodgeMonitor",
-            MagicMock(return_value=dodge_monitor),
-        )
+        visibility_service.create_monitor.return_value = dodge_monitor
 
         result = factory_mod.build_dock_window(
             config=config,
@@ -39,6 +36,7 @@ class TestBuildDockWindow:
             theme=theme,
             window_tracker=tracker,
             preview_service=preview_service,
+            visibility_service=visibility_service,
             launcher=launcher,
         )
 
@@ -52,8 +50,40 @@ class TestBuildDockWindow:
             launcher=launcher,
             preview_service=preview_service,
         )
+        kwargs = visibility_service.create_monitor.call_args.kwargs
+        assert callable(kwargs["get_dock_rect"])
+        assert kwargs["on_change"] is window.autohide.set_window_should_hide
         dodge_monitor.start.assert_called_once_with()
         assert window.dodge_monitor is dodge_monitor
+
+    def test_build_dock_window_allows_unsupported_visibility_service(self, monkeypatch):
+        config = MagicMock()
+        model = MagicMock()
+        renderer = MagicMock()
+        theme = MagicMock()
+        tracker = MagicMock()
+        launcher = MagicMock()
+        preview_service = MagicMock()
+        visibility_service = MagicMock()
+        visibility_service.create_monitor.return_value = None
+
+        window = MagicMock()
+        window.autohide = MagicMock()
+        monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
+
+        result = factory_mod.build_dock_window(
+            config=config,
+            model=model,
+            renderer=renderer,
+            theme=theme,
+            window_tracker=tracker,
+            preview_service=preview_service,
+            visibility_service=visibility_service,
+            launcher=launcher,
+        )
+
+        assert result is window
+        assert window.dodge_monitor is None
 
     def test_build_dock_window_exposes_realized_dock_rect_to_dodge_monitor(
         self, monkeypatch
@@ -65,6 +95,7 @@ class TestBuildDockWindow:
         tracker = MagicMock()
         launcher = MagicMock()
         preview_service = MagicMock()
+        visibility_service = MagicMock()
 
         window = MagicMock()
         window.autohide = MagicMock()
@@ -80,7 +111,7 @@ class TestBuildDockWindow:
             return monitor
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
-        monkeypatch.setattr(factory_mod, "WindowDodgeMonitor", _make_dodge_monitor)
+        visibility_service.create_monitor.side_effect = _make_dodge_monitor
 
         factory_mod.build_dock_window(
             config=config,
@@ -89,12 +120,13 @@ class TestBuildDockWindow:
             theme=theme,
             window_tracker=tracker,
             preview_service=preview_service,
+            visibility_service=visibility_service,
             launcher=launcher,
         )
 
         get_dock_rect = cast(Callable[[], object], captured["get_dock_rect"])
         dock_rect = get_dock_rect()
-        assert dock_rect == factory_mod.ScreenRect(x=10, y=20, width=300, height=40)
+        assert dock_rect == factory_mod.Rect(x=10, y=20, width=300, height=40)
 
     def test_build_dock_window_returns_none_rect_until_realized(self, monkeypatch):
         config = MagicMock()
@@ -104,6 +136,7 @@ class TestBuildDockWindow:
         tracker = MagicMock()
         launcher = MagicMock()
         preview_service = MagicMock()
+        visibility_service = MagicMock()
 
         window = MagicMock()
         window.autohide = MagicMock()
@@ -117,7 +150,7 @@ class TestBuildDockWindow:
             return monitor
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
-        monkeypatch.setattr(factory_mod, "WindowDodgeMonitor", _make_dodge_monitor)
+        visibility_service.create_monitor.side_effect = _make_dodge_monitor
 
         factory_mod.build_dock_window(
             config=config,
@@ -126,6 +159,7 @@ class TestBuildDockWindow:
             theme=theme,
             window_tracker=tracker,
             preview_service=preview_service,
+            visibility_service=visibility_service,
             launcher=launcher,
         )
 


### PR DESCRIPTION
## Summary
- add an X11 visibility service that creates the existing WindowDodgeMonitor behind the backend interface
- wire dock window construction through the selected backend visibility service instead of instantiating the X11 monitor directly
- mark the session-backend PR complete in the Wayland migration plan and advance the active step to visibility service wiring

## Notes
- X11VisibilityService.supports_hide_mode() only reports modes that need foreign-window overlap monitoring: intelligent hide, dodge active, window dodge, and dodge maximized.
- NONE, ALWAYS_ON_TOP, and AUTOHIDE remain valid hide modes, but they are handled by the existing autohide/surface paths and do not need a dodge monitor.