### PR TITLE
Fix GNOME workspace initial active state

### DIFF
--- a/docking/platform/backends/gnome/bridge.py
+++ b/docking/platform/backends/gnome/bridge.py
@@ -62,6 +62,8 @@ OBJECT_PATH = "/org/docking/Docking/GnomeShellBridge"
 INTERFACE = "org.docking.Docking.GnomeShellBridge1"
 _DOCK_POSITION_RETRY_MS = 100
 _DOCK_POSITION_RETRY_ATTEMPTS = 15
+_WORKSPACE_INITIAL_RETRY_MS = 100
+_WORKSPACE_INITIAL_RETRY_ATTEMPTS = 15
 
 
 class GnomeShellBridgeClient:
@@ -456,15 +458,25 @@ class GnomeShellBridgeWorkspaceService(WorkspaceService):
         self._next_watch_id = 1
         self._changed_handle: object | None = None
         self._poll_source_id = 0
+        self._initial_retry_source_id = 0
+        self._initial_retry_attempts_remaining = 0
+        self._started = False
 
     def start(self) -> None:
+        self._started = True
         subscribe = getattr(self._bridge, "subscribe_changed", None)
         if callable(subscribe):
             self._changed_handle = subscribe(self.refresh)
         self.refresh()
+        self._ensure_initial_active_workspace()
         self._poll_source_id = GLib.timeout_add_seconds(2, self._poll)
 
     def stop(self) -> None:
+        self._started = False
+        if self._initial_retry_source_id:
+            GLib.source_remove(self._initial_retry_source_id)
+            self._initial_retry_source_id = 0
+        self._initial_retry_attempts_remaining = 0
         if self._poll_source_id:
             GLib.source_remove(self._poll_source_id)
             self._poll_source_id = 0
@@ -476,20 +488,21 @@ class GnomeShellBridgeWorkspaceService(WorkspaceService):
         self._workspaces = ()
 
     def refresh(self) -> None:
-        previous_active = self.active_workspace()
+        previous_signature = _workspace_signature(self._workspaces)
         rows = self._bridge.list_workspaces()
         self._workspaces = tuple(
             workspace
             for row in rows
             if (workspace := _workspace_from_row(row)) is not None
         )
-        current_active = self.active_workspace()
-        if _workspace_identity(previous_active) == _workspace_identity(current_active):
+        if previous_signature == _workspace_signature(self._workspaces):
             return
         for callback in tuple(self._watchers.values()):
             callback()
 
     def list_workspaces(self) -> Sequence[WorkspaceSnapshot]:
+        if not self._workspaces or self.active_workspace() is None:
+            self.refresh()
         return self._workspaces
 
     def active_workspace(self) -> WorkspaceSnapshot | None:
@@ -516,6 +529,29 @@ class GnomeShellBridgeWorkspaceService(WorkspaceService):
     def _poll(self) -> bool:
         self.refresh()
         return True
+
+    def _ensure_initial_active_workspace(self) -> None:
+        if not self._started or self.active_workspace() is not None:
+            return
+        if self._initial_retry_source_id:
+            return
+        self._initial_retry_attempts_remaining = _WORKSPACE_INITIAL_RETRY_ATTEMPTS
+        self._initial_retry_source_id = GLib.timeout_add(
+            _WORKSPACE_INITIAL_RETRY_MS,
+            self._retry_initial_active_workspace,
+        )
+
+    def _retry_initial_active_workspace(self) -> bool:
+        self._initial_retry_attempts_remaining -= 1
+        self.refresh()
+        if (
+            self.active_workspace() is not None
+            or self._initial_retry_attempts_remaining <= 0
+        ):
+            self._initial_retry_source_id = 0
+            self._initial_retry_attempts_remaining = 0
+            return GLib.SOURCE_REMOVE
+        return GLib.SOURCE_CONTINUE
 
 
 def _action_result(ok: bool) -> ActionResult:
@@ -588,8 +624,13 @@ def _workspace_from_row(row: Mapping[str, Any]) -> WorkspaceSnapshot | None:
     )
 
 
-def _workspace_identity(workspace: WorkspaceSnapshot | None) -> str | None:
-    return workspace.id if workspace is not None else None
+def _workspace_signature(
+    workspaces: Sequence[WorkspaceSnapshot],
+) -> tuple[tuple[str, int, str, bool], ...]:
+    return tuple(
+        (workspace.id, workspace.number, workspace.name, workspace.active)
+        for workspace in workspaces
+    )
 
 
 class GnomeShellBridgeSurfaceService(SurfaceService):

--- a/docs/WAYLAND.md
+++ b/docs/WAYLAND.md
@@ -1,11 +1,13 @@
 # Docking on Wayland
 
 This document captures the current understanding of what Wayland means for
-`docking`, why the existing codebase is fundamentally X11-centric, and what
-future work would be required to make the project available on Wayland in a
-serious way.
+`docking`, how the project moved its original X11-centric implementation behind
+backend services, and which Wayland paths are currently available or still
+compositor-dependent.
 
-It is intended as a baseline engineering document, not as a promise of support.
+It is intended as an engineering document for support boundaries, backend
+sequencing, and remaining gaps. The user-facing support summary lives in the
+README and website.
 
 ## Scope
 
@@ -13,14 +15,16 @@ This document focuses on:
 
 - the practical impact of GNOME and Ubuntu moving away from Xorg sessions
 - what still works for GTK applications on Wayland
-- which Docking features are blocked by X11-only assumptions today
+- which Docking features used to be blocked by X11-only assumptions and which
+  ones still require backend-specific services
 - the difference between:
   - features that work with ordinary GTK on Wayland
   - features that require compositor protocols
-  - features that likely require GNOME Shell integration
-- plausible migration strategies for future work
+  - features that use the GNOME Shell bridge
+  - features that deliberately fall back to reduced mode
+- migration strategies for remaining compositor-specific work
 
-This document does not define implementation details for a specific port yet.
+This document records both completed migration work and planned follow-up work.
 
 ## Date Context
 
@@ -38,36 +42,42 @@ GNOME/Ubuntu stack from `GNOME 49` / `Ubuntu 25.10` onward.
 
 ## Executive Summary
 
-There are three very different targets people may mean when they say "support
+There are several different targets people may mean when they say "support
 Wayland":
 
-1. Run the current X11 dock under `XWayland`
-2. Build a native Wayland dock on compositors that expose dock/taskbar
+1. Run the X11 backend under `XWayland`
+2. Run the GNOME Shell bridge backend on GNOME / Mutter
+3. Run the native layer-shell backend on compositors that expose dock/taskbar
    protocols
-3. Build a full GNOME dock on GNOME Wayland
+4. Run the reduced backend when compositor integration is unavailable
 
 These are not equivalent.
 
 Short version:
 
-- Running under `XWayland` may let Docking appear on screen, but it is not a
-  real Wayland port and does not solve the core desktop-integration problem
-- A native Wayland dock is plausible on compositor families that expose
-  layer-shell and foreign-toplevel protocols
-- A full dock on GNOME Wayland is a separate, harder problem because Mutter
-  intentionally does not expose the common protocols that third-party docks use
+- X11 remains the full-featured backend and also works as an XWayland
+  compatibility path where the desktop exposes enough X11 state
+- GNOME / Mutter support is handled through a companion GNOME Shell bridge
+  because Mutter does not expose the common third-party dock protocols
+- wlroots-style native Wayland support depends on layer-shell and related
+  compositor protocols
+- reduced mode keeps the dock visible on unsupported Wayland sessions while
+  intentionally disabling taskbar/window-management features
 
 ## How To Test Today
 
-The most practical test Docking can support today is not "native Wayland".
-It is:
+The most useful smoke tests now cover each backend boundary explicitly:
 
-- a real Wayland desktop session
-- with `XWayland` available
-- forcing Docking to run as an X11 client via `GDK_BACKEND=x11`
+- X11 full functionality on a normal X11 session
+- XWayland compatibility by forcing `GDK_BACKEND=x11` inside a real Wayland
+  session
+- GNOME / Mutter native support through the companion Shell bridge backend
+- wlroots-style native placement through the layer-shell backend where the
+  compositor advertises the needed protocols
+- reduced backend startup on unsupported native Wayland sessions
 
-That is the correct compatibility test for the current codebase because Docking
-still depends heavily on X11-only integration such as:
+The X11 and XWayland paths remain important because several full-featured dock
+capabilities are still implemented through X11-specific services:
 
 - `libwnck` window tracking
 - X11 window IDs and foreign-window capture

--- a/tests/platform/test_gnome_shell_bridge.py
+++ b/tests/platform/test_gnome_shell_bridge.py
@@ -183,6 +183,25 @@ def test_gnome_shell_bridge_workspace_service_lists_and_activates_workspaces():
     bridge.activate_workspace.assert_called_once_with("1")
 
 
+def test_gnome_shell_bridge_workspace_service_refreshes_empty_cache_on_list():
+    bridge = _bridge()
+    bridge.list_workspaces.side_effect = [
+        [],
+        [
+            {"id": 0, "index": 0, "name": "1", "active": True},
+            {"id": 1, "index": 1, "name": "2", "active": False},
+        ],
+    ]
+    service = GnomeShellBridgeWorkspaceService(bridge=bridge)
+
+    service.refresh()
+    workspaces = service.list_workspaces()
+
+    assert len(workspaces) == 2
+    assert workspaces[0].active is True
+    assert bridge.list_workspaces.call_count == 2
+
+
 def test_gnome_shell_bridge_workspace_watchers_are_called_on_refresh():
     bridge = _bridge()
     service = GnomeShellBridgeWorkspaceService(bridge=bridge)
@@ -202,6 +221,36 @@ def test_gnome_shell_bridge_workspace_watchers_are_called_on_refresh():
     service.refresh()
 
     assert callback.call_count == 2
+
+
+def test_gnome_shell_bridge_workspace_service_retries_initial_active_workspace(
+    monkeypatch,
+):
+    scheduled: list[object] = []
+    monkeypatch.setattr(
+        bridge_mod.GLib,
+        "timeout_add",
+        lambda _interval, callback: scheduled.append(callback) or 55,
+    )
+    monkeypatch.setattr(bridge_mod.GLib, "timeout_add_seconds", lambda *_args: 66)
+    bridge = _bridge()
+    bridge.list_workspaces.side_effect = [
+        [],
+        [
+            {"id": 0, "index": 0, "name": "1", "active": True},
+            {"id": 1, "index": 1, "name": "2", "active": False},
+        ],
+    ]
+    service = GnomeShellBridgeWorkspaceService(bridge=bridge)
+    callback = MagicMock()
+
+    service.start()
+    service.watch_active_workspace(callback)
+
+    assert len(scheduled) == 1
+    assert scheduled[0]() is bridge_mod.GLib.SOURCE_REMOVE
+    assert service.active_workspace().id == "0"
+    callback.assert_called_once_with()
 
 
 def test_gnome_shell_bridge_surface_retries_latest_position_request(monkeypatch):

--- a/website/index.html
+++ b/website/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Docking - Open Source Linux Dock with Applets, Themes and Desktop Integration</title>
-  <meta name="description" content="Docking is an open source dock for Linux (X11) with 56 built-in applets, customizable themes, multi-monitor support, and full desktop integration. Written in Python with GTK and Cairo.">
+  <meta name="description" content="Docking is an open source dock for Linux with X11 and Wayland backends, 52 built-in applets, customizable themes, multi-monitor support, and desktop integration. Written in Python with GTK and Cairo.">
   <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/edumucelli/docking/master/packaging/deb/icons/hicolor/32x32/apps/org.docking.Docking.png">
   <link rel="canonical" href="https://docking.cc">
   <meta property="og:title" content="Docking - Open Source Linux Dock with Applets, Themes and Desktop Integration">
-  <meta property="og:description" content="Fast, customizable dock for Linux (X11) with 56 built-in applets, themes, multi-monitor support, and desktop integration. Written in Python with GTK and Cairo.">
+  <meta property="og:description" content="Fast, customizable dock for Linux with X11 and Wayland backends, 52 built-in applets, themes, multi-monitor support, and desktop integration. Written in Python with GTK and Cairo.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://docking.cc">
   <meta property="og:image" content="https://raw.githubusercontent.com/edumucelli/docking/master/website/hero.png">
@@ -17,7 +17,7 @@
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "Docking",
-    "description": "Open source dock for Linux (X11) with 56 built-in applets, customizable themes, multi-monitor support, and full desktop integration.",
+    "description": "Open source dock for Linux with X11 and Wayland backends, 52 built-in applets, customizable themes, multi-monitor support, and desktop integration.",
     "applicationCategory": "DesktopEnhancement",
     "operatingSystem": "Linux",
     "url": "https://docking.cc",
@@ -47,7 +47,7 @@
         "name": "What Linux desktop environments does Docking support?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Docking runs on any Linux desktop environment using X11, including GNOME, KDE Plasma, XFCE, MATE, Cinnamon, and others. It uses GTK 3 and Cairo for rendering, with Wnck for window tracking."
+          "text": "Docking supports full functionality on X11 desktops and Wayland support through backend-specific integrations: GNOME / Mutter via the companion Shell bridge, wlroots compositors via layer-shell where available, and reduced mode on other Wayland compositors."
         }
       },
       {
@@ -63,7 +63,7 @@
         "name": "Does Docking support Wayland?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Docking currently targets X11. Wayland support is not available yet due to fundamental differences in how Wayland handles window positioning, struts, and input grabbing."
+          "text": "Yes. Docking supports X11 for full dock functionality and has native Wayland paths for GNOME / Mutter through the companion Shell bridge, wlroots layer-shell compositors where the required protocols are available, and reduced mode when compositor integration is unavailable."
         }
       },
       {
@@ -366,11 +366,11 @@
       <section id="applets" class="mx-auto max-w-7xl px-6 py-16 lg:px-8 lg:py-24">
         <div class="reveal flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
           <div class="max-w-3xl">
-            <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">56 built-in applets: useful widgets, already in the dock</h2>
+            <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">52 built-in applets: useful widgets, already in the dock</h2>
             <p class="mt-4 text-lg leading-8 text-slate-300">Small tools with real utility: glanceable information, richer controls, and compact workflow helpers. Browse the full applet catalog without leaving the page.</p>
           </div>
           <div class="flex items-center gap-3 self-start lg:self-auto">
-            <div class="rounded-full border border-white/15 bg-gradient-to-r from-skyline/8 to-ember/8 px-5 py-3 text-sm text-slate-200 backdrop-blur-xl">56 built-in applets, with more room to explore</div>
+            <div class="rounded-full border border-white/15 bg-gradient-to-r from-skyline/8 to-ember/8 px-5 py-3 text-sm text-slate-200 backdrop-blur-xl">52 built-in applets, with more room to explore</div>
             <div class="hidden items-center gap-2 sm:flex">
               <button type="button" data-carousel-target="applets-carousel" data-carousel-direction="prev" class="flex h-11 w-11 items-center justify-center rounded-full border border-white/15 bg-white/10 text-white transition hover:border-white/30 hover:bg-white/14" aria-label="Previous applets">
                 <svg viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="1.8"><path d="m15 18-6-6 6-6"></path></svg>
@@ -1075,7 +1075,7 @@ pip install -e ".[dev]"</code></pre>
           <div class="mt-10 space-y-6">
             <details class="group rounded-2xl border border-white/12 bg-gradient-to-br from-skyline/8 to-skyline/4 p-5 backdrop-blur-xl">
               <summary class="flex cursor-pointer items-center justify-between text-lg font-medium text-white"><span>What Linux desktop environments does Docking support?</span><svg viewBox="0 0 24 24" class="h-5 w-5 shrink-0 text-slate-400 transition group-open:rotate-45" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M12 5v14"></path><path d="M5 12h14"></path></svg></summary>
-              <p class="mt-4 text-sm leading-7 text-slate-300">Docking runs on any Linux desktop environment using X11, including GNOME, KDE Plasma, XFCE, MATE, Cinnamon, and others. It uses GTK 3 and Cairo for rendering, with Wnck for window tracking.</p>
+              <p class="mt-4 text-sm leading-7 text-slate-300">Docking supports full functionality on X11 desktops and Wayland support through backend-specific integrations: GNOME / Mutter via the companion Shell bridge, wlroots compositors via layer-shell where available, and reduced mode on other Wayland compositors.</p>
             </details>
             <details class="group rounded-2xl border border-white/12 bg-gradient-to-br from-accent/8 to-accent/4 p-5 backdrop-blur-xl">
               <summary class="flex cursor-pointer items-center justify-between text-lg font-medium text-white"><span>Can I create my own applets?</span><svg viewBox="0 0 24 24" class="h-5 w-5 shrink-0 text-slate-400 transition group-open:rotate-45" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M12 5v14"></path><path d="M5 12h14"></path></svg></summary>
@@ -1083,7 +1083,7 @@ pip install -e ".[dev]"</code></pre>
             </details>
             <details class="group rounded-2xl border border-white/12 bg-gradient-to-br from-skyline/8 to-accent/4 p-5 backdrop-blur-xl">
               <summary class="flex cursor-pointer items-center justify-between text-lg font-medium text-white"><span>Does Docking support Wayland?</span><svg viewBox="0 0 24 24" class="h-5 w-5 shrink-0 text-slate-400 transition group-open:rotate-45" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M12 5v14"></path><path d="M5 12h14"></path></svg></summary>
-              <p class="mt-4 text-sm leading-7 text-slate-300">Docking currently targets X11. Wayland support is not available yet due to fundamental differences in how Wayland handles window positioning, struts, and input grabbing.</p>
+              <p class="mt-4 text-sm leading-7 text-slate-300">Yes. Docking supports X11 for full dock functionality and has native Wayland paths for GNOME / Mutter through the companion Shell bridge, wlroots layer-shell compositors where the required protocols are available, and reduced mode when compositor integration is unavailable.</p>
             </details>
             <details class="group rounded-2xl border border-white/12 bg-gradient-to-br from-ember/8 to-skyline/4 p-5 backdrop-blur-xl">
               <summary class="flex cursor-pointer items-center justify-between text-lg font-medium text-white"><span>Is Docking free and open source?</span><svg viewBox="0 0 24 24" class="h-5 w-5 shrink-0 text-slate-400 transition group-open:rotate-45" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M12 5v14"></path><path d="M5 12h14"></path></svg></summary>
@@ -1114,7 +1114,7 @@ pip install -e ".[dev]"</code></pre>
 
     <footer class="border-t border-white/10">
       <div class="mx-auto flex max-w-7xl flex-col gap-4 px-6 py-8 text-sm text-slate-300 lg:flex-row lg:items-center lg:justify-between lg:px-8">
-        <div>Docking is an open source dock for Linux (X11), written in Python with GTK and Cairo.</div>
+        <div>Docking is an open source dock for Linux with X11 and Wayland backends, written in Python with GTK and Cairo.</div>
         <div class="flex items-center gap-6">
           <a href="https://github.com/edumucelli/docking" target="_blank" rel="noopener noreferrer" class="transition hover:text-white">GitHub</a>
           <a href="https://github.com/edumucelli/docking/releases" target="_blank" rel="noopener noreferrer" class="transition hover:text-white">Releases</a>


### PR DESCRIPTION
## Summary
- refresh GNOME bridge workspaces on demand when the cache has no active workspace
- retry briefly during startup until the initial active workspace is available
- notify workspace applets on any workspace snapshot change, not only active ID changes

## Tests
- .venv/bin/pytest tests/applets/test_workspaces.py tests/platform/test_gnome_shell_bridge.py
- .venv/bin/pytest tests/platform/test_gnome_shell_bridge.py tests/platform/test_backend_selection.py tests/platform/test_wayland_workspace_portal.py tests/platform/test_x11_workspaces.py
- .venv/bin/python -m ruff check docking/ tests/
- .venv/bin/python -m ruff format --check docking/ tests/
- .venv/bin/python -m ty check docking/