### PR TITLE
Fix Wayland popup coordinates

### DIFF
--- a/docking/platform/backends/wayland/services.py
+++ b/docking/platform/backends/wayland/services.py
@@ -84,12 +84,30 @@ class WaylandLayerShellSurfaceService(SurfaceService):
         self._window: object | None = None
         self._exclusive_zone: int = 0
         self._on_layer_surface_ready = on_layer_surface_ready
+        self._surface_x: int | None = None
+        self._surface_y: int | None = None
+        self._monitor: MonitorSnapshot | None = None
 
     def start(self) -> None:
         """No service-level runtime loop is needed."""
 
     def stop(self) -> None:
         """No service-level resources are held."""
+        self._window = None
+        self._surface_x = None
+        self._surface_y = None
+        self._monitor = None
+
+    @property
+    def popups_use_parent_relative_coordinates(self) -> bool:
+        """Layer-shell GTK popups are positioned relative to their parent."""
+        return True
+
+    def get_surface_position(self) -> tuple[int, int] | None:
+        """Return the last compositor placement requested for the dock."""
+        if self._surface_x is not None and self._surface_y is not None:
+            return self._surface_x, self._surface_y
+        return None
 
     def configure_before_realize(self, window: object) -> None:
         """Assign the layer-shell role before the GTK window is mapped."""
@@ -137,7 +155,10 @@ class WaylandLayerShellSurfaceService(SurfaceService):
         if position is None:
             return
 
-        self._set_monitor(request.monitor)
+        self._surface_x = request.x
+        self._surface_y = request.y
+        self._monitor = request.monitor
+        self._set_monitor_for_window(window, request.monitor)
         self._set_anchors(position)
         self._set_margins(position=position, gap=0)
         _call_if_available(
@@ -198,6 +219,9 @@ class WaylandLayerShellSurfaceService(SurfaceService):
         window = self._window
         if window is None:
             return
+        self._set_monitor_for_window(window, monitor)
+
+    def _set_monitor_for_window(self, window: object, monitor: MonitorSnapshot) -> None:
         display = _call_if_available(window, "get_display")
         if display is None:
             return

--- a/docking/ui/display.py
+++ b/docking/ui/display.py
@@ -35,6 +35,55 @@ class ScreenPosition(NamedTuple):
     y: int
 
 
+def backend_surface_position(window: object) -> ScreenPosition | None:
+    """Return backend-owned screen coordinates for a window, when known."""
+    surface_service = window_surface_service(window)
+    get_surface_position = getattr(surface_service, "get_surface_position", None)
+    if not callable(get_surface_position):
+        return None
+    try:
+        position = get_surface_position()
+    except Exception as exc:
+        log.debug("Failed to query backend surface position: %s", exc)
+        return None
+    if position is None:
+        return None
+    try:
+        x, y = position
+    except (TypeError, ValueError):
+        return None
+    try:
+        return ScreenPosition(x=int(x), y=int(y))
+    except (TypeError, ValueError):
+        return None
+
+
+def window_screen_position(window: Gtk.Window) -> ScreenPosition:
+    """Return the best known screen position for a GTK window.
+
+    Native Wayland backends can position the dock through the compositor, which
+    means GTK may report ``(0, 0)`` even when the surface is edge-anchored on a
+    monitor.  Prefer the backend-owned position when it exists and fall back to
+    GTK for X11 and generic GTK sessions.
+    """
+    backend_position = backend_surface_position(window)
+    if backend_position is not None:
+        return backend_position
+    x, y = window.get_position()
+    return ScreenPosition(x=int(x), y=int(y))
+
+
+def window_surface_service(window: object) -> object | None:
+    """Return an explicitly attached surface service, if one exists."""
+    try:
+        attrs = vars(window)
+    except TypeError:
+        return None
+    if "surface_service" in attrs:
+        return attrs["surface_service"]
+    return None
+
+
 def get_pointer_position(display: Gdk.Display) -> ScreenPosition | None:
     """Return screen coordinates of the pointer, or *None* if unavailable."""
     seat = display.get_default_seat()
@@ -79,16 +128,25 @@ def clamp_popup(
     regardless of ``set_transient_for``, so we clamp to the screen.
 
     On Wayland a popup with a transient parent receives *parent-relative*
-    coordinates, and the compositor handles on-screen clamping for us.
+    coordinates, and the compositor handles on-screen clamping for us. Callers
+    pass screen-absolute coordinates; this helper converts them to parent-local
+    coordinates when the backend reports a known parent surface position.
     Which coordinate space is in use is determined by the surface service
     backing the transient parent (``popups_use_parent_relative_coordinates``
     property).
     """
     parent = popup.get_transient_for()
+    surface_service = window_surface_service(parent) if parent is not None else None
     if (
         parent is not None
-        and parent.surface_service.popups_use_parent_relative_coordinates
+        and getattr(surface_service, "popups_use_parent_relative_coordinates", False)
     ):
+        parent_position = backend_surface_position(parent)
+        if parent_position is not None:
+            return ScreenPosition(
+                x=popup_x - parent_position.x,
+                y=popup_y - parent_position.y,
+            )
         return ScreenPosition(x=popup_x, y=popup_y)
     # Screen-absolute or no parent: clamp to screen bounds.
     screen = popup.get_screen()

--- a/docking/ui/display.py
+++ b/docking/ui/display.py
@@ -38,11 +38,10 @@ class ScreenPosition(NamedTuple):
 def backend_surface_position(window: object) -> ScreenPosition | None:
     """Return backend-owned screen coordinates for a window, when known."""
     surface_service = window_surface_service(window)
-    get_surface_position = getattr(surface_service, "get_surface_position", None)
-    if not callable(get_surface_position):
+    if surface_service is None:
         return None
     try:
-        position = get_surface_position()
+        position = surface_service.get_surface_position()
     except Exception as exc:
         log.debug("Failed to query backend surface position: %s", exc)
         return None
@@ -139,7 +138,8 @@ def clamp_popup(
     surface_service = window_surface_service(parent) if parent is not None else None
     if (
         parent is not None
-        and getattr(surface_service, "popups_use_parent_relative_coordinates", False)
+        and surface_service is not None
+        and surface_service.popups_use_parent_relative_coordinates
     ):
         parent_position = backend_surface_position(parent)
         if parent_position is not None:

--- a/docking/ui/dnd.py
+++ b/docking/ui/dnd.py
@@ -163,7 +163,7 @@ from docking.core.config import PinnedEntry
 from docking.core.items import APP_KIND, APPLET_KIND, FILE_KIND, FOLDER_KIND, DockItem
 from docking.core.position import Position, is_horizontal
 from docking.log import get_logger
-from docking.ui.display import get_pointer_position
+from docking.ui.display import get_pointer_position, window_screen_position
 from docking.ui.geometry import DockGeometryBuilder
 from docking.ui.poof import show_poof
 
@@ -659,7 +659,8 @@ class DnDHandler:
             pos = get_pointer_position(display)
             screen_x = pos.x if pos is not None else 0
             screen_y = pos.y if pos is not None else 0
-            win_x, win_y = self._window.get_position()
+            window_pos = window_screen_position(self._window)
+            win_x, win_y = window_pos.x, window_pos.y
             win_w, win_h = self._window.get_size()
 
             # Outside if cursor moved away from the dock edge

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -215,6 +215,7 @@ from docking.platform.launcher import launch, launch_new_window, open_target
 from docking.ui import geometry
 from docking.ui.about import AboutDialogController
 from docking.ui.autohide import AutoHideController, HideState
+from docking.ui.display import window_screen_position
 from docking.ui.dnd import DnDHandler
 from docking.ui.effects import ZoomAnimator
 from docking.ui.geometry import (
@@ -633,7 +634,8 @@ class DockWindow(Gtk.Window):
         geometry = frame.geometry_for_item(item)
         if geometry is None:
             return None
-        win_x, win_y = self.get_position()
+        window_pos = window_screen_position(self)
+        win_x, win_y = window_pos.x, window_pos.y
         x, y = geometry.anchor_point(
             win_x=win_x,
             win_y=win_y,
@@ -836,7 +838,8 @@ class DockWindow(Gtk.Window):
     ) -> None:
         item_geometry = frame.geometry_for_item(item)
         if item_geometry is not None:
-            win_x, win_y = self.get_position()
+            window_pos = window_screen_position(self)
+            win_x, win_y = window_pos.x, window_pos.y
             anchor_x, anchor_y = item_geometry.anchor_point(
                 win_x=win_x,
                 win_y=win_y,
@@ -844,7 +847,8 @@ class DockWindow(Gtk.Window):
             )
             icon_w = int(item_geometry.draw_rect.w)
         else:
-            win_x, win_y = self.get_position()
+            window_pos = window_screen_position(self)
+            win_x, win_y = window_pos.x, window_pos.y
             anchor_x = win_x + int(fallback_x)
             anchor_y = win_y + int(fallback_y)
             icon_w = int(self.config.icon_size)

--- a/docking/ui/factory.py
+++ b/docking/ui/factory.py
@@ -31,6 +31,7 @@ from docking.platform.backends.base import (
 )
 from docking.platform.launcher import Launcher
 from docking.platform.model import DockModel
+from docking.ui.display import window_screen_position
 from docking.ui.dock_window import DockWindow
 from docking.ui.renderer import DockRenderer
 
@@ -62,7 +63,8 @@ def build_dock_window(
     def _get_dock_rect() -> Rect | None:
         if not window.get_realized():
             return None
-        wx, wy = window.get_position()
+        window_pos = window_screen_position(window)
+        wx, wy = window_pos.x, window_pos.y
         dock_rect = window.geometry.build_frame().background_rect
         return Rect(
             x=wx + dock_rect.x,

--- a/docking/ui/hover.py
+++ b/docking/ui/hover.py
@@ -176,6 +176,7 @@ from gi.repository import GLib
 from docking.core.position import Position
 from docking.log import get_logger
 from docking.ui.autohide import HideState
+from docking.ui.display import window_screen_position
 from docking.ui.geometry import DockGeometryBuilder, DockGeometryFrame
 
 log = get_logger(name="hover")
@@ -352,7 +353,8 @@ class HoverManager:
             return False
         pos = self._config.pos
 
-        win_x, win_y = self._window.get_position()
+        window_pos = window_screen_position(self._window)
+        win_x, win_y = window_pos.x, window_pos.y
         draw_rect = geometry.draw_rect
         main_size = (
             draw_rect.w if pos in (Position.BOTTOM, Position.TOP) else draw_rect.h

--- a/docking/ui/interaction.py
+++ b/docking/ui/interaction.py
@@ -267,18 +267,41 @@ class DockInteractionCoordinator:
         if pos is None:
             return False
         try:
-            window_pos = window_screen_position(self._window)
-            win_x, win_y = window_pos.x, window_pos.y
+            gtk_x, gtk_y = self._window.get_position()
         except Exception as exc:
             log.debug(
-                "Failed to query pointer/window position for dock hit test: %s",
+                "Failed to query GTK window position for dock hit test: %s",
                 exc,
             )
             return False
 
-        local_x = pos.x - win_x
-        local_y = pos.y - win_y
-        return point_inside_input_rect(frame, x=local_x, y=local_y)
+        if _point_inside_frame_at_window_position(
+            frame=frame,
+            screen_x=pos.x,
+            screen_y=pos.y,
+            window_x=int(gtk_x),
+            window_y=int(gtk_y),
+        ):
+            return True
+
+        try:
+            backend_pos = window_screen_position(self._window)
+        except Exception as exc:
+            log.debug(
+                "Failed to query backend window position for dock hit test: %s",
+                exc,
+            )
+            return False
+        if backend_pos.x == int(gtk_x) and backend_pos.y == int(gtk_y):
+            return False
+
+        return _point_inside_frame_at_window_position(
+            frame=frame,
+            screen_x=pos.x,
+            screen_y=pos.y,
+            window_x=backend_pos.x,
+            window_y=backend_pos.y,
+        )
 
     def on_effective_enter(self) -> None:
         if self._window.dock_hovered:
@@ -347,3 +370,16 @@ class DockInteractionCoordinator:
         if input_rect is None:
             return False
         return input_rect.contains(x, y)
+
+
+def _point_inside_frame_at_window_position(
+    *,
+    frame: object,
+    screen_x: int,
+    screen_y: int,
+    window_x: int,
+    window_y: int,
+) -> bool:
+    local_x = screen_x - window_x
+    local_y = screen_y - window_y
+    return point_inside_input_rect(frame, x=local_x, y=local_y)

--- a/docking/ui/interaction.py
+++ b/docking/ui/interaction.py
@@ -183,7 +183,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from docking.log import get_logger
-from docking.ui.display import get_pointer_position
+from docking.ui.display import get_pointer_position, window_screen_position
 from docking.ui.geometry import current_input_rect, point_inside_input_rect
 
 if TYPE_CHECKING:
@@ -267,7 +267,8 @@ class DockInteractionCoordinator:
         if pos is None:
             return False
         try:
-            win_x, win_y = self._window.get_position()
+            window_pos = window_screen_position(self._window)
+            win_x, win_y = window_pos.x, window_pos.y
         except Exception as exc:
             log.debug(
                 "Failed to query pointer/window position for dock hit test: %s",

--- a/docking/ui/new_year.py
+++ b/docking/ui/new_year.py
@@ -40,7 +40,7 @@ from docking.core.greeting import consume_new_year_greeting
 from docking.core.position import Position, is_horizontal
 from docking.i18n import _
 from docking.log import get_logger
-from docking.ui.display import clamp_popup
+from docking.ui.display import clamp_popup, window_screen_position
 from docking.ui.tooltip import compute_tooltip_position
 
 log = get_logger("new_year")
@@ -184,7 +184,8 @@ class NewYearGreetingController:
         if self._popup is None:
             return
 
-        win_x, win_y = self._window.get_position()
+        window_pos = window_screen_position(self._window)
+        win_x, win_y = window_pos.x, window_pos.y
         win_w, win_h = self._window.get_size()
         pref = self._popup.get_preferred_size()[1]
         popup_w = max(pref.width, 1)

--- a/docking/ui/tooltip.py
+++ b/docking/ui/tooltip.py
@@ -172,7 +172,7 @@ from gi.repository import Gdk, GLib, Gtk
 
 from docking.core.position import Position
 from docking.log import get_logger
-from docking.ui.display import clamp_popup
+from docking.ui.display import clamp_popup, window_screen_position
 from docking.ui.geometry import DockGeometryFrame
 
 log = get_logger(name="tooltip")
@@ -283,9 +283,9 @@ class TooltipManager:
             self.hide()
             return
         pos = self._config.pos
-        win_x, win_y = self._window.get_position()
-        anchor_x = win_x + item_geometry.anchor_x
-        anchor_y = win_y + item_geometry.anchor_y
+        window_pos = window_screen_position(self._window)
+        anchor_x = window_pos.x + item_geometry.anchor_x
+        anchor_y = window_pos.y + item_geometry.anchor_y
 
         if not content_changed:
             self._cancel_pending_show()

--- a/docking/ui/update_popup.py
+++ b/docking/ui/update_popup.py
@@ -40,7 +40,7 @@ from docking.core.updates import (
 )
 from docking.i18n import _
 from docking.log import get_logger
-from docking.ui.display import clamp_popup
+from docking.ui.display import clamp_popup, window_screen_position
 from docking.ui.tooltip import compute_tooltip_position
 
 if TYPE_CHECKING:
@@ -214,7 +214,8 @@ class UpdateCheckController:
     def _position_popup(self) -> None:
         if self._popup is None:
             return
-        win_x, win_y = self._window.get_position()
+        window_pos = window_screen_position(self._window)
+        win_x, win_y = window_pos.x, window_pos.y
         win_w, win_h = self._window.get_size()
         pref = self._popup.get_preferred_size()[1]
         popup_w = max(pref.width, 1)

--- a/tests/platform/test_wayland_layer_shell_session.py
+++ b/tests/platform/test_wayland_layer_shell_session.py
@@ -252,6 +252,26 @@ def test_position_or_anchor_maps_placement_to_layer_shell():
     window.set_size_request.assert_called_with(64, 560)
     window.resize.assert_called_with(64, 560)
     window.move.assert_not_called()
+    assert service.popups_use_parent_relative_coordinates is True
+    assert service.get_surface_position() == (100, 220)
+
+
+def test_layer_shell_surface_position_clears_on_stop():
+    service = WaylandLayerShellSurfaceService(layer_shell=_layer_shell())
+    service.configure_before_realize(MagicMock())
+
+    service.position_or_anchor(
+        PlacementRequest(
+            monitor=_monitor_snapshot(),
+            position=Position.BOTTOM,
+            x=100,
+            y=720,
+            size=Size(width=800, height=64),
+        )
+    )
+    service.stop()
+
+    assert service.get_surface_position() is None
 
 
 def test_reservation_updates_layer_shell_exclusive_zone():

--- a/tests/ui/test_interaction.py
+++ b/tests/ui/test_interaction.py
@@ -271,6 +271,36 @@ class TestPointerContainment:
 
         assert coordinator.pointer_inside_input_rect() is False
 
+    def test_pointer_inside_input_rect_prefers_gtk_coordinate_space(self):
+        window, _item = _make_window()
+        window.get_position.return_value = (0, 0)
+        window.surface_service = SimpleNamespace(
+            get_surface_position=lambda: (0, 1000),
+        )
+        pointer = SimpleNamespace(get_position=MagicMock(return_value=(None, 50, 50)))
+        seat = SimpleNamespace(get_pointer=lambda: pointer)
+        display = SimpleNamespace(get_default_seat=lambda: seat)
+        window.get_display.return_value = display
+        coordinator = DockInteractionCoordinator(window)
+
+        assert coordinator.pointer_inside_input_rect() is True
+
+    def test_pointer_inside_input_rect_falls_back_to_backend_surface_position(self):
+        window, _item = _make_window()
+        window.get_position.return_value = (0, 0)
+        window.surface_service = SimpleNamespace(
+            get_surface_position=lambda: (100, 1000),
+        )
+        pointer = SimpleNamespace(
+            get_position=MagicMock(return_value=(None, 100, 1050))
+        )
+        seat = SimpleNamespace(get_pointer=lambda: pointer)
+        display = SimpleNamespace(get_default_seat=lambda: seat)
+        window.get_display.return_value = display
+        coordinator = DockInteractionCoordinator(window)
+
+        assert coordinator.pointer_inside_input_rect() is True
+
     def test_point_inside_event_frame_returns_false_without_input_rect(self):
         window, _item = _make_window()
         window._cache.geometry_frame = None

--- a/tests/ui/test_tooltip.py
+++ b/tests/ui/test_tooltip.py
@@ -770,3 +770,65 @@ class TestTooltipIntegrationBranches:
         show_tooltip.assert_called_once()
         kwargs = show_tooltip.call_args.kwargs
         assert kwargs["widget"] is built_widget
+
+    def test_update_uses_backend_surface_position_for_wayland_anchor(
+        self, monkeypatch
+    ):
+        window = MagicMock()
+        window.get_position.return_value = (0, 0)
+        window.surface_service = SimpleNamespace(
+            get_surface_position=lambda: (100, 200),
+            popups_use_parent_relative_coordinates=True,
+        )
+        config = SimpleNamespace(
+            pos=Position.BOTTOM,
+            icon_size=48,
+            tooltips_enabled=True,
+        )
+        item = _make_item("Weather")
+        tooltip = TooltipManager(
+            window,
+            config,
+            MagicMock(),
+            SimpleNamespace(launch_bounce_height=0.0),
+        )
+        show_tooltip = MagicMock()
+        tooltip._show_tooltip = show_tooltip  # type: ignore[method-assign]
+        frame = _frame_for_item(item, anchor_x=40.0, anchor_y=10.0)
+        monkeypatch.setattr(
+            tooltip_mod.GLib, "idle_add", lambda callback: callback() or 1
+        )
+
+        tooltip.update(item=item, geometry=frame)
+
+        kwargs = show_tooltip.call_args.kwargs
+        assert kwargs["anchor_x"] == 140.0
+        assert kwargs["anchor_y"] == 210.0
+
+    def test_show_tooltip_converts_absolute_position_to_parent_relative_wayland(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(tooltip_mod, "Gtk", _FakeGtk)
+        monkeypatch.setattr(tooltip_mod, "Gdk", _FakeGdk)
+        window = MagicMock()
+        window.surface_service = SimpleNamespace(
+            get_surface_position=lambda: (100, 200),
+            popups_use_parent_relative_coordinates=True,
+        )
+        tooltip = TooltipManager(
+            window,
+            SimpleNamespace(icon_size=48),
+            MagicMock(),
+            SimpleNamespace(launch_bounce_height=0.0),
+        )
+
+        tooltip._show_tooltip(
+            text="Weather",
+            pos=Position.BOTTOM,
+            anchor_x=140.0,
+            anchor_y=210.0,
+            widget=None,
+            content_changed=True,
+        )
+
+        assert tooltip._tooltip_window._moved == (-20, -30)

--- a/tests/ui/test_tooltip.py
+++ b/tests/ui/test_tooltip.py
@@ -771,9 +771,7 @@ class TestTooltipIntegrationBranches:
         kwargs = show_tooltip.call_args.kwargs
         assert kwargs["widget"] is built_widget
 
-    def test_update_uses_backend_surface_position_for_wayland_anchor(
-        self, monkeypatch
-    ):
+    def test_update_uses_backend_surface_position_for_wayland_anchor(self, monkeypatch):
         window = MagicMock()
         window.get_position.return_value = (0, 0)
         window.surface_service = SimpleNamespace(


### PR DESCRIPTION
## Summary
- track backend-owned Wayland dock surface positions for popup placement instead of relying on Gtk.Window.get_position()
- convert transient popup coordinates to parent-relative coordinates when the backend reports Wayland popup semantics
- update tooltip and other popup/anchor call sites to use the shared screen-position helper
- preserve GTK pointer-coordinate containment for autohide so the dock remains hovered while the cursor is still on the shelf/icon area

## Validation
- .venv/bin/pytest tests/ui/test_tooltip.py tests/platform/test_wayland_layer_shell_session.py
- .venv/bin/pytest tests/ui/test_interaction.py
- .venv/bin/pytest tests/ui/test_tooltip.py tests/platform/test_wayland_layer_shell_session.py tests/ui/test_interaction.py tests/ui/test_dock_window_integration.py tests/ui/test_pointer_scenarios.py tests/ui/test_dnd_integration.py tests/ui/test_factory.py
- .venv/bin/ruff check docking/ui/interaction.py tests/ui/test_interaction.py
- git diff --check