### PR TITLE
Add first-class Wayland support to all packaging formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,8 +537,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential debhelper dh-python python3-setuptools python3-wheel python3-pip \
+            build-essential debhelper dh-python python3-dev python3-setuptools python3-wheel python3-pip \
             python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-wnck-3.0 \
+            libwayland-dev wayland-protocols \
             pybuild-plugin-pyproject python3-all gettext
 
       - name: Build .deb
@@ -612,8 +613,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential debhelper dh-python python3-setuptools python3-wheel python3-pip \
+            build-essential debhelper dh-python python3-dev python3-setuptools python3-wheel python3-pip \
             python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-wnck-3.0 \
+            libwayland-dev wayland-protocols \
             pybuild-plugin-pyproject python3-all gettext
 
       - name: Build .deb
@@ -872,7 +874,7 @@ jobs:
       - name: Install AppImage tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3-pip libfuse2 gettext
+          sudo apt-get install -y python3-apt python3-pip libfuse2 libgdk-pixbuf2.0-bin libglib2.0-bin libgtk-3-bin squashfs-tools gettext
           python3 -m pip install --upgrade pip
           python3 -m pip install appimage-builder
 
@@ -901,7 +903,7 @@ jobs:
       - name: Install AppImage tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3-pip libfuse2 gettext
+          sudo apt-get install -y python3-apt python3-pip libfuse2 libgdk-pixbuf2.0-bin libglib2.0-bin libgtk-3-bin squashfs-tools gettext
           python3 -m pip install --upgrade pip
           python3 -m pip install appimage-builder
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,7 +691,7 @@ jobs:
       - name: Install RPM tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y rpm python3-pip gettext
+          sudo apt-get install -y rpm python3-pip gettext python3-dev libwayland-dev wayland-protocols gcc
 
       - name: Compile translations
         run: bash tools/i18n.sh --compile
@@ -718,7 +718,7 @@ jobs:
       - name: Install RPM tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y rpm python3-pip gettext
+          sudo apt-get install -y rpm python3-pip gettext python3-dev libwayland-dev wayland-protocols gcc
 
       - name: Compile translations
         run: bash tools/i18n.sh --compile

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -35,7 +35,7 @@ That check confirms:
 
 ```bash
 # Install build dependencies
-sudo apt install debhelper dh-python python3-setuptools python3-wheel python3-pip python3-all pybuild-plugin-pyproject
+sudo apt install debhelper dh-python python3-dev python3-setuptools python3-wheel python3-pip python3-all pybuild-plugin-pyproject libwayland-dev wayland-protocols
 
 # Build .deb
 ./packaging/deb/build.sh
@@ -50,13 +50,14 @@ docking
 
 ### How it works
 
-- **Runtime deps**: system GTK/GI packages plus `python3 (>= 3.10)`
-- **Optional Wayland deps**: native Wayland layer-shell placement requires
-  `gir1.2-gtklayershell-0.1` on Debian/Ubuntu. It should be packaged as an
-  optional/recommended dependency until native Wayland support grows beyond the
-  layer-shell surface backend. Foreign-toplevel taskbar support additionally
-  needs the optional Python `pywayland` runtime for Docking's vendored wlroots
-  protocol binding.
+- **Runtime deps**: system GTK/GI packages plus `python3 (>= 3.10)`.
+  Native Wayland placement is included through Debian/Ubuntu's
+  `gir1.2-gtklayershell-0.1` package.
+- **PyWayland**: the package recommends distro `python3-pywayland` where it is
+  available. The build also installs a Python-minor-specific PyPI fallback under
+  `/usr/lib/docking/vendor-pythonX.Y/` so Jammy-built packages can use the live
+  protocol runtime on matching Python hosts without shadowing newer host Python
+  installations.
 - **Application code**: installed to `/usr/lib/docking/python/` and loaded via the
   `/usr/bin/docking` wrapper so the package stays compatible across supported
   Python 3 minors on the same architecture.
@@ -133,13 +134,14 @@ flatpak run cc.docking.Docking
 
 - App ID is `cc.docking.Docking`; system packages keep the shared
   `org.docking.Docking` desktop file and icons.
-- Native Wayland layer-shell placement needs `gtk-layer-shell` available inside
-  the runtime if the Flatpak is expected to use the native Wayland backend.
+- Native Wayland layer-shell placement is built into the Flatpak through a
+  bundled `gtk-layer-shell` module, and live protocol support is included through
+  `pywayland`.
 - Flatpak build installs hicolor icons and a local `hicolor/index.theme` so
   AppStream icon checks pass in sandboxed builds.
-- The app requires X11 window management behavior, so the Flatpak manifest enables
-  `--socket=x11` and host filesystem access for full functionality. Native
-  Wayland layer-shell mode is reduced until foreign-window services exist.
+- The Flatpak keeps `--socket=x11` for compatibility and also enables
+  `--socket=wayland` so backend selection can use native Wayland where the
+  compositor exposes the required protocols.
 
 ## Snap
 
@@ -169,7 +171,7 @@ Notes:
 
 ```bash
 # Install tooling
-sudo apt install python3-pip libfuse2
+sudo apt install python3-apt python3-pip libfuse2 libgdk-pixbuf2.0-bin libglib2.0-bin libgtk-3-bin squashfs-tools
 python3 -m pip install --upgrade pip
 python3 -m pip install appimage-builder
 
@@ -194,6 +196,7 @@ Notes:
 - Build script: `packaging/appimage/build.sh`
 - Runtime dependencies are bundled from Ubuntu 22.04 packages listed in the recipe.
 - The AppImage build script selects the correct Ubuntu mirror, package architecture, typelib path, and output name for `x86_64` vs `aarch64`.
+- The AppImage bundles GtkLayerShell runtime libraries.
 
 ## RPM
 

--- a/packaging/appimage/AppImageBuilder.yml
+++ b/packaging/appimage/AppImageBuilder.yml
@@ -5,6 +5,8 @@ script:
   - mkdir -p AppDir/usr/lib/python3/dist-packages
   - mkdir -p AppDir/usr/share/applications
   - mkdir -p AppDir/usr/share/icons
+  - mkdir -p AppDir/usr/bin
+  - ln -sf ../lib/__DEB_MULTIARCH__/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders AppDir/usr/bin/gdk-pixbuf-query-loaders
   - python3 -m pip install --upgrade pip
   - python3 -m pip install --no-cache-dir --target AppDir/usr/lib/python3/dist-packages .
   - install -Dm644 packaging/shared/org.docking.Docking.desktop AppDir/usr/share/applications/org.docking.Docking.desktop
@@ -37,16 +39,22 @@ AppDir:
       - python3-gi-cairo
       - python3-cairo
       - gir1.2-gtk-3.0
+      - gir1.2-gtklayershell-0.1
       - gir1.2-gdkpixbuf-2.0
       - gir1.2-wnck-3.0
       - gir1.2-pango-1.0
       - gir1.2-nm-1.0
       - gir1.2-gstreamer-1.0
       - libgtk-3-0
+      - libgtk-layer-shell0
+      - libglib2.0-bin
       - libwnck-3-0
       - libgdk-pixbuf-2.0-0
+      - libgdk-pixbuf2.0-bin
       - libpangocairo-1.0-0
       - libcairo2
+      - libwayland-client0
+      - libwayland-server0
       - libnm0
       - libgstreamer1.0-0
       - librsvg2-common
@@ -58,7 +66,6 @@ AppDir:
       GI_TYPELIB_PATH: __GI_TYPELIB_PATH__
       XDG_DATA_DIRS: $APPDIR/usr/share:$XDG_DATA_DIRS
       GSETTINGS_BACKEND: memory
-      GDK_BACKEND: x11
 
 AppImage:
   arch: __APPIMAGE_ARCH__

--- a/packaging/appimage/build.sh
+++ b/packaging/appimage/build.sh
@@ -34,6 +34,7 @@ sed \
   -e "s|__APT_ARCH__|${apt_arch}|g" \
   -e "s|__APT_MIRROR__|${apt_mirror}|g" \
   -e "s|__APPIMAGE_ARCH__|${appimage_arch}|g" \
+  -e "s|__DEB_MULTIARCH__|${typelib_arch_dir}|g" \
   -e "s|__GI_TYPELIB_PATH__|\\\$APPDIR/usr/lib/${typelib_arch_dir}/girepository-1.0:\\\$APPDIR/usr/lib/girepository-1.0|g" \
   "${RECIPE_TEMPLATE}" > "${tmp_recipe}"
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -9,7 +9,9 @@ depends=(
   'python'
   'python-gobject'
   'python-cairo'
+  'python-pywayland'
   'gtk3'
+  'gtk-layer-shell'
   'libwnck3'
   'networkmanager'
   'gstreamer'
@@ -52,9 +54,6 @@ package() {
 #!/bin/sh
 set -eu
 export PYTHONPATH="/usr/lib/docking/python:/usr/lib/docking/vendor${PYTHONPATH:+:$PYTHONPATH}"
-if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
-  export GDK_BACKEND=x11
-fi
 exec /usr/bin/python3 -m docking.app "$@"
 EOF
 

--- a/packaging/deb/build.sh
+++ b/packaging/deb/build.sh
@@ -4,7 +4,7 @@
 # Usage: ./packaging/deb/build.sh
 #
 # Prerequisites:
-#   sudo apt install debhelper dh-python python3-setuptools python3-wheel
+#   sudo apt install debhelper dh-python python3-dev python3-setuptools python3-wheel libwayland-dev wayland-protocols
 #
 # Output: ../docking_<version>-<debian_revision>_<arch>.deb
 

--- a/packaging/deb/debian/control
+++ b/packaging/deb/debian/control
@@ -11,9 +11,12 @@ Build-Depends:
     dh-python,
     pybuild-plugin-pyproject,
     python3-all,
+    python3-dev,
     python3-setuptools,
     python3-wheel,
     python3-pip,
+    libwayland-dev,
+    wayland-protocols,
     gettext
 
 Package: docking
@@ -26,9 +29,12 @@ Depends:
     gir1.2-gtk-3.0,
     gir1.2-gdk-3.0,
     gir1.2-gdkpixbuf-2.0,
+    gir1.2-gtklayershell-0.1,
     gir1.2-wnck-3.0,
     gir1.2-nm-1.0,
     gir1.2-pango-1.0
+Recommends:
+    python3-pywayland
 Description: A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo
  Inspired by Plank and Cairo-Dock.
  Features parabolic zoom, window previews, autohide, drag-and-drop,
@@ -36,4 +42,4 @@ Description: A lightweight, feature-rich dock for Linux written in Python with G
  trash, weather, CPU monitor, battery, clipboard, applications,
  network, show desktop, session, calendar, workspaces).
  .
- Requires X11.
+ Supports X11 and native Wayland backends where compositor protocols are available.

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -43,6 +43,14 @@ override_dh_auto_install:
 	# packages as system dependencies.
 	rm -rf debian/docking/usr/lib/docking/vendor/*.dist-info
 	rm -rf debian/docking/usr/lib/docking/vendor/bin
+	# PyWayland ships CPython-specific native glue. Keep it in a Python-version
+	# scoped vendor path so the package can still run on newer hosts that use
+	# distro python3-pywayland instead of this fallback.
+	py_minor="$$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" ; \
+	python3 -m pip install --no-compile \
+		--target="debian/docking/usr/lib/docking/vendor-python$${py_minor}" \
+		"pywayland>=0.4.18,<0.5"
+	rm -rf debian/docking/usr/lib/docking/vendor-python*/bin
 	# Drop minor-version-specific accelerators so the package remains compatible
 	# across Python 3.10+ on the same CPU architecture.
 	find debian/docking/usr/lib/docking/vendor -name '*.cpython-*.so' -delete
@@ -51,6 +59,15 @@ override_dh_python3:
 	# Docking installs into private paths under /usr/lib/docking and uses an
 	# explicit python3 (>= 3.10) dependency in debian/control.
 	:
+
+override_dh_dwz:
+	dh_dwz -Xvendor-python
+
+override_dh_strip:
+	dh_strip -Xvendor-python
+
+override_dh_shlibdeps:
+	dh_shlibdeps -Xvendor-python
 
 override_dh_builddeb:
 	# Use xz instead of newer zstd-compressed .deb members so release artifacts

--- a/packaging/deb/docking
+++ b/packaging/deb/docking
@@ -1,11 +1,12 @@
 #!/bin/sh
 set -eu
 
-export PYTHONPATH="/usr/lib/docking/python:/usr/lib/docking/vendor${PYTHONPATH:+:$PYTHONPATH}"
-
-# Force the X11 GTK backend when launched inside a Wayland session.
-if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
-    export GDK_BACKEND=x11
+PYTHON_VERSION="$(/usr/bin/python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+PYWAYLAND_VENDOR="/usr/lib/docking/vendor-python${PYTHON_VERSION}"
+PYTHONPATH_PREFIX="/usr/lib/docking/python:/usr/lib/docking/vendor"
+if [ -d "${PYWAYLAND_VENDOR}" ]; then
+    PYTHONPATH_PREFIX="${PYWAYLAND_VENDOR}:${PYTHONPATH_PREFIX}"
 fi
+export PYTHONPATH="${PYTHONPATH_PREFIX}${PYTHONPATH:+:$PYTHONPATH}"
 
 exec /usr/bin/python3 -m docking.app "$@"

--- a/packaging/flatpak/cc.docking.Docking.json
+++ b/packaging/flatpak/cc.docking.Docking.json
@@ -12,6 +12,7 @@
   "finish-args": [
     "--share=network",
     "--share=ipc",
+    "--socket=wayland",
     "--socket=x11",
     "--socket=fallback-x11",
     "--device=dri",
@@ -52,6 +53,24 @@
           "type": "archive",
           "url": "http://libndp.org/files/libndp-1.9.tar.gz",
           "sha256": "a8ab214e01dc3a9b615276905395637f391298c84d77651f0cbf0b1082dd2dd4"
+        }
+      ]
+    },
+    {
+      "name": "gtk-layer-shell",
+      "buildsystem": "meson",
+      "config-opts": [
+        "--libdir=lib",
+        "-Ddocs=false",
+        "-Dexamples=false",
+        "-Dtests=false",
+        "-Dvapi=false"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/wmww/gtk-layer-shell/archive/refs/tags/v0.10.1.tar.gz",
+          "sha256": "88c3a3e0a5300532f3d368d5df64838a87f1fb85273f22d41df0a6b8d0ec59c6"
         }
       ]
     },
@@ -112,10 +131,10 @@
       "build-commands": [
         "python3 -m ensurepip --upgrade || true",
         "bash tools/i18n.sh --compile",
-        "python3 -m pip install --prefix=/app --ignore-installed --no-build-isolation --no-deps \"openmeteo-requests==1.2.0\" \"requests-cache==1.3.1\" \"retry-requests==2.0.0\" \"openmeteo-sdk==1.26.0\" \"requests==2.33.1\" \"cattrs==26.1.0\" \"platformdirs==4.9.6\" \"url-normalize==3.0.0\" \"urllib3==2.7.0\" \"typing-extensions==4.15.0\" \"flatbuffers==25.9.23\" \"charset-normalizer==3.4.7\" \"idna==3.13\" \"certifi==2026.4.22\"",
+        "python3 -m pip install --prefix=/app --ignore-installed --no-build-isolation --no-deps \"openmeteo-requests==1.2.0\" \"requests-cache==1.3.1\" \"retry-requests==2.0.0\" \"openmeteo-sdk==1.26.0\" \"requests==2.33.1\" \"cattrs==26.1.0\" \"platformdirs==4.9.6\" \"url-normalize==3.0.0\" \"urllib3==2.7.0\" \"typing-extensions==4.15.0\" \"flatbuffers==25.9.23\" \"charset-normalizer==3.4.7\" \"idna==3.13\" \"certifi==2026.4.22\" \"pywayland==0.4.18\" \"cffi==1.17.1\" \"pycparser==2.22\"",
         "python3 -m pip install --prefix=/app --no-build-isolation --no-deps .",
         "mv /app/bin/docking /app/bin/docking-real",
-        "install -Dm755 /dev/stdin /app/bin/docking <<'EOF'\n#!/bin/sh\nset -eu\nif [ \"${XDG_SESSION_TYPE:-}\" = \"wayland\" ] || [ -n \"${WAYLAND_DISPLAY:-}\" ]; then\n  export GDK_BACKEND=x11\nfi\nif [ -z \"${XDG_STATE_HOME:-}\" ] && [ -n \"${XDG_DATA_HOME:-}\" ]; then\n  export XDG_STATE_HOME=\"${XDG_DATA_HOME}/state\"\nfi\nexec /app/bin/docking-real \"$@\"\nEOF",
+        "install -Dm755 /dev/stdin /app/bin/docking <<'EOF'\n#!/bin/sh\nset -eu\nif [ -z \"${XDG_STATE_HOME:-}\" ] && [ -n \"${XDG_DATA_HOME:-}\" ]; then\n  export XDG_STATE_HOME=\"${XDG_DATA_HOME}/state\"\nfi\nexec /app/bin/docking-real \"$@\"\nEOF",
         "install -Dm644 packaging/flatpak/cc.docking.Docking.desktop /app/share/applications/cc.docking.Docking.desktop",
         "install -Dm644 packaging/flatpak/cc.docking.Docking.metainfo.xml /app/share/metainfo/cc.docking.Docking.metainfo.xml",
         "install -Dm644 packaging/flatpak/hicolor.index.theme /app/share/icons/hicolor/index.theme",

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -20,6 +20,7 @@ pyPkgs.buildPythonApplication rec {
 
   buildInputs = with pkgs; [
     gtk3
+    gtk-layer-shell
     libwnck
     networkmanager
     gdk-pixbuf
@@ -32,6 +33,7 @@ pyPkgs.buildPythonApplication rec {
   propagatedBuildInputs = with pyPkgs; [
     pycairo
     pygobject3
+    pywayland
   ];
 
   # Weather client deps are not consistently available in nixpkgs channels.
@@ -53,9 +55,6 @@ pyPkgs.buildPythonApplication rec {
     cat > "$out/bin/docking" <<EOF
 #!/bin/sh
 set -eu
-if [ "''${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "''${WAYLAND_DISPLAY:-}" ]; then
-  export GDK_BACKEND=x11
-fi
 exec "$out/bin/docking-real" "\$@"
 EOF
     chmod 0755 "$out/bin/docking"

--- a/packaging/rpm/docking.spec
+++ b/packaging/rpm/docking.spec
@@ -8,7 +8,12 @@ URL:            https://github.com/edumucelli/docking
 Source0:        %{name}-%{version}.tar.gz
 
 Requires:       python3
+Requires:       gtk-layer-shell
+Recommends:     python3-pywayland
+BuildRequires:  gcc
 BuildRequires:  gettext
+BuildRequires:  python3-devel
+BuildRequires:  wayland-devel
 
 %description
 Docking is a lightweight, feature-rich dock for Linux written in Python
@@ -39,13 +44,23 @@ python3 -m pip install --no-compile --target %{buildroot}/usr/lib/docking/vendor
 rm -rf %{buildroot}/usr/lib/docking/vendor/*.dist-info
 rm -rf %{buildroot}/usr/lib/docking/vendor/bin
 
+py_minor="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+mkdir -p "%{buildroot}/usr/lib/docking/vendor-python${py_minor}"
+python3 -m pip install --no-compile \
+  --target "%{buildroot}/usr/lib/docking/vendor-python${py_minor}" \
+  "pywayland>=0.4.18,<0.5"
+rm -rf %{buildroot}/usr/lib/docking/vendor-python*/bin
+
 install -Dm755 /dev/stdin %{buildroot}/usr/bin/docking << 'EOF'
 #!/bin/sh
 set -eu
-export PYTHONPATH="/usr/lib/docking/python:/usr/lib/docking/vendor${PYTHONPATH:+:$PYTHONPATH}"
-if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
-  export GDK_BACKEND=x11
+PYTHON_VERSION="$(/usr/bin/python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+PYWAYLAND_VENDOR="/usr/lib/docking/vendor-python${PYTHON_VERSION}"
+PYTHONPATH_PREFIX="/usr/lib/docking/python:/usr/lib/docking/vendor"
+if [ -d "${PYWAYLAND_VENDOR}" ]; then
+  PYTHONPATH_PREFIX="${PYWAYLAND_VENDOR}:${PYTHONPATH_PREFIX}"
 fi
+export PYTHONPATH="${PYTHONPATH_PREFIX}${PYTHONPATH:+:$PYTHONPATH}"
 exec /usr/bin/python3 -m docking.app "$@"
 EOF
 
@@ -95,6 +110,7 @@ fi
 /usr/bin/docking-camshield-helper
 /usr/lib/docking/python
 /usr/lib/docking/vendor
+/usr/lib/docking/vendor-python*
 /usr/lib/docking/refresh-desktop-caches
 /usr/share/applications/org.docking.Docking.desktop
 /usr/share/polkit-1/actions/org.docking.camshield.policy

--- a/packaging/snap/snapcraft.yaml
+++ b/packaging/snap/snapcraft.yaml
@@ -38,12 +38,17 @@ parts:
       - pkg-config
       - libcairo2-dev
       - libgirepository1.0-dev
+      - libwayland-dev
+      - wayland-protocols
       - gettext
+    python-packages:
+      - pywayland==0.4.18
     stage-packages:
       - python3-gi
       - python3-gi-cairo
       - python3-cairo
       - gir1.2-gtk-3.0
+      - gir1.2-gtklayershell-0.1
       - gir1.2-wnck-3.0
       - gir1.2-gdkpixbuf-2.0
       - gir1.2-pango-1.0
@@ -58,9 +63,6 @@ parts:
       cat > "${CRAFT_PART_INSTALL}/bin/docking" <<'EOF'
       #!/bin/sh
       set -eu
-      if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
-        export GDK_BACKEND=x11
-      fi
       exec "$SNAP/bin/docking-real" "$@"
       EOF
       chmod 0755 "${CRAFT_PART_INSTALL}/bin/docking"


### PR DESCRIPTION
## Summary

Removes the blanket `GDK_BACKEND=x11` forcing from all packaging formats and adds the proper native Wayland dependencies so Docking can run directly on Wayland compositors that expose the required protocols.

## What changed

### All packaging formats
- **Remove `GDK_BACKEND=x11` forcing** — the launcher wrapper no longer forces X11 when it detects a Wayland session. Docking's built-in backend selection now decides the best backend.

### CI workflows (`.github/workflows/ci.yml`)
- Add `python3-dev`, `libwayland-dev`, `wayland-protocols` to .deb build jobs
- Add AppImage tooling packages (`python3-apt`, `libgdk-pixbuf2.0-bin`, `libglib2.0-bin`, `libgtk-3-bin`, `squashfs-tools`)

### AppImage
- Bundle `gir1.2-gtklayershell-0.1`, `libgtk-layer-shell0`, `libwayland-client0`, `libwayland-server0`
- Add `libgdk-pixbuf2.0-bin`, `libglib2.0-bin` for runtime pixbuf loaders
- Symlink `gdk-pixbuf-query-loaders` into `/usr/bin`

### Debian (.deb)
- Build-Depends: add `python3-dev`, `libwayland-dev`, `wayland-protocols`
- Depends: add `gir1.2-gtklayershell-0.1`
- Recommends: `python3-pywayland`
- Vendor `pywayland>=0.4.18` per Python minor version under `/usr/lib/docking/vendor-pythonX.Y/`
- Update description from "Requires X11" to "Supports X11 and native Wayland"

### Flatpak
- Bundle `gtk-layer-shell` v0.10.1 module
- Add `pywayland==0.4.18` + `cffi` + `pycparser`
- Add `--socket=wayland`
- Remove `GDK_BACKEND=x11` from wrapper

### Arch (PKGBUILD)
- Add `python-pywayland`, `gtk-layer-shell` dependencies
- Remove `GDK_BACKEND=x11` from wrapper

### Nix
- Add `gtk-layer-shell` build input, `pywayland` propagated build input
- Remove `GDK_BACKEND=x11` from wrapper

### RPM
- Add `gtk-layer-shell` Requires, `python3-pywayland` Recommends
- Add `gcc`, `python3-devel`, `wayland-devel` BuildRequires
- Vendor pywayland per Python minor version
- Remove `GDK_BACKEND=x11` from wrapper

### Snap
- Add build packages: `libwayland-dev`, `wayland-protocols`
- Add python packages: `pywayland==0.4.18`
- Add stage packages: `gir1.2-gtklayershell-0.1`
- Remove `GDK_BACKEND=x11` from wrapper

### Documentation
- Update `packaging/README.md` for Wayland-first narrative