### PR TITLE
Add GNOME Shell bridge prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ Highlights:
 ## Requirements
 
 - Linux with X11 for full dock functionality
-- Native Wayland support is experimental and currently limited to layer-shell
-  dock placement on compositors that support `zwlr_layer_shell_v1`
+- Wayland: full support on GNOME / Mutter 45+ via the companion
+  `docking-bridge@docking.org` GNOME Shell extension; layer-shell support
+  on wlroots-based compositors (Hyprland, Sway); reduced mode on other
+  Wayland compositors
 - Python 3.10+
 - System packages (Ubuntu/Debian):
 
@@ -169,36 +171,71 @@ python run.py
 DOCKING_LOG_LEVEL=DEBUG python run.py
 ```
 
-### Wayland Notes
+### Wayland Support
 
-X11 remains the full-support backend. Native Wayland support is experimental:
-`gtk-layer-shell` provides dock placement/reservation on supported compositors,
-and foreign-toplevel support can provide running/active indicators when the
-protocol adapter is available. Unsupported native Wayland sessions fall back to
-reduced mode; GNOME/Mutter still needs future Shell integration for parity.
+X11 remains the primary backend. Native Wayland is supported through two
+backends, selected automatically or via `DOCKING_BACKEND`:
 
-Native Wayland features are enabled per advertised compositor protocol:
+| Backend | Compositor | Coverage |
+|---|---|---|
+| **GNOME Shell bridge** | GNOME / Mutter 45+ | Full: dock placement, window tracking, window actions (activate / minimize / close), window previews, workspace switching, Show Desktop, Alt+Tab hiding |
+| **Native layer-shell** | wlroots-based (Hyprland, Sway) | Dock placement, window tracking, workspace switching (varies by compositor protocol support) |
+| **Reduced** | Any Wayland | Dock visible but no window management (no running indicators, no previews, no workspace switching) |
 
-| Feature | Required support |
-| --- | --- |
-| Dock surface/reservation | `zwlr_layer_shell_v1` via `gtk-layer-shell` |
-| Running/active windows and basic actions | `zwlr_foreign_toplevel_manager_v1`; `wl_seat` for activate |
-| Workspace applet | `ext_workspace_manager_v1` |
-| Color picker | XDG Desktop Portal `org.freedesktop.portal.Screenshot.PickColor` |
-| Preview thumbnails | Generic: `ext_foreign_toplevel_list_v1`, `ext_foreign_toplevel_image_capture_source_manager_v1`, `ext_image_copy_capture_manager_v1`, and `wl_shm` with ARGB/XRGB (`AR24`/`XR24`, formats `0`/`1`); Hyprland: `hyprland_toplevel_export_manager_v1` v2 |
+#### GNOME Shell Bridge (Mutter 45+)
 
-Check a Wayland session with:
+On GNOME, Docking uses a companion GNOME Shell extension
+(`docking-bridge@docking.org`) that provides window management, previews,
+workspace switching, and Show Desktop over a private session D-Bus interface.
 
+**How to enable:**
 ```bash
-wayland-info | grep -E 'zwlr_layer_shell_v1|zwlr_foreign_toplevel_manager_v1|ext_workspace_manager_v1|ext_foreign_toplevel_list_v1|ext_foreign_toplevel_image_capture_source_manager_v1|ext_image_copy_capture_manager_v1|wl_shm'
+# Install and enable the extension (one-time)
+tools/gnome_bridge.sh install
+
+# Run the dock with the GNOME Shell bridge backend
+DOCKING_BACKEND=gnome-shell docking
 ```
 
-To force a backend for testing:
+The extension is included in the system package (deb / rpm / Arch) and
+auto-enabled on install when a D-Bus session is available. AppImage and
+Nix users should run `tools/gnome_bridge.sh install` once, or copy
+`docking/platform/backends/gnome/extension/` to
+`~/.local/share/gnome-shell/extensions/docking-bridge@docking.org/`.
+
+#### Native layer-shell
+
+Native Wayland layer-shell placement requires a compositor with
+`zwlr_layer_shell_v1` plus the system `gtk-layer-shell` GIR package:
 
 ```bash
-DOCKING_BACKEND=wayland-layer-shell docking
-DOCKING_BACKEND=reduced docking
-DOCKING_BACKEND=x11 docking
+# Debian / Ubuntu
+sudo apt install gir1.2-gtklayershell-0.1
+
+# Fedora
+sudo dnf install gtk-layer-shell
+
+# Arch
+sudo pacman -S gtk-layer-shell
+```
+
+Optional live Wayland protocol backends need the `[wayland]` extra:
+```bash
+sudo apt install libwayland-dev wayland-protocols
+pip install -e ".[wayland]"
+```
+
+Check capabilities:
+```bash
+wayland-info | grep -E 'zwlr_layer_shell_v1|zwlr_foreign_toplevel_manager_v1|ext_workspace_manager_v1'
+```
+
+To force a specific backend for testing:
+```bash
+DOCKING_BACKEND=gnome-shell docking       # GNOME / Mutter 45+
+DOCKING_BACKEND=wayland-layer-shell docking  # wlroots compositors
+DOCKING_BACKEND=reduced docking           # any Wayland (no WM integration)
+DOCKING_BACKEND=x11 docking               # X11 (full support)
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Highlights:
 - Wayland: full support on GNOME / Mutter 45+ via the companion
   `docking-bridge@docking.org` GNOME Shell extension; layer-shell support
   on wlroots-based compositors (Hyprland, Sway); reduced mode on other
-  Wayland compositors
+  Wayland compositors. Recent GNOME / Mutter 45+ examples include Ubuntu
+  26.04 LTS and Fedora Workstation 40+.
 - Python 3.10+
 - System packages (Ubuntu/Debian):
 
@@ -187,6 +188,8 @@ backends, selected automatically or via `DOCKING_BACKEND`:
 On GNOME, Docking uses a companion GNOME Shell extension
 (`docking-bridge@docking.org`) that provides window management, previews,
 workspace switching, and Show Desktop over a private session D-Bus interface.
+Recent GNOME / Mutter 45+ examples include Ubuntu 26.04 LTS and Fedora
+Workstation 40+.
 
 **How to enable:**
 ```bash

--- a/docking/app.py
+++ b/docking/app.py
@@ -49,6 +49,7 @@ cleanly?
 from __future__ import annotations
 
 import faulthandler
+import os
 import signal
 import sys
 from pathlib import Path
@@ -75,6 +76,10 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import GLib, Gtk
 
+# Give GTK / Mutter a stable program name so the GNOME Shell extension
+# can find the dock window on Wayland (where WM_CLASS is not forwarded).
+GLib.set_prgname("Docking")
+
 from docking.applets.services import AppletServices
 from docking.core.config import Config
 from docking.core.theme import Theme
@@ -90,6 +95,8 @@ from docking.ui.renderer import DockRenderer
 
 if TYPE_CHECKING:
     from docking.platform.backends.base import SessionBackend
+
+_FORCE_QUIT_SOURCE_ID = 0
 
 
 def main() -> None:
@@ -164,8 +171,16 @@ def _start_runtime(
 
 
 def _quit() -> bool:
+    global _FORCE_QUIT_SOURCE_ID
+
     Gtk.main_quit()
+    if _FORCE_QUIT_SOURCE_ID == 0:
+        _FORCE_QUIT_SOURCE_ID = GLib.timeout_add_seconds(3, _force_quit)
     return False
+
+
+def _force_quit() -> bool:
+    os._exit(0)
 
 
 if __name__ == "__main__":

--- a/docking/applets/popup.py
+++ b/docking/applets/popup.py
@@ -23,7 +23,7 @@ gi.require_version("Gdk", "3.0")
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, Gtk
 
-from docking.ui.display import clamp_to_screen, get_pointer_position
+from docking.ui.display import clamp_popup, clamp_to_screen, get_pointer_position
 
 _POPUP_CLASS = "applet-popup-surface"
 _POPUP_CSS = f"""
@@ -38,6 +38,19 @@ _POPUP_CSS = f"""
 _popup_css_provider: Gtk.CssProvider | None = None
 
 DEFAULT_POPUP_CURSOR_GAP_PX = 20
+
+# Set by the dock window so popup creation code can call set_transient_for
+# before the xdg-popup is realised (required on Wayland).  Has no effect on
+# X11 where move() always uses screen-absolute coordinates.
+_dock_window: Gtk.Window | None = None
+_surface_svc: object | None = None
+
+
+def set_dock_window(window: Gtk.Window) -> None:
+    """Register the dock window for popup parent and coordinate conversion."""
+    global _dock_window, _surface_svc
+    _dock_window = window
+    _surface_svc = getattr(window, "surface_service", None)
 DEFAULT_DIALOG_CONTENT_SPACING_PX = 8
 DEFAULT_DIALOG_MARGIN_PX = 12
 
@@ -126,6 +139,8 @@ def create_popup_window() -> Gtk.Window:
     window.set_accept_focus(True)
     window.set_focus_on_map(True)
     window.set_type_hint(Gdk.WindowTypeHint.UTILITY)
+    if _dock_window is not None:
+        window.set_transient_for(_dock_window)
     return window
 
 
@@ -156,21 +171,37 @@ def position_popup_near_pointer(
     mouse_x = pos.x if pos is not None else 0
     mouse_y = pos.y if pos is not None else 0
 
+    # On Wayland the popup has transient_for set (xdg-popup parent-relative
+    # coordinates).  Convert the pointer's screen-absolute position to
+    # parent-relative so move() works correctly.
+    use_parent_relative = False
+    svc = _surface_svc
+    if svc is not None and svc.popups_use_parent_relative_coordinates:
+        surface_pos = svc.get_surface_position()
+        if surface_pos is not None:
+            mouse_x -= surface_pos[0]
+            mouse_y -= surface_pos[1]
+            use_parent_relative = True
+
     pref = window.get_preferred_size()[1]
     popup_w = max(pref.width, 1)
     popup_h = max(pref.height, 1)
 
-    screen = window.get_screen()
     popup_x = int(mouse_x - popup_w / 2)
     popup_y = int(mouse_y - popup_h - gap_px)
-    popup_pos = clamp_to_screen(
-        popup_x,
-        popup_y,
-        popup_w,
-        popup_h,
-        screen.get_width(),
-        screen.get_height(),
-    )
+
+    if use_parent_relative:
+        popup_pos = clamp_popup(window, popup_x, popup_y, popup_w, popup_h)
+    else:
+        screen = window.get_screen()
+        popup_pos = clamp_to_screen(
+            popup_x,
+            popup_y,
+            popup_w,
+            popup_h,
+            screen.get_width(),
+            screen.get_height(),
+        )
     window.move(popup_pos.x, popup_pos.y)
 
 
@@ -185,6 +216,8 @@ def prepare_dialog_content(
     resizable: bool | None = None,
 ) -> Gtk.Box:
     """Apply standard applet dialog sizing, placement, and content spacing."""
+    if _dock_window is not None:
+        dialog.set_transient_for(_dock_window)
     if width is not None:
         dialog.set_default_size(width, height)
     dialog.set_position(Gtk.WindowPosition.MOUSE)

--- a/docking/applets/popup.py
+++ b/docking/applets/popup.py
@@ -185,6 +185,13 @@ def prepare_dialog_content(
     resizable: bool | None = None,
 ) -> Gtk.Box:
     """Apply standard applet dialog sizing, placement, and content spacing."""
+    # Window-manager hints: applet-owned dialogs are secondary UI, so they
+    # should not become separate dock/task-list/pager entries on X11.
+    dialog.set_skip_taskbar_hint(True)
+    dialog.set_skip_pager_hint(True)
+
+    # Window geometry: make dialogs open near the pointer and honor optional
+    # caller-provided size, resize, and default-response settings.
     if width is not None:
         dialog.set_default_size(width, height)
     dialog.set_position(Gtk.WindowPosition.MOUSE)
@@ -193,6 +200,7 @@ def prepare_dialog_content(
     if default_response is not None:
         dialog.set_default_response(default_response)
 
+    # Content layout: standardize spacing and margins for applet dialog bodies.
     box = dialog.get_content_area()
     box.set_spacing(spacing)
     box.set_margin_start(margin)

--- a/docking/applets/popup.py
+++ b/docking/applets/popup.py
@@ -23,7 +23,7 @@ gi.require_version("Gdk", "3.0")
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, Gtk
 
-from docking.ui.display import clamp_popup, clamp_to_screen, get_pointer_position
+from docking.ui.display import clamp_to_screen, get_pointer_position
 
 _POPUP_CLASS = "applet-popup-surface"
 _POPUP_CSS = f"""
@@ -38,19 +38,6 @@ _POPUP_CSS = f"""
 _popup_css_provider: Gtk.CssProvider | None = None
 
 DEFAULT_POPUP_CURSOR_GAP_PX = 20
-
-# Set by the dock window so popup creation code can call set_transient_for
-# before the xdg-popup is realised (required on Wayland).  Has no effect on
-# X11 where move() always uses screen-absolute coordinates.
-_dock_window: Gtk.Window | None = None
-_surface_svc: object | None = None
-
-
-def set_dock_window(window: Gtk.Window) -> None:
-    """Register the dock window for popup parent and coordinate conversion."""
-    global _dock_window, _surface_svc
-    _dock_window = window
-    _surface_svc = getattr(window, "surface_service", None)
 DEFAULT_DIALOG_CONTENT_SPACING_PX = 8
 DEFAULT_DIALOG_MARGIN_PX = 12
 
@@ -139,8 +126,6 @@ def create_popup_window() -> Gtk.Window:
     window.set_accept_focus(True)
     window.set_focus_on_map(True)
     window.set_type_hint(Gdk.WindowTypeHint.UTILITY)
-    if _dock_window is not None:
-        window.set_transient_for(_dock_window)
     return window
 
 
@@ -171,37 +156,21 @@ def position_popup_near_pointer(
     mouse_x = pos.x if pos is not None else 0
     mouse_y = pos.y if pos is not None else 0
 
-    # On Wayland the popup has transient_for set (xdg-popup parent-relative
-    # coordinates).  Convert the pointer's screen-absolute position to
-    # parent-relative so move() works correctly.
-    use_parent_relative = False
-    svc = _surface_svc
-    if svc is not None and svc.popups_use_parent_relative_coordinates:
-        surface_pos = svc.get_surface_position()
-        if surface_pos is not None:
-            mouse_x -= surface_pos[0]
-            mouse_y -= surface_pos[1]
-            use_parent_relative = True
-
     pref = window.get_preferred_size()[1]
     popup_w = max(pref.width, 1)
     popup_h = max(pref.height, 1)
 
+    screen = window.get_screen()
     popup_x = int(mouse_x - popup_w / 2)
     popup_y = int(mouse_y - popup_h - gap_px)
-
-    if use_parent_relative:
-        popup_pos = clamp_popup(window, popup_x, popup_y, popup_w, popup_h)
-    else:
-        screen = window.get_screen()
-        popup_pos = clamp_to_screen(
-            popup_x,
-            popup_y,
-            popup_w,
-            popup_h,
-            screen.get_width(),
-            screen.get_height(),
-        )
+    popup_pos = clamp_to_screen(
+        popup_x,
+        popup_y,
+        popup_w,
+        popup_h,
+        screen.get_width(),
+        screen.get_height(),
+    )
     window.move(popup_pos.x, popup_pos.y)
 
 
@@ -216,8 +185,6 @@ def prepare_dialog_content(
     resizable: bool | None = None,
 ) -> Gtk.Box:
     """Apply standard applet dialog sizing, placement, and content spacing."""
-    if _dock_window is not None:
-        dialog.set_transient_for(_dock_window)
     if width is not None:
         dialog.set_default_size(width, height)
     dialog.set_position(Gtk.WindowPosition.MOUSE)

--- a/docking/platform/backends/base.py
+++ b/docking/platform/backends/base.py
@@ -337,6 +337,32 @@ class SurfaceService(Service):
     def set_blur_region(self, rect: Rect | None) -> None:
         """Set or clear a compositor blur hint, if supported."""
 
+    @property
+    def popups_use_parent_relative_coordinates(self) -> bool:
+        """True when ``Gtk.Window.move()`` on a popup child uses
+        parent-relative coordinates.
+
+        On X11 ``move()`` always receives screen-absolute coordinates
+        regardless of ``set_transient_for()``, so the default is
+        ``False``.  Wayland compositor-positioned backends override this
+        to ``True`` because xdg-popup coordinates are always relative to
+        the parent surface.
+        """
+        return False
+
+    def get_surface_position(self) -> tuple[int, int] | None:
+        """Return the dock surface's screen (root) position, if known.
+
+        Returns ``None`` when the backend cannot track the surface position,
+        which means the caller should fall back to
+        ``Gtk.Window.get_position()``.
+
+        Backends that position the surface through the compositor (e.g.
+        Wayland) are expected to override this because GTK always reports
+        ``(0, 0)`` when it has no knowledge of the absolute placement.
+        """
+        return None
+
 
 class VisibilityMonitor(ABC):
     """Runtime monitor for overlap-driven hide modes."""

--- a/docking/platform/backends/gnome/__init__.py
+++ b/docking/platform/backends/gnome/__init__.py
@@ -1,0 +1,2 @@
+"""GNOME Shell bridge backend."""
+

--- a/docking/platform/backends/gnome/__init__.py
+++ b/docking/platform/backends/gnome/__init__.py
@@ -1,2 +1,1 @@
 """GNOME Shell bridge backend."""
-

--- a/docking/platform/backends/gnome/bridge.py
+++ b/docking/platform/backends/gnome/bridge.py
@@ -60,6 +60,8 @@ log = get_logger(name="backend.gnome.bridge")
 BUS_NAME = "org.docking.Docking.GnomeShellBridge"
 OBJECT_PATH = "/org/docking/Docking/GnomeShellBridge"
 INTERFACE = "org.docking.Docking.GnomeShellBridge1"
+_DOCK_POSITION_RETRY_MS = 100
+_DOCK_POSITION_RETRY_ATTEMPTS = 15
 
 
 class GnomeShellBridgeClient:
@@ -604,6 +606,8 @@ class GnomeShellBridgeSurfaceService(SurfaceService):
         self._bridge = bridge
         self._window: object | None = None
         self._position_retry_source_id: int = 0
+        self._position_retry_attempts_remaining: int = 0
+        self._latest_position_request: PlacementRequest | None = None
         # Wayland: GTK does not know the absolute screen position.
         # We track it here so get_surface_position() can return it.
         self._surface_x: int | None = None
@@ -622,6 +626,8 @@ class GnomeShellBridgeSurfaceService(SurfaceService):
         if self._position_retry_source_id:
             GLib.source_remove(self._position_retry_source_id)
             self._position_retry_source_id = 0
+        self._position_retry_attempts_remaining = 0
+        self._latest_position_request = None
         self._window = None
         self._surface_x = None
         self._surface_y = None
@@ -648,22 +654,10 @@ class GnomeShellBridgeSurfaceService(SurfaceService):
         )
         _call_method(window, "resize", request.size.width, request.size.height)
 
-        # Track the compositor-assigned position so get_surface_position()
-        # can report it.  GTK's get_position() returns (0,0) on Wayland.
-        self._surface_x = request.x
-        self._surface_y = request.y
-
-        # Mutter's initial placement (centre-screen) fires during the
-        # map phase and overrides any move before the window is fully
-        # realised.  Call immediately for subsequent repositioning and
-        # schedule a delayed call that runs after Mutter settles.
-        self._bridge.position_dock(
-            request.x, request.y, request.size.width, request.size.height
-        )
-        if self._position_retry_source_id == 0:
-            self._position_retry_source_id = GLib.timeout_add(
-                500, self._retry_position, request
-            )
+        self._latest_position_request = request
+        self._position_retry_attempts_remaining = _DOCK_POSITION_RETRY_ATTEMPTS
+        self._apply_position_request(request)
+        self._schedule_position_retry()
 
     def set_workspace_scope(self, *, current_workspace_only: bool) -> None:
         pass
@@ -693,14 +687,39 @@ class GnomeShellBridgeSurfaceService(SurfaceService):
 
     # -- internals --------------------------------------------------------
 
-    def _retry_position(self, request: PlacementRequest) -> bool:
+    def _retry_latest_position(self) -> bool:
         self._position_retry_source_id = 0
+        request = self._latest_position_request
+        if request is None or self._position_retry_attempts_remaining <= 0:
+            return False
+
+        self._position_retry_attempts_remaining -= 1
+        self._apply_position_request(request)
+        self._schedule_position_retry()
+        return False
+
+    def _schedule_position_retry(self) -> None:
+        if self._position_retry_source_id:
+            return
+        if (
+            self._latest_position_request is None
+            or self._position_retry_attempts_remaining <= 0
+        ):
+            return
+        self._position_retry_source_id = GLib.timeout_add(
+            _DOCK_POSITION_RETRY_MS, self._retry_latest_position
+        )
+
+    def _apply_position_request(self, request: PlacementRequest) -> bool:
+        # Track the compositor-assigned position so get_surface_position()
+        # can report it.  GTK's get_position() returns (0,0) on Wayland.
         self._surface_x = request.x
         self._surface_y = request.y
-        self._bridge.position_dock(
-            request.x, request.y, request.size.width, request.size.height
+        return bool(
+            self._bridge.position_dock(
+                request.x, request.y, request.size.width, request.size.height
+            )
         )
-        return False  # GLib.SOURCE_REMOVE
 
 
 # -- surface helpers (mirror reduced/services.py) ----------------------------

--- a/docking/platform/backends/gnome/bridge.py
+++ b/docking/platform/backends/gnome/bridge.py
@@ -1,0 +1,832 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""GNOME Shell bridge services.
+
+Docking cannot get full GNOME Wayland dock behavior from an ordinary GTK
+client. This backend is the first bridge prototype: a GNOME Shell extension
+exports shell-owned window/workspace facts over D-Bus, and Docking consumes
+them through the same backend-neutral contracts used by X11 and Wayland.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import gi
+
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio, GLib
+
+from docking.log import get_logger
+from docking.platform.backends.base import (
+    ActionResult,
+    DesktopActionService,
+    DisplayServer,
+    PlacementRequest,
+    PreviewImage,
+    PreviewService,
+    Rect,
+    ReservationRequest,
+    SurfaceService,
+    WindowId,
+    WindowService,
+    WindowSnapshot,
+    WorkspaceService,
+    WorkspaceSnapshot,
+)
+from docking.platform.backends.wayland.toplevels import WaylandAppIdMatcher
+from docking.platform.running import RunningAppInfo, RunningWindowInfo
+
+if TYPE_CHECKING:
+    from docking.platform.launcher import Launcher
+    from docking.platform.model import DockModel
+
+log = get_logger(name="backend.gnome.bridge")
+
+BUS_NAME = "org.docking.Docking.GnomeShellBridge"
+OBJECT_PATH = "/org/docking/Docking/GnomeShellBridge"
+INTERFACE = "org.docking.Docking.GnomeShellBridge1"
+
+
+class GnomeShellBridgeClient:
+    """Synchronous session-bus client for the GNOME Shell bridge extension."""
+
+    def __init__(self, proxy: Gio.DBusProxy) -> None:
+        self._proxy = proxy
+
+    @classmethod
+    def connect(cls) -> GnomeShellBridgeClient | None:
+        """Return a bridge client when the extension D-Bus name is available."""
+        try:
+            proxy = Gio.DBusProxy.new_for_bus_sync(
+                Gio.BusType.SESSION,
+                Gio.DBusProxyFlags.DO_NOT_AUTO_START,
+                None,
+                BUS_NAME,
+                OBJECT_PATH,
+                INTERFACE,
+                None,
+            )
+            proxy.call_sync(
+                "ListWindows",
+                None,
+                Gio.DBusCallFlags.NO_AUTO_START,
+                1000,
+                None,
+            )
+        except Exception as exc:
+            log.info("GNOME Shell bridge unavailable: %s", exc)
+            return None
+        return cls(proxy=proxy)
+
+    def list_windows(self) -> Sequence[Mapping[str, Any]]:
+        """Return raw window rows exported by the Shell extension."""
+        result = self._call("ListWindows")
+        if result is None:
+            return ()
+        return _json_rows(result.unpack()[0])
+
+    def list_workspaces(self) -> Sequence[Mapping[str, Any]]:
+        """Return raw workspace rows exported by the Shell extension."""
+        result = self._call("ListWorkspaces")
+        if result is None:
+            return ()
+        return _json_rows(result.unpack()[0])
+
+    def activate(self, bridge_id: int) -> bool:
+        return self._call_window_action("Activate", bridge_id)
+
+    def minimize(self, bridge_id: int) -> bool:
+        return self._call_window_action("Minimize", bridge_id)
+
+    def close(self, bridge_id: int) -> bool:
+        return self._call_window_action("Close", bridge_id)
+
+    def position_dock(self, x: int, y: int, width: int, height: int) -> bool:
+        """Ask the GNOME Shell extension to position the dock window via Mutter."""
+        result = self._call(
+            "PositionDock",
+            GLib.Variant("(iiii)", (x, y, width, height)),
+        )
+        return bool(result.unpack()[0]) if result is not None else False
+
+    def capture_window(
+        self, bridge_id: int, *, width: int, height: int
+    ) -> bytes | None:
+        """Request a PNG thumbnail of a window from the GNOME Shell extension.
+
+        Returns raw PNG bytes, or ``None`` when capture is unavailable.
+        """
+        result = self._call(
+            "CaptureWindow",
+            GLib.Variant("(uii)", (bridge_id, width, height)),
+        )
+        if result is None:
+            return None
+        try:
+            png_base64 = result.unpack()[0]
+        except (TypeError, ValueError, IndexError):
+            return None
+        if not png_base64:
+            return None
+        return GLib.base64_decode(png_base64)
+
+    def show_desktop(self) -> bool:
+        """Toggle show-desktop state via the GNOME Shell extension."""
+        result = self._call("ShowDesktop")
+        if result is None:
+            return False
+        try:
+            return bool(result.unpack()[0])
+        except (TypeError, ValueError, IndexError):
+            return False
+
+    def activate_workspace(self, workspace_id: str) -> bool:
+        try:
+            bridge_id = int(workspace_id)
+        except (TypeError, ValueError):
+            return False
+        result = self._call("ActivateWorkspace", GLib.Variant("(u)", (bridge_id,)))
+        return bool(result.unpack()[0]) if result is not None else False
+
+    def subscribe_changed(self, callback: Callable[[], None]) -> object | None:
+        """Subscribe to extension state changes."""
+        connection = self._proxy.get_connection()
+        if connection is None:
+            return None
+
+        def handle_signal(
+            _connection: Gio.DBusConnection,
+            _sender_name: str,
+            _object_path: str,
+            _interface_name: str,
+            _signal_name: str,
+            _parameters: GLib.Variant,
+        ) -> None:
+            callback()
+
+        return connection.signal_subscribe(
+            BUS_NAME,
+            INTERFACE,
+            "Changed",
+            OBJECT_PATH,
+            None,
+            Gio.DBusSignalFlags.NONE,
+            handle_signal,
+        )
+
+    def unsubscribe_changed(self, handle: object) -> None:
+        connection = self._proxy.get_connection()
+        if connection is None:
+            return
+        try:
+            connection.signal_unsubscribe(int(handle))
+        except (TypeError, ValueError):
+            return
+
+    def _call(
+        self, method: str, parameters: GLib.Variant | None = None
+    ) -> GLib.Variant | None:
+        try:
+            return self._proxy.call_sync(
+                method,
+                parameters,
+                Gio.DBusCallFlags.NO_AUTO_START,
+                1000,
+                None,
+            )
+        except Exception as exc:
+            log.warning("GNOME Shell bridge call %s failed: %s", method, exc)
+            return None
+
+    def _call_window_action(self, method: str, bridge_id: int) -> bool:
+        result = self._call(method, GLib.Variant("(u)", (bridge_id,)))
+        return bool(result.unpack()[0]) if result is not None else False
+
+
+@dataclass(frozen=True)
+class _BridgeWindow:
+    bridge_id: int
+    title: str
+    app_id: str
+    desktop_id: str | None
+    active: bool
+    minimized: bool
+    maximized: bool
+    fullscreen: bool
+    monitor: int | None
+    workspace_id: str | None
+    geometry: Rect | None
+
+    @property
+    def window_id(self) -> WindowId:
+        return WindowId(backend=DisplayServer.WAYLAND, value=f"gnome:{self.bridge_id}")
+
+
+class GnomeShellBridgeWindowService(WindowService):
+    """WindowService backed by the GNOME Shell bridge extension."""
+
+    def __init__(
+        self,
+        *,
+        model: DockModel,
+        launcher: Launcher,
+        bridge: object,
+    ) -> None:
+        self._model = model
+        self._matcher = WaylandAppIdMatcher(launcher=launcher)
+        self._bridge = bridge
+        self._windows_by_id: dict[int, _BridgeWindow] = {}
+        self._changed_handle: object | None = None
+        self._poll_source_id = 0
+
+    def start(self) -> None:
+        subscribe = getattr(self._bridge, "subscribe_changed", None)
+        if callable(subscribe):
+            self._changed_handle = subscribe(self.refresh)
+        self.refresh()
+        self._poll_source_id = GLib.timeout_add_seconds(2, self._poll)
+
+    def stop(self) -> None:
+        if self._poll_source_id:
+            GLib.source_remove(self._poll_source_id)
+            self._poll_source_id = 0
+        unsubscribe = getattr(self._bridge, "unsubscribe_changed", None)
+        if callable(unsubscribe) and self._changed_handle is not None:
+            unsubscribe(self._changed_handle)
+        self._changed_handle = None
+        self._windows_by_id.clear()
+        self._model.update_running(running={})
+
+    def refresh(self) -> None:
+        """Refresh cached bridge state and publish running app state."""
+        self._matcher.sync_visible_items(self._model.visible_items())
+        rows = self._bridge.list_windows()
+        windows: dict[int, _BridgeWindow] = {}
+        for row in rows:
+            window = self._window_from_row(row)
+            if window is not None:
+                windows[window.bridge_id] = window
+        self._windows_by_id = windows
+        self._publish_running()
+
+    def list_windows(self, desktop_id: str) -> Sequence[WindowSnapshot]:
+        return tuple(
+            self._snapshot_for(window)
+            for window in self._windows_by_id.values()
+            if window.desktop_id == desktop_id
+        )
+
+    def list_preview_windows(self, desktop_id: str) -> Sequence[WindowSnapshot]:
+        return self.list_windows(desktop_id=desktop_id)
+
+    def icon_name_for_desktop(self, desktop_id: str) -> str:
+        return "application-x-executable"
+
+    def activate(self, window_id: WindowId) -> ActionResult:
+        window = self._window_for_id(window_id)
+        if window is None:
+            return ActionResult.NOT_FOUND
+        return _action_result(self._bridge.activate(window.bridge_id))
+
+    def activate_most_recent(self, desktop_id: str) -> ActionResult:
+        window = self._first_window_for_desktop(desktop_id)
+        if window is None:
+            return ActionResult.NOT_FOUND
+        return _action_result(self._bridge.activate(window.bridge_id))
+
+    def cycle(self, desktop_id: str) -> ActionResult:
+        return self.activate_most_recent(desktop_id=desktop_id)
+
+    def minimize_all(self, desktop_id: str) -> ActionResult:
+        windows = self._windows_for_desktop(desktop_id)
+        if not windows:
+            return ActionResult.NOT_FOUND
+        result = ActionResult.OK
+        for window in windows:
+            if not self._bridge.minimize(window.bridge_id):
+                result = ActionResult.FAILED
+        return result
+
+    def close(self, window_id: WindowId) -> ActionResult:
+        window = self._window_for_id(window_id)
+        if window is None:
+            return ActionResult.NOT_FOUND
+        return _action_result(self._bridge.close(window.bridge_id))
+
+    def close_all(self, desktop_id: str) -> ActionResult:
+        windows = self._windows_for_desktop(desktop_id)
+        if not windows:
+            return ActionResult.NOT_FOUND
+        result = ActionResult.OK
+        for window in windows:
+            if not self._bridge.close(window.bridge_id):
+                result = ActionResult.FAILED
+        return result
+
+    def close_focused(self, desktop_id: str) -> ActionResult:
+        windows = self._windows_for_desktop(desktop_id)
+        if not windows:
+            return ActionResult.NOT_FOUND
+        window = next((item for item in windows if item.active), windows[0])
+        return _action_result(self._bridge.close(window.bridge_id))
+
+    def toggle_focus(self, desktop_id: str) -> ActionResult:
+        window = self._first_window_for_desktop(desktop_id)
+        if window is None:
+            return ActionResult.NOT_FOUND
+        if window.active and self._bridge.minimize(window.bridge_id):
+            return ActionResult.OK
+        return _action_result(self._bridge.activate(window.bridge_id))
+
+    def _poll(self) -> bool:
+        self.refresh()
+        return True
+
+    def _window_from_row(self, row: Mapping[str, Any]) -> _BridgeWindow | None:
+        bridge_id = _int_from_row(row, "id")
+        if bridge_id is None:
+            return None
+        app_id = _str_from_row(row, "app-id")
+        desktop_id = self._matcher.match(app_id) if app_id else None
+        geometry = _rect_from_row(row)
+        return _BridgeWindow(
+            bridge_id=bridge_id,
+            title=_str_from_row(row, "title") or "Window",
+            app_id=app_id,
+            desktop_id=desktop_id,
+            active=_bool_from_row(row, "active"),
+            minimized=_bool_from_row(row, "minimized"),
+            maximized=_bool_from_row(row, "maximized"),
+            fullscreen=_bool_from_row(row, "fullscreen"),
+            monitor=_int_from_row(row, "monitor"),
+            workspace_id=_workspace_id_from_row(row),
+            geometry=geometry,
+        )
+
+    def _publish_running(self) -> None:
+        windows_by_desktop: dict[str, list[RunningWindowInfo]] = {}
+        for window in self._windows_by_id.values():
+            if window.desktop_id is None:
+                continue
+            windows_by_desktop.setdefault(window.desktop_id, []).append(
+                RunningWindowInfo(
+                    desktop_id=window.desktop_id,
+                    xid=window.bridge_id,
+                    window_id=window.window_id,
+                    active=window.active,
+                    urgent=False,
+                    window=window.bridge_id,
+                )
+            )
+        self._model.update_running(
+            running={
+                desktop_id: RunningAppInfo.from_windows(items)
+                for desktop_id, items in windows_by_desktop.items()
+            }
+        )
+
+    def _snapshot_for(self, window: _BridgeWindow) -> WindowSnapshot:
+        return WindowSnapshot(
+            id=window.window_id,
+            desktop_id=window.desktop_id or "",
+            title=window.title,
+            app_id=window.app_id or None,
+            active=window.active,
+            minimized=window.minimized,
+            maximized=window.maximized,
+            fullscreen=window.fullscreen,
+            geometry=window.geometry,
+            workspace_id=window.workspace_id,
+            can_activate=True,
+            can_minimize=True,
+            can_close=True,
+            can_preview=True,
+        )
+
+    def _windows_for_desktop(self, desktop_id: str) -> list[_BridgeWindow]:
+        return [
+            window
+            for window in self._windows_by_id.values()
+            if window.desktop_id == desktop_id
+        ]
+
+    def _first_window_for_desktop(self, desktop_id: str) -> _BridgeWindow | None:
+        windows = self._windows_for_desktop(desktop_id)
+        if not windows:
+            return None
+        return next((window for window in windows if window.active), windows[0])
+
+    def _window_for_id(self, window_id: WindowId) -> _BridgeWindow | None:
+        if window_id.backend is not DisplayServer.WAYLAND:
+            return None
+        value = str(window_id.value)
+        if not value.startswith("gnome:"):
+            return None
+        try:
+            bridge_id = int(value.removeprefix("gnome:"))
+        except ValueError:
+            return None
+        return self._windows_by_id.get(bridge_id)
+
+
+class GnomeShellBridgeWorkspaceService(WorkspaceService):
+    """WorkspaceService backed by the GNOME Shell bridge extension."""
+
+    def __init__(self, *, bridge: object) -> None:
+        self._bridge = bridge
+        self._workspaces: tuple[WorkspaceSnapshot, ...] = ()
+        self._watchers: dict[int, Callable[[], None]] = {}
+        self._next_watch_id = 1
+        self._changed_handle: object | None = None
+        self._poll_source_id = 0
+
+    def start(self) -> None:
+        subscribe = getattr(self._bridge, "subscribe_changed", None)
+        if callable(subscribe):
+            self._changed_handle = subscribe(self.refresh)
+        self.refresh()
+        self._poll_source_id = GLib.timeout_add_seconds(2, self._poll)
+
+    def stop(self) -> None:
+        if self._poll_source_id:
+            GLib.source_remove(self._poll_source_id)
+            self._poll_source_id = 0
+        unsubscribe = getattr(self._bridge, "unsubscribe_changed", None)
+        if callable(unsubscribe) and self._changed_handle is not None:
+            unsubscribe(self._changed_handle)
+        self._changed_handle = None
+        self._watchers.clear()
+        self._workspaces = ()
+
+    def refresh(self) -> None:
+        previous_active = self.active_workspace()
+        rows = self._bridge.list_workspaces()
+        self._workspaces = tuple(
+            workspace
+            for row in rows
+            if (workspace := _workspace_from_row(row)) is not None
+        )
+        current_active = self.active_workspace()
+        if _workspace_identity(previous_active) == _workspace_identity(current_active):
+            return
+        for callback in tuple(self._watchers.values()):
+            callback()
+
+    def list_workspaces(self) -> Sequence[WorkspaceSnapshot]:
+        return self._workspaces
+
+    def active_workspace(self) -> WorkspaceSnapshot | None:
+        return next(
+            (workspace for workspace in self._workspaces if workspace.active),
+            None,
+        )
+
+    def activate(self, workspace_id: str) -> ActionResult:
+        return _action_result(self._bridge.activate_workspace(workspace_id))
+
+    def watch_active_workspace(self, on_change: Callable[[], None]) -> object | None:
+        handle = self._next_watch_id
+        self._next_watch_id += 1
+        self._watchers[handle] = on_change
+        return handle
+
+    def unwatch_active_workspace(self, handle: object) -> None:
+        try:
+            self._watchers.pop(int(handle), None)
+        except (TypeError, ValueError):
+            return
+
+    def _poll(self) -> bool:
+        self.refresh()
+        return True
+
+
+def _action_result(ok: bool) -> ActionResult:
+    return ActionResult.OK if ok else ActionResult.FAILED
+
+
+def _variant_value(value: Any) -> Any:
+    return value.unpack() if hasattr(value, "unpack") else value
+
+
+def _json_rows(value: object) -> tuple[Mapping[str, Any], ...]:
+    try:
+        decoded = json.loads(str(value))
+    except json.JSONDecodeError as exc:
+        log.warning("GNOME Shell bridge returned invalid JSON: %s", exc)
+        return ()
+    if not isinstance(decoded, list):
+        return ()
+    return tuple(row for row in decoded if isinstance(row, dict))
+
+
+def _row_value(row: Mapping[str, Any], key: str, default: Any = None) -> Any:
+    return _variant_value(row.get(key, default))
+
+
+def _str_from_row(row: Mapping[str, Any], key: str) -> str:
+    value = _row_value(row, key, "")
+    return str(value).strip() if value is not None else ""
+
+
+def _bool_from_row(row: Mapping[str, Any], key: str) -> bool:
+    return bool(_row_value(row, key, False))
+
+
+def _int_from_row(row: Mapping[str, Any], key: str) -> int | None:
+    value = _row_value(row, key)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _workspace_id_from_row(row: Mapping[str, Any]) -> str | None:
+    value = _int_from_row(row, "workspace")
+    return str(value) if value is not None else None
+
+
+def _rect_from_row(row: Mapping[str, Any]) -> Rect | None:
+    x = _int_from_row(row, "x")
+    y = _int_from_row(row, "y")
+    width = _int_from_row(row, "width")
+    height = _int_from_row(row, "height")
+    if x is None or y is None or width is None or height is None:
+        return None
+    return Rect(x=x, y=y, width=width, height=height)
+
+
+def _workspace_from_row(row: Mapping[str, Any]) -> WorkspaceSnapshot | None:
+    workspace_id = _int_from_row(row, "id")
+    if workspace_id is None:
+        return None
+    number = _int_from_row(row, "index")
+    return WorkspaceSnapshot(
+        id=str(workspace_id),
+        number=number if number is not None else workspace_id,
+        name=_str_from_row(row, "name"),
+        active=_bool_from_row(row, "active"),
+    )
+
+
+def _workspace_identity(workspace: WorkspaceSnapshot | None) -> str | None:
+    return workspace.id if workspace is not None else None
+
+
+class GnomeShellBridgeSurfaceService(SurfaceService):
+    """SurfaceService that delegates edge positioning to the GNOME Shell extension.
+
+    On Wayland the compositor ignores client-side ``gtk_window_move()``, so
+    ordinary GTK positioning is a no-op.  This service asks the shell
+    extension to reposition the dock window via Mutter's own
+    ``Meta.Window.move_resize_frame()``, which works because the extension
+    runs inside the shell process with full window-management privileges.
+    """
+
+    def __init__(self, *, bridge: object) -> None:
+        self._bridge = bridge
+        self._window: object | None = None
+        self._position_retry_source_id: int = 0
+        # Wayland: GTK does not know the absolute screen position.
+        # We track it here so get_surface_position() can return it.
+        self._surface_x: int | None = None
+        self._surface_y: int | None = None
+
+    # -- SurfaceService ---------------------------------------------------
+
+    def start(self) -> None:
+        pass
+
+    @property
+    def popups_use_parent_relative_coordinates(self) -> bool:
+        return True
+
+    def stop(self) -> None:
+        if self._position_retry_source_id:
+            GLib.source_remove(self._position_retry_source_id)
+            self._position_retry_source_id = 0
+        self._window = None
+        self._surface_x = None
+        self._surface_y = None
+
+    def get_surface_position(self) -> tuple[int, int] | None:
+        if self._surface_x is not None and self._surface_y is not None:
+            return self._surface_x, self._surface_y
+        return None
+
+    def configure_before_realize(self, window: object) -> None:
+        self._window = window
+        _apply_dock_window_hints(window)
+
+    def on_realize(self, window: object) -> None:
+        self._window = window
+        _apply_dock_window_hints(window)
+
+    def position_or_anchor(self, request: PlacementRequest) -> None:
+        window = self._window
+        if window is None:
+            return
+        _call_method(
+            window, "set_size_request", request.size.width, request.size.height
+        )
+        _call_method(window, "resize", request.size.width, request.size.height)
+
+        # Track the compositor-assigned position so get_surface_position()
+        # can report it.  GTK's get_position() returns (0,0) on Wayland.
+        self._surface_x = request.x
+        self._surface_y = request.y
+
+        # Mutter's initial placement (centre-screen) fires during the
+        # map phase and overrides any move before the window is fully
+        # realised.  Call immediately for subsequent repositioning and
+        # schedule a delayed call that runs after Mutter settles.
+        self._bridge.position_dock(
+            request.x, request.y, request.size.width, request.size.height
+        )
+        if self._position_retry_source_id == 0:
+            self._position_retry_source_id = GLib.timeout_add(
+                500, self._retry_position, request
+            )
+
+    def set_workspace_scope(self, *, current_workspace_only: bool) -> None:
+        pass
+
+    def set_reservation(self, request: ReservationRequest) -> None:
+        pass
+
+    def clear_reservation(self) -> None:
+        pass
+
+    def update_pointer_barrier(
+        self,
+        *,
+        monitor: Any = None,
+        position: Any = None,
+        enabled: bool = False,
+        pressure_callback: Any = None,
+        pressure_threshold: int = 1,
+    ) -> None:
+        pass
+
+    def update_input_region(self, rect: Rect) -> None:
+        pass
+
+    def set_blur_region(self, rect: Rect | None) -> None:
+        pass
+
+    # -- internals --------------------------------------------------------
+
+    def _retry_position(self, request: PlacementRequest) -> bool:
+        self._position_retry_source_id = 0
+        self._surface_x = request.x
+        self._surface_y = request.y
+        self._bridge.position_dock(
+            request.x, request.y, request.size.width, request.size.height
+        )
+        return False  # GLib.SOURCE_REMOVE
+
+
+# -- surface helpers (mirror reduced/services.py) ----------------------------
+
+
+def _apply_dock_window_hints(window: object) -> None:
+    _call_method(window, "set_skip_taskbar_hint", True)
+    _call_method(window, "set_skip_pager_hint", True)
+    _call_method(window, "set_accept_focus", False)
+    _call_method(window, "set_focus_on_map", False)
+    _call_method(window, "stick")
+    _call_method(window, "set_keep_above", True)
+    _set_dock_type_hint(window)
+
+
+def _call_method(target: object, method_name: str, *args: object) -> None:
+    method = getattr(target, method_name, None)
+    if callable(method):
+        method(*args)
+
+
+def _set_dock_type_hint(window: object) -> None:
+    set_type_hint = getattr(window, "set_type_hint", None)
+    if not callable(set_type_hint):
+        return
+    try:
+        from gi.repository import Gdk
+    except (ImportError, ValueError):
+        return
+    set_type_hint(Gdk.WindowTypeHint.DOCK)
+
+
+# -- preview service ----------------------------------------------------------
+
+
+class GnomeShellBridgePreviewService(PreviewService):
+    """Window preview capture backed by the GNOME Shell bridge extension.
+
+    On Wayland only the compositor can read window pixels.  This service
+    delegates to the bridge extension, which calls
+    ``Meta.WindowActor.get_image()`` inside the shell process.
+    """
+
+    def __init__(self, *, bridge: GnomeShellBridgeClient) -> None:
+        self._bridge = bridge
+
+    def start(self) -> None:
+        """Nothing to initialise."""
+
+    def stop(self) -> None:
+        """No persistent resources."""
+
+    def capture(
+        self, window_id: WindowId, *, width: int, height: int
+    ) -> PreviewImage | None:
+        return self._do_capture(window_id, width, height)
+
+    def thumbnail(
+        self, window_id: WindowId, *, width: int, height: int
+    ) -> PreviewImage | None:
+        return self._do_capture(window_id, width, height)
+
+    # -- internals --------------------------------------------------------
+
+    def _do_capture(
+        self, window_id: WindowId, width: int, height: int
+    ) -> PreviewImage | None:
+        bridge_id = self._bridge_id(window_id)
+        if bridge_id is None:
+            return None
+        png_bytes = self._bridge.capture_window(
+            bridge_id, width=width, height=height
+        )
+        if not png_bytes:
+            return None
+        # Decode PNG → GdkPixbuf so the UI can use it directly.
+        return self._pixbuf_from_png(png_bytes, width, height)
+
+    @staticmethod
+    def _bridge_id(window_id: WindowId) -> int | None:
+        if window_id.backend is not DisplayServer.WAYLAND:
+            return None
+        value = str(window_id.value)
+        if not value.startswith("gnome:"):
+            return None
+        try:
+            return int(value.removeprefix("gnome:"))
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _pixbuf_from_png(
+        data: bytes, width: int, height: int
+    ) -> PreviewImage | None:
+        import gi
+
+        gi.require_version("GdkPixbuf", "2.0")
+        from gi.repository import GdkPixbuf
+
+        try:
+            loader = GdkPixbuf.PixbufLoader.new_with_type("png")
+            loader.write(data)
+            loader.close()
+            pixbuf = loader.get_pixbuf()
+        except Exception:
+            return None
+        if pixbuf is None:
+            return None
+        return PreviewImage(image=pixbuf, width=width, height=height)
+
+
+# -- desktop actions service -------------------------------------------------
+
+
+class GnomeShellBridgeDesktopActionService(DesktopActionService):
+    """Show-desktop toggle backed by the GNOME Shell bridge extension."""
+
+    def __init__(self, *, bridge: GnomeShellBridgeClient) -> None:
+        self._bridge = bridge
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def show_desktop(self, show: bool | None = None) -> ActionResult:
+        ok = self._bridge.show_desktop()
+        return ActionResult.OK if ok else ActionResult.FAILED

--- a/docking/platform/backends/gnome/bridge.py
+++ b/docking/platform/backends/gnome/bridge.py
@@ -790,9 +790,7 @@ class GnomeShellBridgePreviewService(PreviewService):
         bridge_id = self._bridge_id(window_id)
         if bridge_id is None:
             return None
-        png_bytes = self._bridge.capture_window(
-            bridge_id, width=width, height=height
-        )
+        png_bytes = self._bridge.capture_window(bridge_id, width=width, height=height)
         if not png_bytes:
             return None
         # Decode PNG → GdkPixbuf so the UI can use it directly.
@@ -811,9 +809,7 @@ class GnomeShellBridgePreviewService(PreviewService):
             return None
 
     @staticmethod
-    def _pixbuf_from_png(
-        data: bytes, width: int, height: int
-    ) -> PreviewImage | None:
+    def _pixbuf_from_png(data: bytes, width: int, height: int) -> PreviewImage | None:
         import gi
 
         gi.require_version("GdkPixbuf", "2.0")

--- a/docking/platform/backends/gnome/extension/README.md
+++ b/docking/platform/backends/gnome/extension/README.md
@@ -1,0 +1,35 @@
+# Docking GNOME Shell Bridge Prototype
+
+This extension is an experimental bridge for GNOME Shell on Wayland. It does
+not draw Docking inside GNOME Shell and does not provide panel edge
+reservation. It exposes read-only window/workspace state plus a few actions over
+the session bus so the Python app can use GNOME-owned Mutter state.
+
+Install for local testing:
+
+```bash
+tools/gnome_bridge.sh install
+tools/gnome_bridge.sh enable
+```
+
+Check the bridge:
+
+```bash
+gdbus call --session \
+  --dest org.docking.Docking.GnomeShellBridge \
+  --object-path /org/docking/Docking/GnomeShellBridge \
+  --method org.docking.Docking.GnomeShellBridge1.ListWindows
+```
+
+Run Docking against it:
+
+```bash
+DOCKING_BACKEND=gnome-shell python3 run.py
+```
+
+On GNOME Wayland, a newly installed user extension may not be visible to the
+running Shell until the session is restarted. GNOME Shell can also keep a GJS
+module cached for an extension UUID after source edits, even if the extension is
+disabled and enabled again. After changing `extension.js`, log out and back in
+before trusting the live D-Bus result. `tools/gnome_bridge.sh status` reports
+both GNOME's extension state and whether the bridge D-Bus API is available.

--- a/docking/platform/backends/gnome/extension/extension.js
+++ b/docking/platform/backends/gnome/extension/extension.js
@@ -1,0 +1,439 @@
+import Cairo from "cairo";
+import Gio from "gi://Gio";
+import GLib from "gi://GLib";
+import Meta from "gi://Meta";
+import Shell from "gi://Shell";
+import {Extension} from "resource:///org/gnome/shell/extensions/extension.js";
+
+const BUS_NAME = "org.docking.Docking.GnomeShellBridge";
+const OBJECT_PATH = "/org/docking/Docking/GnomeShellBridge";
+const INTERFACE = "org.docking.Docking.GnomeShellBridge1";
+
+const INTROSPECTION_XML = `
+<node>
+  <interface name="${INTERFACE}">
+    <method name="ListWindows">
+      <arg name="windows" type="s" direction="out"/>
+    </method>
+    <method name="ListWorkspaces">
+      <arg name="workspaces" type="s" direction="out"/>
+    </method>
+    <method name="Activate">
+      <arg name="id" type="u" direction="in"/>
+      <arg name="ok" type="b" direction="out"/>
+    </method>
+    <method name="Minimize">
+      <arg name="id" type="u" direction="in"/>
+      <arg name="ok" type="b" direction="out"/>
+    </method>
+    <method name="Close">
+      <arg name="id" type="u" direction="in"/>
+      <arg name="ok" type="b" direction="out"/>
+    </method>
+    <method name="ActivateWorkspace">
+      <arg name="id" type="u" direction="in"/>
+      <arg name="ok" type="b" direction="out"/>
+    </method>
+    <method name="PositionDock">
+      <arg name="x" type="i" direction="in"/>
+      <arg name="y" type="i" direction="in"/>
+      <arg name="width" type="i" direction="in"/>
+      <arg name="height" type="i" direction="in"/>
+      <arg name="ok" type="b" direction="out"/>
+    </method>
+    <method name="CaptureWindow">
+      <arg name="id" type="u" direction="in"/>
+      <arg name="width" type="i" direction="in"/>
+      <arg name="height" type="i" direction="in"/>
+      <arg name="png_base64" type="s" direction="out"/>
+    </method>
+    <method name="ShowDesktop">
+      <arg name="ok" type="b" direction="out"/>
+    </method>
+    <signal name="Changed"/>
+  </interface>
+</node>`;
+
+export default class DockingBridgeExtension extends Extension {
+  enable() {
+    this._dbusImpl = Gio.DBusExportedObject.wrapJSObject(INTROSPECTION_XML, this);
+    this._dbusImpl.export(Gio.DBus.session, OBJECT_PATH);
+    this._ownerId = Gio.bus_own_name_on_connection(
+      Gio.DBus.session,
+      BUS_NAME,
+      Gio.BusNameOwnerFlags.NONE,
+      null,
+      null
+    );
+
+    this._nextId = 1;
+    this._idByWindow = new Map();
+    this._windowById = new Map();
+    this._signals = [];
+    this._dockConfigured = false;
+    this._dockConfigureTimerId = 0;
+    this._connect(global.display, "window-created", () => this._queueChanged());
+    this._connect(global.display, "notify::focus-window", () => this._queueChanged());
+    this._connect(global.workspace_manager, "workspace-switched", () => this._queueChanged());
+
+    this._refreshWindowSignals();
+    this._queueChanged();
+
+    // Proactively hide the dock window from Alt+Tab after a GNOME
+    // Shell restart (when PositionDock is not re-called).  We must
+    // NOT call set_type(DOCK) here — Mutter may re-centre the window
+    // when its type changes, and PositionDock has not run yet.
+    // The full configuration happens in PositionDock.
+    this._dockConfigureRetries = 10;
+    this._dockConfigureTimerId = GLib.timeout_add(
+      GLib.PRIORITY_DEFAULT, 500, () => {
+        if (this._dockConfigured) {
+          this._dockConfigureTimerId = 0;
+          return GLib.SOURCE_REMOVE;
+        }
+        const win = this._findDockWindow();
+        if (win) {
+          this._hideDockFromSwitcher(win);
+          // Don't set _dockConfigured — PositionDock will do the
+          // full config when it arrives.
+          this._dockConfigureTimerId = 0;
+          return GLib.SOURCE_REMOVE;
+        }
+        this._dockConfigureRetries -= 1;
+        if (this._dockConfigureRetries <= 0) {
+          this._dockConfigureTimerId = 0;
+          return GLib.SOURCE_REMOVE;
+        }
+        return GLib.SOURCE_CONTINUE;
+      }
+    );
+  }
+
+  disable() {
+    if (this._dockConfigureTimerId) {
+      GLib.source_remove(this._dockConfigureTimerId);
+      this._dockConfigureTimerId = 0;
+    }
+    if (this._changedSourceId) {
+      GLib.source_remove(this._changedSourceId);
+      this._changedSourceId = 0;
+    }
+
+    this._dockConfigured = false;
+
+    for (const [object, signalId] of this._signals)
+      object.disconnect(signalId);
+    this._signals = [];
+    this._idByWindow = null;
+    this._windowById = null;
+
+    if (this._ownerId) {
+      Gio.bus_unown_name(this._ownerId);
+      this._ownerId = 0;
+    }
+    if (this._dbusImpl) {
+      this._dbusImpl.unexport();
+      this._dbusImpl = null;
+    }
+  }
+
+  ListWindows() {
+    this._refreshWindowSignals();
+    return JSON.stringify(this._listWindows());
+  }
+
+  ListWorkspaces() {
+    const manager = global.workspace_manager;
+    const active = manager.get_active_workspace_index();
+    const rows = [];
+    for (let index = 0; index < manager.n_workspaces; index++) {
+      const workspace = manager.get_workspace_by_index(index);
+      rows.push({
+        "id": index,
+        "index": index,
+        "name": workspace?.get_name?.() || `${index + 1}`,
+        "active": index === active,
+      });
+    }
+    return JSON.stringify(rows);
+  }
+
+  Activate(id) {
+    const window = this._windowById.get(id);
+    if (!window)
+      return false;
+    if (window.minimized && typeof window.unminimize === "function")
+      window.unminimize();
+    window.activate(global.get_current_time());
+    return true;
+  }
+
+  Minimize(id) {
+    const window = this._windowById.get(id);
+    if (!window || !window.minimize)
+      return false;
+    window.minimize();
+    return true;
+  }
+
+  Close(id) {
+    const window = this._windowById.get(id);
+    if (!window || !window.delete)
+      return false;
+    window.delete(global.get_current_time());
+    return true;
+  }
+
+  ActivateWorkspace(id) {
+    const workspace = global.workspace_manager.get_workspace_by_index(id);
+    if (!workspace)
+      return false;
+    workspace.activate(global.get_current_time());
+    return true;
+  }
+
+  ShowDesktop() {
+    // Toggle show-desktop: minimise all minimisable windows on the
+    // active workspace when any are visible, or restore them when all
+    // are already minimised.
+    const workspace = global.workspace_manager.get_active_workspace();
+    const windows = global.display.get_tab_list(
+      Meta.TabList.NORMAL_ALL, workspace
+    );
+    const minimisable = windows.filter(
+      w => w.can_minimize() && !w.skip_taskbar
+    );
+    if (minimisable.length === 0)
+      return false;
+
+    const anyVisible = minimisable.some(w => !w.minimized);
+    if (anyVisible) {
+      for (const w of minimisable)
+        w.minimize();
+    } else {
+      for (const w of minimisable)
+        w.unminimize();
+    }
+    return true;
+  }
+
+  PositionDock(x, y, width, height) {
+    const win = this._findDockWindow();
+    if (!win)
+      return false;
+    if (!this._dockConfigured) {
+      this._configureDockWindow(win);
+      this._dockConfigured = true;
+    }
+    // gravity 0 = NORTH_WEST: (x,y) is the top-left corner
+    win.move_resize_frame(0, x, y, width, height);
+    return true;
+  }
+
+  _hideDockFromSwitcher(win) {
+    // Hide from Alt+Tab *without* changing the window type.
+    // Safe to call before the window is positioned — set_type(DOCK)
+    // must wait until PositionDock arrives, otherwise Mutter may
+    // re-centre the window.
+    if (typeof win.set_skip_taskbar === "function")
+      win.set_skip_taskbar(true);
+    if (typeof win.hide_from_window_list === "function")
+      win.hide_from_window_list();
+    if (typeof win.make_above === "function")
+      win.make_above();
+  }
+
+  _configureDockWindow(win) {
+    // Full dock configuration — called from PositionDock after the
+    // window has been positioned.  Safe to set the type now.
+    this._hideDockFromSwitcher(win);
+    if (typeof win.set_type === "function")
+      win.set_type(Meta.WindowType.DOCK);
+  }
+
+  CaptureWindow(id, width, height) {
+    const window = this._windowById.get(id);
+    if (!window)
+      return "";
+    try {
+      return this._captureWindowImage(id, window, width, height);
+    } catch (e) {
+      log("Docking bridge: CaptureWindow failed: " + e);
+      return "";
+    }
+  }
+
+  _captureWindowImage(id, window, width, height) {
+    const actor = window.get_compositor_private();
+    if (!actor || typeof actor.get_image !== "function")
+      return "";
+
+    // Capture the window content at its native size.
+    const fullSurface = actor.get_image(null);
+    if (!fullSurface)
+      return "";
+
+    const srcW = fullSurface.getWidth();
+    const srcH = fullSurface.getHeight();
+    if (srcW <= 0 || srcH <= 0) {
+      // cairo surfaces must be explicitly destroyed
+      return "";
+    }
+
+    // Scale to cover the requested thumbnail size (fill, not fit).
+    // Excess is cropped equally on both sides.
+    const scale = Math.max(width / srcW, height / srcH);
+    const destW = Math.max(1, Math.floor(srcW * scale));
+    const destH = Math.max(1, Math.floor(srcH * scale));
+    const offsetX = Math.floor((width - destW) / 2);
+    const offsetY = Math.floor((height - destH) / 2);
+
+    const thumb = new Cairo.ImageSurface(Cairo.Format.ARGB32, width, height);
+    const cr = new Cairo.Context(thumb);
+
+    // Fill opaque black behind any source transparency.
+    cr.setSourceRGBA(0, 0, 0, 1);
+    cr.paint();
+
+    cr.translate(offsetX, offsetY);
+    cr.scale(scale, scale);
+    cr.setSourceSurface(fullSurface, 0, 0);
+    cr.paint();
+
+    // Write the thumbnail to a temporary PNG file
+    const tmpPath = GLib.build_filenamev([
+      GLib.get_tmp_dir(),
+      `docking-preview-${id}.png`,
+    ]);
+    thumb.writeToPNG(tmpPath);
+
+    const [ok, contents] = GLib.file_get_contents(tmpPath);
+    GLib.unlink(tmpPath);
+
+    if (!ok || !contents)
+      return "";
+
+    return GLib.base64_encode(contents);
+  }
+
+  _findDockWindow() {
+    for (const actor of global.get_window_actors()) {
+      const win = actor.meta_window;
+      const wmClass = win.get_wm_class();
+      const title = win.get_title();
+      if (wmClass === "Docking" || title === "Docking")
+        return win;
+    }
+    return null;
+  }
+
+  _connect(object, signal, callback) {
+    this._signals.push([object, object.connect(signal, callback)]);
+  }
+
+  _refreshWindowSignals() {
+    const current = new Set(global.get_window_actors().map(actor => actor.meta_window));
+    for (const window of current) {
+      if (this._idByWindow.has(window))
+        continue;
+      this._idByWindow.set(window, this._nextId);
+      this._windowById.set(this._nextId, window);
+      this._nextId += 1;
+      this._connect(window, "unmanaged", () => this._forgetWindow(window));
+      this._connect(window, "notify::title", () => this._queueChanged());
+      this._connect(window, "notify::minimized", () => this._queueChanged());
+      this._connect(window, "position-changed", () => this._queueChanged());
+      this._connect(window, "size-changed", () => this._queueChanged());
+    }
+  }
+
+  _forgetWindow(window) {
+    const id = this._idByWindow.get(window);
+    if (id)
+      this._windowById.delete(id);
+    this._idByWindow.delete(window);
+    this._queueChanged();
+  }
+
+  _listWindows() {
+    const tracker = Shell.WindowTracker.get_default();
+    const rows = [];
+    for (const actor of global.get_window_actors()) {
+      const window = actor.meta_window;
+      if (!this._shouldExportWindow(window))
+        continue;
+      const id = this._idForWindow(window);
+      const rect = window.get_frame_rect();
+      const workspace = window.get_workspace();
+      const app = tracker.get_window_app(window);
+      rows.push({
+        "id": id,
+        "title": window.get_title() || "Window",
+        "app-id": this._appIdFor(app, window),
+        "active": global.display.focus_window === window,
+        "minimized": Boolean(window.minimized),
+        "maximized": this._isMaximized(window),
+        "fullscreen": Boolean(window.fullscreen),
+        "monitor": window.get_monitor(),
+        "workspace": workspace ? workspace.index() : -1,
+        "x": rect.x,
+        "y": rect.y,
+        "width": rect.width,
+        "height": rect.height,
+      });
+    }
+    return rows;
+  }
+
+  _idForWindow(window) {
+    let id = this._idByWindow.get(window);
+    if (!id) {
+      id = this._nextId;
+      this._nextId += 1;
+      this._idByWindow.set(window, id);
+      this._windowById.set(id, window);
+    }
+    return id;
+  }
+
+  _shouldExportWindow(window) {
+    if (!window || window.skip_taskbar)
+      return false;
+    // Never export the docking surface itself — it is a panel, not a
+    // managed application window.
+    if (window.get_wm_class() === "Docking" || window.get_title() === "Docking")
+      return false;
+    const type = window.get_window_type();
+    return type === Meta.WindowType.NORMAL || type === Meta.WindowType.DIALOG;
+  }
+
+  _appIdFor(app, window) {
+    if (app?.get_id)
+      return app.get_id() || "";
+    if (window.get_wm_class)
+      return window.get_wm_class() || "";
+    return "";
+  }
+
+  _isMaximized(window) {
+    if (typeof window.get_maximized === "function") {
+      const flags = Meta.MaximizeFlags;
+      return Boolean(window.get_maximized() & (flags.HORIZONTAL | flags.VERTICAL));
+    }
+    // GNOME < 46 fallback
+    if ("maximized_horizontally" in window || "maximized_vertically" in window)
+      return Boolean(window.maximized_horizontally || window.maximized_vertically);
+    return false;
+  }
+
+  _queueChanged() {
+    if (this._changedSourceId)
+      return;
+    this._changedSourceId = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+      this._changedSourceId = 0;
+      if (this._dbusImpl)
+        this._dbusImpl.emit_signal("Changed", null);
+      return GLib.SOURCE_REMOVE;
+    });
+  }
+}

--- a/docking/platform/backends/gnome/extension/extension.js
+++ b/docking/platform/backends/gnome/extension/extension.js
@@ -71,7 +71,9 @@ export default class DockingBridgeExtension extends Extension {
     this._windowById = new Map();
     this._signals = [];
     this._dockConfigured = false;
+    this._configuredDockWindow = null;
     this._dockConfigureTimerId = 0;
+    this._changedSourceId = 0;
     this._connect(global.display, "window-created", () => this._queueChanged());
     this._connect(global.display, "notify::focus-window", () => this._queueChanged());
     this._connect(global.workspace_manager, "workspace-switched", () => this._queueChanged());
@@ -120,6 +122,7 @@ export default class DockingBridgeExtension extends Extension {
     }
 
     this._dockConfigured = false;
+    this._configuredDockWindow = null;
 
     for (const [object, signalId] of this._signals)
       object.disconnect(signalId);
@@ -221,9 +224,10 @@ export default class DockingBridgeExtension extends Extension {
     const win = this._findDockWindow();
     if (!win)
       return false;
-    if (!this._dockConfigured) {
+    if (!this._dockConfigured || this._configuredDockWindow !== win) {
       this._configureDockWindow(win);
       this._dockConfigured = true;
+      this._configuredDockWindow = win;
     }
     // gravity 0 = NORTH_WEST: (x,y) is the top-left corner
     win.move_resize_frame(0, x, y, width, height);
@@ -352,6 +356,10 @@ export default class DockingBridgeExtension extends Extension {
     if (id)
       this._windowById.delete(id);
     this._idByWindow.delete(window);
+    if (this._configuredDockWindow === window) {
+      this._configuredDockWindow = null;
+      this._dockConfigured = false;
+    }
     this._queueChanged();
   }
 

--- a/docking/platform/backends/gnome/extension/metadata.json
+++ b/docking/platform/backends/gnome/extension/metadata.json
@@ -1,0 +1,7 @@
+{
+  "uuid": "docking-bridge@docking.org",
+  "name": "Docking Bridge",
+  "description": "Prototype D-Bus bridge for Docking window and workspace state on GNOME Shell.",
+  "shell-version": ["45", "46", "47", "48", "49", "50"],
+  "url": "https://github.com/edumucelli/docking"
+}

--- a/docking/platform/backends/gnome/session.py
+++ b/docking/platform/backends/gnome/session.py
@@ -1,0 +1,152 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""GNOME Shell bridge session backend."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from docking.platform.backends.base import (
+    DesktopActionService,
+    DisplayServer,
+    IdleService,
+    PlatformCapabilities,
+    PreviewService,
+    ScreenCaptureService,
+    SessionBackend,
+    SurfaceService,
+    VisibilityService,
+    WindowPickService,
+    WindowService,
+    WorkspaceService,
+)
+from docking.platform.backends.gnome.bridge import (
+    GnomeShellBridgeDesktopActionService,
+    GnomeShellBridgePreviewService,
+    GnomeShellBridgeSurfaceService,
+    GnomeShellBridgeWindowService,
+    GnomeShellBridgeWorkspaceService,
+)
+from docking.platform.backends.reduced.services import (
+    ReducedVisibilityService,
+)
+
+
+@dataclass(frozen=True)
+class GnomeShellBridgeRuntimeServices:
+    """Concrete services for the GNOME Shell bridge prototype."""
+
+    windows: GnomeShellBridgeWindowService
+    workspaces: GnomeShellBridgeWorkspaceService
+    previews: GnomeShellBridgePreviewService
+    surface: GnomeShellBridgeSurfaceService
+    visibility: ReducedVisibilityService
+    desktop_actions: GnomeShellBridgeDesktopActionService
+
+
+class GnomeShellBridgeSessionBackend(SessionBackend):
+    """GNOME Shell bridge backend with reduced GTK surface integration."""
+
+    def __init__(self, *, model, launcher, bridge: object) -> None:
+        self._services = GnomeShellBridgeRuntimeServices(
+            windows=GnomeShellBridgeWindowService(
+                model=model,
+                launcher=launcher,
+                bridge=bridge,
+            ),
+            workspaces=GnomeShellBridgeWorkspaceService(bridge=bridge),
+            previews=GnomeShellBridgePreviewService(bridge=bridge),
+            surface=GnomeShellBridgeSurfaceService(bridge=bridge),
+            visibility=ReducedVisibilityService(),
+            desktop_actions=GnomeShellBridgeDesktopActionService(bridge=bridge),
+        )
+
+    @property
+    def name(self) -> str:
+        return "gnome-shell-bridge"
+
+    @property
+    def display_server(self) -> DisplayServer:
+        return DisplayServer.WAYLAND
+
+    @property
+    def capabilities(self) -> PlatformCapabilities:
+        return PlatformCapabilities(
+            tracks_windows=True,
+            tracks_active_window=True,
+            tracks_minimized=True,
+            tracks_maximized=True,
+            tracks_fullscreen=True,
+            supports_activate=True,
+            supports_minimize=True,
+            supports_close=True,
+            supports_window_menu=True,
+            tracks_window_geometry=True,
+            tracks_window_workspace=True,
+            supports_current_workspace_filter=True,
+            supports_workspace_list=True,
+            supports_workspace_switch=True,
+            supports_show_desktop=True,
+        )
+
+    @property
+    def windows(self) -> WindowService:
+        return self._services.windows
+
+    @property
+    def surface(self) -> SurfaceService:
+        return self._services.surface
+
+    @property
+    def visibility(self) -> VisibilityService:
+        return self._services.visibility
+
+    @property
+    def previews(self) -> PreviewService:
+        return self._services.previews
+
+    @property
+    def workspaces(self) -> WorkspaceService | None:
+        return self._services.workspaces
+
+    @property
+    def desktop_actions(self) -> DesktopActionService | None:
+        return self._services.desktop_actions
+
+    @property
+    def screen_capture(self) -> ScreenCaptureService | None:
+        return None
+
+    @property
+    def idle(self) -> IdleService | None:
+        return None
+
+    @property
+    def window_picker(self) -> WindowPickService | None:
+        return None
+
+    def start(self) -> None:
+        self._services.previews.start()
+        self._services.windows.start()
+        self._services.surface.start()
+        self._services.visibility.start()
+        self._services.workspaces.start()
+
+    def stop(self) -> None:
+        self._services.workspaces.stop()
+        self._services.visibility.stop()
+        self._services.surface.stop()
+        self._services.windows.stop()
+        self._services.previews.stop()
+

--- a/docking/platform/backends/gnome/session.py
+++ b/docking/platform/backends/gnome/session.py
@@ -149,4 +149,3 @@ class GnomeShellBridgeSessionBackend(SessionBackend):
         self._services.surface.stop()
         self._services.windows.stop()
         self._services.previews.stop()
-

--- a/docking/platform/backends/selection.py
+++ b/docking/platform/backends/selection.py
@@ -56,6 +56,17 @@ def create_session_backend(
             model=model,
             reason="requested by DOCKING_BACKEND=x11",
         )
+    if requested in {"gnome", "gnome-shell", "gnome-shell-bridge"}:
+        backend = _create_gnome_shell_bridge_backend(
+            launcher=launcher,
+            model=model,
+            reason=f"requested by DOCKING_BACKEND={requested}",
+        )
+        if backend is not None:
+            return backend
+        return _create_reduced_backend(
+            reason=f"GNOME Shell bridge unavailable after DOCKING_BACKEND={requested}"
+        )
     if requested in {"wayland", "wayland-layer-shell", "layer-shell"}:
         backend = _create_wayland_layer_shell_backend(
             launcher=launcher,
@@ -70,6 +81,13 @@ def create_session_backend(
 
     if not is_x11_backend():
         backend = _create_wayland_layer_shell_backend(
+            launcher=launcher,
+            model=model,
+            reason=_non_x11_reason(),
+        )
+        if backend is not None:
+            return backend
+        backend = _create_gnome_shell_bridge_backend(
             launcher=launcher,
             model=model,
             reason=_non_x11_reason(),
@@ -119,6 +137,24 @@ def _create_wayland_layer_shell_backend(
         layer_shell=layer_shell,
         launcher=launcher,
         model=model,
+    )
+    log.info("Selected session backend: %s (%s)", backend.name, reason)
+    return backend
+
+
+def _create_gnome_shell_bridge_backend(
+    *, launcher: Launcher, model: DockModel, reason: str
+) -> SessionBackend | None:
+    from docking.platform.backends.gnome.bridge import GnomeShellBridgeClient
+    from docking.platform.backends.gnome.session import GnomeShellBridgeSessionBackend
+
+    bridge = GnomeShellBridgeClient.connect()
+    if bridge is None:
+        return None
+    backend = GnomeShellBridgeSessionBackend(
+        model=model,
+        launcher=launcher,
+        bridge=bridge,
     )
     log.info("Selected session backend: %s (%s)", backend.name, reason)
     return backend

--- a/docking/platform/backends/wayland/__init__.py
+++ b/docking/platform/backends/wayland/__init__.py
@@ -13,13 +13,6 @@
 
 """Native Wayland backend package."""
 
-from docking.platform.backends.wayland.hyprland_ipc import (
-    HyprlandIpcClient,
-    HyprlandWindowService,
-    hyprland_socket_paths,
-    load_hyprland_window_service,
-    parse_hyprland_event,
-)
 from docking.platform.backends.wayland.portals import (
     WaylandPortalColorPickerService,
     XdgDesktopPortalColorPicker,
@@ -50,8 +43,6 @@ from docking.platform.backends.wayland.workspaces import (
 
 __all__ = [
     "ForeignToplevelProtocolAdapter",
-    "HyprlandIpcClient",
-    "HyprlandWindowService",
     "WaylandAppIdMatcher",
     "WaylandForeignToplevelWindowService",
     "WaylandLayerShellSessionBackend",
@@ -62,13 +53,10 @@ __all__ = [
     "WaylandWorkspaceService",
     "WorkspaceProtocolAdapter",
     "XdgDesktopPortalColorPicker",
-    "hyprland_socket_paths",
     "layer_shell_is_supported",
     "load_foreign_toplevel_protocol",
     "load_gtk_layer_shell",
-    "load_hyprland_window_service",
     "load_portal_color_picker",
     "load_protocol_factories",
     "load_workspace_protocol",
-    "parse_hyprland_event",
 ]

--- a/docking/platform/backends/wayland/session.py
+++ b/docking/platform/backends/wayland/session.py
@@ -36,10 +36,6 @@ from docking.platform.backends.reduced.services import (
     ReducedVisibilityService,
     ReducedWindowService,
 )
-from docking.platform.backends.wayland.hyprland_ipc import (
-    HyprlandWindowService,
-    load_hyprland_window_service,
-)
 from docking.platform.backends.wayland.portals import (
     WaylandPortalColorPickerService,
     load_portal_color_picker,
@@ -123,30 +119,7 @@ class WaylandLayerShellSessionBackend(SessionBackend):
         )
         windows: WindowService
         preview_handles: WaylandPreviewHandleTracker | None = None
-        hyprland_windows = (
-            load_hyprland_window_service(model=model, launcher=launcher)
-            if model is not None and launcher is not None
-            else None
-        )
-        if hyprland_windows is not None:
-            windows = hyprland_windows
-            if (
-                hyprland_preview_protocol is not None
-                and foreign_protocol is not None
-                and model is not None
-                and launcher is not None
-            ):
-                hyprland_windows.set_preview_handle_source(
-                    WaylandForeignToplevelWindowService(
-                        model=model,
-                        launcher=launcher,
-                        protocol=foreign_protocol,
-                        can_preview=True,
-                    )
-                )
-        elif (
-            foreign_protocol is not None and model is not None and launcher is not None
-        ):
+        if foreign_protocol is not None and model is not None and launcher is not None:
             if preview_protocol is not None:
                 preview_handles = WaylandPreviewHandleTracker(
                     model=model,
@@ -169,7 +142,7 @@ class WaylandLayerShellSessionBackend(SessionBackend):
                 handles=preview_handles,
             )
         elif hyprland_preview_protocol is not None and isinstance(
-            windows, (WaylandForeignToplevelWindowService, HyprlandWindowService)
+            windows, WaylandForeignToplevelWindowService
         ):
             previews = HyprlandPreviewService(
                 protocol=hyprland_preview_protocol,
@@ -205,10 +178,8 @@ class WaylandLayerShellSessionBackend(SessionBackend):
     @property
     def capabilities(self) -> PlatformCapabilities:
         tracks_windows = isinstance(
-            self._services.windows,
-            (WaylandForeignToplevelWindowService, HyprlandWindowService),
+            self._services.windows, WaylandForeignToplevelWindowService
         )
-        tracks_geometry = isinstance(self._services.windows, HyprlandWindowService)
         supports_workspaces = isinstance(
             self._services.workspaces, WaylandWorkspaceService
         )
@@ -225,8 +196,6 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             supports_minimize=tracks_windows,
             supports_close=tracks_windows,
             supports_window_menu=tracks_windows,
-            tracks_window_geometry=tracks_geometry,
-            tracks_window_workspace=tracks_geometry,
             supports_workspace_list=supports_workspaces,
             supports_workspace_switch=supports_workspaces,
             supports_screen_color_pick=supports_color_pick,

--- a/docking/platform/backends/wayland/toplevels.py
+++ b/docking/platform/backends/wayland/toplevels.py
@@ -461,10 +461,7 @@ def _app_id_candidates(app_id: str) -> list[str]:
     body = stripped.removesuffix(DESKTOP_SUFFIX)
     if "_" in body:
         segments = body.split("_")
-        prefixes = [
-            "_".join(segments[: i + 1])
-            for i in range(len(segments) - 1)
-        ]
+        prefixes = ["_".join(segments[: i + 1]) for i in range(len(segments) - 1)]
         for prefix in prefixes:
             candidates.append(prefix)
             candidates.append(f"{prefix}{DESKTOP_SUFFIX}")

--- a/docking/platform/backends/wayland/toplevels.py
+++ b/docking/platform/backends/wayland/toplevels.py
@@ -175,27 +175,6 @@ class WaylandForeignToplevelWindowService(WindowService):
         state = self._state_for_window_id(window_id)
         return state.handle if state is not None else None
 
-    def protocol_handle_for_match(
-        self,
-        *,
-        desktop_id: str | None,
-        app_id: str,
-        title: str,
-    ) -> object | None:
-        """Return a protocol handle matching backend-neutral window facts."""
-        for state in self._state_by_id.values():
-            if state.closed:
-                continue
-            if state.desktop_id is None:
-                self._refresh_match(state=state)
-            if desktop_id and state.desktop_id != desktop_id:
-                continue
-            if title and state.title and state.title == title:
-                return state.handle
-            if app_id and state.app_id and state.app_id == app_id:
-                return state.handle
-        return None
-
     def activate(self, window_id: WindowId) -> ActionResult:
         """Activate one foreign toplevel by backend ID."""
         state = self._state_for_window_id(window_id)
@@ -477,6 +456,20 @@ def _app_id_candidates(app_id: str) -> list[str]:
     ]
     if "." in stripped:
         candidates.append(stripped.split(".")[-1])
+    # Snap / container app-ids like firefox_firefox.desktop: also try the
+    # leading segment so the launcher can match firefox.desktop.
+    body = stripped.removesuffix(DESKTOP_SUFFIX)
+    if "_" in body:
+        segments = body.split("_")
+        prefixes = [
+            "_".join(segments[: i + 1])
+            for i in range(len(segments) - 1)
+        ]
+        for prefix in prefixes:
+            candidates.append(prefix)
+            candidates.append(f"{prefix}{DESKTOP_SUFFIX}")
+            candidates.append(prefix.lower())
+            candidates.append(f"{prefix.lower()}{DESKTOP_SUFFIX}")
     return list(dict.fromkeys(candidate for candidate in candidates if candidate))
 
 

--- a/docking/ui/display.py
+++ b/docking/ui/display.py
@@ -85,7 +85,10 @@ def clamp_popup(
     property).
     """
     parent = popup.get_transient_for()
-    if parent is not None and parent.surface_service.popups_use_parent_relative_coordinates:
+    if (
+        parent is not None
+        and parent.surface_service.popups_use_parent_relative_coordinates
+    ):
         return ScreenPosition(x=popup_x, y=popup_y)
     # Screen-absolute or no parent: clamp to screen bounds.
     screen = popup.get_screen()

--- a/docking/ui/display.py
+++ b/docking/ui/display.py
@@ -20,7 +20,8 @@ from typing import NamedTuple
 import gi
 
 gi.require_version("Gdk", "3.0")
-from gi.repository import Gdk
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk, Gtk
 
 from docking.log import get_logger
 
@@ -62,4 +63,33 @@ def clamp_to_screen(
     return ScreenPosition(
         x=max(0, min(rect_x, screen_w - rect_w)),
         y=max(0, min(rect_y, screen_h - rect_h)),
+    )
+
+
+def clamp_popup(
+    popup: Gtk.Window,
+    popup_x: int,
+    popup_y: int,
+    popup_w: int,
+    popup_h: int,
+) -> ScreenPosition:
+    """Clamp a popup to screen bounds, respecting the coordinate space.
+
+    On X11 ``Gtk.Window.move()`` uses screen-absolute coordinates
+    regardless of ``set_transient_for``, so we clamp to the screen.
+
+    On Wayland a popup with a transient parent receives *parent-relative*
+    coordinates, and the compositor handles on-screen clamping for us.
+    Which coordinate space is in use is determined by the surface service
+    backing the transient parent (``popups_use_parent_relative_coordinates``
+    property).
+    """
+    parent = popup.get_transient_for()
+    if parent is not None and parent.surface_service.popups_use_parent_relative_coordinates:
+        return ScreenPosition(x=popup_x, y=popup_y)
+    # Screen-absolute or no parent: clamp to screen bounds.
+    screen = popup.get_screen()
+    return clamp_to_screen(
+        popup_x, popup_y, popup_w, popup_h,
+        screen.get_width(), screen.get_height(),
     )

--- a/docking/ui/display.py
+++ b/docking/ui/display.py
@@ -93,6 +93,10 @@ def clamp_popup(
     # Screen-absolute or no parent: clamp to screen bounds.
     screen = popup.get_screen()
     return clamp_to_screen(
-        popup_x, popup_y, popup_w, popup_h,
-        screen.get_width(), screen.get_height(),
+        popup_x,
+        popup_y,
+        popup_w,
+        popup_h,
+        screen.get_width(),
+        screen.get_height(),
     )

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -199,6 +199,7 @@ gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk, GLib, Gtk
 
 from docking.applets.identity import is_applet_desktop_id as is_applet
+from docking.applets.popup import set_dock_window
 from docking.core.config import FolderStackUnfold, LeftClickAction, MiddleClickAction
 from docking.core.items import FILE_KIND, FOLDER_KIND
 from docking.core.position import is_horizontal
@@ -402,6 +403,7 @@ class DockWindow(Gtk.Window):
         self.surface_service.set_workspace_scope(
             current_workspace_only=self.config.current_workspace_only
         )
+        set_dock_window(self)
 
         # Enable RGBA visual for transparency
         screen = self.get_screen()

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -199,7 +199,6 @@ gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk, GLib, Gtk
 
 from docking.applets.identity import is_applet_desktop_id as is_applet
-from docking.applets.popup import set_dock_window
 from docking.core.config import FolderStackUnfold, LeftClickAction, MiddleClickAction
 from docking.core.items import FILE_KIND, FOLDER_KIND
 from docking.core.position import is_horizontal
@@ -403,7 +402,6 @@ class DockWindow(Gtk.Window):
         self.surface_service.set_workspace_scope(
             current_workspace_only=self.config.current_workspace_only
         )
-        set_dock_window(self)
 
         # Enable RGBA visual for transparency
         screen = self.get_screen()

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -394,6 +394,7 @@ class DockWindow(Gtk.Window):
         sticky) and enables RGBA visual for composited transparency.
         """
         self.set_title(_("Docking"))
+        self.set_wmclass("Docking", "Docking")
         self.set_decorated(False)
         self.set_app_paintable(True)
         self.set_resizable(False)
@@ -515,12 +516,14 @@ class DockWindow(Gtk.Window):
             preview_service=self.preview_service,
             geometry_builder=self.geometry,
             launcher=launcher,
+            dock_window=self,
         )
         self._menu.schedule_visible_folder_stack_prewarm(self.model.visible_items())
         self.preview = PreviewPopup(
             window_tracker=self.window_tracker,
             preview_service=self.preview_service,
         )
+        self.preview.set_transient_for(self)
         self.preview.set_pointer_inside_dock_probe(self.is_pointer_inside_dock)
         self.preview.set_autohide(controller=self.autohide)
         self.hover.set_preview(preview=self.preview)

--- a/docking/ui/folder/stack.py
+++ b/docking/ui/folder/stack.py
@@ -35,7 +35,7 @@ from docking.core.items import FOLDER_KIND
 from docking.core.position import Position
 from docking.i18n import _
 from docking.log import get_logger
-from docking.ui.display import clamp_to_screen
+from docking.ui.display import clamp_popup
 from docking.ui.folder._browser import (
     FOLDER_SMALL_ICON_PX,
     FOLDER_SORT_OPTIONS,
@@ -252,10 +252,12 @@ class FolderStackController:
         config: Config,
         runtime: DockRuntime,
         launcher: Launcher | None,
+        dock_window: Gtk.Window | None = None,
     ) -> None:
         self._config = config
         self._runtime = runtime
         self._launcher = launcher
+        self._dock_window = dock_window
         self._browser = FolderBrowser(launcher=launcher)
         self._folder_stack_cache = FolderStackCache()
         self._folder_stack_window: Gtk.Window | None = None
@@ -463,6 +465,11 @@ class FolderStackController:
         window.set_type_hint(Gdk.WindowTypeHint.TOOLTIP)
         window.set_app_paintable(True)
 
+        # On Wayland popups need a transient parent so the compositor
+        # positions them relative to the dock rather than at (0,0).
+        if self._dock_window is not None:
+            window.set_transient_for(self._dock_window)
+
         screen = window.get_screen()
         visual = screen.get_rgba_visual()
         if visual:
@@ -535,15 +542,7 @@ class FolderStackController:
                 else int(anchor_x - popup_w - FOLDER_STACK_GAP_PX)
             )
 
-        screen = window.get_screen()
-        popup_pos = clamp_to_screen(
-            popup_x,
-            popup_y,
-            popup_w,
-            popup_h,
-            screen.get_width(),
-            screen.get_height(),
-        )
+        popup_pos = clamp_popup(window, popup_x, popup_y, popup_w, popup_h)
         window.move(popup_pos.x, popup_pos.y)
 
     def _track_folder_stack(self, target: str) -> None:

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -300,6 +300,7 @@ class MenuHandler:
         preview_service: PreviewService,
         geometry_builder: DockGeometryBuilder,
         launcher: Launcher | None = None,
+        dock_window: Gtk.Window | None = None,
     ) -> None:
         self._about = about
         self._settings = settings
@@ -310,10 +311,12 @@ class MenuHandler:
         self._preview_service = preview_service
         self._launcher = launcher
         self._geometry_builder = geometry_builder
+        self._dock_window = dock_window
         self._folder_stack = FolderStackController(
             config=config,
             runtime=runtime,
             launcher=launcher,
+            dock_window=dock_window,
         )
         self._folder_menu_monitors: dict[int, Gio.FileMonitor] = {}
         self._folder_menu_context: dict[int, tuple[Gtk.Menu, DockItem, str, bool]] = {}

--- a/docking/ui/new_year.py
+++ b/docking/ui/new_year.py
@@ -40,7 +40,7 @@ from docking.core.greeting import consume_new_year_greeting
 from docking.core.position import Position, is_horizontal
 from docking.i18n import _
 from docking.log import get_logger
-from docking.ui.display import clamp_to_screen
+from docking.ui.display import clamp_popup
 from docking.ui.tooltip import compute_tooltip_position
 
 log = get_logger("new_year")
@@ -207,15 +207,7 @@ class NewYearGreetingController:
             gap=GREETING_GAP_PX,
         )
 
-        screen = self._popup.get_screen()
-        clamped = clamp_to_screen(
-            popup_x,
-            popup_y,
-            popup_w,
-            popup_h,
-            screen.get_width(),
-            screen.get_height(),
-        )
+        clamped = clamp_popup(self._popup, popup_x, popup_y, popup_w, popup_h)
         log.debug(
             "Positioned New Year greeting popup at (%s, %s) "
             "size=%sx%s dock=(%s,%s %sx%s pos=%s)",

--- a/docking/ui/preview.py
+++ b/docking/ui/preview.py
@@ -123,7 +123,7 @@ from gi.repository import Gdk, GLib, Gtk
 from docking.core.position import Position, is_horizontal
 from docking.log import get_logger
 from docking.platform.backends.base import WindowId, WindowService, WindowSnapshot
-from docking.ui.display import clamp_to_screen
+from docking.ui.display import clamp_popup
 
 if TYPE_CHECKING:
     from docking.platform.backends.base import PreviewService
@@ -290,13 +290,8 @@ class PreviewPopup(Gtk.Window):
             popup_x = int(anchor_x - popup_width - PREVIEW_GAP_PX)
             popup_y = int(anchor_y + icon_w / 2 - popup_height / 2)
 
-        # Clamp to screen
-        screen = self.get_screen()
-        screen_w = screen.get_width()
-        screen_h = screen.get_height()
-        popup_pos = clamp_to_screen(
-            popup_x, popup_y, popup_width, popup_height, screen_w, screen_h
-        )
+        # Clamp to screen (respects parent-relative vs screen-absolute coords)
+        popup_pos = clamp_popup(self, popup_x, popup_y, popup_width, popup_height)
 
         self.move(popup_pos.x, popup_pos.y)
         self.show_all()

--- a/docking/ui/tooltip.py
+++ b/docking/ui/tooltip.py
@@ -172,7 +172,7 @@ from gi.repository import Gdk, GLib, Gtk
 
 from docking.core.position import Position
 from docking.log import get_logger
-from docking.ui.display import clamp_to_screen
+from docking.ui.display import clamp_popup
 from docking.ui.geometry import DockGeometryFrame
 
 log = get_logger(name="tooltip")
@@ -436,11 +436,8 @@ class TooltipManager:
             gap=gap,
         )
 
-        # Clamp to screen
-        screen = self._tooltip_window.get_screen()
-        screen_w = screen.get_width()
-        screen_h = screen.get_height()
-        tooltip_pos = clamp_to_screen(tx, ty, tw, th, screen_w, screen_h)
+        # Clamp to screen (respects parent-relative vs screen-absolute coords)
+        tooltip_pos = clamp_popup(self._tooltip_window, tx, ty, tw, th)
         tx, ty = tooltip_pos.x, tooltip_pos.y
 
         log.debug(

--- a/docking/ui/update_popup.py
+++ b/docking/ui/update_popup.py
@@ -40,7 +40,7 @@ from docking.core.updates import (
 )
 from docking.i18n import _
 from docking.log import get_logger
-from docking.ui.display import clamp_to_screen
+from docking.ui.display import clamp_popup
 from docking.ui.tooltip import compute_tooltip_position
 
 if TYPE_CHECKING:
@@ -234,15 +234,7 @@ class UpdateCheckController:
             tooltip_h=popup_h,
             gap=UPDATE_POPUP_GAP_PX,
         )
-        screen = self._popup.get_screen()
-        clamped = clamp_to_screen(
-            popup_x,
-            popup_y,
-            popup_w,
-            popup_h,
-            screen.get_width(),
-            screen.get_height(),
-        )
+        clamped = clamp_popup(self._popup, popup_x, popup_y, popup_w, popup_h)
         self._popup.move(clamped.x, clamped.y)
 
     def _on_view_release(self, _button: Gtk.Button) -> None:

--- a/docs/WAYLAND.md
+++ b/docs/WAYLAND.md
@@ -122,6 +122,44 @@ GDK_BACKEND=x11 .venv/bin/docking
 
 This is the mode that should be tested and documented today.
 
+## GNOME Shell Bridge Prototype
+
+Docking also has an experimental GNOME Shell bridge under
+`docking/platform/backends/gnome/extension/`.
+
+This is not a full GNOME dock frontend. The visible dock is still the Python/GTK
+window, so this prototype does not provide GNOME panel placement or edge
+reservation. The bridge only exposes GNOME Shell/Mutter window and workspace
+state over D-Bus so Docking can validate native GNOME Wayland running
+indicators, active-window state, workspace filtering, and basic window actions.
+
+Local test flow:
+
+```bash
+tools/gnome_bridge.sh install
+tools/gnome_bridge.sh enable
+tools/gnome_bridge.sh status
+DOCKING_BACKEND=gnome-shell python3 run.py
+```
+
+If the bridge is active, this command should return workspace rows:
+
+```bash
+gdbus call --session \
+  --dest org.docking.Docking.GnomeShellBridge \
+  --object-path /org/docking/Docking/GnomeShellBridge \
+  --method org.docking.Docking.GnomeShellBridge1.ListWorkspaces
+```
+
+Current caveat from GNOME Shell 50.1 testing: the extension bundle can be packed
+and installed, and the UUID can be added to `org.gnome.shell enabled-extensions`,
+but the running Shell did not discover the new user extension immediately in the
+tested Wayland session. A logout/login or fresh Shell session may be required
+before the bridge D-Bus name appears. After editing `extension.js`, GNOME Shell
+may also keep serving the old GJS module for the same extension UUID until the
+next login; disable/enable is not enough for reliable source reloads on the
+tested GNOME 50.1 session.
+
 ### What To Verify
 
 Smoke-test these behaviors first:
@@ -258,6 +296,31 @@ Observed facts:
   the main dock surface has stopped repainting.
 - Some failing runs suggested compositor trouble as well: the runtime snapshot
   recorded `xwayland=True` with `compositor_active=False`.
+
+#### Test: GNOME Shell bridge prototype
+
+- Date: 2026-06-06
+- Distro: Ubuntu GNOME
+- Desktop: GNOME Shell 50.1
+- Session type: Wayland
+- Compositor: GNOME Shell / Mutter
+- Display variables: `XDG_SESSION_TYPE=wayland`, `WAYLAND_DISPLAY=wayland-0`, `DISPLAY=:0`
+- Launch command: `DOCKING_BACKEND=gnome-shell python3 run.py`
+- Result summary: The GNOME Shell extension bridge loads, exports D-Bus state,
+  and Docking selects the `gnome-shell-bridge` backend. Active indicators and
+  workspace switching work in manual testing.
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Extension load | works | `tools/gnome_bridge.sh status` reports the extension as enabled/active and the bridge D-Bus API as available. |
+| Backend selection | works | Log reports `Selected session backend: gnome-shell-bridge`. |
+| Running-window tracking | partly works | The bridge exports native GNOME window rows and active state; active indicators work in manual testing. App matching now handles Snap-style app-ids (e.g., `firefox_firefox.desktop`) by also trying leading underscore segments. |
+| Workspace switching | works | The Workspaces applet can switch GNOME workspaces through the bridge. |
+| Minimize / restore / focus cycling | works | Activate, Minimize, and Close bridge methods validated live against GNOME Shell 50.1. Activate now calls `unminimize()` before `activate()` for minimized windows (needs logout/login to reload the updated extension due to GJS module caching). |
+| Window previews | fails | The bridge does not implement preview capture. |
+| Screen-edge reservation / struts | works | The GNOME Shell extension positions the dock window at the configured screen edge via Mutter's `move_resize_frame()`. The Docking GTK window identifies itself via `GLib.set_prgname("Docking")` so the extension can find it. Fully Wayland-native — no XWayland required. |
+| Shutdown | works | Direct SIGTERM smoke test exited within 2 seconds after adding a GTK-main fallback. |
+| Notes / anomalies | partly works | GNOME Shell may cache GJS modules for an extension UUID. After editing `extension.js`, a logout/login was required before the running Shell used the corrected source. |
 
 What this means:
 
@@ -1075,7 +1138,7 @@ Yes, but they fit the current Docking codebase at different depths.
 
 The bridge extension is the cleanest fit. It can live in the same repository as
 an optional GNOME integration package, for example under
-`gnome-shell-extension/bridge/` or `extensions/gnome-shell/bridge/`. The
+`docking/platform/backends/gnome/extension/`. The
 extension would expose D-Bus state/actions, and the existing Python app would
 consume that through a GNOME-specific backend service.
 
@@ -1099,9 +1162,8 @@ docking/
     x11/
     reduced/
     wayland/
-gnome-shell-extension/
-  bridge/
-  frontend/
+    gnome/
+      extension/    # GNOME Shell JS extension
 shared/
   app-matching-rules.json
   theme-tokens.json

--- a/packaging/appimage/AppImageBuilder.yml
+++ b/packaging/appimage/AppImageBuilder.yml
@@ -8,6 +8,8 @@ script:
   - python3 -m pip install --upgrade pip
   - python3 -m pip install --no-cache-dir --target AppDir/usr/lib/python3/dist-packages .
   - install -Dm644 packaging/shared/org.docking.Docking.desktop AppDir/usr/share/applications/org.docking.Docking.desktop
+  - install -Dm644 docking/platform/backends/gnome/extension/metadata.json AppDir/usr/share/gnome-shell/extensions/docking-bridge@docking.org/metadata.json
+  - install -Dm644 docking/platform/backends/gnome/extension/extension.js AppDir/usr/share/gnome-shell/extensions/docking-bridge@docking.org/extension.js
   - cp -r packaging/deb/icons/hicolor AppDir/usr/share/icons/
 
 AppDir:

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -67,6 +67,11 @@ EOF
   install -Dm644 packaging/shared/org.docking.camshield.policy \
     "${pkgdir}/usr/share/polkit-1/actions/org.docking.camshield.policy"
 
+  install -Dm644 docking/platform/backends/gnome/extension/metadata.json \
+    "${pkgdir}/usr/share/gnome-shell/extensions/docking-bridge@docking.org/metadata.json"
+  install -Dm644 docking/platform/backends/gnome/extension/extension.js \
+    "${pkgdir}/usr/share/gnome-shell/extensions/docking-bridge@docking.org/extension.js"
+
   if [ -d packaging/deb/icons/hicolor ]; then
     mkdir -p "${pkgdir}/usr/share/icons/hicolor"
     cp -a packaging/deb/icons/hicolor/. "${pkgdir}/usr/share/icons/hicolor/"

--- a/packaging/arch/docking.install
+++ b/packaging/arch/docking.install
@@ -1,0 +1,26 @@
+post_install() {
+  if [ -x /usr/lib/docking/refresh-desktop-caches ]; then
+    /usr/lib/docking/refresh-desktop-caches
+  fi
+  if command -v gnome-extensions >/dev/null 2>&1 \
+     && [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+    gnome-extensions enable docking-bridge@docking.org || true
+  fi
+}
+
+post_upgrade() {
+  post_install
+}
+
+pre_remove() {
+  if command -v gnome-extensions >/dev/null 2>&1 \
+     && [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+    gnome-extensions disable docking-bridge@docking.org || true
+  fi
+}
+
+post_remove() {
+  if [ -x /usr/lib/docking/refresh-desktop-caches ]; then
+    /usr/lib/docking/refresh-desktop-caches
+  fi
+}

--- a/packaging/deb/debian/install
+++ b/packaging/deb/debian/install
@@ -1,3 +1,5 @@
 packaging/shared/org.docking.Docking.desktop usr/share/applications
 packaging/shared/org.docking.camshield.policy usr/share/polkit-1/actions
 packaging/shared/refresh-desktop-caches.sh usr/lib/docking/refresh-desktop-caches
+docking/platform/backends/gnome/extension/metadata.json usr/share/gnome-shell/extensions/docking-bridge@docking.org/
+docking/platform/backends/gnome/extension/extension.js usr/share/gnome-shell/extensions/docking-bridge@docking.org/

--- a/packaging/deb/debian/postinst
+++ b/packaging/deb/debian/postinst
@@ -6,6 +6,13 @@ case "${1:-}" in
         if [ -f /usr/lib/docking/refresh-desktop-caches ]; then
             sh /usr/lib/docking/refresh-desktop-caches
         fi
+        # Enable the GNOME Shell bridge extension system-wide.
+        # gnome-extensions requires a running session bus; skip when
+        # unavailable (e.g. headless / CI installs).
+        if command -v gnome-extensions >/dev/null 2>&1 \
+           && [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+            gnome-extensions enable docking-bridge@docking.org || true
+        fi
         ;;
 esac
 

--- a/packaging/deb/debian/postrm
+++ b/packaging/deb/debian/postrm
@@ -6,6 +6,10 @@ case "${1:-}" in
         if [ -f /usr/lib/docking/refresh-desktop-caches ]; then
             sh /usr/lib/docking/refresh-desktop-caches
         fi
+        if command -v gnome-extensions >/dev/null 2>&1 \
+           && [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+            gnome-extensions disable docking-bridge@docking.org || true
+        fi
         ;;
 esac
 

--- a/packaging/deb/org.docking.Docking.desktop
+++ b/packaging/deb/org.docking.Docking.desktop
@@ -7,4 +7,3 @@ Icon=org.docking.Docking
 Categories=Utility;GTK;
 Terminal=false
 StartupNotify=false
-X-GNOME-Autostart-enabled=false

--- a/packaging/flatpak/cc.docking.Docking.desktop
+++ b/packaging/flatpak/cc.docking.Docking.desktop
@@ -7,4 +7,3 @@ Icon=cc.docking.Docking
 Categories=Utility;GTK;
 Terminal=false
 StartupNotify=false
-X-GNOME-Autostart-enabled=false

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -70,6 +70,11 @@ EOF
 
     mkdir -p "$out/share/icons/hicolor"
     cp -a ${../deb/icons/hicolor}/. "$out/share/icons/hicolor/"
+
+    install -Dm644 ${../../docking/platform/backends/gnome/extension/metadata.json} \
+      "$out/share/gnome-shell/extensions/docking-bridge@docking.org/metadata.json"
+    install -Dm644 ${../../docking/platform/backends/gnome/extension/extension.js} \
+      "$out/share/gnome-shell/extensions/docking-bridge@docking.org/extension.js"
   '';
 
   meta = with pkgs.lib; {

--- a/packaging/rpm/docking.spec
+++ b/packaging/rpm/docking.spec
@@ -61,6 +61,11 @@ install -Dm644 packaging/shared/org.docking.camshield.policy \
 install -Dm755 packaging/shared/refresh-desktop-caches.sh \
   %{buildroot}/usr/lib/docking/refresh-desktop-caches
 
+install -Dm644 docking/platform/backends/gnome/extension/metadata.json \
+  %{buildroot}/usr/share/gnome-shell/extensions/docking-bridge@docking.org/metadata.json
+install -Dm644 docking/platform/backends/gnome/extension/extension.js \
+  %{buildroot}/usr/share/gnome-shell/extensions/docking-bridge@docking.org/extension.js
+
 if [ -d packaging/deb/icons/hicolor ]; then
   mkdir -p %{buildroot}/usr/share/icons/hicolor
   cp -a packaging/deb/icons/hicolor/. %{buildroot}/usr/share/icons/hicolor/
@@ -70,10 +75,18 @@ fi
 if [ -x /usr/lib/docking/refresh-desktop-caches ]; then
   /usr/lib/docking/refresh-desktop-caches
 fi
+if command -v gnome-extensions >/dev/null 2>&1 \
+   && [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+  gnome-extensions enable docking-bridge@docking.org || true
+fi
 
 %postun
 if [ -x /usr/lib/docking/refresh-desktop-caches ]; then
   /usr/lib/docking/refresh-desktop-caches
+fi
+if [ "$1" -eq 0 ] && command -v gnome-extensions >/dev/null 2>&1 \
+   && [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ]; then
+  gnome-extensions disable docking-bridge@docking.org || true
 fi
 
 %files
@@ -85,6 +98,7 @@ fi
 /usr/lib/docking/refresh-desktop-caches
 /usr/share/applications/org.docking.Docking.desktop
 /usr/share/polkit-1/actions/org.docking.camshield.policy
+/usr/share/gnome-shell/extensions/docking-bridge@docking.org
 /usr/share/icons/hicolor
 
 %changelog

--- a/packaging/shared/org.docking.Docking.desktop
+++ b/packaging/shared/org.docking.Docking.desktop
@@ -7,4 +7,3 @@ Icon=org.docking.Docking
 Categories=Utility;GTK;
 Terminal=false
 StartupNotify=false
-X-GNOME-Autostart-enabled=false

--- a/tests/applets/test_bookmarks.py
+++ b/tests/applets/test_bookmarks.py
@@ -219,6 +219,12 @@ class TestApplet:
             def add_buttons(self, *_args):
                 return
 
+            def set_skip_taskbar_hint(self, _value):
+                return
+
+            def set_skip_pager_hint(self, _value):
+                return
+
             def set_default_size(self, *_args):
                 return
 
@@ -303,6 +309,12 @@ class TestApplet:
                 self.content = _FakeBox()
 
             def add_buttons(self, *_args):
+                return
+
+            def set_skip_taskbar_hint(self, _value):
+                return
+
+            def set_skip_pager_hint(self, _value):
                 return
 
             def set_default_size(self, *_args):

--- a/tests/applets/test_popup.py
+++ b/tests/applets/test_popup.py
@@ -127,7 +127,15 @@ class _FakeDialog:
         self.position = None
         self.resizable = None
         self.default_response = None
+        self.skip_taskbar = None
+        self.skip_pager = None
         self.buttons: list[object] = []
+
+    def set_skip_taskbar_hint(self, value: bool) -> None:
+        self.skip_taskbar = value
+
+    def set_skip_pager_hint(self, value: bool) -> None:
+        self.skip_pager = value
 
     def set_default_size(self, width: int, height: int) -> None:
         self.size = (width, height)
@@ -322,6 +330,8 @@ def test_prepare_dialog_content_applies_standard_layout():
     )
 
     assert box is dialog.box
+    assert dialog.skip_taskbar is True
+    assert dialog.skip_pager is True
     assert dialog.size == (320, 120)
     assert dialog.position == popup.Gtk.WindowPosition.MOUSE
     assert dialog.resizable is False

--- a/tests/applets/test_quicknote.py
+++ b/tests/applets/test_quicknote.py
@@ -244,6 +244,12 @@ class TestApplet:
                 self.content = _FakeBox()
                 self.response_cb = None
 
+            def set_skip_taskbar_hint(self, _value):
+                return
+
+            def set_skip_pager_hint(self, _value):
+                return
+
             def set_default_size(self, *_args):
                 return
 

--- a/tests/applets/test_unitconverter.py
+++ b/tests/applets/test_unitconverter.py
@@ -68,6 +68,12 @@ class _FakePopupWindow:
     def connect(self, signal: str, callback) -> None:
         self.connected = (signal, callback)
 
+    def set_skip_taskbar_hint(self, value: bool) -> None:
+        self.skip_taskbar = value
+
+    def set_skip_pager_hint(self, value: bool) -> None:
+        self.skip_pager = value
+
     def set_default_size(self, width: int, height: int) -> None:
         self.size = (width, height)
 

--- a/tests/applets/test_urlshortener.py
+++ b/tests/applets/test_urlshortener.py
@@ -51,6 +51,12 @@ class _FakeDialog:
     def set_default_size(self, *_args) -> None:
         return
 
+    def set_skip_taskbar_hint(self, _value: bool) -> None:
+        return
+
+    def set_skip_pager_hint(self, _value: bool) -> None:
+        return
+
     def set_position(self, *_args) -> None:
         return
 

--- a/tests/applets/test_weather.py
+++ b/tests/applets/test_weather.py
@@ -876,6 +876,12 @@ class _FakeWeatherDialog:
     def set_default_size(self, *_args) -> None:
         return
 
+    def set_skip_taskbar_hint(self, _value: bool) -> None:
+        return
+
+    def set_skip_pager_hint(self, _value: bool) -> None:
+        return
+
     def set_position(self, *_args) -> None:
         return
 

--- a/tests/platform/test_backend_selection.py
+++ b/tests/platform/test_backend_selection.py
@@ -45,6 +45,9 @@ def test_create_session_backend_selects_reduced_for_non_x11_without_x11_import(
     monkeypatch.setattr(
         selection, "_create_wayland_layer_shell_backend", lambda **_: None
     )
+    monkeypatch.setattr(
+        selection, "_create_gnome_shell_bridge_backend", lambda **_: None
+    )
 
     def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
         if name == "docking.platform.backends.x11.session":
@@ -82,6 +85,28 @@ def test_create_session_backend_selects_layer_shell_for_supported_wayland(monkey
     create_wayland.assert_called_once()
 
 
+def test_create_session_backend_selects_gnome_bridge_after_layer_shell_fallback(
+    monkeypatch,
+):
+    monkeypatch.delenv("DOCKING_BACKEND", raising=False)
+    monkeypatch.setattr(selection, "is_x11_backend", lambda: False)
+    monkeypatch.setattr(
+        selection, "_create_wayland_layer_shell_backend", lambda **_: None
+    )
+    backend = MagicMock(name="gnome-shell-bridge")
+    create_gnome = MagicMock(return_value=backend)
+    monkeypatch.setattr(selection, "_create_gnome_shell_bridge_backend", create_gnome)
+
+    result = selection.create_session_backend(
+        config=MagicMock(),
+        launcher=MagicMock(),
+        model=MagicMock(),
+    )
+
+    assert result is backend
+    create_gnome.assert_called_once()
+
+
 def test_create_session_backend_can_force_layer_shell_backend(monkeypatch):
     monkeypatch.setenv("DOCKING_BACKEND", "wayland-layer-shell")
     monkeypatch.setattr(selection, "is_x11_backend", lambda: True)
@@ -99,6 +124,23 @@ def test_create_session_backend_can_force_layer_shell_backend(monkeypatch):
 
     assert result is backend
     create_wayland.assert_called_once()
+
+
+def test_create_session_backend_can_force_gnome_bridge_backend(monkeypatch):
+    monkeypatch.setenv("DOCKING_BACKEND", "gnome-shell")
+    monkeypatch.setattr(selection, "is_x11_backend", lambda: True)
+    backend = MagicMock(name="gnome-shell-bridge")
+    create_gnome = MagicMock(return_value=backend)
+    monkeypatch.setattr(selection, "_create_gnome_shell_bridge_backend", create_gnome)
+
+    result = selection.create_session_backend(
+        config=MagicMock(),
+        launcher=MagicMock(),
+        model=MagicMock(),
+    )
+
+    assert result is backend
+    create_gnome.assert_called_once()
 
 
 def test_create_session_backend_can_select_reduced_backend_by_override(monkeypatch):

--- a/tests/platform/test_gnome_shell_bridge.py
+++ b/tests/platform/test_gnome_shell_bridge.py
@@ -1,0 +1,181 @@
+"""Tests for the GNOME Shell bridge backend."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from docking.platform.backends.base import ActionResult, DisplayServer
+from docking.platform.backends.gnome.bridge import (
+    GnomeShellBridgeWindowService,
+    GnomeShellBridgeWorkspaceService,
+)
+
+
+def _item(desktop_id: str, wm_class: str = "") -> SimpleNamespace:
+    return SimpleNamespace(desktop_id=desktop_id, wm_class=wm_class)
+
+
+def _launcher() -> SimpleNamespace:
+    resolved = {
+        "org.gnome.Nautilus.desktop": SimpleNamespace(
+            desktop_id="org.gnome.Nautilus.desktop"
+        ),
+        "firefox.desktop": SimpleNamespace(desktop_id="firefox.desktop"),
+    }
+    aliases = {
+        "firefox": SimpleNamespace(desktop_id="firefox.desktop"),
+        "nautilus": SimpleNamespace(desktop_id="org.gnome.Nautilus.desktop"),
+    }
+    return SimpleNamespace(
+        resolve=MagicMock(side_effect=lambda desktop_id, **_: resolved.get(desktop_id)),
+        resolve_by_wm_class=MagicMock(
+            side_effect=lambda wm_class: aliases.get(wm_class.lower())
+        ),
+    )
+
+
+def _model(*items: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        visible_items=MagicMock(return_value=list(items)),
+        update_running=MagicMock(),
+    )
+
+
+def _bridge() -> SimpleNamespace:
+    return SimpleNamespace(
+        list_windows=MagicMock(
+            return_value=[
+                {
+                    "id": 7,
+                    "title": "Files",
+                    "app-id": "org.gnome.Nautilus",
+                    "active": True,
+                    "minimized": False,
+                    "maximized": True,
+                    "fullscreen": False,
+                    "monitor": 0,
+                    "workspace": 1,
+                    "x": 10,
+                    "y": 20,
+                    "width": 800,
+                    "height": 600,
+                }
+            ]
+        ),
+        list_workspaces=MagicMock(
+            return_value=[
+                {"id": 0, "index": 0, "name": "1", "active": False},
+                {"id": 1, "index": 1, "name": "2", "active": True},
+            ]
+        ),
+        activate=MagicMock(return_value=True),
+        minimize=MagicMock(return_value=True),
+        close=MagicMock(return_value=True),
+        activate_workspace=MagicMock(return_value=True),
+        subscribe_changed=MagicMock(return_value=99),
+        unsubscribe_changed=MagicMock(),
+    )
+
+
+def test_gnome_shell_bridge_window_service_publishes_running_state_and_snapshots():
+    model = _model(_item("org.gnome.Nautilus.desktop"))
+    bridge = _bridge()
+    service = GnomeShellBridgeWindowService(
+        model=model,
+        launcher=_launcher(),
+        bridge=bridge,
+    )
+
+    service.refresh()
+
+    running = model.update_running.call_args.kwargs["running"]
+    info = running["org.gnome.Nautilus.desktop"]
+    assert info.count == 1
+    assert info.active is True
+
+    snapshots = service.list_windows("org.gnome.Nautilus.desktop")
+    assert len(snapshots) == 1
+    snapshot = snapshots[0]
+    assert snapshot.id.backend is DisplayServer.WAYLAND
+    assert snapshot.id.value == "gnome:7"
+    assert snapshot.title == "Files"
+    assert snapshot.app_id == "org.gnome.Nautilus"
+    assert snapshot.active is True
+    assert snapshot.maximized is True
+    assert snapshot.geometry.x == 10
+    assert snapshot.geometry.width == 800
+    assert snapshot.workspace_id == "1"
+    assert snapshot.can_activate is True
+    assert snapshot.can_close is True
+    assert snapshot.can_minimize is True
+
+
+def test_gnome_shell_bridge_window_service_actions_call_bridge():
+    bridge = _bridge()
+    service = GnomeShellBridgeWindowService(
+        model=_model(_item("org.gnome.Nautilus.desktop")),
+        launcher=_launcher(),
+        bridge=bridge,
+    )
+    service.refresh()
+    window_id = service.list_windows("org.gnome.Nautilus.desktop")[0].id
+
+    assert service.activate(window_id) is ActionResult.OK
+    assert service.activate_most_recent("org.gnome.Nautilus.desktop") is ActionResult.OK
+    assert service.minimize_all("org.gnome.Nautilus.desktop") is ActionResult.OK
+    assert service.close(window_id) is ActionResult.OK
+    assert service.close_all("org.gnome.Nautilus.desktop") is ActionResult.OK
+    assert service.close_focused("org.gnome.Nautilus.desktop") is ActionResult.OK
+
+    bridge.activate.assert_any_call(7)
+    bridge.minimize.assert_any_call(7)
+    bridge.close.assert_any_call(7)
+
+
+def test_gnome_shell_bridge_window_service_returns_not_found_for_unknown_window():
+    service = GnomeShellBridgeWindowService(
+        model=_model(),
+        launcher=_launcher(),
+        bridge=_bridge(),
+    )
+
+    assert service.activate_most_recent("missing.desktop") is ActionResult.NOT_FOUND
+    assert (
+        service.activate(SimpleNamespace(backend=DisplayServer.X11, value=1))
+        is ActionResult.NOT_FOUND
+    )
+
+
+def test_gnome_shell_bridge_workspace_service_lists_and_activates_workspaces():
+    bridge = _bridge()
+    service = GnomeShellBridgeWorkspaceService(bridge=bridge)
+
+    service.refresh()
+
+    workspaces = service.list_workspaces()
+    assert len(workspaces) == 2
+    assert service.active_workspace().id == "1"
+    assert service.activate("1") is ActionResult.OK
+    bridge.activate_workspace.assert_called_once_with("1")
+
+
+def test_gnome_shell_bridge_workspace_watchers_are_called_on_refresh():
+    bridge = _bridge()
+    service = GnomeShellBridgeWorkspaceService(bridge=bridge)
+    callback = MagicMock()
+    handle = service.watch_active_workspace(callback)
+
+    service.refresh()
+    service.refresh()
+    assert callback.call_count == 1
+
+    bridge.list_workspaces.return_value = [
+        {"id": 0, "index": 0, "name": "1", "active": True},
+        {"id": 1, "index": 1, "name": "2", "active": False},
+    ]
+    service.refresh()
+    service.unwatch_active_workspace(handle)
+    service.refresh()
+
+    assert callback.call_count == 2

--- a/tests/platform/test_gnome_shell_bridge.py
+++ b/tests/platform/test_gnome_shell_bridge.py
@@ -5,8 +5,17 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from docking.platform.backends.base import ActionResult, DisplayServer
+import docking.platform.backends.gnome.bridge as bridge_mod
+from docking.platform.backends.base import (
+    ActionResult,
+    DisplayServer,
+    MonitorSnapshot,
+    PlacementRequest,
+    Rect,
+    Size,
+)
 from docking.platform.backends.gnome.bridge import (
+    GnomeShellBridgeSurfaceService,
     GnomeShellBridgeWindowService,
     GnomeShellBridgeWorkspaceService,
 )
@@ -73,8 +82,22 @@ def _bridge() -> SimpleNamespace:
         minimize=MagicMock(return_value=True),
         close=MagicMock(return_value=True),
         activate_workspace=MagicMock(return_value=True),
+        position_dock=MagicMock(return_value=True),
         subscribe_changed=MagicMock(return_value=99),
         unsubscribe_changed=MagicMock(),
+    )
+
+
+def _placement(x: int, y: int, width: int, height: int) -> PlacementRequest:
+    return PlacementRequest(
+        monitor=MonitorSnapshot(
+            index=0,
+            geometry=Rect(x=0, y=0, width=1920, height=1080),
+        ),
+        position=SimpleNamespace(value="bottom"),
+        x=x,
+        y=y,
+        size=Size(width=width, height=height),
     )
 
 
@@ -179,3 +202,45 @@ def test_gnome_shell_bridge_workspace_watchers_are_called_on_refresh():
     service.refresh()
 
     assert callback.call_count == 2
+
+
+def test_gnome_shell_bridge_surface_retries_latest_position_request(monkeypatch):
+    scheduled: list[object] = []
+    monkeypatch.setattr(
+        bridge_mod.GLib,
+        "timeout_add",
+        lambda _interval, callback: scheduled.append(callback) or 77,
+    )
+    shell_bridge = _bridge()
+    service = GnomeShellBridgeSurfaceService(bridge=shell_bridge)
+    window = MagicMock()
+    service.configure_before_realize(window)
+
+    service.position_or_anchor(_placement(0, 1000, 1920, 80))
+    service.position_or_anchor(_placement(0, 990, 1920, 90))
+
+    assert len(scheduled) == 1
+    assert shell_bridge.position_dock.call_args_list[-1].args == (0, 990, 1920, 90)
+
+    scheduled[0]()
+
+    assert shell_bridge.position_dock.call_args_list[-1].args == (0, 990, 1920, 90)
+    assert service.get_surface_position() == (0, 990)
+
+
+def test_gnome_shell_bridge_surface_stop_removes_pending_position_retry(monkeypatch):
+    removed: list[int] = []
+    monkeypatch.setattr(bridge_mod.GLib, "timeout_add", lambda _interval, _callback: 88)
+    monkeypatch.setattr(
+        bridge_mod.GLib,
+        "source_remove",
+        lambda source_id: removed.append(source_id),
+    )
+    service = GnomeShellBridgeSurfaceService(bridge=_bridge())
+    service.configure_before_realize(MagicMock())
+
+    service.position_or_anchor(_placement(0, 1000, 1920, 80))
+    service.stop()
+
+    assert removed == [88]
+    assert service.get_surface_position() is None

--- a/tests/platform/test_wayland_foreign_toplevel.py
+++ b/tests/platform/test_wayland_foreign_toplevel.py
@@ -75,6 +75,15 @@ def test_wayland_app_id_matcher_falls_back_to_launcher_aliases():
     assert matcher.match("unknown") is None
 
 
+def test_wayland_app_id_matcher_handles_snap_container_app_ids():
+    launcher = _launcher()
+    matcher = WaylandAppIdMatcher(launcher=launcher)
+    matcher.sync_visible_items([])
+
+    assert matcher.match("firefox_firefox.desktop") == "firefox.desktop"
+    assert matcher.match("firefox_firefox") == "firefox.desktop"
+
+
 def test_foreign_toplevel_service_publishes_running_state_and_snapshots():
     model = _model(_item("org.gnome.Nautilus.desktop"))
     protocol = _protocol()

--- a/tests/platform/test_wayland_layer_shell_session.py
+++ b/tests/platform/test_wayland_layer_shell_session.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-import pytest
-
 from docking.core.position import Position
 from docking.platform.backends.base import (
     DisplayServer,
@@ -21,8 +19,6 @@ from docking.platform.backends.reduced.services import (
     ReducedVisibilityService,
     ReducedWindowService,
 )
-from docking.platform.backends.wayland import session as session_mod
-from docking.platform.backends.wayland.hyprland_ipc import HyprlandWindowService
 from docking.platform.backends.wayland.portals import WaylandPortalColorPickerService
 from docking.platform.backends.wayland.previews import (
     HyprlandPreviewService,
@@ -73,15 +69,6 @@ def _empty_runtime() -> SimpleNamespace:
         preview_protocol=None,
         hyprland_preview_protocol=None,
         stop=MagicMock(),
-    )
-
-
-@pytest.fixture(autouse=True)
-def _disable_real_hyprland_ipc(monkeypatch):
-    monkeypatch.setattr(
-        session_mod,
-        "load_hyprland_window_service",
-        lambda **_kwargs: None,
     )
 
 
@@ -186,48 +173,6 @@ def test_wayland_layer_shell_session_uses_hyprland_previews_when_available():
 
     assert isinstance(backend.windows, WaylandForeignToplevelWindowService)
     assert isinstance(backend.previews, HyprlandPreviewService)
-
-
-def test_wayland_layer_shell_session_prefers_hyprland_ipc_windows(monkeypatch):
-    hyprland_preview_protocol = SimpleNamespace(
-        capture_available=True,
-        create_frame=MagicMock(),
-        create_shm_pool=MagicMock(),
-        flush=MagicMock(),
-    )
-    hyprland_windows = HyprlandWindowService(
-        model=SimpleNamespace(
-            visible_items=MagicMock(return_value=[]),
-            update_running=MagicMock(),
-        ),
-        launcher=SimpleNamespace(resolve=MagicMock(), resolve_by_wm_class=MagicMock()),
-        client=SimpleNamespace(query_json=MagicMock(), dispatch=MagicMock()),
-    )
-    monkeypatch.setattr(
-        session_mod,
-        "load_hyprland_window_service",
-        MagicMock(return_value=hyprland_windows),
-    )
-
-    backend = WaylandLayerShellSessionBackend(
-        layer_shell=_layer_shell(),
-        model=SimpleNamespace(),
-        launcher=SimpleNamespace(),
-        foreign_toplevel_protocol=SimpleNamespace(),
-        protocol_runtime=SimpleNamespace(
-            foreign_toplevel_protocol=None,
-            workspace_protocol=None,
-            preview_protocol=None,
-            hyprland_preview_protocol=hyprland_preview_protocol,
-            stop=MagicMock(),
-        ),
-    )
-
-    assert backend.windows is hyprland_windows
-    assert isinstance(backend.previews, HyprlandPreviewService)
-    assert backend.capabilities.tracks_windows is True
-    assert backend.capabilities.tracks_window_geometry is True
-    assert backend.capabilities.tracks_window_workspace is True
 
 
 def test_wayland_layer_shell_session_uses_workspace_and_capture_services_when_available():

--- a/tests/smoke/test_python314_smoke.py
+++ b/tests/smoke/test_python314_smoke.py
@@ -19,8 +19,10 @@ def _install_fake_gi(monkeypatch):
         PRIORITY_HIGH=100,
         Error=RuntimeError,
         markup_escape_text=lambda text: text,
+        set_prgname=MagicMock(),
         unix_signal_add=MagicMock(),
         idle_add=MagicMock(),
+        timeout_add_seconds=MagicMock(return_value=77),
     )
     fake_gio = SimpleNamespace(
         AppInfo=SimpleNamespace(launch_default_for_uri=MagicMock())
@@ -307,3 +309,4 @@ def test_app_quit_smoke(monkeypatch):
 
     assert result is False
     fake_gtk.main_quit.assert_called_once()
+    _fake_glib.timeout_add_seconds.assert_called_once_with(3, app_mod._force_quit)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -15,8 +15,10 @@ from unittest.mock import MagicMock
 def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
     fake_glib = SimpleNamespace(
         PRIORITY_HIGH=100,
+        set_prgname=MagicMock(),
         unix_signal_add=MagicMock(),
         idle_add=MagicMock(),
+        timeout_add_seconds=MagicMock(return_value=77),
     )
     fake_gtk = SimpleNamespace(main=MagicMock(), main_quit=MagicMock())
     fake_repo = SimpleNamespace(GLib=fake_glib, Gtk=fake_gtk)
@@ -361,9 +363,30 @@ class TestAppMain:
 
     def test_quit_requests_gtk_main_quit(self, monkeypatch):
         # Given
-        app_mod, _fake_glib, fake_gtk = _load_app_module(monkeypatch)
+        app_mod, fake_glib, fake_gtk = _load_app_module(monkeypatch)
         # When
         result = app_mod._quit()
         # Then
         assert result is False
         fake_gtk.main_quit.assert_called_once()
+        fake_glib.timeout_add_seconds.assert_called_once_with(3, app_mod._force_quit)
+
+    def test_quit_schedules_force_quit_once(self, monkeypatch):
+        # Given
+        app_mod, fake_glib, fake_gtk = _load_app_module(monkeypatch)
+        # When
+        app_mod._quit()
+        app_mod._quit()
+        # Then
+        assert fake_gtk.main_quit.call_count == 2
+        fake_glib.timeout_add_seconds.assert_called_once_with(3, app_mod._force_quit)
+
+    def test_force_quit_exits_process(self, monkeypatch):
+        # Given
+        app_mod, _fake_glib, _fake_gtk = _load_app_module(monkeypatch)
+        exit_mock = MagicMock()
+        monkeypatch.setattr(app_mod.os, "_exit", exit_mock)
+        # When
+        app_mod._force_quit()
+        # Then
+        exit_mock.assert_called_once_with(0)

--- a/tests/test_packaging_refresh.py
+++ b/tests/test_packaging_refresh.py
@@ -56,3 +56,15 @@ def test_packaging_uses_shared_canonical_desktop_entry():
     assert expected in appimage
     assert "../shared/org.docking.Docking.desktop" in nix
     assert "printf '%s\\n'" not in snap
+
+
+def test_application_desktop_entries_do_not_disable_autostart():
+    desktop_entries = (
+        ROOT / "packaging/shared/org.docking.Docking.desktop",
+        ROOT / "packaging/deb/org.docking.Docking.desktop",
+        ROOT / "packaging/flatpak/cc.docking.Docking.desktop",
+    )
+
+    for desktop_entry in desktop_entries:
+        content = desktop_entry.read_text(encoding="utf-8")
+        assert "X-GNOME-Autostart-enabled" not in content

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -796,6 +796,7 @@ class TestDockWindowSetupAndGeometry:
         )
         stub = SimpleNamespace(
             set_title=MagicMock(),
+            set_wmclass=MagicMock(),
             set_decorated=MagicMock(),
             set_skip_taskbar_hint=MagicMock(),
             set_skip_pager_hint=MagicMock(),

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -507,6 +507,9 @@ class FakeWindow:
     def get_screen(self):
         return self.screen
 
+    def get_transient_for(self):
+        return None
+
 
 class FakeRevealer:
     def __init__(self) -> None:

--- a/tests/ui/test_new_year.py
+++ b/tests/ui/test_new_year.py
@@ -70,6 +70,9 @@ class _FakePopup:
     def set_transient_for(self, window):
         self.transient_for = window
 
+    def get_transient_for(self):
+        return getattr(self, "transient_for", None)
+
     def connect(self, signal, callback):
         self.connections[signal] = callback
 
@@ -157,6 +160,9 @@ class _FakeWindow:
     def __init__(self, *, pos=Position.BOTTOM, realized=True) -> None:
         self.config = SimpleNamespace(pos=pos)
         self.realized = realized
+        self.surface_service = SimpleNamespace(
+            popups_use_parent_relative_coordinates=False,
+        )
 
     def get_realized(self):
         return self.realized

--- a/tests/ui/test_preview_popup_integration.py
+++ b/tests/ui/test_preview_popup_integration.py
@@ -212,6 +212,7 @@ def _make_popup():
     popup._pointer_inside_dock = None
     popup._hide_timer_id = 0
     popup._current_desktop_id = ""
+    popup.get_transient_for = MagicMock(return_value=None)
     return popup
 
 
@@ -245,6 +246,7 @@ class TestPreviewPopupIntegration:
         popup.get_child = MagicMock(return_value=None)
         popup.remove = MagicMock()
         popup.add = MagicMock()
+        popup.get_transient_for = MagicMock(return_value=None)
         popup.get_screen = MagicMock(return_value=FakeScreen(width=320, height=200))
         popup.move = MagicMock()
         popup.show_all = MagicMock()

--- a/tests/ui/test_tooltip.py
+++ b/tests/ui/test_tooltip.py
@@ -466,6 +466,9 @@ class _FakeTooltipWindow:
     def set_transient_for(self, window) -> None:
         self._transient_for = window
 
+    def get_transient_for(self):
+        return self._transient_for
+
     def set_attached_to(self, window) -> None:
         self._attached_to = window
 
@@ -570,6 +573,7 @@ class TestTooltipIntegrationBranches:
         monkeypatch.setattr(tooltip_mod, "Gtk", _FakeGtk)
         monkeypatch.setattr(tooltip_mod, "Gdk", _FakeGdk)
         window = MagicMock()
+        window.surface_service.popups_use_parent_relative_coordinates = False
         config = SimpleNamespace(icon_size=48)
         model = MagicMock()
         theme = SimpleNamespace(launch_bounce_height=0.5)

--- a/tools/gnome_bridge.sh
+++ b/tools/gnome_bridge.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXT_DIR="${ROOT_DIR}/docking/platform/backends/gnome/extension"
+UUID="docking-bridge@docking.org"
+ZIP="${ROOT_DIR}/${UUID}.shell-extension.zip"
+
+usage() {
+  cat <<EOF
+Usage: tools/gnome_bridge.sh COMMAND
+
+Commands:
+  pack      Build a local GNOME Shell extension bundle
+  install   Pack and install the extension for the current user
+  enable    Enable the installed extension
+  status    Show extension status and bridge D-Bus availability
+  query     Call the bridge ListWindows method
+EOF
+}
+
+pack() {
+  rm -f "${ZIP}"
+  (cd "${ROOT_DIR}" && gnome-extensions pack --force "${EXT_DIR}")
+}
+
+install_extension() {
+  pack
+  gnome-extensions install --force "${ZIP}"
+  rm -f "${ZIP}"
+}
+
+enable_extension() {
+  gnome-extensions enable "${UUID}"
+}
+
+status() {
+  echo "GNOME Shell: $(gnome-shell --version)"
+  echo
+  if gnome-extensions info "${UUID}"; then
+    true
+  else
+    echo "Extension is not visible to gnome-extensions yet."
+  fi
+  echo
+  if gdbus call --session \
+    --dest org.docking.Docking.GnomeShellBridge \
+    --object-path /org/docking/Docking/GnomeShellBridge \
+    --method org.docking.Docking.GnomeShellBridge1.ListWorkspaces >/dev/null; then
+    echo "Bridge D-Bus API: available"
+  else
+    echo "Bridge D-Bus API: unavailable"
+  fi
+}
+
+query() {
+  gdbus call --session \
+    --dest org.docking.Docking.GnomeShellBridge \
+    --object-path /org/docking/Docking/GnomeShellBridge \
+    --method org.docking.Docking.GnomeShellBridge1.ListWindows
+}
+
+case "${1:-}" in
+  pack)
+    pack
+    ;;
+  install)
+    install_extension
+    ;;
+  enable)
+    enable_extension
+    ;;
+  status)
+    status
+    ;;
+  query)
+    query
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+


### PR DESCRIPTION
## Summary
- add a GNOME Shell bridge extension prototype that exports window/workspace state over D-Bus
- add a Docking GNOME bridge backend for active indicators, workspace listing/switching, and basic window actions
- add helper tooling/docs for installing and validating the bridge on GNOME Shell
- harden SIGTERM shutdown with a fallback if GTK does not leave the main loop