### PR TITLE
Suppress gdbus stdout in screenshot portal calls

### DIFF
--- a/docking/applets/screenshot/state.py
+++ b/docking/applets/screenshot/state.py
@@ -51,6 +51,12 @@ _PORTAL_METHOD = f"{_PORTAL_INTERFACE}.Screenshot"
 
 
 _TOOLS: tuple[Tool, ...] = (
+    Tool(
+        command="cosmic-screenshot",
+        full=["--interactive=false"],
+        window=["--interactive=true"],
+        region=["--interactive=true"],
+    ),
     Tool(command="mate-screenshot", full=[], window=["-w"], region=["-a"]),
     Tool(command="gnome-screenshot", full=[], window=["-w"], region=["-a"]),
     Tool(command="xfce4-screenshooter", full=["-f"], window=["-w"], region=["-r"]),
@@ -176,14 +182,21 @@ def _portal_args(*, mode: Mode) -> list[str]:
 
 def _launch(*, cmd: list[str], delay_seconds: int) -> None:
     """Launch *cmd* immediately or after a simple in-process delay."""
+    kwargs: dict = {"start_new_session": True}
+    # Suppress stdout/stderr for portal calls — the D-Bus request handle
+    # emitted to stdout is noise to the user and the portal completes
+    # asynchronously.
+    if cmd[0] == "gdbus":
+        kwargs["stdout"] = subprocess.DEVNULL
+        kwargs["stderr"] = subprocess.DEVNULL
     if delay_seconds <= 0:
-        subprocess.Popen(cmd, start_new_session=True)
+        subprocess.Popen(cmd, **kwargs)
         return
     timer = threading.Timer(
         delay_seconds,
         subprocess.Popen,
         args=(cmd,),
-        kwargs={"start_new_session": True},
+        kwargs=kwargs,
     )
     timer.daemon = True
     timer.start()

--- a/tests/applets/test_screenshot.py
+++ b/tests/applets/test_screenshot.py
@@ -23,6 +23,7 @@ class TestTool:
     def test_tools_order(self):
         commands = [t.command for t in _TOOLS]
         assert commands == [
+            "cosmic-screenshot",
             "mate-screenshot",
             "gnome-screenshot",
             "xfce4-screenshooter",
@@ -50,7 +51,7 @@ class TestDetectTool:
             patch.object(screenshot_state, "_portal_available", return_value=False),
             patch(
                 "docking.applets.screenshot.state.shutil.which",
-                side_effect=[None, "/usr/bin/gnome-screenshot"],
+                side_effect=[None, None, "/usr/bin/gnome-screenshot"],
             ),
         ):
             result = _detect_tool()
@@ -92,8 +93,14 @@ class TestDetectTool:
         ):
             result = _detect_tool()
 
-        assert result == Tool("mate-screenshot", [], ["-w"], ["-a"], "flatpak-host")
-        available.assert_called_once_with("mate-screenshot")
+        assert result == Tool(
+            "cosmic-screenshot",
+            ["--interactive=false"],
+            ["--interactive=true"],
+            ["--interactive=true"],
+            "flatpak-host",
+        )
+        available.assert_called_once_with("cosmic-screenshot")
 
 
 class TestPortal:
@@ -300,7 +307,7 @@ class TestRun:
         monkeypatch.setattr(
             screenshot_state.subprocess,
             "Popen",
-            lambda cmd, start_new_session=True: launched.append(list(cmd)),
+            lambda cmd, **_: launched.append(list(cmd)),
         )
 
         cmd = _run(tool=screenshot_state._PORTAL_TOOL, mode="window")


### PR DESCRIPTION
The XDG screenshot portal call via `gdbus` returns a D-Bus request handle path to stdout (e.g. `/org/freedesktop/portal/desktop/request/1_857/t`). This leaks to the terminal and is confusing to users — the portal handles the screenshot asynchronously.

Redirect `gdbus` stdout/stderr to `DEVNULL` for portal screenshot calls.