### PR TITLE
Anchor applet popups to dock icons

### DIFF
--- a/docking/applets/base.py
+++ b/docking/applets/base.py
@@ -79,6 +79,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GdkPixbuf, GLib, Gtk, Pango, PangoCairo
 
 from docking.applets.identity import applet_desktop_id
+from docking.applets.popup import PopupAnchor
 from docking.core.items import APPLET_KIND, DockItem
 from docking.log import get_logger
 
@@ -343,6 +344,7 @@ class Applet(ABC):
         self._config = config
         self._icon_size = icon_size
         self._notify: Callable[[], None] | None = None
+        self._popup_anchor: PopupAnchor | None = None
         self.item = DockItem(
             desktop_id=self.desktop_id,
             kind=APPLET_KIND,
@@ -426,6 +428,15 @@ class Applet(ABC):
     def on_clicked(self) -> None:
         """Handle left-click (default: no-op)."""
         return
+
+    @property
+    def popup_anchor(self) -> PopupAnchor | None:
+        """Most recent dock icon anchor for applet-owned popup surfaces."""
+        return self._popup_anchor
+
+    def set_popup_anchor(self, anchor: PopupAnchor | None) -> None:
+        """Update the dock icon anchor used by applet-owned popup surfaces."""
+        self._popup_anchor = anchor
 
     def on_scroll(self, direction_up: bool) -> None:
         """Handle scroll wheel on applet icon (default: no-op)."""

--- a/docking/applets/calculator/applet.py
+++ b/docking/applets/calculator/applet.py
@@ -116,6 +116,7 @@ class CalculatorApplet(Applet):
             window=self._popup,
             content=self._build_popup_content(),
             gap_px=POPUP_CURSOR_GAP_PX,
+            anchor=self.popup_anchor,
         )
 
     def _build_popup_content(self) -> Gtk.Box:

--- a/docking/applets/calendar/applet.py
+++ b/docking/applets/calendar/applet.py
@@ -104,4 +104,5 @@ class CalendarApplet(Applet):
             window=self._popup,
             content=calendar,
             gap_px=CALENDAR_POPUP_CURSOR_GAP_PX,
+            anchor=self.popup_anchor,
         )

--- a/docking/applets/popup.py
+++ b/docking/applets/popup.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import gi
 
@@ -23,7 +24,8 @@ gi.require_version("Gdk", "3.0")
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, Gtk
 
-from docking.ui.display import clamp_to_screen, get_pointer_position
+from docking.core.position import Position
+from docking.ui.display import clamp_popup, clamp_to_screen, get_pointer_position
 
 _POPUP_CLASS = "applet-popup-surface"
 _POPUP_CSS = f"""
@@ -40,6 +42,16 @@ _popup_css_provider: Gtk.CssProvider | None = None
 DEFAULT_POPUP_CURSOR_GAP_PX = 20
 DEFAULT_DIALOG_CONTENT_SPACING_PX = 8
 DEFAULT_DIALOG_MARGIN_PX = 12
+
+
+@dataclass(frozen=True, slots=True)
+class PopupAnchor:
+    """Screen-space applet popup anchor."""
+
+    x: int
+    y: int
+    position: Position
+    parent: Gtk.Window | None = None
 
 
 def entry_completion_combo(
@@ -134,15 +146,50 @@ def show_wrapped_popup(
     window: Gtk.Window,
     content: Gtk.Widget,
     gap_px: int = DEFAULT_POPUP_CURSOR_GAP_PX,
+    anchor: PopupAnchor | None = None,
 ) -> None:
-    """Replace popup content, show it, and place it near the pointer."""
+    """Replace popup content, show it, and place it near the applet anchor."""
     child = window.get_child()
     if child:
         window.remove(child)
 
+    if anchor is not None and anchor.parent is not None:
+        window.set_transient_for(anchor.parent)
+        window.set_attached_to(anchor.parent)
     window.add(wrap_popup(content))
     window.show_all()
-    position_popup_near_pointer(window=window, gap_px=gap_px)
+    if anchor is not None:
+        position_popup_near_anchor(window=window, anchor=anchor, gap_px=gap_px)
+    else:
+        position_popup_near_pointer(window=window, gap_px=gap_px)
+
+
+def position_popup_near_anchor(
+    *,
+    window: Gtk.Window,
+    anchor: PopupAnchor,
+    gap_px: int = DEFAULT_POPUP_CURSOR_GAP_PX,
+) -> None:
+    """Position a popup near an icon anchor, clamped to the current screen."""
+    pref = window.get_preferred_size()[1]
+    popup_w = max(pref.width, 1)
+    popup_h = max(pref.height, 1)
+
+    if anchor.position == Position.BOTTOM:
+        popup_x = int(anchor.x - popup_w / 2)
+        popup_y = int(anchor.y - popup_h - gap_px)
+    elif anchor.position == Position.TOP:
+        popup_x = int(anchor.x - popup_w / 2)
+        popup_y = int(anchor.y + gap_px)
+    elif anchor.position == Position.LEFT:
+        popup_x = int(anchor.x + gap_px)
+        popup_y = int(anchor.y - popup_h / 2)
+    else:
+        popup_x = int(anchor.x - popup_w - gap_px)
+        popup_y = int(anchor.y - popup_h / 2)
+
+    popup_pos = clamp_popup(window, popup_x, popup_y, popup_w, popup_h)
+    window.move(popup_pos.x, popup_pos.y)
 
 
 def position_popup_near_pointer(

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -199,6 +199,7 @@ gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk, GLib, Gtk
 
 from docking.applets.identity import is_applet_desktop_id as is_applet
+from docking.applets.popup import PopupAnchor
 from docking.core.config import FolderStackUnfold, LeftClickAction, MiddleClickAction
 from docking.core.items import FILE_KIND, FOLDER_KIND
 from docking.core.position import is_horizontal
@@ -927,6 +928,7 @@ class DockWindow(Gtk.Window):
             if is_applet(desktop_id=item.desktop_id):
                 applet = self.model.get_applet(item.desktop_id)
                 if applet:
+                    applet.set_popup_anchor(self._popup_anchor_for_item(item, frame))
                     applet.on_clicked()
                     # Refresh tooltip immediately so applet name/tooltip
                     # changes are visible without waiting for pointer motion.
@@ -985,6 +987,28 @@ class DockWindow(Gtk.Window):
                 self.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
 
         return True
+
+    def _popup_anchor_for_item(
+        self,
+        item: DockItem,
+        frame: DockGeometryFrame,
+    ) -> PopupAnchor | None:
+        """Build the current screen-space popup anchor for one dock item."""
+        item_geometry = frame.geometry_for_item(item)
+        if item_geometry is None:
+            return None
+        window_pos = window_screen_position(self)
+        anchor_x, anchor_y = item_geometry.anchor_point(
+            win_x=window_pos.x,
+            win_y=window_pos.y,
+            position=self.config.pos,
+        )
+        return PopupAnchor(
+            x=anchor_x,
+            y=anchor_y,
+            position=self.config.pos,
+            parent=self,
+        )
 
     def _on_scroll(self, _widget: Gtk.DrawingArea, event: Gdk.EventScroll) -> bool:
         """Forward scroll events to the applet under the cursor, if any.

--- a/tests/applets/test_calculator.py
+++ b/tests/applets/test_calculator.py
@@ -255,8 +255,9 @@ class TestAppletPopup:
             applet._entry.connect("activate", lambda _entry: applet._do_evaluate())
             return {"expr": applet._last_expr}
 
-        def show_wrapped_popup(*, window, content, gap_px):
+        def show_wrapped_popup(*, window, content, gap_px, anchor=None):
             _ = gap_px
+            assert anchor is applet.popup_anchor
             window.add(content)
             window.show_all()
             window.move(80, 80)
@@ -338,6 +339,7 @@ class TestAppletPopup:
             window=fake_popup,
             content="content",
             gap_px=calculator_applet_mod.POPUP_CURSOR_GAP_PX,
+            anchor=None,
         )
         applet.stop()
 

--- a/tests/applets/test_calendar.py
+++ b/tests/applets/test_calendar.py
@@ -233,10 +233,11 @@ class TestCalendarPopup:
         fake_popup = _FakePopupWindow()
         shown: dict[str, object] = {}
 
-        def show_wrapped_popup(*, window, content, gap_px):
+        def show_wrapped_popup(*, window, content, gap_px, anchor=None):
             shown["window"] = window
             shown["content"] = content
             shown["gap_px"] = gap_px
+            shown["anchor"] = anchor
             window.add(content)
             window.show_all()
 
@@ -264,6 +265,7 @@ class TestCalendarPopup:
         assert shown["window"] is fake_popup
         assert isinstance(shown["content"], _FakeCalendar)
         assert shown["gap_px"] == calendar_applet_mod.CALENDAR_POPUP_CURSOR_GAP_PX
+        assert shown["anchor"] is None
 
     def test_stop_destroys_popup(self):
         # Given

--- a/tests/applets/test_popup.py
+++ b/tests/applets/test_popup.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import docking.applets.popup as popup
+from docking.core.position import Position
 from docking.ui.display import ScreenPosition
 
 
@@ -51,6 +52,8 @@ class _FakePopupWindow:
         self.type_hint = None
         self.accept_focus = None
         self.focus_on_map = None
+        self.transient_for = None
+        self.attached_to = None
 
     def set_decorated(self, value: bool) -> None:
         self.decorated = value
@@ -69,6 +72,15 @@ class _FakePopupWindow:
 
     def set_type_hint(self, hint) -> None:
         self.type_hint = hint
+
+    def set_transient_for(self, parent) -> None:
+        self.transient_for = parent
+
+    def set_attached_to(self, parent) -> None:
+        self.attached_to = parent
+
+    def get_transient_for(self):
+        return self.transient_for
 
     def get_child(self):
         return self.child
@@ -302,6 +314,35 @@ def test_show_wrapped_popup_replaces_content_and_positions(monkeypatch):
     position.assert_called_once_with(window=window, gap_px=24)
 
 
+def test_show_wrapped_popup_positions_from_anchor(monkeypatch):
+    window = _FakePopupWindow()
+    wrapped = object()
+    parent = object()
+    anchor = popup.PopupAnchor(
+        x=40,
+        y=50,
+        position=Position.BOTTOM,
+        parent=parent,
+    )
+    position_anchor = MagicMock()
+    position_pointer = MagicMock()
+    monkeypatch.setattr(popup, "wrap_popup", lambda _content: wrapped)
+    monkeypatch.setattr(popup, "position_popup_near_anchor", position_anchor)
+    monkeypatch.setattr(popup, "position_popup_near_pointer", position_pointer)
+
+    popup.show_wrapped_popup(
+        window=window,
+        content="content",
+        gap_px=12,
+        anchor=anchor,
+    )
+
+    assert window.transient_for is parent
+    assert window.attached_to is parent
+    position_anchor.assert_called_once_with(window=window, anchor=anchor, gap_px=12)
+    position_pointer.assert_not_called()
+
+
 def test_position_popup_near_pointer_clamps_to_screen(monkeypatch):
     window = _FakePopupWindow()
     monkeypatch.setattr(popup.Gdk.Display, "get_default", lambda: object())
@@ -314,6 +355,15 @@ def test_position_popup_near_pointer_clamps_to_screen(monkeypatch):
     popup.position_popup_near_pointer(window=window, gap_px=20)
 
     assert window.moved_to == (0, 0)
+
+
+def test_position_popup_near_anchor_uses_bottom_edge():
+    window = _FakePopupWindow()
+    anchor = popup.PopupAnchor(x=50, y=60, position=Position.BOTTOM)
+
+    popup.position_popup_near_anchor(window=window, anchor=anchor, gap_px=10)
+
+    assert window.moved_to == (10, 10)
 
 
 def test_prepare_dialog_content_applies_standard_layout():

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -73,6 +73,9 @@ def _bind_geometry_signature(stub):
     stub._show_folder_stack_for_item = MethodType(
         dock_window_mod.DockWindow._show_folder_stack_for_item, stub
     )
+    stub._popup_anchor_for_item = MethodType(
+        dock_window_mod.DockWindow._popup_anchor_for_item, stub
+    )
     return stub
 
 
@@ -155,6 +158,10 @@ class TestButtonReleaseFlow:
         # Given
         item = DockItem(desktop_id="applet://quote")
         stub, _ = _make_stub(item=item)
+        stub._test_geometry_frame.geometry_for_item.return_value = SimpleNamespace(
+            draw_rect=SimpleNamespace(x=4, y=5, w=48, h=48),
+            anchor_point=lambda *, win_x, win_y, position: (win_x + 4, win_y + 5),
+        )
         applet = MagicMock()
         stub.model.get_applet.return_value = applet
         event = SimpleNamespace(
@@ -173,6 +180,11 @@ class TestButtonReleaseFlow:
         )
         # Then
         assert handled is True
+        anchor = applet.set_popup_anchor.call_args.args[0]
+        assert anchor.x == 104
+        assert anchor.y == 205
+        assert anchor.position == Position.BOTTOM
+        assert anchor.parent is stub
         applet.on_clicked.assert_called_once()
         stub.tooltip.update.assert_called_once_with(item, stub._test_geometry_frame)
         stub.hover.start_anim_pump.assert_called_once_with(350)


### PR DESCRIPTION
## Summary
- pass geometry-derived dock icon anchors to applets before click handling
- position shared applet popup windows from those anchors instead of the pointer
- route popup coordinates through the backend-aware clamp_popup helper for Wayland parent-relative positioning
- update Calculator and Calendar to use the stored popup anchor