### PR TITLE
Add missing Claude Opus 4.7/4.8 and Sonnet 4.5/4.6 pricing tiers

### DIFF
--- a/docking/applets/aiusage/state.py
+++ b/docking/applets/aiusage/state.py
@@ -48,10 +48,14 @@ _OPUS46 = {"input": 5.0, "output": 25.0, "cache_write": 6.25, "cache_read": 0.50
 _OPUS4 = {"input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50}
 
 CLAUDE_PRICING: tuple[tuple[str, dict[str, float]], ...] = (
-    ("opus-4-5", _OPUS46),
+    ("opus-4-8", _OPUS46),
+    ("opus-4-7", _OPUS46),
     ("opus-4-6", _OPUS46),
+    ("opus-4-5", _OPUS46),
     ("opus-4-1", _OPUS4),
     ("opus-4", _OPUS4),
+    ("sonnet-4-6", {"input": 3, "output": 15, "cache_write": 3.75, "cache_read": 0.30}),
+    ("sonnet-4-5", {"input": 3, "output": 15, "cache_write": 3.75, "cache_read": 0.30}),
     ("sonnet", {"input": 3, "output": 15, "cache_write": 3.75, "cache_read": 0.30}),
     ("haiku-4-5", {"input": 1, "output": 5, "cache_write": 1.25, "cache_read": 0.10}),
     ("haiku", {"input": 0.80, "output": 4, "cache_write": 1.0, "cache_read": 0.08}),


### PR DESCRIPTION
## Problem

The AI usage applet uses substring matching to map model IDs to pricing tiers. Model IDs like `claude-opus-4-8` fell through all specific tiers and matched the generic `opus-4` catch-all, which maps to the **old $15/$75 per MTok** pricing — 3x the correct rate.

## Fix

Added explicit pricing entries for missing models, ordered most-specific-first:

| Model | Input | Output | Cache Write | Cache Read |
|-------|-------|--------|-------------|------------|
| opus-4-8 | $5 | $25 | $6.25 | $0.50 |
| opus-4-7 | $5 | $25 | $6.25 | $0.50 |
| sonnet-4-6 | $3 | $15 | $3.75 | $0.30 |
| sonnet-4-5 | $3 | $15 | $3.75 | $0.30 |

Prices verified against the current [Anthropic pricing page](https://docs.anthropic.com/en/docs/about-claude/pricing). The existing prices for all other models remain correct.

## Verification

- All 90 existing tests pass
- ruff format + lint clean
- Manual verification of matching:
  - `claude-opus-4-8` → tier `opus-4-8` → $5.00/M (was $15.00/M before)
  - `claude-opus-4-7` → tier `opus-4-7` → $5.00/M (was $15.00/M before)
  - Legacy `claude-opus-4-20250514` still correctly matches `opus-4` → $15.00/M