### PR TITLE
Fix settings info popovers on Wayland

### DIFF
--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -42,8 +42,9 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import gi
 
 gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
 gi.require_version("GdkPixbuf", "2.0")
-from gi.repository import GLib, Gtk
+from gi.repository import Gdk, GLib, Gtk
 
 from docking.applets import get_applet_catalog
 from docking.applets.base import load_catalog_icon
@@ -113,6 +114,7 @@ TRANSPARENCY_PERCENT_SCALE = 100
 TRANSPARENCY_PERCENT_STEP = 5
 HIDE_DELAY_MAX_MS = 5000
 HIDE_DELAY_STEP_MS = 50
+INFO_POPOVER_PADDING_PX = 8
 log = get_logger("settings")
 
 
@@ -497,15 +499,50 @@ class SettingsWindowController:
         icon = Gtk.EventBox()
         icon.set_visible_window(False)
         icon.set_size_request(HIDE_MODE_INFO_ICON_WIDTH_PX, -1)
-        if tooltip:
-            icon.set_tooltip_text(tooltip)
+        icon.add_events(
+            Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK
+        )
         icon.add(
             Gtk.Image.new_from_icon_name(
                 "dialog-information-symbolic",
                 Gtk.IconSize.MENU,
             )
         )
+
+        popover = Gtk.Popover.new(icon)
+        popover.set_modal(False)
+        popover.set_position(Gtk.PositionType.TOP)
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        content.set_border_width(INFO_POPOVER_PADDING_PX)
+        label = Gtk.Label()
+        label.set_xalign(0.0)
+        label.set_line_wrap(True)
+        label.set_max_width_chars(48)
+        content.pack_start(label, False, False, 0)
+        popover.add(content)
+
+        icon._docking_info_popover = popover
+        icon._docking_info_label = label
+        icon._docking_info_text = ""
+        icon.connect("enter-notify-event", self._on_info_icon_enter)
+        icon.connect("leave-notify-event", self._on_info_icon_leave)
+        self._set_info_icon_text(icon, tooltip)
         return icon
+
+    def _set_info_icon_text(self, icon: Gtk.Widget, text: str) -> None:
+        icon._docking_info_text = text
+        icon._docking_info_label.set_label(text)
+
+    def _on_info_icon_enter(self, icon: Gtk.Widget, _event) -> bool:
+        if not icon._docking_info_text:
+            return False
+        icon._docking_info_popover.show_all()
+        icon._docking_info_popover.popup()
+        return False
+
+    def _on_info_icon_leave(self, icon: Gtk.Widget, _event) -> bool:
+        icon._docking_info_popover.popdown()
+        return False
 
     def _build_applets_tab(self) -> Gtk.Widget:
         scroller = Gtk.ScrolledWindow()
@@ -1055,7 +1092,7 @@ class SettingsWindowController:
             return
         mode = self._hide_mode_combo.get_active_id() or "none"
         desc = self._HIDE_MODE_DESCRIPTIONS.get(mode, "")
-        self._hide_mode_info.set_tooltip_text(desc)
+        self._set_info_icon_text(self._hide_mode_info, desc)
 
     def _after_tooltips_changed(self, active: bool) -> None:
         if not active:

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -362,6 +362,8 @@ class FakeImage:
     def __init__(self, source: object) -> None:
         self.source = source
         self.pixel_size = None
+        self.size_request = None
+        self.tooltip_text = None
 
     @classmethod
     def new_from_icon_name(cls, icon_name: str, icon_size):
@@ -373,6 +375,12 @@ class FakeImage:
 
     def set_pixel_size(self, value: int) -> None:
         self.pixel_size = value
+
+    def set_size_request(self, width: int, height: int) -> None:
+        self.size_request = (width, height)
+
+    def set_tooltip_text(self, value: str) -> None:
+        self.tooltip_text = value
 
 
 class FakePixbuf:
@@ -406,6 +414,8 @@ class FakeEventBox:
         self.visible_window = True
         self.size_request = None
         self.tooltip_text = None
+        self.events = 0
+        self.callbacks: dict[str, object] = {}
 
     def set_visible_window(self, value: bool) -> None:
         self.visible_window = value
@@ -413,11 +423,60 @@ class FakeEventBox:
     def set_size_request(self, width: int, height: int) -> None:
         self.size_request = (width, height)
 
+    def add_events(self, events: int) -> None:
+        self.events |= events
+
+    def connect(self, signal: str, callback) -> None:
+        self.callbacks[signal] = callback
+
     def set_tooltip_text(self, value: str) -> None:
         self.tooltip_text = value
 
     def add(self, child) -> None:
         self.child = child
+
+    def emit_enter(self) -> None:
+        callback = self.callbacks.get("enter-notify-event")
+        if callback is not None:
+            callback(self, object())
+
+    def emit_leave(self) -> None:
+        callback = self.callbacks.get("leave-notify-event")
+        if callback is not None:
+            callback(self, object())
+
+
+class FakePopover:
+    def __init__(self, relative_to) -> None:
+        self.relative_to = relative_to
+        self.child = None
+        self.modal = True
+        self.position = None
+        self.popup_count = 0
+        self.popdown_count = 0
+        self.show_all_count = 0
+
+    @classmethod
+    def new(cls, relative_to):
+        return cls(relative_to)
+
+    def set_modal(self, value: bool) -> None:
+        self.modal = value
+
+    def set_position(self, value) -> None:
+        self.position = value
+
+    def add(self, child) -> None:
+        self.child = child
+
+    def show_all(self) -> None:
+        self.show_all_count += 1
+
+    def popup(self) -> None:
+        self.popup_count += 1
+
+    def popdown(self) -> None:
+        self.popdown_count += 1
 
 
 class FakeScrolledWindow:
@@ -453,6 +512,15 @@ class FakeAlign:
 
 class FakeIconSize:
     MENU = 0
+
+
+class FakePositionType:
+    TOP = 0
+
+
+class FakeEventMask:
+    ENTER_NOTIFY_MASK = 1
+    LEAVE_NOTIFY_MASK = 2
 
 
 class FakeWindowPosition:
@@ -494,13 +562,19 @@ class FakeGtk:
     Button = FakeButton
     Image = FakeImage
     EventBox = FakeEventBox
+    Popover = FakePopover
     ScrolledWindow = FakeScrolledWindow
     Orientation = FakeOrientation
     PolicyType = FakePolicyType
     Align = FakeAlign
     IconSize = FakeIconSize
+    PositionType = FakePositionType
     WindowPosition = FakeWindowPosition
     Settings = FakeGtkSettings
+
+
+class FakeGdk:
+    EventMask = FakeEventMask
 
 
 def _config():
@@ -538,6 +612,7 @@ def _config():
 class TestSettingsWindowController:
     def test_show_reuses_single_window_and_builds_four_tabs(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
         monkeypatch.setattr(
             settings_mod, "load_catalog_icon", lambda applet_id, size: None
         )
@@ -600,6 +675,7 @@ class TestSettingsWindowController:
 
     def test_numeric_spin_buttons_use_simple_im_context(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
         monkeypatch.setattr(
             settings_mod, "load_catalog_icon", lambda applet_id, size: None
         )
@@ -630,6 +706,7 @@ class TestSettingsWindowController:
 
     def test_hide_controls_exist_only_in_behavior_tab(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
         monkeypatch.setattr(
             settings_mod, "load_catalog_icon", lambda applet_id, size: None
         )
@@ -676,6 +753,7 @@ class TestSettingsWindowController:
 
     def test_pressure_threshold_uses_info_icon_tooltip(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
         monkeypatch.setattr(
             settings_mod, "load_catalog_icon", lambda applet_id, size: None
         )
@@ -716,7 +794,25 @@ class TestSettingsWindowController:
             controller._pressure_threshold_info,
         ]
         assert isinstance(controller._pressure_threshold_info, FakeEventBox)
-        assert "cursor pressure" in controller._pressure_threshold_info.tooltip_text
+        assert controller._pressure_threshold_info.tooltip_text is None
+        assert controller._pressure_threshold_info.events == (
+            FakeEventMask.ENTER_NOTIFY_MASK | FakeEventMask.LEAVE_NOTIFY_MASK
+        )
+        assert "cursor pressure" in (
+            controller._pressure_threshold_info._docking_info_label.get_label()
+        )
+
+        controller._pressure_threshold_info.emit_enter()
+        popover = controller._pressure_threshold_info._docking_info_popover
+        assert isinstance(popover.child, FakeBox)
+        assert popover.child.border_width == settings_mod.INFO_POPOVER_PADDING_PX
+        assert popover.child.get_children() == [
+            controller._pressure_threshold_info._docking_info_label
+        ]
+        assert popover.show_all_count == 1
+        assert popover.popup_count == 1
+        controller._pressure_threshold_info.emit_leave()
+        assert popover.popdown_count == 1
 
     def test_theme_change_updates_config_and_runtime(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)


### PR DESCRIPTION
## Summary
- replace GTK tooltip text on settings info icons with hover-triggered popovers
- anchor the popovers to the info icons so Wayland does not hit child-window tooltip positioning failures
- add padded popover content and focused settings tests

## Tests
- .venv/bin/ruff check docking/ui/settings.py tests/ui/test_settings.py
- .venv/bin/pytest tests/ui/test_settings.py