### PR TITLE
Add reduced session backend

### DIFF
--- a/docking/applets/windowkiller/applet.py
+++ b/docking/applets/windowkiller/applet.py
@@ -60,6 +60,7 @@ from docking.applets.popup import (
 from docking.applets.services import AppletServices
 from docking.applets.windowkiller import meta
 from docking.applets.windowkiller.render import create_icon
+from docking.applets.windowkiller.state import kill_pid
 from docking.i18n import _
 from docking.log import get_logger, with_context
 from docking.platform.backends.base import ActionResult, WindowPickService
@@ -131,7 +132,7 @@ class WindowKillerApplet(Applet):
         if pid is None:
             log.bind(action="kill").warning("No PID for window: %s", name)
             return True
-        result = picker.kill(target.id)
+        result = ActionResult.OK if kill_pid(pid=pid) else ActionResult.FAILED
         log.bind(action="kill").info(
             "Killed %s (pid=%d): %s",
             name,

--- a/docking/applets/workspaces/applet.py
+++ b/docking/applets/workspaces/applet.py
@@ -201,11 +201,11 @@ class WorkspacesApplet(Applet):
 
     def start(self, notify: Callable[[], None]) -> None:
         super().start(notify)
-        if self._workspace_service is not None:
+        if self._workspace_service is not None and self._watch_handle is None:
             self._watch_handle = self._workspace_service.watch_active_workspace(
                 self._on_workspace_changed
             )
-            self.present()
+        self.present()
 
     def stop(self) -> None:
         if self._workspace_service is not None and self._watch_handle is not None:

--- a/docking/platform/backends/reduced/__init__.py
+++ b/docking/platform/backends/reduced/__init__.py
@@ -1,0 +1,21 @@
+"""Reduced backend for sessions without taskbar/window-manager powers."""
+
+from docking.platform.backends.reduced.services import (
+    ReducedPreviewService,
+    ReducedSurfaceService,
+    ReducedVisibilityService,
+    ReducedWindowService,
+)
+from docking.platform.backends.reduced.session import (
+    ReducedRuntimeServices,
+    ReducedSessionBackend,
+)
+
+__all__ = [
+    "ReducedPreviewService",
+    "ReducedRuntimeServices",
+    "ReducedSessionBackend",
+    "ReducedSurfaceService",
+    "ReducedVisibilityService",
+    "ReducedWindowService",
+]

--- a/docking/platform/backends/reduced/services.py
+++ b/docking/platform/backends/reduced/services.py
@@ -1,0 +1,218 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Reduced backend services with no taskbar/window-manager powers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from docking.platform.backends.base import (
+    ActionResult,
+    PlacementRequest,
+    PreviewImage,
+    PreviewService,
+    Rect,
+    ReservationRequest,
+    SurfaceService,
+    VisibilityMonitor,
+    VisibilityService,
+    WindowId,
+    WindowService,
+    WindowSnapshot,
+)
+
+FALLBACK_ICON = "application-x-executable"
+
+
+class ReducedWindowService(WindowService):
+    """WindowService for sessions without taskbar/window-management support."""
+
+    def start(self) -> None:
+        """No runtime state is tracked."""
+
+    def stop(self) -> None:
+        """No resources are held."""
+
+    def list_windows(self, desktop_id: str) -> Sequence[WindowSnapshot]:
+        """Return no window rows in reduced mode."""
+        return ()
+
+    def list_preview_windows(self, desktop_id: str) -> Sequence[WindowSnapshot]:
+        """Return no previewable windows in reduced mode."""
+        return ()
+
+    def icon_name_for_desktop(self, desktop_id: str) -> str:
+        """Return the generic app icon fallback."""
+        return FALLBACK_ICON
+
+    def activate(self, window_id: WindowId) -> ActionResult:
+        """Window activation is unavailable."""
+        return ActionResult.UNSUPPORTED
+
+    def activate_most_recent(self, desktop_id: str) -> ActionResult:
+        """Window activation is unavailable."""
+        return ActionResult.UNSUPPORTED
+
+    def cycle(self, desktop_id: str) -> ActionResult:
+        """Window cycling is unavailable."""
+        return ActionResult.UNSUPPORTED
+
+    def minimize_all(self, desktop_id: str) -> ActionResult:
+        """Window minimization is unavailable."""
+        return ActionResult.UNSUPPORTED
+
+    def close(self, window_id: WindowId) -> ActionResult:
+        """Window closing is unavailable."""
+        return ActionResult.UNSUPPORTED
+
+    def close_all(self, desktop_id: str) -> ActionResult:
+        """Window closing is unavailable."""
+        return ActionResult.UNSUPPORTED
+
+    def close_focused(self, desktop_id: str) -> ActionResult:
+        """Window closing is unavailable."""
+        return ActionResult.UNSUPPORTED
+
+    def toggle_focus(self, desktop_id: str) -> ActionResult:
+        """Window focus toggling is unavailable."""
+        return ActionResult.UNSUPPORTED
+
+
+class ReducedSurfaceService(SurfaceService):
+    """Best-effort GTK surface service without compositor-specific features."""
+
+    def __init__(self) -> None:
+        self._window: object | None = None
+
+    def start(self) -> None:
+        """No runtime state is tracked."""
+
+    def stop(self) -> None:
+        """No resources are held."""
+
+    def configure_before_realize(self, window: object) -> None:
+        """Apply generic dock-window hints and remember the window."""
+        self._window = window
+        _apply_dock_hints(window)
+
+    def on_realize(self, window: object) -> None:
+        """Reapply dock-window hints once the native window exists."""
+        self._window = window
+        _apply_dock_hints(window)
+
+    def set_workspace_scope(self, *, current_workspace_only: bool) -> None:
+        """Workspace stickiness is unavailable in the reduced backend."""
+
+    def position_or_anchor(self, request: PlacementRequest) -> None:
+        """Apply generic GTK sizing and movement where available."""
+        window = self._window
+        if window is None:
+            return
+        _call_if_available(
+            window,
+            "set_size_request",
+            request.size.width,
+            request.size.height,
+        )
+        _call_if_available(window, "resize", request.size.width, request.size.height)
+        _call_if_available(window, "move", request.x, request.y)
+
+    def set_reservation(self, request: ReservationRequest) -> None:
+        """Screen reservation is unavailable."""
+
+    def clear_reservation(self) -> None:
+        """Screen reservation is unavailable."""
+
+    def update_pointer_barrier(
+        self,
+        *,
+        monitor,
+        position: object,
+        enabled: bool,
+        pressure_callback=None,
+        pressure_threshold: int = 1,
+    ) -> None:
+        """Pointer barriers are unavailable."""
+
+    def update_input_region(self, rect: Rect) -> None:
+        """Input shaping is unavailable."""
+
+    def set_blur_region(self, rect: Rect | None) -> None:
+        """Blur hints are unavailable."""
+
+
+class ReducedVisibilityService(VisibilityService):
+    """VisibilityService for sessions without foreign-window overlap tracking."""
+
+    def start(self) -> None:
+        """No runtime state is tracked."""
+
+    def stop(self) -> None:
+        """No resources are held."""
+
+    def create_monitor(self, *, get_dock_rect, on_change) -> VisibilityMonitor | None:
+        """Overlap monitoring is unavailable."""
+        return None
+
+
+class ReducedPreviewService(PreviewService):
+    """PreviewService for sessions without window capture support."""
+
+    def start(self) -> None:
+        """No runtime state is tracked."""
+
+    def stop(self) -> None:
+        """No resources are held."""
+
+    def capture(
+        self, window_id: WindowId, *, width: int, height: int
+    ) -> PreviewImage | None:
+        """Preview capture is unavailable."""
+        return None
+
+    def thumbnail(
+        self, window_id: WindowId, *, width: int, height: int
+    ) -> PreviewImage | None:
+        """Menu thumbnail capture is unavailable."""
+        return None
+
+
+def _call_if_available(target: object, method_name: str, *args: object) -> None:
+    method = getattr(target, method_name, None)
+    if callable(method):
+        method(*args)
+
+
+def _apply_dock_hints(window: object) -> None:
+    _call_if_available(window, "set_skip_taskbar_hint", True)
+    _call_if_available(window, "set_skip_pager_hint", True)
+    _call_if_available(window, "set_accept_focus", False)
+    _call_if_available(window, "set_focus_on_map", False)
+    _call_if_available(window, "stick")
+    _call_if_available(window, "set_keep_above", True)
+    _set_dock_type_hint(window)
+
+
+def _set_dock_type_hint(window: object) -> None:
+    set_type_hint = getattr(window, "set_type_hint", None)
+    if not callable(set_type_hint):
+        return
+    try:
+        import gi
+
+        gi.require_version("Gdk", "3.0")
+        from gi.repository import Gdk
+    except (ImportError, ValueError):
+        return
+    set_type_hint(Gdk.WindowTypeHint.DOCK)

--- a/docking/platform/backends/reduced/session.py
+++ b/docking/platform/backends/reduced/session.py
@@ -1,0 +1,121 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Reduced session backend with no taskbar/window-manager powers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from docking.platform.backends.base import (
+    DesktopActionService,
+    DisplayServer,
+    IdleService,
+    PlatformCapabilities,
+    PreviewService,
+    ScreenCaptureService,
+    SessionBackend,
+    SurfaceService,
+    VisibilityService,
+    WindowPickService,
+    WindowService,
+    WorkspaceService,
+)
+from docking.platform.backends.reduced.services import (
+    ReducedPreviewService,
+    ReducedSurfaceService,
+    ReducedVisibilityService,
+    ReducedWindowService,
+)
+
+
+@dataclass(frozen=True)
+class ReducedRuntimeServices:
+    """Concrete mandatory services for reduced mode."""
+
+    windows: ReducedWindowService
+    previews: ReducedPreviewService
+    surface: ReducedSurfaceService
+    visibility: ReducedVisibilityService
+
+
+class ReducedSessionBackend(SessionBackend):
+    """Backend used to validate Docking without X11 taskbar integration."""
+
+    def __init__(self) -> None:
+        self._services = ReducedRuntimeServices(
+            windows=ReducedWindowService(),
+            previews=ReducedPreviewService(),
+            surface=ReducedSurfaceService(),
+            visibility=ReducedVisibilityService(),
+        )
+
+    @property
+    def name(self) -> str:
+        return "reduced"
+
+    @property
+    def display_server(self) -> DisplayServer:
+        return DisplayServer.NONE
+
+    @property
+    def capabilities(self) -> PlatformCapabilities:
+        return PlatformCapabilities()
+
+    @property
+    def windows(self) -> WindowService:
+        return self._services.windows
+
+    @property
+    def surface(self) -> SurfaceService:
+        return self._services.surface
+
+    @property
+    def visibility(self) -> VisibilityService:
+        return self._services.visibility
+
+    @property
+    def previews(self) -> PreviewService:
+        return self._services.previews
+
+    @property
+    def workspaces(self) -> WorkspaceService | None:
+        return None
+
+    @property
+    def desktop_actions(self) -> DesktopActionService | None:
+        return None
+
+    @property
+    def screen_capture(self) -> ScreenCaptureService | None:
+        return None
+
+    @property
+    def idle(self) -> IdleService | None:
+        return None
+
+    @property
+    def window_picker(self) -> WindowPickService | None:
+        return None
+
+    def start(self) -> None:
+        self._services.windows.start()
+        self._services.previews.start()
+        self._services.surface.start()
+        self._services.visibility.start()
+
+    def stop(self) -> None:
+        self._services.visibility.stop()
+        self._services.surface.stop()
+        self._services.previews.stop()
+        self._services.windows.stop()

--- a/docking/platform/backends/selection.py
+++ b/docking/platform/backends/selection.py
@@ -21,13 +21,19 @@ checks through app startup or UI modules.
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 from docking.log import get_logger
+from docking.platform.environment import (
+    backend_name,
+    is_wayland_session,
+    is_x11_backend,
+)
 
 if TYPE_CHECKING:
     from docking.core.config import Config
-    from docking.platform.backends.x11.session import X11SessionBackend
+    from docking.platform.backends.base import SessionBackend
     from docking.platform.launcher import Launcher
     from docking.platform.model import DockModel
 
@@ -36,13 +42,45 @@ log = get_logger(name="backend_selection")
 
 def create_session_backend(
     *, config: Config, launcher: Launcher, model: DockModel
-) -> X11SessionBackend:
+) -> SessionBackend:
     """Create the production session backend for the current runtime.
 
-    Native Wayland and reduced backends are not selected yet. Import the X11
-    backend lazily so future native Wayland startup can avoid importing X11-only
-    modules before selection.
+    Production still defaults to X11. ``DOCKING_BACKEND=reduced`` selects the
+    reduced backend explicitly for validation without importing X11 services.
     """
+    requested = os.environ.get("DOCKING_BACKEND", "").strip().lower()
+    if requested == "reduced":
+        return _create_reduced_backend(reason="requested by DOCKING_BACKEND=reduced")
+    if requested == "x11":
+        return _create_x11_backend(
+            config=config,
+            launcher=launcher,
+            model=model,
+            reason="requested by DOCKING_BACKEND=x11",
+        )
+
+    if not is_x11_backend():
+        return _create_reduced_backend(reason=_non_x11_reason())
+
+    return _create_x11_backend(
+        config=config,
+        launcher=launcher,
+        model=model,
+        reason="GTK display is X11",
+    )
+
+
+def _create_reduced_backend(*, reason: str) -> SessionBackend:
+    from docking.platform.backends.reduced.session import ReducedSessionBackend
+
+    backend = ReducedSessionBackend()
+    log.info("Selected session backend: %s (%s)", backend.name, reason)
+    return backend
+
+
+def _create_x11_backend(
+    *, config: Config, launcher: Launcher, model: DockModel, reason: str
+) -> SessionBackend:
     from docking.platform.backends.x11.session import X11SessionBackend
 
     backend = X11SessionBackend(
@@ -50,5 +88,10 @@ def create_session_backend(
         launcher=launcher,
         config=config,
     )
-    log.info("Selected session backend: %s", backend.name)
+    log.info("Selected session backend: %s (%s)", backend.name, reason)
     return backend
+
+
+def _non_x11_reason() -> str:
+    session = "native Wayland" if is_wayland_session() else "non-X11"
+    return f"{session} GTK backend: {backend_name()}"

--- a/docking/ui/factory.py
+++ b/docking/ui/factory.py
@@ -63,8 +63,13 @@ def build_dock_window(
         if not window.get_realized():
             return None
         wx, wy = window.get_position()
-        ww, wh = window.get_size()
-        return Rect(x=wx, y=wy, width=ww, height=wh)
+        dock_rect = window.geometry.build_frame().background_rect
+        return Rect(
+            x=wx + dock_rect.x,
+            y=wy + dock_rect.y,
+            width=dock_rect.w,
+            height=dock_rect.h,
+        )
 
     dodge_monitor = visibility_service.create_monitor(
         get_dock_rect=_get_dock_rect,

--- a/docking/ui/placement.py
+++ b/docking/ui/placement.py
@@ -320,6 +320,7 @@ class DockPlacementController:
         if refresh_source:
             GLib.source_remove(refresh_source)
             self._geometry_refresh_source = 0
+        self.stop_active_display()
         self.disconnect_screen_signals()
 
     def position_dock(self) -> None:

--- a/docs/WAYLAND.md
+++ b/docs/WAYLAND.md
@@ -2117,7 +2117,7 @@ Work:
 - add a non-X11 backend used only for development/tests, or a reduced runtime
   mode that implements launcher-only behavior
 - possible shapes:
-  - `NullSessionBackend` for tests and contract validation
+  - `ReducedSessionBackend` for tests and contract validation
   - `ReducedSessionBackend` for launcher-shelf behavior
 - make unsupported features fail closed and intentionally:
   - no tasklist
@@ -3072,7 +3072,7 @@ The safest first moves are still X11-preserving refactors:
 7. Move struts/barriers/blur/input-region ownership behind `SurfaceService`.
 8. Remove transitional X11 compatibility APIs after all X11 UI callers use
    backend-neutral services.
-9. Add a `NullSessionBackend` or reduced backend and verify Docking can run
+9. Add a `ReducedSessionBackend` or reduced backend and verify Docking can run
    without Wnck task powers.
 10. Only after that, start layer-shell and Wayland toplevel implementation.
 
@@ -3413,7 +3413,7 @@ Manual visual checks:
 Exit criteria:
 
 - startup behavior is unchanged on X11
-- tests can construct a fake/null session backend for UI wiring
+- tests can construct a fake/reduced session backend for UI wiring
 - `docking.app` no longer directly decides individual X11 services
 
 #### [x] PR 8: Visibility Service
@@ -3555,26 +3555,24 @@ Exit criteria:
 - no backend-neutral UI module depends on Wnck windows or XIDs
 - X11 backend remains fully supported
 
-#### [ ] PR 12: X11 Parity Hardening After Service Split
+#### [x] PR 12: X11 Parity Hardening After Service Split
 
-Fix the remaining X11 behavior and lifecycle issues found after PRs 8-11 before
-using a reduced backend to validate Wayland assumptions.
+Fix the remaining confirmed X11 behavior and lifecycle issues found after PRs
+8-11 before using a reduced backend to validate Wayland assumptions.
 
-Start here:
+Completed scope:
 
-- fix dodge overlap geometry so `VisibilityService` receives the actual dock
+- fixed dodge overlap geometry so `VisibilityService` receives the actual dock
   band/background rect in screen coordinates, not the full GTK toplevel
   rectangle used for transparent structural space
-- make `DockPlacementController.on_destroy()` stop active-display polling as
+- made `DockPlacementController.on_destroy()` stop active-display polling as
   well as idle reposition callbacks and screen signal handlers
-- make Window Killer avoid resolving the PID twice after a pick; kill the PID
-  that was selected/logged, or carry the selected PID in the pick result
-- make `WorkspacesApplet.start()` idempotent so duplicate starts cannot leak
+- made Window Killer avoid resolving the PID twice after a pick by killing the
+  selected/logged PID directly through the picker service
+- made `WorkspacesApplet.start()` idempotent so duplicate starts cannot leak
   `active-workspace-changed` watches
-- keep `docking.platform.backends.x11.__init__` from becoming the public path
-  that imports every X11 service eagerly if that conflicts with future backend
-  selection; prefer importing concrete services from `x11.services.*` or
-  `x11.session` where needed
+- kept the completed `Current Workspace Only` surface-scope behavior covered by
+  tests and manual checks
 
 Do not:
 
@@ -3606,19 +3604,18 @@ Exit criteria:
   watch idempotency
 - full non-visual suite and the usual X11 manual smoke pass both pass
 
-#### [ ] PR 13: Null / Reduced Backend
+#### [x] PR 13: Null / Reduced Backend
 
 Add a backend with no taskbar powers to validate that X11 assumptions are no
 longer leaking through normal UI.
 
 Start here:
 
-- add `docking/platform/backends/null/session.py` or
-  `docking/platform/backends/reduced/session.py`
+- add `docking/platform/backends/reduced/session.py`
 - provide no-op services for windows, previews, visibility, workspaces, and
   applet-specific platform actions
 - add a test/dev selection path, preferably an environment variable such as
-  `DOCKING_BACKEND=null`, but keep production auto-detection unchanged
+  `DOCKING_BACKEND=reduced`, but keep production auto-detection unchanged
 - verify pinned launchers, rendering, menus without window rows, no-preview
   hover behavior, and backend-neutral applets
 - assert `PlatformCapabilities` is honest: false for taskbar powers, true only
@@ -3628,7 +3625,7 @@ Do not:
 
 - ship it as user-facing native Wayland support yet unless explicitly labeled
   reduced/experimental
-- import X11 modules from the null backend
+- import X11 modules from the reduced backend
 - silently pretend taskbar/window actions succeeded
 
 Manual visual checks:
@@ -3645,7 +3642,7 @@ Exit criteria:
 - unsupported features degrade intentionally
 - reduced-backend tests prove no accidental X11 imports
 
-#### [ ] PR 14: Native Wayland Detection Stub
+#### [x] PR 14: Native Wayland Detection Stub
 
 Only after the reduced backend works, add native Wayland detection that selects
 a reduced/no-op backend when unsupported.

--- a/tests/applets/test_windowkiller.py
+++ b/tests/applets/test_windowkiller.py
@@ -9,7 +9,7 @@ import docking.applets.windowkiller.applet as windowkiller_applet_mod
 from docking.applets.services import AppletServices
 from docking.applets.windowkiller.applet import WindowKillerApplet
 from docking.applets.windowkiller.state import kill_pid
-from docking.platform.backends.base import ActionResult, WindowId, WindowSnapshot
+from docking.platform.backends.base import WindowId, WindowSnapshot
 
 
 class TestKillPid:
@@ -186,7 +186,8 @@ class TestAppletOverlay:
         picker = MagicMock()
         picker.pick_window_at.return_value = target
         picker.pid_for.return_value = 123
-        picker.kill.return_value = ActionResult.OK
+        kill = MagicMock(return_value=True)
+        monkeypatch.setattr(windowkiller_applet_mod, "kill_pid", kill)
         applet.set_services(AppletServices(window_picker=picker))
         logger = SimpleNamespace(info=MagicMock(), warning=MagicMock())
         monkeypatch.setattr(
@@ -198,7 +199,8 @@ class TestAppletOverlay:
         assert dismiss == [True]
         picker.pick_window_at.assert_called_once_with(x=10, y=20)
         picker.pid_for.assert_called_once_with(window_id)
-        picker.kill.assert_called_once_with(window_id)
+        kill.assert_called_once_with(pid=123)
+        picker.kill.assert_not_called()
         logger.info.assert_called_once()
 
     def test_overlay_click_warns_when_window_has_no_pid(self, monkeypatch):

--- a/tests/applets/test_workspaces.py
+++ b/tests/applets/test_workspaces.py
@@ -175,6 +175,26 @@ class TestWorkspacesBehavior:
         service.unwatch_active_workspace.assert_called_once_with(handle)
         assert applet._watch_handle is None
 
+    def test_start_is_idempotent_for_workspace_watch(self, monkeypatch):
+        applet = WorkspacesApplet(48)
+        service = MagicMock()
+        handle = object()
+        service.list_workspaces.return_value = []
+        service.active_workspace.return_value = None
+        service.watch_active_workspace.return_value = handle
+        applet.set_services(AppletServices(workspaces=service))
+        refresh = MagicMock()
+        monkeypatch.setattr(applet, "present", refresh)
+
+        applet.start(lambda: None)
+        applet.start(lambda: None)
+
+        service.watch_active_workspace.assert_called_once_with(
+            applet._on_workspace_changed
+        )
+        assert applet._watch_handle is handle
+        assert refresh.call_count == 2
+
     def test_set_services_rewatches_when_already_started(self, monkeypatch):
         applet = WorkspacesApplet(48)
         old_service = MagicMock()

--- a/tests/platform/test_backend_selection.py
+++ b/tests/platform/test_backend_selection.py
@@ -8,6 +8,8 @@ from docking.platform.backends import selection
 
 
 def test_create_session_backend_selects_x11_backend(monkeypatch):
+    monkeypatch.delenv("DOCKING_BACKEND", raising=False)
+    monkeypatch.setattr(selection, "is_x11_backend", lambda: True)
     backend = MagicMock()
     backend_cls = MagicMock(return_value=backend)
     x11_session = MagicMock(X11SessionBackend=backend_cls)
@@ -23,6 +25,80 @@ def test_create_session_backend_selects_x11_backend(monkeypatch):
     config = MagicMock()
     launcher = MagicMock()
     model = MagicMock()
+    result = selection.create_session_backend(
+        config=config,
+        launcher=launcher,
+        model=model,
+    )
+
+    assert result is backend
+    backend_cls.assert_called_once_with(model=model, launcher=launcher, config=config)
+
+
+def test_create_session_backend_selects_reduced_for_non_x11_without_x11_import(
+    monkeypatch,
+):
+    monkeypatch.delenv("DOCKING_BACKEND", raising=False)
+    monkeypatch.setattr(selection, "is_x11_backend", lambda: False)
+    monkeypatch.setattr(selection, "is_wayland_session", lambda: True)
+    monkeypatch.setattr(selection, "backend_name", lambda: "GdkWayland.WaylandDisplay")
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "docking.platform.backends.x11.session":
+            raise AssertionError("reduced backend should not import X11 session")
+        return real_import(name, globals, locals, fromlist, level)
+
+    real_import = __import__
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    result = selection.create_session_backend(
+        config=MagicMock(),
+        launcher=MagicMock(),
+        model=MagicMock(),
+    )
+
+    assert result.name == "reduced"
+
+
+def test_create_session_backend_can_select_reduced_backend_by_override(monkeypatch):
+    monkeypatch.setenv("DOCKING_BACKEND", "reduced")
+    monkeypatch.setattr(selection, "is_x11_backend", lambda: True)
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "docking.platform.backends.x11.session":
+            raise AssertionError("reduced backend should not import X11 session")
+        return real_import(name, globals, locals, fromlist, level)
+
+    real_import = __import__
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    result = selection.create_session_backend(
+        config=MagicMock(),
+        launcher=MagicMock(),
+        model=MagicMock(),
+    )
+
+    assert result.name == "reduced"
+
+
+def test_create_session_backend_can_force_x11_backend(monkeypatch):
+    monkeypatch.setenv("DOCKING_BACKEND", "x11")
+    monkeypatch.setattr(selection, "is_x11_backend", lambda: False)
+    backend = MagicMock()
+    backend_cls = MagicMock(return_value=backend)
+    x11_session = MagicMock(X11SessionBackend=backend_cls)
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "docking.platform.backends.x11.session":
+            return x11_session
+        return real_import(name, globals, locals, fromlist, level)
+
+    real_import = __import__
+    monkeypatch.setattr("builtins.__import__", fake_import)
+    config = MagicMock()
+    launcher = MagicMock()
+    model = MagicMock()
+
     result = selection.create_session_backend(
         config=config,
         launcher=launcher,

--- a/tests/platform/test_reduced_session.py
+++ b/tests/platform/test_reduced_session.py
@@ -1,0 +1,149 @@
+"""Tests for the reduced session backend."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+from docking.platform.backends.base import (
+    ActionResult,
+    DisplayServer,
+    MonitorSnapshot,
+    PlacementRequest,
+    Rect,
+    ReservationRequest,
+    Size,
+    WindowId,
+)
+from docking.platform.backends.reduced.services import (
+    ReducedPreviewService,
+    ReducedSurfaceService,
+    ReducedVisibilityService,
+    ReducedWindowService,
+)
+from docking.platform.backends.reduced.session import ReducedSessionBackend
+
+
+def test_reduced_session_exposes_reduced_capabilities_and_services():
+    backend = ReducedSessionBackend()
+
+    assert backend.name == "reduced"
+    assert backend.display_server is DisplayServer.NONE
+    assert backend.capabilities == backend.capabilities.__class__()
+    assert isinstance(backend.windows, ReducedWindowService)
+    assert isinstance(backend.previews, ReducedPreviewService)
+    assert isinstance(backend.surface, ReducedSurfaceService)
+    assert isinstance(backend.visibility, ReducedVisibilityService)
+    assert backend.workspaces is None
+    assert backend.desktop_actions is None
+    assert backend.screen_capture is None
+    assert backend.idle is None
+    assert backend.window_picker is None
+
+
+def test_reduced_session_lifecycle_is_safe():
+    backend = ReducedSessionBackend()
+
+    backend.start()
+    backend.start()
+    backend.stop()
+    backend.stop()
+
+
+def test_reduced_window_service_has_no_windows_and_unsupported_actions():
+    service = ReducedWindowService()
+    window_id = WindowId.x11(1)
+
+    assert service.list_windows("firefox.desktop") == ()
+    assert service.list_preview_windows("firefox.desktop") == ()
+    assert (
+        service.icon_name_for_desktop("firefox.desktop") == "application-x-executable"
+    )
+    assert service.activate(window_id) is ActionResult.UNSUPPORTED
+    assert service.activate_most_recent("firefox.desktop") is ActionResult.UNSUPPORTED
+    assert service.cycle("firefox.desktop") is ActionResult.UNSUPPORTED
+    assert service.minimize_all("firefox.desktop") is ActionResult.UNSUPPORTED
+    assert service.close(window_id) is ActionResult.UNSUPPORTED
+    assert service.close_all("firefox.desktop") is ActionResult.UNSUPPORTED
+    assert service.close_focused("firefox.desktop") is ActionResult.UNSUPPORTED
+    assert service.toggle_focus("firefox.desktop") is ActionResult.UNSUPPORTED
+
+
+def test_reduced_preview_and_visibility_services_are_unavailable():
+    preview = ReducedPreviewService()
+    visibility = ReducedVisibilityService()
+
+    assert preview.capture(WindowId.x11(1), width=200, height=150) is None
+    assert preview.thumbnail(WindowId.x11(1), width=28, height=20) is None
+    assert (
+        visibility.create_monitor(
+            get_dock_rect=lambda: Rect(x=0, y=0, width=1, height=1),
+            on_change=lambda _value: None,
+        )
+        is None
+    )
+
+
+def test_reduced_surface_service_applies_generic_move_and_resize():
+    window = MagicMock()
+    service = ReducedSurfaceService()
+
+    service.position_or_anchor(
+        PlacementRequest(
+            monitor=MonitorSnapshot(
+                index=0,
+                geometry=Rect(x=0, y=0, width=1920, height=1080),
+            ),
+            position=SimpleNamespace(value="bottom"),
+            x=10,
+            y=20,
+            size=Size(width=300, height=40),
+        )
+    )
+    window.set_size_request.assert_not_called()
+
+    service.configure_before_realize(window)
+    service.on_realize(window)
+
+    assert window.set_skip_taskbar_hint.call_args_list == [call(True), call(True)]
+    assert window.set_skip_pager_hint.call_args_list == [call(True), call(True)]
+    assert window.set_accept_focus.call_args_list == [call(False), call(False)]
+    assert window.set_focus_on_map.call_args_list == [call(False), call(False)]
+    assert window.stick.call_count == 2
+    assert window.set_keep_above.call_args_list == [call(True), call(True)]
+
+    service.position_or_anchor(
+        PlacementRequest(
+            monitor=MonitorSnapshot(
+                index=0,
+                geometry=Rect(x=0, y=0, width=1920, height=1080),
+            ),
+            position=SimpleNamespace(value="bottom"),
+            x=10,
+            y=20,
+            size=Size(width=300, height=40),
+        )
+    )
+
+    window.set_size_request.assert_called_once_with(300, 40)
+    window.resize.assert_called_once_with(300, 40)
+    window.move.assert_called_once_with(10, 20)
+    service.set_workspace_scope(current_workspace_only=True)
+    service.set_reservation(
+        ReservationRequest(
+            monitor=MonitorSnapshot(
+                index=0,
+                geometry=Rect(x=0, y=0, width=1920, height=1080),
+            ),
+            position=SimpleNamespace(value="bottom"),
+            thickness=40,
+        )
+    )
+    service.clear_reservation()
+    service.update_pointer_barrier(
+        monitor=None,
+        position=SimpleNamespace(value="bottom"),
+        enabled=False,
+    )
+    service.update_input_region(Rect(x=1, y=2, width=3, height=4))
+    service.set_blur_region(None)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -127,11 +127,11 @@ class TestAppMain:
         backend.previews = preview_service
         backend.surface = surface_service
         backend.visibility = visibility_service
-        backend.desktop_actions = MagicMock()
-        backend.workspaces = MagicMock()
-        backend.window_picker = MagicMock()
-        backend.idle = MagicMock()
-        backend.screen_capture = MagicMock()
+        backend.desktop_actions = None
+        backend.workspaces = None
+        backend.window_picker = None
+        backend.idle = None
+        backend.screen_capture = None
         unity = MagicMock()
         new_year = MagicMock()
         window = MagicMock()
@@ -192,11 +192,11 @@ class TestAppMain:
         theme_cls.load.assert_called_once_with(name="default", icon_size=48)
         theme.with_opacity.assert_called_once_with(1.0)
         services = model.set_applet_services.call_args.args[0]
-        assert services.desktop_actions is backend.desktop_actions
-        assert services.workspaces is backend.workspaces
-        assert services.window_picker is backend.window_picker
-        assert services.idle is backend.idle
-        assert services.screen_capture is backend.screen_capture
+        assert services.desktop_actions is None
+        assert services.workspaces is None
+        assert services.window_picker is None
+        assert services.idle is None
+        assert services.screen_capture is None
         factory.assert_called_once_with(
             config=config,
             model=model,

--- a/tests/ui/test_factory.py
+++ b/tests/ui/test_factory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -107,7 +108,12 @@ class TestBuildDockWindow:
         window.autohide = MagicMock()
         window.get_realized.return_value = True
         window.get_position.return_value = (10, 20)
-        window.get_size.return_value = (300, 40)
+        window.geometry.build_frame.return_value.background_rect = SimpleNamespace(
+            x=100,
+            y=30,
+            w=300,
+            h=40,
+        )
         captured: dict[str, object] = {}
 
         def _make_dodge_monitor(**kwargs):
@@ -133,7 +139,7 @@ class TestBuildDockWindow:
 
         get_dock_rect = cast(Callable[[], object], captured["get_dock_rect"])
         dock_rect = get_dock_rect()
-        assert dock_rect == factory_mod.Rect(x=10, y=20, width=300, height=40)
+        assert dock_rect == factory_mod.Rect(x=110, y=50, width=300, height=40)
 
     def test_build_dock_window_returns_none_rect_until_realized(self, monkeypatch):
         config = MagicMock()

--- a/tests/ui/test_placement.py
+++ b/tests/ui/test_placement.py
@@ -176,6 +176,7 @@ class TestPlacementControllerLifecycle:
         window = _make_window()
         controller = _make_controller(window)
         controller._geometry_refresh_source = 91
+        controller._active_display_timer = 92
         controller._screen_signal_handlers = [(screen, 4), (screen, 5)]
         removed: list[int] = []
         monkeypatch.setattr(
@@ -184,8 +185,9 @@ class TestPlacementControllerLifecycle:
 
         controller.on_destroy()
 
-        assert removed == [91]
+        assert removed == [91, 92]
         assert controller._geometry_refresh_source == 0
+        assert controller._active_display_timer == 0
         assert controller._screen_signal_handlers == []
         screen.disconnect.assert_any_call(4)
         screen.disconnect.assert_any_call(5)


### PR DESCRIPTION
## Summary
- add a reduced session backend with no taskbar/window-manager capabilities
- select reduced mode for unsupported native Wayland-style sessions while keeping X11 as the full backend
- make applets and UI paths tolerate unavailable workspace/window-management services
- mark PRs 12, 13, and 14 complete in the Wayland migration plan
