### PR TITLE
Replace getattr with direct attribute access for Config fields in placement.py

### DIFF
--- a/docking/ui/placement.py
+++ b/docking/ui/placement.py
@@ -421,14 +421,14 @@ class DockPlacementController:
                     monitor=monitor,
                     monitor_idx=self._monitor_index(display=display, monitor=monitor),
                 ),
-                position=getattr(self._window.config, "pos", Position.BOTTOM),
+                position=self._window.config.pos,
                 thickness=strut_height,
             )
         )
 
     def update_barrier(self) -> None:
         """Create or destroy the pointer barrier based on autohide state."""
-        position = getattr(self._window.config, "pos", Position.BOTTOM)
+        position = self._window.config.pos
         if self._window.config.hide_mode in ("none", "always-on-top"):
             self._surface.update_pointer_barrier(
                 monitor=None,
@@ -543,17 +543,14 @@ class DockPlacementController:
 
     def _resolve_target_monitor(self, display: Gdk.Display) -> Gdk.Monitor | None:
         """Resolve configured monitor, falling back to primary monitor."""
-        if (
-            getattr(self._window.config, "active_display", False)
-            and self._active_monitor is not None
-        ):
+        if self._window.config.active_display and self._active_monitor is not None:
             return self._active_monitor
 
         n_monitors = display.get_n_monitors()
         if n_monitors <= 0:
             return None
 
-        selected = int(getattr(self._window.config, "monitor_index", -1))
+        selected = int(self._window.config.monitor_index)
         if 0 <= selected < n_monitors:
             monitor = display.get_monitor(selected)
             if monitor is not None:

--- a/tests/ui/test_placement.py
+++ b/tests/ui/test_placement.py
@@ -582,7 +582,10 @@ class TestPlacementControllerStruts:
     def test_update_barrier_handles_supported_states(self):
         window = _make_window(
             config=SimpleNamespace(
-                hide_mode="none", pressure_reveal_enabled=False, pressure_threshold=50
+                hide_mode="none",
+                pos=Position.BOTTOM,
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
             )
         )
         controller = _make_controller(window)


### PR DESCRIPTION
## Problem

`DockPlacementController` used `getattr(config, 'pos', BOTTOM)` and similar
patterns to access `Config` dataclass fields. These attributes (`pos`,
`active_display`, `monitor_index`) are always present on the `Config`
dataclass — the `getattr` with defaults was unnecessary defensive coding that:

- Obscured type errors (mypy/pyright can't check string-keyed getattr)
- Made refactoring harder (rename `pos` → `position` wouldn't flag these)
- Suggested the attributes might be optional when they never are

## Fix

Replaced four `getattr` calls with direct attribute access:

| Before | After |
|--------|-------|
| `getattr(config, "pos", Position.BOTTOM)` | `config.pos` |
| `getattr(config, "active_display", False)` | `config.active_display` |
| `getattr(config, "monitor_index", -1)` | `config.monitor_index` |

The one remaining `getattr` in placement.py (line 465, for
`self._window.autohide`) is legitimate — it guards against barrier
callbacks firing during teardown when the autohide controller may have
been cleared.

## Broader audit

Reviewed all ~80 `getattr` calls across the production codebase:

- **~50 calls** in Wayland/X11/GNOME protocol dispatch — legitimate dynamic dispatch
- **~14 calls** for feature detection, duck typing, GTK version compat — legitimate
- **~11 calls** for structured data access (logging, config bindings, module discovery) — legitimate
- **4 calls** for DRY timer cleanup (iterating hardcoded timer attr tuples) — legitimate
- **2 calls** for one-off sentinel checks — legitimate
- **4 calls** in placement.py accessing known Config fields — **fixed here**