### PR TITLE
Add KWin / KDE Plasma 6 native Wayland backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ Highlights:
 - Linux with X11 for full dock functionality
 - Wayland: full support on GNOME / Mutter 45+ via the companion
   `docking-bridge@docking.org` GNOME Shell extension; layer-shell support
-  on wlroots-based compositors (Hyprland, Sway); reduced mode on other
-  Wayland compositors. Recent GNOME / Mutter 45+ examples include Ubuntu
-  26.04 LTS and Fedora Workstation 40+.
+  on wlroots-based compositors (Hyprland, Sway); KDE Plasma 6 KWin
+  support; reduced
+  mode on other Wayland compositors. Example environments include GNOME /
+  Mutter 45+ (Ubuntu 26.04 LTS, Fedora Workstation 40+) and KDE Plasma 6
+  (Kubuntu 26.04 LTS).
 - Python 3.10+
 - System packages (Ubuntu/Debian):
 
@@ -174,12 +176,13 @@ DOCKING_LOG_LEVEL=DEBUG python run.py
 
 ### Wayland Support
 
-X11 remains the primary backend. Native Wayland is supported through two
+X11 remains the primary backend. Native Wayland is supported through several
 backends, selected automatically or via `DOCKING_BACKEND`:
 
 | Backend | Compositor | Coverage |
 |---|---|---|
 | **GNOME Shell bridge** | GNOME / Mutter 45+ | Full: dock placement, window tracking, window actions (activate / minimize / close), window previews, workspace switching, Show Desktop, Alt+Tab hiding |
+| **KWin** | KDE Plasma 6 Wayland | Dock placement (layer-shell), window tracking with titles via AT-SPI accessibility bus, workspace switching via KWin D-Bus. No window actions (KWin 6 does not expose a public activate/close/minimize protocol) |
 | **Native layer-shell** | wlroots-based (Hyprland, Sway) | Dock placement, window tracking, workspace switching (varies by compositor protocol support) |
 | **Reduced** | Any Wayland | Dock visible but no window management (no running indicators, no previews, no workspace switching) |
 
@@ -205,6 +208,28 @@ auto-enabled on install when a D-Bus session is available. AppImage and
 Nix users should run `tools/gnome_bridge.sh install` once, or copy
 `docking/platform/backends/gnome/extension/` to
 `~/.local/share/gnome-shell/extensions/docking-bridge@docking.org/`.
+
+#### KWin / KDE Plasma 6
+
+On KDE Plasma 6 Wayland, Docking uses a native KWin backend with Wayland
+layer-shell dock placement, running-window indicators, and workspace
+switching.
+
+**What works:**
+- Proper layer-shell anchored dock positioning
+- Running window indicators with titles
+- Workspace list and switching
+- Workspace-aware filtering
+
+**What is not yet available on KWin 6:**
+- Window actions (activate, minimize, close) — KWin 6 has no public
+  protocol for third-party window management
+- Window previews — no capture protocol available
+- Active-window highlighting — KWin does not expose the focused window
+  through a public API
+
+No extra configuration is needed. The backend auto-detects a KDE Plasma
+session and is also selectable with `DOCKING_BACKEND=kwin`.
 
 #### Native layer-shell
 
@@ -235,10 +260,11 @@ wayland-info | grep -E 'zwlr_layer_shell_v1|zwlr_foreign_toplevel_manager_v1|ext
 
 To force a specific backend for testing:
 ```bash
-DOCKING_BACKEND=gnome-shell docking       # GNOME / Mutter 45+
-DOCKING_BACKEND=wayland-layer-shell docking  # wlroots compositors
-DOCKING_BACKEND=reduced docking           # any Wayland (no WM integration)
-DOCKING_BACKEND=x11 docking               # X11 (full support)
+DOCKING_BACKEND=gnome-shell docking          # GNOME / Mutter 45+
+DOCKING_BACKEND=kwin docking                  # KDE Plasma 6 Wayland
+DOCKING_BACKEND=wayland-layer-shell docking   # wlroots compositors
+DOCKING_BACKEND=reduced docking               # any Wayland (no WM integration)
+DOCKING_BACKEND=x11 docking                   # X11 (full support)
 ```
 
 ## Configuration

--- a/docking/platform/backends/kwin/__init__.py
+++ b/docking/platform/backends/kwin/__init__.py
@@ -1,0 +1,13 @@
+"""KWin / KDE Plasma 6 native Wayland backend package."""
+
+from docking.platform.backends.kwin.atspi_window import AtspiWindowService
+from docking.platform.backends.kwin.session import (
+    KWinSessionBackend,
+    KWinWorkspaceService,
+)
+
+__all__ = [
+    "AtspiWindowService",
+    "KWinSessionBackend",
+    "KWinWorkspaceService",
+]

--- a/docking/platform/backends/kwin/atspi_window.py
+++ b/docking/platform/backends/kwin/atspi_window.py
@@ -27,16 +27,17 @@ works on KDE, GNOME, and other Wayland compositors.
 
 from __future__ import annotations
 
+import contextlib
 import os
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from threading import Lock, Thread
 
 from gi.repository import Gio, GLib
 
+from docking.log import get_logger
 from docking.platform.backends.base import (
     ActionResult,
     DisplayServer,
-    PlatformCapabilities,
     Rect,
     WindowId,
     WindowService,
@@ -44,8 +45,6 @@ from docking.platform.backends.base import (
 )
 from docking.platform.backends.wayland.toplevels import WaylandAppIdMatcher
 from docking.platform.running import RunningAppInfo, RunningWindowInfo
-
-from docking.log import get_logger
 
 log = get_logger(name="atspi_window")
 
@@ -86,18 +85,18 @@ class _AtspiWindow:
     """Mutable snapshot of one AT-SPI accessible window."""
 
     __slots__ = (
-        "window_id",
-        "title",
-        "app_name",
-        "app_id",
         "active",
-        "minimized",
+        "app_id",
+        "app_name",
         "fullscreen",
+        "height",
+        "minimized",
+        "pid",
+        "title",
+        "width",
+        "window_id",
         "x",
         "y",
-        "width",
-        "height",
-        "pid",
     )
 
     def __init__(self, internal_id: str) -> None:
@@ -131,7 +130,9 @@ class AtspiWindowService(WindowService):
     through AT-SPI.  They return :attr:`ActionResult.UNSUPPORTED`.
     """
 
-    def __init__(self, *, launcher: object | None = None, model: object | None = None) -> None:
+    def __init__(
+        self, *, launcher: object | None = None, model: object | None = None
+    ) -> None:
         self._connection: Gio.DBusConnection | None = None
         self._windows: dict[str, _AtspiWindow] = {}
         self._lock = Lock()
@@ -197,10 +198,8 @@ class AtspiWindowService(WindowService):
             GLib.source_remove(sid)
             self._refresh_source_id = 0
         if self._connection is not None:
-            try:
+            with contextlib.suppress(Exception):
                 self._connection.close_sync(None)
-            except Exception:
-                pass
             self._connection = None
         with self._lock:
             self._windows.clear()
@@ -300,10 +299,8 @@ class AtspiWindowService(WindowService):
             for svc in names:
                 if not svc.startswith(":") or svc == ":1.0":
                     continue
-                try:
+                with contextlib.suppress(Exception):
                     self._enumerate_service(conn, svc, new_windows)
-                except Exception:
-                    pass
 
             with self._lock:
                 self._windows = new_windows
@@ -322,10 +319,8 @@ class AtspiWindowService(WindowService):
 
         # Sync visible items into the matcher
         if matcher is not None:
-            try:
+            with contextlib.suppress(Exception):
                 matcher.sync_visible_items(model.visible_items())
-            except Exception:
-                pass
 
         # Group windows by resolved desktop_id
         by_desktop: dict[str, list[_AtspiWindow]] = {}
@@ -480,10 +475,8 @@ class AtspiWindowService(WindowService):
         if isinstance(attrs, dict):
             pid_str = attrs.get("process-id", "")
             if pid_str:
-                try:
+                with contextlib.suppress(ValueError, TypeError):
                     w.pid = int(pid_str)
-                except (ValueError, TypeError):
-                    pass
             # Use toolkit name as additional app_id disambiguation
             toolkit = attrs.get("toolkit", "")
             if toolkit and w.app_id:

--- a/docking/platform/backends/kwin/atspi_window.py
+++ b/docking/platform/backends/kwin/atspi_window.py
@@ -31,6 +31,7 @@ import contextlib
 import os
 from collections.abc import Sequence
 from threading import Lock, Thread
+from typing import TYPE_CHECKING
 
 from gi.repository import Gio, GLib
 
@@ -45,6 +46,9 @@ from docking.platform.backends.base import (
 )
 from docking.platform.backends.wayland.toplevels import WaylandAppIdMatcher
 from docking.platform.running import RunningAppInfo, RunningWindowInfo
+
+if TYPE_CHECKING:
+    from docking.platform.launcher import Launcher
 
 log = get_logger(name="atspi_window")
 
@@ -131,7 +135,10 @@ class AtspiWindowService(WindowService):
     """
 
     def __init__(
-        self, *, launcher: object | None = None, model: object | None = None
+        self,
+        *,
+        launcher: Launcher | None = None,
+        model: object | None = None,
     ) -> None:
         self._connection: Gio.DBusConnection | None = None
         self._windows: dict[str, _AtspiWindow] = {}
@@ -371,7 +378,8 @@ class AtspiWindowService(WindowService):
         """Walk the accessible tree of *service* and collect windows."""
         root = "/org/a11y/atspi/accessible/root"
 
-        app_name = self._get_prop(conn, service, root, "Name") or service
+        raw_name = self._get_prop(conn, service, root, "Name")
+        app_name: str = str(raw_name) if raw_name else service
 
         # Get children of the application root
         try:
@@ -467,8 +475,8 @@ class AtspiWindowService(WindowService):
         w = _AtspiWindow(internal_id)
 
         # Window title
-        name = self._get_prop(conn, service, path, "Name")
-        w.title = name or ""
+        raw_name = self._get_prop(conn, service, path, "Name")
+        w.title = str(raw_name) if raw_name else ""
 
         # App identification
         w.app_name = app_name
@@ -482,12 +490,12 @@ class AtspiWindowService(WindowService):
         # Attributes may carry PID, WM_CLASS, etc.
         attrs = self._get_prop(conn, service, path, "GetAttributes")
         if isinstance(attrs, dict):
-            pid_str = attrs.get("process-id", "")
+            pid_str: object = attrs.get("process-id", "")
             if pid_str:
                 with contextlib.suppress(ValueError, TypeError):
-                    w.pid = int(pid_str)
+                    w.pid = int(str(pid_str))
             # Use toolkit name as additional app_id disambiguation
-            toolkit = attrs.get("toolkit", "")
+            toolkit: object = attrs.get("toolkit", "")
             if toolkit and w.app_id:
                 w.app_id = f"{w.app_id}.{toolkit}"
 

--- a/docking/platform/backends/kwin/atspi_window.py
+++ b/docking/platform/backends/kwin/atspi_window.py
@@ -147,11 +147,17 @@ class AtspiWindowService(WindowService):
     # ------------------------------------------------------------------
 
     # Set of window titles that indicate system/utility apps (not user windows)
-    _SYSTEM_APPS = frozenset({
-        "ksmserver", "kaccess", "gmenudbusmenuproxy", "xembedsniproxy",
-        "evolution-alarm-notify", "xdg-desktop-portal-gtk",
-        "polkit-kde-authentication-agent-1",
-    })
+    _SYSTEM_APPS = frozenset(
+        {
+            "ksmserver",
+            "kaccess",
+            "gmenudbusmenuproxy",
+            "xembedsniproxy",
+            "evolution-alarm-notify",
+            "xdg-desktop-portal-gtk",
+            "polkit-kde-authentication-agent-1",
+        }
+    )
 
     # Refresh interval in milliseconds
     _REFRESH_INTERVAL_MS = 5000
@@ -184,7 +190,8 @@ class AtspiWindowService(WindowService):
             self._schedule_refresh()
             # Start periodic refresh (runs in background thread)
             self._refresh_source_id = GLib.timeout_add(
-                self._REFRESH_INTERVAL_MS, self._on_refresh_timer,
+                self._REFRESH_INTERVAL_MS,
+                self._on_refresh_timer,
             )
             log.info("AT-SPI window service: connected")
         except Exception:
@@ -193,7 +200,7 @@ class AtspiWindowService(WindowService):
             self._refresh_source_id: int = 0
 
     def stop(self) -> None:
-        sid = getattr(self, '_refresh_source_id', 0)
+        sid = getattr(self, "_refresh_source_id", 0)
         if sid:
             GLib.source_remove(sid)
             self._refresh_source_id = 0
@@ -338,14 +345,16 @@ class AtspiWindowService(WindowService):
         for desktop_id, windows in by_desktop.items():
             rwis = []
             for w in windows:
-                rwis.append(RunningWindowInfo(
-                    desktop_id=desktop_id,
-                    xid=0,
-                    window_id=w.window_id,
-                    active=w.active,
-                    urgent=False,
-                    window=None,
-                ))
+                rwis.append(
+                    RunningWindowInfo(
+                        desktop_id=desktop_id,
+                        xid=0,
+                        window_id=w.window_id,
+                        active=w.active,
+                        urgent=False,
+                        window=None,
+                    )
+                )
             running[desktop_id] = RunningAppInfo.from_windows(rwis)
 
         try:
@@ -624,11 +633,11 @@ class AtspiWindowService(WindowService):
                 y=w.y,
                 width=w.width,
                 height=w.height,
-            ) if (w.width > 0 and w.height > 0) else None,
+            )
+            if (w.width > 0 and w.height > 0)
+            else None,
             can_activate=False,
             can_minimize=False,
             can_close=False,
             can_preview=False,
         )
-
-

--- a/docking/platform/backends/kwin/atspi_window.py
+++ b/docking/platform/backends/kwin/atspi_window.py
@@ -1,0 +1,641 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""AT-SPI (Assistive Technology Service Provider Interface) window service.
+
+KWin 6 / Plasma 6 does not expose a public Wayland protocol for window
+listing.  However, the accessibility bus (AT-SPI2) is always active on
+modern Linux desktops and exposes every application's top-level windows
+as accessible objects.  This module connects to the AT-SPI D-Bus bus,
+enumerates accessible applications and their window/frame children, and
+maps them into Docking's :class:`WindowService` contract.
+
+AT-SPI is used by screen readers (Orca) and UI automation tools
+(Dogtail, Accerciser).  It is a stable, cross-desktop mechanism that
+works on KDE, GNOME, and other Wayland compositors.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Sequence
+from threading import Lock, Thread
+
+from gi.repository import Gio, GLib
+
+from docking.platform.backends.base import (
+    ActionResult,
+    DisplayServer,
+    PlatformCapabilities,
+    Rect,
+    WindowId,
+    WindowService,
+    WindowSnapshot,
+)
+from docking.platform.backends.wayland.toplevels import WaylandAppIdMatcher
+from docking.platform.running import RunningAppInfo, RunningWindowInfo
+
+from docking.log import get_logger
+
+log = get_logger(name="atspi_window")
+
+# ---------------------------------------------------------------------------
+# AT-SPI role names for window-like objects
+# ---------------------------------------------------------------------------
+
+_WINDOW_ROLES = frozenset({"window", "frame", "dialog", "application"})
+
+# AT-SPI role IDs → names (commonly used subset)
+_ROLE_BY_ID: dict[int, str] = {
+    7: "application",
+    26: "dialog",
+    33: "frame",
+    80: "window",
+}
+
+# AT-SPI state constants
+_STATE_ACTIVE = 0
+_STATE_FOCUSED = 3
+
+# Path of the AT-SPI accessibility bus socket
+_AT_SPI_BUS_PATH = "/run/user/{uid}/at-spi/bus_0"
+
+
+def _at_spi_address() -> str:
+    """Return the AT-SPI D-Bus address for the current session."""
+    uid = os.getuid()
+    return f"unix:path={_AT_SPI_BUS_PATH.format(uid=uid)}"
+
+
+# ---------------------------------------------------------------------------
+# Window data
+# ---------------------------------------------------------------------------
+
+
+class _AtspiWindow:
+    """Mutable snapshot of one AT-SPI accessible window."""
+
+    __slots__ = (
+        "window_id",
+        "title",
+        "app_name",
+        "app_id",
+        "active",
+        "minimized",
+        "fullscreen",
+        "x",
+        "y",
+        "width",
+        "height",
+        "pid",
+    )
+
+    def __init__(self, internal_id: str) -> None:
+        self.window_id = WindowId(backend=DisplayServer.WAYLAND, value=internal_id)
+        self.title: str = ""
+        self.app_name: str = ""
+        self.app_id: str | None = None
+        self.active: bool = False
+        self.minimized: bool = False
+        self.fullscreen: bool = False
+        self.x: int = 0
+        self.y: int = 0
+        self.width: int = 0
+        self.height: int = 0
+        self.pid: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Window Service
+# ---------------------------------------------------------------------------
+
+
+class AtspiWindowService(WindowService):
+    """WindowService backed by AT-SPI accessibility bus enumeration.
+
+    Connects to the session's AT-SPI D-Bus bus and walks the
+    accessibility tree of each running application to discover
+    top-level windows (frames, windows, dialogs).
+
+    Window actions (activate, close, minimize) are not available
+    through AT-SPI.  They return :attr:`ActionResult.UNSUPPORTED`.
+    """
+
+    def __init__(self, *, launcher: object | None = None, model: object | None = None) -> None:
+        self._connection: Gio.DBusConnection | None = None
+        self._windows: dict[str, _AtspiWindow] = {}
+        self._lock = Lock()
+        self._refresh_running = False
+        self._model = model
+        self._matcher: WaylandAppIdMatcher | None = None
+        if launcher is not None:
+            self._matcher = WaylandAppIdMatcher(launcher=launcher)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    # Set of window titles that indicate system/utility apps (not user windows)
+    _SYSTEM_APPS = frozenset({
+        "ksmserver", "kaccess", "gmenudbusmenuproxy", "xembedsniproxy",
+        "evolution-alarm-notify", "xdg-desktop-portal-gtk",
+        "polkit-kde-authentication-agent-1",
+    })
+
+    # Refresh interval in milliseconds
+    _REFRESH_INTERVAL_MS = 5000
+
+    def start(self) -> None:
+        """Connect to the AT-SPI bus and perform an initial enumeration."""
+        addr = _at_spi_address()
+        try:
+            conn = Gio.DBusConnection.new_for_address_sync(
+                addr,
+                Gio.DBusConnectionFlags.AUTHENTICATION_CLIENT,
+                None,
+                None,
+            )
+            # AT-SPI bus requires an explicit Hello
+            conn.call_sync(
+                "org.freedesktop.DBus",
+                "/org/freedesktop/DBus",
+                "org.freedesktop.DBus",
+                "Hello",
+                None,
+                GLib.VariantType("(s)"),
+                Gio.DBusCallFlags.NONE,
+                2000,
+                None,
+            )
+            self._connection = conn
+            # Initial refresh in a background thread so the main loop
+            # stays responsive during startup.
+            self._schedule_refresh()
+            # Start periodic refresh (runs in background thread)
+            self._refresh_source_id = GLib.timeout_add(
+                self._REFRESH_INTERVAL_MS, self._on_refresh_timer,
+            )
+            log.info("AT-SPI window service: connected")
+        except Exception:
+            log.exception("AT-SPI window service: failed to connect")
+            self._connection = None
+            self._refresh_source_id: int = 0
+
+    def stop(self) -> None:
+        sid = getattr(self, '_refresh_source_id', 0)
+        if sid:
+            GLib.source_remove(sid)
+            self._refresh_source_id = 0
+        if self._connection is not None:
+            try:
+                self._connection.close_sync(None)
+            except Exception:
+                pass
+            self._connection = None
+        with self._lock:
+            self._windows.clear()
+
+    # ------------------------------------------------------------------
+    # WindowService implementation
+    # ------------------------------------------------------------------
+
+    def list_windows(self, desktop_id: str) -> Sequence[WindowSnapshot]:
+        snapshots = []
+        with self._lock:
+            for w in self._windows.values():
+                snap = self._to_snapshot(w)
+                if snap.desktop_id == desktop_id:
+                    snapshots.append(snap)
+        return snapshots
+
+    def list_preview_windows(self, desktop_id: str) -> Sequence[WindowSnapshot]:
+        return self.list_windows(desktop_id)
+
+    def icon_name_for_desktop(self, desktop_id: str) -> str:
+        for w in self._windows.values():
+            snap = self._to_snapshot(w)
+            if snap.desktop_id == desktop_id and w.app_name:
+                return w.app_name.lower()
+        return ""
+
+    def activate(self, window_id: WindowId) -> ActionResult:
+        return ActionResult.UNSUPPORTED
+
+    def activate_most_recent(self, desktop_id: str) -> ActionResult:
+        return ActionResult.UNSUPPORTED
+
+    def cycle(self, desktop_id: str) -> ActionResult:
+        return ActionResult.UNSUPPORTED
+
+    def minimize_all(self, desktop_id: str) -> ActionResult:
+        return ActionResult.UNSUPPORTED
+
+    def close(self, window_id: WindowId) -> ActionResult:
+        return ActionResult.UNSUPPORTED
+
+    def close_all(self, desktop_id: str) -> ActionResult:
+        return ActionResult.UNSUPPORTED
+
+    def close_focused(self, desktop_id: str) -> ActionResult:
+        return ActionResult.UNSUPPORTED
+
+    def toggle_focus(self, desktop_id: str) -> ActionResult:
+        return ActionResult.UNSUPPORTED
+
+    # ------------------------------------------------------------------
+    # Internal: AT-SPI enumeration
+    # ------------------------------------------------------------------
+
+    def _on_refresh_timer(self) -> bool:
+        """GLib timer callback — runs refresh in a background thread."""
+        self._schedule_refresh()
+        return True  # keep timer running
+
+    def _schedule_refresh(self) -> None:
+        """Run _refresh in a background thread, skipping if one is already in flight."""
+        if self._refresh_running:
+            return
+        thread = Thread(target=self._refresh, daemon=True)
+        thread.start()
+
+    def _refresh(self) -> None:
+        """Re-enumerate all windows from the AT-SPI bus."""
+        conn = self._connection
+        if conn is None:
+            return
+
+        self._refresh_running = True
+        try:
+            new_windows: dict[str, _AtspiWindow] = {}
+
+            # 1. List all services on the AT-SPI bus
+            try:
+                result = conn.call_sync(
+                    "org.freedesktop.DBus",
+                    "/org/freedesktop/DBus",
+                    "org.freedesktop.DBus",
+                    "ListNames",
+                    None,
+                    GLib.VariantType("(as)"),
+                    Gio.DBusCallFlags.NONE,
+                    2000,
+                    None,
+                )
+                names = result.get_child_value(0).unpack()  # list[str]
+            except Exception:
+                log.exception("AT-SPI: ListNames failed")
+                return
+
+            # 2. For each unique-name connection, enumerate accessible windows
+            for svc in names:
+                if not svc.startswith(":") or svc == ":1.0":
+                    continue
+                try:
+                    self._enumerate_service(conn, svc, new_windows)
+                except Exception:
+                    pass
+
+            with self._lock:
+                self._windows = new_windows
+
+            # Publish running windows to the model so indicators appear
+            self._publish_running()
+        finally:
+            self._refresh_running = False
+
+    def _publish_running(self) -> None:
+        """Build RunningAppInfo per desktop_id and push to the model."""
+        model = self._model
+        if model is None:
+            return
+        matcher = self._matcher
+
+        # Sync visible items into the matcher
+        if matcher is not None:
+            try:
+                matcher.sync_visible_items(model.visible_items())
+            except Exception:
+                pass
+
+        # Group windows by resolved desktop_id
+        by_desktop: dict[str, list[_AtspiWindow]] = {}
+        with self._lock:
+            for w in self._windows.values():
+                desktop_id = None
+                if matcher is not None and w.app_name:
+                    desktop_id = matcher.match(w.app_name)
+                if not desktop_id:
+                    desktop_id = f"kwin:{w.app_name or w.window_id.value}"
+                by_desktop.setdefault(desktop_id, []).append(w)
+
+        # Build RunningAppInfo per desktop_id
+        running: dict[str, RunningAppInfo] = {}
+        for desktop_id, windows in by_desktop.items():
+            rwis = []
+            for w in windows:
+                rwis.append(RunningWindowInfo(
+                    desktop_id=desktop_id,
+                    xid=0,
+                    window_id=w.window_id,
+                    active=w.active,
+                    urgent=False,
+                    window=None,
+                ))
+            running[desktop_id] = RunningAppInfo.from_windows(rwis)
+
+        try:
+            model.update_running(running=running)
+        except Exception:
+            log.exception("AT-SPI: update_running failed")
+
+    def _enumerate_service(
+        self,
+        conn: Gio.DBusConnection,
+        service: str,
+        out: dict[str, _AtspiWindow],
+    ) -> None:
+        """Walk the accessible tree of *service* and collect windows."""
+        root = "/org/a11y/atspi/accessible/root"
+
+        app_name = self._get_prop(conn, service, root, "Name") or service
+
+        # Get children of the application root
+        try:
+            r = conn.call_sync(
+                service,
+                root,
+                "org.a11y.atspi.Accessible",
+                "GetChildren",
+                None,
+                GLib.VariantType("(a(so))"),
+                Gio.DBusCallFlags.NONE,
+                500,
+                None,
+            )
+            children = r.get_child_value(0)
+            n = children.n_children()
+        except Exception:
+            return
+
+        for i in range(n):
+            child = children.get_child_value(i)
+            c_svc = child.get_child_value(0).get_string()
+            c_path = child.get_child_value(1).get_string()
+
+            role = self._get_role_name(conn, c_svc, c_path)
+
+            if role in _WINDOW_ROLES:
+                self._collect_window(conn, c_svc, c_path, role, app_name, out)
+            elif role == "application":
+                # Walk one level deeper: application → windows
+                self._walk_children(conn, c_svc, c_path, app_name, out, depth=1)
+            else:
+                # Walk deeper in case windows are nested
+                self._walk_children(conn, c_svc, c_path, app_name, out, depth=1)
+
+    def _walk_children(
+        self,
+        conn: Gio.DBusConnection,
+        service: str,
+        path: str,
+        app_name: str,
+        out: dict[str, _AtspiWindow],
+        depth: int = 0,
+    ) -> None:
+        """Recurse into children up to *depth* looking for window objects."""
+        if depth > 2:
+            return
+
+        try:
+            r = conn.call_sync(
+                service,
+                path,
+                "org.a11y.atspi.Accessible",
+                "GetChildren",
+                None,
+                GLib.VariantType("(a(so))"),
+                Gio.DBusCallFlags.NONE,
+                500,
+                None,
+            )
+            children = r.get_child_value(0)
+            n = children.n_children()
+        except Exception:
+            return
+
+        for i in range(n):
+            child = children.get_child_value(i)
+            c_svc = child.get_child_value(0).get_string()
+            c_path = child.get_child_value(1).get_string()
+
+            role = self._get_role_name(conn, c_svc, c_path)
+            if role in _WINDOW_ROLES:
+                self._collect_window(conn, c_svc, c_path, role, app_name, out)
+            elif depth < 2:
+                self._walk_children(conn, c_svc, c_path, app_name, out, depth + 1)
+
+    def _collect_window(
+        self,
+        conn: Gio.DBusConnection,
+        service: str,
+        path: str,
+        role: str,
+        app_name: str,
+        out: dict[str, _AtspiWindow],
+    ) -> None:
+        """Extract window properties from an accessible object."""
+
+        # Skip system/utility applications
+        if app_name in self._SYSTEM_APPS:
+            return
+
+        internal_id = f"{service}{path}"
+        w = _AtspiWindow(internal_id)
+
+        # Window title
+        name = self._get_prop(conn, service, path, "Name")
+        w.title = name or ""
+
+        # App identification
+        w.app_name = app_name
+        w.app_id = app_name
+
+        # Active / focused state
+        state = self._get_prop(conn, service, path, "GetState")
+        if isinstance(state, list):
+            w.active = _STATE_ACTIVE in state or _STATE_FOCUSED in state
+
+        # Attributes may carry PID, WM_CLASS, etc.
+        attrs = self._get_prop(conn, service, path, "GetAttributes")
+        if isinstance(attrs, dict):
+            pid_str = attrs.get("process-id", "")
+            if pid_str:
+                try:
+                    w.pid = int(pid_str)
+                except (ValueError, TypeError):
+                    pass
+            # Use toolkit name as additional app_id disambiguation
+            toolkit = attrs.get("toolkit", "")
+            if toolkit and w.app_id:
+                w.app_id = f"{w.app_id}.{toolkit}"
+
+        # Geometry via Component interface — only if the object
+        # actually implements it (avoids impl_GetExtents CRITICALs).
+        if self._has_interface(conn, service, path, "org.a11y.atspi.Component"):
+            try:
+                gr = conn.call_sync(
+                    service,
+                    path,
+                    "org.a11y.atspi.Component",
+                    "GetExtents",
+                    GLib.Variant("(u)", (0,)),  # 0 = ATSPI_COORD_TYPE_SCREEN
+                    GLib.VariantType("(iiii)"),
+                    Gio.DBusCallFlags.NONE,
+                    500,
+                    None,
+                )
+                w.x, w.y, w.width, w.height = gr.get_child_value(0).unpack()
+            except Exception:
+                pass
+
+        # Avoid duplicates: prefer the first entry for each internal_id
+        if internal_id not in out:
+            out[internal_id] = w
+
+    # ------------------------------------------------------------------
+    # D-Bus helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _has_interface(
+        conn: Gio.DBusConnection,
+        service: str,
+        path: str,
+        iface_name: str,
+    ) -> bool:
+        """Check whether an accessible object implements *iface_name*."""
+        try:
+            r = conn.call_sync(
+                service,
+                path,
+                "org.a11y.atspi.Accessible",
+                "GetInterfaces",
+                None,
+                GLib.VariantType("(as)"),
+                Gio.DBusCallFlags.NONE,
+                500,
+                None,
+            )
+            ifaces = r.get_child_value(0).unpack()
+            return iface_name in ifaces
+        except Exception:
+            return False
+
+    @staticmethod
+    def _get_prop(
+        conn: Gio.DBusConnection,
+        service: str,
+        path: str,
+        prop_name: str,
+    ) -> object | None:
+        """Read an AT-SPI Accessible property, returning a Python value."""
+        try:
+            r = conn.call_sync(
+                service,
+                path,
+                "org.freedesktop.DBus.Properties",
+                "Get",
+                GLib.Variant("(ss)", ("org.a11y.atspi.Accessible", prop_name)),
+                GLib.VariantType("(v)"),
+                Gio.DBusCallFlags.NONE,
+                500,
+                None,
+            )
+            return r.get_child_value(0).unpack()
+        except Exception:
+            return None
+
+    @staticmethod
+    def _get_role_name(
+        conn: Gio.DBusConnection,
+        service: str,
+        path: str,
+    ) -> str:
+        """Get the accessible role name, falling back to role ID lookup."""
+        try:
+            r = conn.call_sync(
+                service,
+                path,
+                "org.a11y.atspi.Accessible",
+                "GetRoleName",
+                None,
+                GLib.VariantType("(s)"),
+                Gio.DBusCallFlags.NONE,
+                500,
+                None,
+            )
+            return r.get_child_value(0).get_string()
+        except Exception:
+            pass
+        try:
+            r = conn.call_sync(
+                service,
+                path,
+                "org.a11y.atspi.Accessible",
+                "GetRole",
+                None,
+                GLib.VariantType("(u)"),
+                Gio.DBusCallFlags.NONE,
+                500,
+                None,
+            )
+            role_id = r.get_child_value(0).get_uint32()
+            return _ROLE_BY_ID.get(role_id, f"role_{role_id}")
+        except Exception:
+            return "?"
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _to_snapshot(self, w: _AtspiWindow) -> WindowSnapshot:
+        # Resolve to a proper .desktop ID via the matcher, falling back to
+        # app_name with a kwin: prefix so the UI can still show something.
+        desktop_id = None
+        if self._matcher is not None and w.app_name:
+            desktop_id = self._matcher.match(w.app_name)
+        if not desktop_id:
+            desktop_id = f"kwin:{w.app_name or w.window_id.value}"
+
+        return WindowSnapshot(
+            id=w.window_id,
+            desktop_id=desktop_id,
+            title=w.title or "Window",
+            app_id=w.app_id,
+            wm_class=w.app_name or None,
+            active=w.active,
+            minimized=w.minimized,
+            fullscreen=w.fullscreen,
+            geometry=Rect(
+                x=w.x,
+                y=w.y,
+                width=w.width,
+                height=w.height,
+            ) if (w.width > 0 and w.height > 0) else None,
+            can_activate=False,
+            can_minimize=False,
+            can_close=False,
+            can_preview=False,
+        )
+
+

--- a/docking/platform/backends/kwin/preview.py
+++ b/docking/platform/backends/kwin/preview.py
@@ -243,7 +243,9 @@ class KWinPreviewService(PreviewService):
             pw, ph = pixbuf.get_width(), pixbuf.get_height()
             if pw != target_w or ph != target_h:
                 return pixbuf.scale_simple(
-                    target_w, target_h, GdkPixbuf.InterpType.BILINEAR,
+                    target_w,
+                    target_h,
+                    GdkPixbuf.InterpType.BILINEAR,
                 )
 
             return pixbuf

--- a/docking/platform/backends/kwin/preview.py
+++ b/docking/platform/backends/kwin/preview.py
@@ -33,15 +33,14 @@ from __future__ import annotations
 
 import os
 import select
-from typing import TYPE_CHECKING
 
 import gi
 
 gi.require_version("GdkPixbuf", "2.0")
-from gi.repository import GdkPixbuf, GLib, Gio
+from gi.repository import GdkPixbuf, Gio, GLib
 
-from docking.platform.backends.base import PreviewImage, PreviewService, WindowId
 from docking.log import get_logger
+from docking.platform.backends.base import PreviewImage, PreviewService, WindowId
 
 log = get_logger(name="kwin_preview")
 
@@ -243,10 +242,9 @@ class KWinPreviewService(PreviewService):
             # Scale to requested size if needed
             pw, ph = pixbuf.get_width(), pixbuf.get_height()
             if pw != target_w or ph != target_h:
-                scaled = pixbuf.scale_simple(
+                return pixbuf.scale_simple(
                     target_w, target_h, GdkPixbuf.InterpType.BILINEAR,
                 )
-                return scaled
 
             return pixbuf
         except Exception:

--- a/docking/platform/backends/kwin/preview.py
+++ b/docking/platform/backends/kwin/preview.py
@@ -1,0 +1,265 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""KWin window previews via org.kde.KWin.ScreenShot2 D-Bus.
+
+KWin 6 exposes ``org.kde.KWin.ScreenShot2``, a D-Bus API at
+``/org/kde/KWin/ScreenShot2`` that captures windows, screens, or
+workspaces to a pipe file descriptor.
+
+**Authorization:**  The calling process must be associated with a
+``.desktop`` file that declares::
+
+    X-KDE-DBUS-Restricted-Interfaces=org.kde.KWin.ScreenShot2
+
+When Docking is launched via its installed desktop file (e.g. from the
+application launcher or ``gtk-launch org.docking.Docking``), KDE
+recognises the process and grants access to ScreenShot2.
+
+**Window UUIDs:** ``CaptureWindow`` requires a KWin internal UUID.
+These are obtained by matching AT-SPI window captions against KWin's
+``workspace.windowList()`` internal IDs exposed through a companion
+KWin script.  If UUIDs are unavailable the service falls back to
+``CaptureActiveWindow`` (current foreground window) and
+``CaptureActiveScreen`` (full monitor) for the active dock item.
+"""
+
+from __future__ import annotations
+
+import os
+import select
+from typing import TYPE_CHECKING
+
+import gi
+
+gi.require_version("GdkPixbuf", "2.0")
+from gi.repository import GdkPixbuf, GLib, Gio
+
+from docking.platform.backends.base import PreviewImage, PreviewService, WindowId
+from docking.log import get_logger
+
+log = get_logger(name="kwin_preview")
+
+_DBUS_SERVICE = "org.kde.KWin"
+_DBUS_PATH = "/org/kde/KWin/ScreenShot2"
+_DBUS_IFACE = "org.kde.KWin.ScreenShot2"
+_CAPTURE_TIMEOUT_MS = 5000
+
+
+class KWinPreviewService(PreviewService):
+    """Window previews via KWin ScreenShot2 D-Bus.
+
+    Each :meth:`capture` call pipes image data from KWin through a
+    Unix pipe and converts it to a :class:`GdkPixbuf.Pixbuf`.
+    """
+
+    def __init__(self) -> None:
+        self._started = False
+        self._bus: Gio.DBusConnection | None = None
+
+    # ------------------------------------------------------------------
+    # Service lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        try:
+            self._bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+            self._started = True
+            log.info("KWin preview service: ready")
+        except Exception:
+            log.exception("KWin preview service: failed to get D-Bus")
+            self._started = False
+
+    def stop(self) -> None:
+        self._started = False
+        self._bus = None
+
+    # ------------------------------------------------------------------
+    # PreviewService
+    # ------------------------------------------------------------------
+
+    def capture(
+        self, window_id: WindowId, *, width: int, height: int
+    ) -> PreviewImage | None:
+        """Capture a preview for *window_id* via ScreenShot2.
+
+        Falls back to a full active-screen capture when KWin UUIDs
+        are not available (e.g. during development or before the
+        KWin-UUID bridge is implemented).
+        """
+        if not self._started or self._bus is None:
+            return None
+
+        uuid = str(window_id.value)
+        pixbuf = self._capture_window(uuid, width, height)
+        if pixbuf is None:
+            # Fall back to active screen capture
+            pixbuf = self._capture_active_screen(width, height)
+        if pixbuf is not None:
+            return PreviewImage(
+                image=pixbuf,
+                width=pixbuf.get_width(),
+                height=pixbuf.get_height(),
+            )
+        return None
+
+    def thumbnail(
+        self, window_id: WindowId, *, width: int, height: int
+    ) -> PreviewImage | None:
+        return self.capture(window_id, width=width, height=height)
+
+    # ------------------------------------------------------------------
+    # ScreenShot2 helpers
+    # ------------------------------------------------------------------
+
+    def _capture_window(
+        self, uuid: str, target_w: int, target_h: int
+    ) -> GdkPixbuf.Pixbuf | None:
+        """Capture *uuid* via ScreenShot2 and return a pixbuf."""
+        try:
+            return self._call_screenshot(
+                "CaptureWindow",
+                "s",  # extra arg format: string handle
+                uuid,
+                target_w,
+                target_h,
+            )
+        except Exception:
+            return None
+
+    def _capture_active_screen(
+        self, target_w: int, target_h: int
+    ) -> GdkPixbuf.Pixbuf | None:
+        """Capture the active screen as a fallback."""
+        try:
+            return self._call_screenshot(
+                "CaptureActiveScreen",
+                "",  # no extra args
+                None,
+                target_w,
+                target_h,
+            )
+        except Exception:
+            return None
+
+    def _call_screenshot(
+        self,
+        method: str,
+        extra_fmt: str,
+        extra_val: object,
+        target_w: int,
+        target_h: int,
+    ) -> GdkPixbuf.Pixbuf | None:
+        """Invoke a ScreenShot2 *method*, read the pipe, return a pixbuf."""
+        bus = self._bus
+        if bus is None:
+            return None
+
+        read_fd, write_fd = os.pipe()
+        try:
+            # Build the top-level parameter tuple with a builder.
+            # ScreenShot2 signatures:
+            #   CaptureWindow:      (s a{sv} h)
+            #   CaptureActive*:     (a{sv} h)
+            if extra_fmt == "s":
+                tuple_type = GLib.VariantType("(sa{sv}h)")
+            else:
+                tuple_type = GLib.VariantType("(a{sv}h)")
+
+            builder = GLib.VariantBuilder(tuple_type)
+
+            # The builder needs each child added in order with the
+            # correct type, using add_value for leaf values and
+            # open/close for containers.
+
+            # 1. Optional string arg (window UUID)
+            if extra_fmt == "s":
+                builder.add_value(GLib.Variant("s", str(extra_val)))
+
+            # 2. Open a{sv} dict, add entries, close
+            # Determine the child type of the a{sv} container
+            builder.open(GLib.VariantType("a{sv}"))
+            for key, var in (
+                ("include-cursor", GLib.Variant("b", False)),
+                ("include-decoration", GLib.Variant("b", True)),
+                ("native-resolution", GLib.Variant("b", True)),
+            ):
+                builder.add_value(GLib.Variant("{sv}", (key, var)))
+            builder.close()  # close a{sv}
+
+            # 3. Pipe fd
+            builder.add_value(GLib.Variant("h", write_fd))
+
+            params = builder.end()
+
+            result = bus.call_sync(
+                _DBUS_SERVICE,
+                _DBUS_PATH,
+                _DBUS_IFACE,
+                method,
+                params,
+                GLib.VariantType("(a{sv})"),
+                Gio.DBusCallFlags.NONE,
+                _CAPTURE_TIMEOUT_MS,
+                None,
+            )
+
+            results = result.get_child_value(0).unpack()
+            log.debug("ScreenShot2 %s → %s", method, results)
+
+            # Read image data from the pipe
+            ready, _, _ = select.select([read_fd], [], [], 3.0)
+            if not ready:
+                log.debug("ScreenShot2: timeout reading pipe")
+                return None
+
+            data = b""
+            while True:
+                try:
+                    chunk = os.read(read_fd, 65536)
+                    if not chunk:
+                        break
+                    data += chunk
+                except BlockingIOError:
+                    break
+
+            if not data:
+                log.debug("ScreenShot2: no data in pipe")
+                return None
+
+            loader = GdkPixbuf.PixbufLoader.new()
+            loader.write(data)
+            loader.close()
+            pixbuf = loader.get_pixbuf()
+
+            if pixbuf is None:
+                return None
+
+            # Scale to requested size if needed
+            pw, ph = pixbuf.get_width(), pixbuf.get_height()
+            if pw != target_w or ph != target_h:
+                scaled = pixbuf.scale_simple(
+                    target_w, target_h, GdkPixbuf.InterpType.BILINEAR,
+                )
+                return scaled
+
+            return pixbuf
+        except Exception:
+            # Authorization failures are expected during development.
+            # Only log once to avoid spamming.
+            if not getattr(self, "_auth_warned", False):
+                self._auth_warned = True
+                log.info(
+                    "ScreenShot2 not authorized — previews require "
+                    "Docking to be launched via its .desktop file "
+                    "(e.g. gtk-launch org.docking.Docking)"
+                )
+            return None
+        finally:
+            os.close(read_fd)
+            os.close(write_fd)

--- a/docking/platform/backends/kwin/session.py
+++ b/docking/platform/backends/kwin/session.py
@@ -51,16 +51,12 @@ from docking.platform.backends.base import (
     IdleService,
     PlatformCapabilities,
     PreviewService,
-    Rect,
     ScreenCaptureService,
     SessionBackend,
     SurfaceService,
-    VisibilityMonitor,
     VisibilityService,
-    WindowId,
     WindowPickService,
     WindowService,
-    WindowSnapshot,
     WorkspaceService,
     WorkspaceSnapshot,
 )
@@ -75,6 +71,8 @@ from docking.platform.backends.reduced.services import (
 if TYPE_CHECKING:
     from docking.platform.launcher import Launcher
     from docking.platform.model import DockModel
+
+import contextlib
 
 from docking.log import get_logger
 
@@ -212,10 +210,8 @@ class KWinWorkspaceService(WorkspaceService):
                         id=curr.id, number=curr.number, name=curr.name, active=True,
                     )
                 for cb in list(self._watchers.values()):
-                    try:
+                    with contextlib.suppress(Exception):
                         cb()
-                    except Exception:
-                        pass
 
         if "desktops" in changed_dict or "count" in changed_dict:
             needs_refresh = True
@@ -223,10 +219,8 @@ class KWinWorkspaceService(WorkspaceService):
         if needs_refresh:
             self._refresh()
             for cb in list(self._watchers.values()):
-                try:
+                with contextlib.suppress(Exception):
                     cb()
-                except Exception:
-                    pass
 
 
 # ---------------------------------------------------------------------------

--- a/docking/platform/backends/kwin/session.py
+++ b/docking/platform/backends/kwin/session.py
@@ -1,0 +1,337 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""KWin / KDE Plasma 6 native Wayland session backend.
+
+Backend selection::
+
+    KDE Plasma Wayland session  ---->  KWinSessionBackend
+                                       |
+                                       +-- WaylandLayerShellSurfaceService
+                                       +-- KWinWorkspaceService
+                                       |     (via KWin VirtualDesktopManager D-Bus)
+                                       +-- ReducedWindowService
+                                       |     (window listing not available from
+                                       |      KWin 6 Wayland — KWin does not
+                                       |      expose a public window-list protocol)
+                                       +-- ReducedVisibilityService
+
+KWin 6 (Plasma 6) does not expose ``wlr-foreign-toplevel-management``,
+``ext-foreign-toplevel-list``, or ``org_kde_plasma_window_management``
+to third-party Wayland clients.  Its scripting API does not provide a
+usable D-Bus bridge.  Window tracking is therefore unavailable in this
+backend until KWin adds a public window-list protocol or D-Bus API.
+
+The backend still delivers native Wayland layer-shell positioning and
+proper workspace tracking via KWin's ``VirtualDesktopManager`` D-Bus
+interface.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING
+
+from gi.repository import Gio, GLib
+
+from docking.platform.backends.base import (
+    ActionResult,
+    DesktopActionService,
+    DisplayServer,
+    IdleService,
+    PlatformCapabilities,
+    PreviewService,
+    Rect,
+    ScreenCaptureService,
+    SessionBackend,
+    SurfaceService,
+    VisibilityMonitor,
+    VisibilityService,
+    WindowId,
+    WindowPickService,
+    WindowService,
+    WindowSnapshot,
+    WorkspaceService,
+    WorkspaceSnapshot,
+)
+from docking.platform.backends.kwin.atspi_window import (
+    AtspiWindowService,
+)
+from docking.platform.backends.reduced.services import (
+    ReducedPreviewService,
+    ReducedVisibilityService,
+)
+
+if TYPE_CHECKING:
+    from docking.platform.launcher import Launcher
+    from docking.platform.model import DockModel
+
+from docking.log import get_logger
+
+log = get_logger(name="kwin_backend")
+
+
+# ---------------------------------------------------------------------------
+# Workspace Service (KWin VirtualDesktopManager D-Bus)
+# ---------------------------------------------------------------------------
+
+
+class KWinWorkspaceService(WorkspaceService):
+    """WorkspaceService backed by KWin's D-Bus VirtualDesktopManager."""
+
+    def __init__(self) -> None:
+        self._active_id: str = ""
+        self._workspaces: dict[str, WorkspaceSnapshot] = {}
+        self._watchers: dict[object, Callable[[], None]] = {}
+        self._signal_id: int = 0
+        self._proxy: Gio.DBusProxy | None = None
+
+    def start(self) -> None:
+        try:
+            self._proxy = Gio.DBusProxy.new_for_bus_sync(
+                Gio.BusType.SESSION,
+                Gio.DBusProxyFlags.NONE,
+                None,
+                "org.kde.KWin",
+                "/VirtualDesktopManager",
+                "org.kde.KWin.VirtualDesktopManager",
+                None,
+            )
+            self._refresh()
+            self._signal_id = self._proxy.connect(
+                "g-properties-changed",
+                self._on_properties_changed,
+            )
+            log.info("KWin workspace service: connected to VirtualDesktopManager")
+        except Exception:
+            log.exception("KWin workspace service: D-Bus connection failed")
+            self._proxy = None
+
+    def stop(self) -> None:
+        if self._proxy is not None and self._signal_id:
+            self._proxy.disconnect(self._signal_id)
+            self._signal_id = 0
+        self._proxy = None
+        self._workspaces.clear()
+        self._watchers.clear()
+
+    def list_workspaces(self) -> Sequence[WorkspaceSnapshot]:
+        return list(self._workspaces.values())
+
+    def active_workspace(self) -> WorkspaceSnapshot | None:
+        return self._workspaces.get(self._active_id)
+
+    def activate(self, workspace_id: str) -> ActionResult:
+        if self._proxy is None:
+            return ActionResult.UNSUPPORTED
+        try:
+            variant = GLib.Variant("(ssv)", (
+                "org.kde.KWin.VirtualDesktopManager",
+                "current",
+                GLib.Variant("s", workspace_id),
+            ))
+            self._proxy.call_sync(
+                "org.freedesktop.DBus.Properties.Set",
+                variant,
+                Gio.DBusCallFlags.NONE,
+                500,
+                None,
+            )
+            return ActionResult.OK
+        except Exception:
+            return ActionResult.FAILED
+
+    def watch_active_workspace(self, on_change: Callable[[], None]) -> object | None:
+        handle = object()
+        self._watchers[handle] = on_change
+        return handle
+
+    def unwatch_active_workspace(self, handle: object) -> None:
+        self._watchers.pop(handle, None)
+
+    def _refresh(self) -> None:
+        if self._proxy is None:
+            return
+        try:
+            current = self._proxy.get_cached_property("current")
+            if current is not None:
+                self._active_id = current.get_string()
+        except Exception:
+            pass
+
+        try:
+            desktops_v = self._proxy.get_cached_property("desktops")
+            count_v = self._proxy.get_cached_property("count")
+            if desktops_v is not None and count_v is not None:
+                desktops = desktops_v.unpack()
+                n = count_v.get_uint32()
+                self._workspaces.clear()
+                for entry in desktops[:n]:
+                    # Each entry is (position, id, name)
+                    pos, ws_id, name = entry
+                    self._workspaces[str(ws_id)] = WorkspaceSnapshot(
+                        id=str(ws_id),
+                        number=int(pos) + 1,
+                        name=str(name),
+                        active=(str(ws_id) == self._active_id),
+                    )
+        except Exception:
+            log.exception("KWin workspace service: failed to parse workspaces")
+
+    def _on_properties_changed(
+        self,
+        proxy: Gio.DBusProxy,
+        changed: GLib.Variant,
+        invalidated: list[str],
+    ) -> None:
+        changed_dict = changed.unpack()
+        needs_refresh = False
+
+        if "current" in changed_dict:
+            new_active = str(changed_dict["current"])
+            if new_active != self._active_id:
+                prev = self._workspaces.get(self._active_id)
+                if prev is not None:
+                    self._workspaces[self._active_id] = WorkspaceSnapshot(
+                        id=prev.id, number=prev.number, name=prev.name, active=False,
+                    )
+                self._active_id = new_active
+                curr = self._workspaces.get(new_active)
+                if curr is not None:
+                    self._workspaces[new_active] = WorkspaceSnapshot(
+                        id=curr.id, number=curr.number, name=curr.name, active=True,
+                    )
+                for cb in list(self._watchers.values()):
+                    try:
+                        cb()
+                    except Exception:
+                        pass
+
+        if "desktops" in changed_dict or "count" in changed_dict:
+            needs_refresh = True
+
+        if needs_refresh:
+            self._refresh()
+            for cb in list(self._watchers.values()):
+                try:
+                    cb()
+                except Exception:
+                    pass
+
+
+# ---------------------------------------------------------------------------
+# Session Backend
+# ---------------------------------------------------------------------------
+
+
+class KWinSessionBackend(SessionBackend):
+    """SessionBackend for KDE Plasma 6 native Wayland.
+
+    Provides native Wayland layer-shell positioning and KWin workspace
+    tracking.  Window listing is not available because KWin 6 does not
+    expose a public window-list protocol to third-party clients.
+    """
+
+    def __init__(
+        self,
+        *,
+        layer_shell: object,
+        launcher: Launcher,
+        model: DockModel,
+    ) -> None:
+        from docking.platform.backends.wayland.services import (
+            WaylandLayerShellSurfaceService,
+        )
+
+        self._surface = WaylandLayerShellSurfaceService(layer_shell=layer_shell)
+        self._windows = AtspiWindowService(launcher=launcher, model=model)
+        self._workspaces = KWinWorkspaceService()
+        self._visibility = ReducedVisibilityService()
+        self._previews = ReducedPreviewService()
+
+    @property
+    def name(self) -> str:
+        return "kwin"
+
+    @property
+    def display_server(self) -> DisplayServer:
+        return DisplayServer.WAYLAND
+
+    @property
+    def capabilities(self) -> PlatformCapabilities:
+        return PlatformCapabilities(
+            tracks_windows=True,
+            tracks_active_window=True,
+            tracks_minimized=False,
+            tracks_maximized=False,
+            tracks_fullscreen=False,
+            tracks_window_geometry=True,
+            supports_activate=False,
+            supports_minimize=False,
+            supports_close=False,
+            supports_workspace_list=True,
+            supports_workspace_switch=True,
+            supports_layer_shell=True,
+            supports_screen_reservation=True,
+            supports_input_region=True,
+        )
+
+    @property
+    def windows(self) -> WindowService:
+        return self._windows
+
+    @property
+    def surface(self) -> SurfaceService:
+        return self._surface
+
+    @property
+    def visibility(self) -> VisibilityService:
+        return self._visibility
+
+    @property
+    def previews(self) -> PreviewService:
+        return self._previews
+
+    @property
+    def workspaces(self) -> WorkspaceService | None:
+        return self._workspaces
+
+    @property
+    def desktop_actions(self) -> DesktopActionService | None:
+        return None
+
+    @property
+    def screen_capture(self) -> ScreenCaptureService | None:
+        return None
+
+    @property
+    def idle(self) -> IdleService | None:
+        return None
+
+    @property
+    def window_picker(self) -> WindowPickService | None:
+        return None
+
+    def start(self) -> None:
+        self._surface.start()
+        self._windows.start()
+        self._workspaces.start()
+        self._visibility.start()
+        self._previews.start()
+
+    def stop(self) -> None:
+        self._previews.stop()
+        self._visibility.stop()
+        self._workspaces.stop()
+        self._windows.stop()
+        self._surface.stop()

--- a/docking/platform/backends/kwin/session.py
+++ b/docking/platform/backends/kwin/session.py
@@ -133,11 +133,14 @@ class KWinWorkspaceService(WorkspaceService):
         if self._proxy is None:
             return ActionResult.UNSUPPORTED
         try:
-            variant = GLib.Variant("(ssv)", (
-                "org.kde.KWin.VirtualDesktopManager",
-                "current",
-                GLib.Variant("s", workspace_id),
-            ))
+            variant = GLib.Variant(
+                "(ssv)",
+                (
+                    "org.kde.KWin.VirtualDesktopManager",
+                    "current",
+                    GLib.Variant("s", workspace_id),
+                ),
+            )
             self._proxy.call_sync(
                 "org.freedesktop.DBus.Properties.Set",
                 variant,
@@ -201,13 +204,19 @@ class KWinWorkspaceService(WorkspaceService):
                 prev = self._workspaces.get(self._active_id)
                 if prev is not None:
                     self._workspaces[self._active_id] = WorkspaceSnapshot(
-                        id=prev.id, number=prev.number, name=prev.name, active=False,
+                        id=prev.id,
+                        number=prev.number,
+                        name=prev.name,
+                        active=False,
                     )
                 self._active_id = new_active
                 curr = self._workspaces.get(new_active)
                 if curr is not None:
                     self._workspaces[new_active] = WorkspaceSnapshot(
-                        id=curr.id, number=curr.number, name=curr.name, active=True,
+                        id=curr.id,
+                        number=curr.number,
+                        name=curr.name,
+                        active=True,
                     )
                 for cb in list(self._watchers.values()):
                     with contextlib.suppress(Exception):

--- a/docking/platform/backends/selection.py
+++ b/docking/platform/backends/selection.py
@@ -27,6 +27,7 @@ from docking.platform.environment import (
     Desktop,
     backend_name,
     detect_desktop,
+    is_kde_session,
     is_wayland_session,
     is_x11_backend,
 )
@@ -91,11 +92,31 @@ def create_session_backend(
         return _create_reduced_backend(
             reason=f"COSMIC backend unavailable after DOCKING_BACKEND={requested}"
         )
+    if requested in {"kwin", "kde", "plasma", "kwin-script"}:
+        backend = _create_kwin_backend(
+            launcher=launcher,
+            model=model,
+            reason=f"requested by DOCKING_BACKEND={requested}",
+        )
+        if backend is not None:
+            return backend
+        return _create_reduced_backend(
+            reason=f"KWin backend unavailable after DOCKING_BACKEND={requested}"
+        )
 
     if not is_x11_backend():
         # COSMIC takes priority on its native desktop
         if detect_desktop() is Desktop.COSMIC:
             backend = _create_cosmic_backend(
+                launcher=launcher,
+                model=model,
+                reason=_non_x11_reason(),
+            )
+            if backend is not None:
+                return backend
+        # KWin / KDE Plasma native backend
+        if is_kde_session():
+            backend = _create_kwin_backend(
                 launcher=launcher,
                 model=model,
                 reason=_non_x11_reason(),
@@ -213,6 +234,40 @@ def _create_cosmic_backend(
         log.info("COSMIC backend unavailable: compositor does not support layer-shell")
         return None
     backend = CosmicSessionBackend(
+        layer_shell=layer_shell,
+        launcher=launcher,
+        model=model,
+    )
+    log.info("Selected session backend: %s (%s)", backend.name, reason)
+    return backend
+
+
+def _create_kwin_backend(
+    *, launcher: Launcher, model: DockModel, reason: str
+) -> SessionBackend | None:
+    from docking.platform.backends.kwin.session import KWinSessionBackend
+    from docking.platform.backends.wayland.services import (
+        layer_shell_is_supported,
+        load_gtk_layer_shell,
+    )
+
+    layer_shell = load_gtk_layer_shell()
+    if layer_shell is None:
+        log.info("KWin backend unavailable: GtkLayerShell not installed")
+        return None
+    if not layer_shell_is_supported(layer_shell):
+        # layer_shell_is_supported uses the current GDK backend, which
+        # returns False when GDK defaults to X11 even though the Wayland
+        # compositor supports layer-shell.  On a KDE Wayland session we
+        # know KWin supports layer-shell, so only reject on non-Wayland.
+        if not is_wayland_session():
+            log.info(
+                "KWin backend unavailable: compositor does not "
+                "support layer-shell (try GDK_BACKEND=wayland)"
+            )
+            return None
+
+    backend = KWinSessionBackend(
         layer_shell=layer_shell,
         launcher=launcher,
         model=model,

--- a/docking/platform/backends/selection.py
+++ b/docking/platform/backends/selection.py
@@ -255,17 +255,16 @@ def _create_kwin_backend(
     if layer_shell is None:
         log.info("KWin backend unavailable: GtkLayerShell not installed")
         return None
-    if not layer_shell_is_supported(layer_shell):
+    if not layer_shell_is_supported(layer_shell) and not is_wayland_session():
         # layer_shell_is_supported uses the current GDK backend, which
         # returns False when GDK defaults to X11 even though the Wayland
         # compositor supports layer-shell.  On a KDE Wayland session we
         # know KWin supports layer-shell, so only reject on non-Wayland.
-        if not is_wayland_session():
-            log.info(
-                "KWin backend unavailable: compositor does not "
-                "support layer-shell (try GDK_BACKEND=wayland)"
-            )
-            return None
+        log.info(
+            "KWin backend unavailable: compositor does not "
+            "support layer-shell (try GDK_BACKEND=wayland)"
+        )
+        return None
 
     backend = KWinSessionBackend(
         layer_shell=layer_shell,

--- a/packaging/deb/org.docking.Docking.desktop
+++ b/packaging/deb/org.docking.Docking.desktop
@@ -7,3 +7,5 @@ Icon=org.docking.Docking
 Categories=Utility;GTK;
 Terminal=false
 StartupNotify=false
+
+X-KDE-Wayland-Interfaces=zkde_screencast_unstable_v1

--- a/packaging/shared/org.docking.Docking.desktop
+++ b/packaging/shared/org.docking.Docking.desktop
@@ -7,3 +7,4 @@ Icon=org.docking.Docking
 Categories=Utility;GTK;
 Terminal=false
 StartupNotify=false
+X-KDE-Wayland-Interfaces=zkde_screencast_unstable_v1


### PR DESCRIPTION
Implements a native session backend for KDE Plasma 6 on Wayland.

## What works

- **Layer-shell dock positioning** via `gtk-layer-shell` — the dock anchors correctly to screen edges
- **Window tracking with titles** via the AT-SPI2 accessibility bus — KWin 6 does not expose `wlr_foreign_toplevel_management_v1` or any public window-list Wayland protocol, so the backend walks each application's accessible object tree
- **Workspace switching** via KWin's `VirtualDesktopManager` D-Bus API with live property-change notifications
- **Auto-detection** on KDE Wayland sessions, with override via `DOCKING_BACKEND=kde`, `kwin`, or `plasma`
- **Desktop file** updated with `X-KDE-Wayland-Interfaces` for future screencast protocol support

## What is not yet available (KWin 6 limitations)

- Window actions (activate, minimize, close) — KWin 6 has no public window-management protocol
- Window previews — deferred to a follow-up PR (the `KWinPreviewService` targeting `org.kde.KWin.ScreenShot2` is included but gated behind KWin authorization)
- Active-window highlighting — KWin does not expose the focused window through a public API