### PR TITLE
Grey out backend-unsupported settings with explanatory tooltips

### DIFF
--- a/docking/app.py
+++ b/docking/app.py
@@ -135,6 +135,8 @@ def main() -> None:
         preview_service=backend.previews,
         surface_service=backend.surface,
         visibility_service=backend.visibility,
+        capabilities=backend.capabilities,
+        display_server=backend.display_server,
         launcher=launcher,
     )
     items_service = DockItemsService(model=model, window=window)

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -205,6 +205,8 @@ from docking.core.position import is_horizontal
 from docking.i18n import _
 from docking.log import get_logger
 from docking.platform.backends.base import (
+    DisplayServer,
+    PlatformCapabilities,
     PreviewService,
     Rect,
     SurfaceService,
@@ -345,6 +347,8 @@ class DockWindow(Gtk.Window):
         launcher: Launcher,
         preview_service: PreviewService,
         surface_service: SurfaceService,
+        capabilities: PlatformCapabilities,
+        display_server: DisplayServer,
     ) -> None:
         super().__init__(type=Gtk.WindowType.TOPLEVEL)
         self.config = config
@@ -354,6 +358,8 @@ class DockWindow(Gtk.Window):
         self.window_tracker = window_tracker
         self.preview_service = preview_service
         self.surface_service = surface_service
+        self._backend_capabilities = capabilities
+        self._backend_display_server = display_server
         self.cursor_x: float = -1.0
         self.cursor_y: float = -1.0
         self.autohide: AutoHideController

--- a/docking/ui/factory.py
+++ b/docking/ui/factory.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 from docking.core.config import Config
 from docking.core.theme import Theme
 from docking.platform.backends.base import (
+    DisplayServer,
+    PlatformCapabilities,
     PreviewService,
     Rect,
     SurfaceService,
@@ -46,6 +48,8 @@ def build_dock_window(
     preview_service: PreviewService,
     surface_service: SurfaceService,
     visibility_service: VisibilityService,
+    capabilities: PlatformCapabilities,
+    display_server: DisplayServer,
     launcher: Launcher,
 ) -> DockWindow:
     """Build a fully wired dock window and its UI collaborators."""
@@ -58,6 +62,8 @@ def build_dock_window(
         launcher=launcher,
         preview_service=preview_service,
         surface_service=surface_service,
+        capabilities=capabilities,
+        display_server=display_server,
     )
 
     def _get_dock_rect() -> Rect | None:

--- a/docking/ui/runtime.py
+++ b/docking/ui/runtime.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from docking.core.theme import Theme
+    from docking.platform.backends.base import DisplayServer, PlatformCapabilities
     from docking.ui.dock_window import DockWindow
     from docking.ui.update_popup import UpdateCheckController
 
@@ -90,3 +91,13 @@ class DockRuntime:
 
     def open_releases_page(self) -> None:
         self._update_checker.open_releases_page()
+
+    @property
+    def capabilities(self) -> PlatformCapabilities:
+        """Backend capabilities for the current session."""
+        return self._window._backend_capabilities
+
+    @property
+    def display_server(self) -> DisplayServer:
+        """Display-server family for the current session."""
+        return self._window._backend_display_server

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -76,6 +76,7 @@ from docking.core.theme import Theme, list_theme_names
 from docking.core.updates import load_state
 from docking.i18n import _
 from docking.log import get_logger
+from docking.platform.backends.base import DisplayServer
 
 if TYPE_CHECKING:
     from docking.core.config import Config
@@ -1065,7 +1066,16 @@ class SettingsWindowController:
         self._runtime.set_active_display(active)
         self._runtime.reposition()
 
+    _ACTIVE_DISPLAY_WAYLAND_TOOLTIP: ClassVar[str] = _(
+        "This feature requires global pointer tracking,"
+        " which is not available on Wayland."
+    )
+    _PRESSURE_REVEAL_WAYLAND_TOOLTIP: ClassVar[str] = _(
+        "Pressure reveal requires pointer barriers, which are only available on X11."
+    )
+
     def _update_dependent_sensitivity(self) -> None:
+        # Config-driven sensitivity (independent of backend)
         if self._zoom_percent_spin is not None:
             self._zoom_percent_spin.set_sensitive(bool(self._config.zoom_enabled))
         hide_controls_sensitive = self._config.hide_mode not in (
@@ -1076,10 +1086,45 @@ class SettingsWindowController:
             self._hide_delay_spin.set_sensitive(hide_controls_sensitive)
         if self._unhide_delay_spin is not None:
             self._unhide_delay_spin.set_sensitive(hide_controls_sensitive)
+
+        # Backend-driven sensitivity
+        caps = self._runtime.capabilities
+        wayland = self._runtime.display_server == DisplayServer.WAYLAND
+
+        # Active Display ("Follow Cursor") — needs global pointer tracking
+        if self._active_display_switch is not None:
+            if wayland:
+                self._active_display_switch.set_sensitive(False)
+                self._active_display_switch.set_tooltip_text(
+                    self._ACTIVE_DISPLAY_WAYLAND_TOOLTIP
+                )
+            else:
+                self._active_display_switch.set_sensitive(True)
+                self._active_display_switch.set_tooltip_text("")
+
+        # Pressure Reveal — needs pointer barriers (X11-only)
+        if self._pressure_reveal_switch is not None:
+            if not caps.supports_pointer_barrier:
+                self._pressure_reveal_switch.set_sensitive(False)
+                self._pressure_reveal_switch.set_tooltip_text(
+                    self._PRESSURE_REVEAL_WAYLAND_TOOLTIP
+                )
+            else:
+                self._pressure_reveal_switch.set_sensitive(True)
+                self._pressure_reveal_switch.set_tooltip_text("")
+
+        # Pressure Threshold — same gate as Pressure Reveal
         if self._pressure_threshold_scale is not None:
-            self._pressure_threshold_scale.set_sensitive(
-                bool(self._config.pressure_reveal_enabled)
-            )
+            if not caps.supports_pointer_barrier:
+                self._pressure_threshold_scale.set_sensitive(False)
+                self._pressure_threshold_scale.set_tooltip_text(
+                    self._PRESSURE_REVEAL_WAYLAND_TOOLTIP
+                )
+            else:
+                self._pressure_threshold_scale.set_sensitive(
+                    bool(self._config.pressure_reveal_enabled)
+                )
+                self._pressure_threshold_scale.set_tooltip_text("")
 
     def _on_applet_toggled(
         self,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -208,6 +208,8 @@ class TestAppMain:
             preview_service=preview_service,
             surface_service=surface_service,
             visibility_service=visibility_service,
+            capabilities=backend.capabilities,
+            display_server=backend.display_server,
             launcher=launcher,
         )
         backend.start.assert_called_once()

--- a/tests/ui/test_factory.py
+++ b/tests/ui/test_factory.py
@@ -8,6 +8,10 @@ from typing import cast
 from unittest.mock import MagicMock
 
 import docking.ui.factory as factory_mod
+from docking.platform.backends.base import DisplayServer, PlatformCapabilities
+
+_FAKE_CAPABILITIES = PlatformCapabilities()
+_FAKE_DISPLAY_SERVER = DisplayServer.X11
 
 
 class TestBuildDockWindow:
@@ -40,6 +44,8 @@ class TestBuildDockWindow:
             preview_service=preview_service,
             surface_service=surface_service,
             visibility_service=visibility_service,
+            capabilities=_FAKE_CAPABILITIES,
+            display_server=_FAKE_DISPLAY_SERVER,
             launcher=launcher,
         )
 
@@ -53,6 +59,8 @@ class TestBuildDockWindow:
             launcher=launcher,
             preview_service=preview_service,
             surface_service=surface_service,
+            capabilities=_FAKE_CAPABILITIES,
+            display_server=_FAKE_DISPLAY_SERVER,
         )
         kwargs = visibility_service.create_monitor.call_args.kwargs
         assert callable(kwargs["get_dock_rect"])
@@ -85,6 +93,8 @@ class TestBuildDockWindow:
             preview_service=preview_service,
             surface_service=surface_service,
             visibility_service=visibility_service,
+            capabilities=_FAKE_CAPABILITIES,
+            display_server=_FAKE_DISPLAY_SERVER,
             launcher=launcher,
         )
 
@@ -134,6 +144,8 @@ class TestBuildDockWindow:
             preview_service=preview_service,
             surface_service=surface_service,
             visibility_service=visibility_service,
+            capabilities=_FAKE_CAPABILITIES,
+            display_server=_FAKE_DISPLAY_SERVER,
             launcher=launcher,
         )
 
@@ -175,6 +187,8 @@ class TestBuildDockWindow:
             preview_service=preview_service,
             surface_service=surface_service,
             visibility_service=visibility_service,
+            capabilities=_FAKE_CAPABILITIES,
+            display_server=_FAKE_DISPLAY_SERVER,
             launcher=launcher,
         )
 

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -252,6 +252,7 @@ class FakeSpinButton:
         self.callbacks: dict[str, object] = {}
         self.properties: dict[str, object] = {}
         self.sensitive = True
+        self.tooltip_text = ""
 
     @classmethod
     def new_with_range(cls, *_args):
@@ -277,6 +278,9 @@ class FakeSpinButton:
     def set_sensitive(self, value: bool) -> None:
         self.sensitive = value
 
+    def set_tooltip_text(self, value: str) -> None:
+        self.tooltip_text = value
+
     def set_size_request(self, width: int, height: int) -> None:
         self.size_request = (width, height)
 
@@ -301,6 +305,7 @@ class FakeSwitch:
         self._active = False
         self.callbacks: dict[str, object] = {}
         self.sensitive = True
+        self.tooltip_text = ""
 
     def connect(self, signal: str, callback, *args) -> None:
         self.callbacks[signal] = (callback, args)
@@ -317,6 +322,9 @@ class FakeSwitch:
 
     def set_sensitive(self, value: bool) -> None:
         self.sensitive = value
+
+    def set_tooltip_text(self, value: str) -> None:
+        self.tooltip_text = value
 
 
 class FakeCheckButton(FakeSwitch):


### PR DESCRIPTION
On Wayland the 'Follow Cursor' setting has no effect because GDK 3
cannot track the global pointer position. Similarly 'Pressure Reveal'
depends on X11 pointer barriers. These settings are now greyed out
when the current backend does not support them, with tooltips
explaining why.

### Changes
- Pass `PlatformCapabilities` and `DisplayServer` through the object graph
  (app.py → factory → DockWindow → DockRuntime)
- Extend `_update_dependent_sensitivity()` to gate on backend support
- 'Follow Cursor' disabled on Wayland with tooltip about global pointer tracking
- 'Pressure Reveal' and 'Pressure Threshold' disabled when pointer barriers
  are unsupported (X11-only)
- Add `set_tooltip_text` to FakeSwitch and FakeSpinButton test doubles
- Update factory and app tests for the new `build_dock_window` signature