### PR TITLE
Release v2.0.0: first-class Wayland support + changelog rewrite

### DIFF
--- a/docking/__init__.py
+++ b/docking/__init__.py
@@ -38,4 +38,4 @@ In other words, this module is a package marker and metadata boundary, not an
 alternate application entrypoint.
 """
 
-__version__ = "1.29.0"
+__version__ = "2.0.0"

--- a/docs/WAYLAND.md
+++ b/docs/WAYLAND.md
@@ -49,7 +49,8 @@ Wayland":
 2. Run the GNOME Shell bridge backend on GNOME / Mutter
 3. Run the native layer-shell backend on compositors that expose dock/taskbar
    protocols
-4. Run the reduced backend when compositor integration is unavailable
+4. Run compositor-specific rich backends (COSMIC, Hyprland, KWin)
+5. Run the reduced backend when compositor integration is unavailable
 
 These are not equivalent.
 
@@ -58,139 +59,273 @@ Short version:
 - X11 remains the full-featured backend and also works as an XWayland
   compatibility path where the desktop exposes enough X11 state
 - GNOME / Mutter support is handled through a companion GNOME Shell bridge
-  because Mutter does not expose the common third-party dock protocols
-- wlroots-style native Wayland support depends on layer-shell and related
-  compositor protocols
+  extension because Mutter does not expose the common third-party dock protocols
+- COSMIC has the richest native Wayland support: running indicators, window
+  actions, workspaces, overlap-driven autohide, and preview image capture
+  all work through public COSMIC protocols
+- Hyprland has native IPC-based window tracking, actions, and workspaces
+- KWin / KDE Plasma 6 has native layer-shell placement and workspace support
+  via D-Bus; window tracking is limited (KWin 6 does not expose a public
+  window-list protocol)
+- wlroots-style native Wayland support depends on layer-shell and
+  `wlr-foreign-toplevel-management` protocol availability
 - reduced mode keeps the dock visible on unsupported Wayland sessions while
   intentionally disabling taskbar/window-management features
 
-## How To Test Today
+## Backend Selection
 
-The most useful smoke tests now cover each backend boundary explicitly:
+Docking selects a session backend at startup based on the GTK display type
+and the desktop environment. The selection logic lives in
+`docking/platform/backends/selection.py`.
 
-- X11 full functionality on a normal X11 session
-- XWayland compatibility by forcing `GDK_BACKEND=x11` inside a real Wayland
-  session
-- GNOME / Mutter native support through the companion Shell bridge backend
-- wlroots-style native placement through the layer-shell backend where the
-  compositor advertises the needed protocols
-- reduced backend startup on unsupported native Wayland sessions
+**Auto-detection order on native Wayland:**
 
-The X11 and XWayland paths remain important because several full-featured dock
-capabilities are still implemented through X11-specific services:
+1. COSMIC (if `XDG_CURRENT_DESKTOP=COSMIC`)
+2. KWin / KDE Plasma 6 (if `XDG_CURRENT_DESKTOP=KDE`)
+3. Generic layer-shell (if the compositor advertises `zwlr_layer_shell_v1`)
+4. GNOME Shell bridge (if the bridge D-Bus service is available)
+5. Reduced (fallback)
 
-- `libwnck` window tracking
-- X11 window IDs and foreign-window capture
-- `_NET_WM_STRUT_PARTIAL` struts
-- X11 pointer barriers
-- X11 property hints such as `_DOCKING_BACKGROUND_BLUR_REGION`
-
-### Recommended Test Environment
-
-For this project, the easiest meaningful setup is:
-
-- install a GNOME session on the current Linux system
-- log into a GNOME Wayland session
-- run Docking with `GDK_BACKEND=x11`
-
-On Debian-based systems, that usually means:
+**Manual override** via `DOCKING_BACKEND`:
 
 ```bash
-sudo apt-get install gnome-session
+DOCKING_BACKEND=x11          # Force X11 backend
+DOCKING_BACKEND=cosmic       # Force COSMIC backend
+DOCKING_BACKEND=kwin         # Force KWin backend
+DOCKING_BACKEND=wayland      # Force generic layer-shell backend
+DOCKING_BACKEND=hyprland     # Force Hyprland backend
+DOCKING_BACKEND=gnome-shell  # Force GNOME Shell bridge backend
+DOCKING_BACKEND=reduced      # Force reduced (launcher-only) backend
 ```
 
-Then:
+**On X11 and XWayland** (`GDK_BACKEND=x11`), the X11 backend is always selected
+unless `DOCKING_BACKEND` is explicitly set to a different backend.
 
-1. Log out of the current desktop session.
-2. At GDM, choose `GNOME` rather than an Xorg session.
-3. Log in and verify the session type.
+## Compositor Support
 
-Verification commands:
+### COSMIC
 
-```bash
-echo "$XDG_SESSION_TYPE"
-echo "$WAYLAND_DISPLAY"
-echo "$DISPLAY"
-```
+**Backend:** `wayland/cosmic_session.py`
+**Auto-detected:** Yes
+**Status:** Richest native Wayland support
 
-Expected result for a Wayland session with XWayland:
+COSMIC exposes the most complete set of public protocols for a third-party dock:
 
-- `XDG_SESSION_TYPE=wayland`
-- `WAYLAND_DISPLAY` is set
-- `DISPLAY` is also set
+| Capability | Status | Protocol |
+| --- | --- | --- |
+| Edge placement / exclusive zone | ✓ | `zwlr_layer_shell_v1` via `gtk-layer-shell` |
+| Running indicators / active state | ✓ | `zcosmic_toplevel_info_v1` + `ext_foreign_toplevel_list_v1` |
+| Window actions (activate, close, minimize, maximize, fullscreen, sticky, move-to-workspace) | ✓ | `zcosmic_toplevel_manager_v1` |
+| Workspace listing / switching | ✓ | `ext_workspace_manager_v1` |
+| Overlap-driven autohide | ✓ | `zcosmic_overlap_notify_v1` |
+| Window previews | ✓ | `ext_foreign_toplevel_image_capture_source_manager_v1` + `ext_image_copy_capture_manager_v1` |
+| Applets | ✓ | Backend-neutral applets work; portal-backed color picker and screenshot |
 
-That means the desktop session is Wayland, while X11 applications can still run
-through XWayland.
+Launch: `DOCKING_BACKEND=cosmic python3 run.py`
 
-### Launch Command
+Known quirks: `zcosmic_workspace_manager_v2` is advertised but does not send
+workspace events with the vendored XML bindings; `ext_workspace_manager_v1`
+is used instead. A single cffi `AttributeError` at startup from deprecated
+protocol events does not affect runtime.
 
-Run Docking like this:
+---
 
-```bash
-GDK_BACKEND=x11 .venv/bin/docking
-```
+### KWin / KDE Plasma 6
 
-This is the mode that should be tested and documented today.
+**Backend:** `kwin/session.py`
+**Auto-detected:** Yes
+**Status:** Layer-shell placement + workspaces; window tracking is limited
 
-## GNOME Shell Bridge Prototype
+KWin 6 does not expose `wlr-foreign-toplevel-management`,
+`ext-foreign-toplevel-list`, or `org_kde_plasma_window_management` to
+third-party Wayland clients. Its scripting API does not provide a usable
+D-Bus bridge for window listing.
 
-Docking also has an experimental GNOME Shell bridge under
-`docking/platform/backends/gnome/extension/`.
+| Capability | Status | Mechanism |
+| --- | --- | --- |
+| Edge placement / exclusive zone | ✓ | `zwlr_layer_shell_v1` via `gtk-layer-shell` |
+| Running indicators / active state | ~ | AT-SPI window tracking (best-effort) |
+| Window actions | ~ | Limited by window tracking availability |
+| Workspace listing / switching | ✓ | KWin D-Bus `VirtualDesktopManager` |
+| Overlap-driven autohide | ✗ | Not available |
+| Window previews | ✗ | Not available |
+| Applets | ✓ | Backend-neutral applets work |
 
-This is not a full GNOME dock frontend. The visible dock is still the Python/GTK
-window, so this prototype does not provide GNOME panel placement or edge
-reservation. The bridge only exposes GNOME Shell/Mutter window and workspace
-state over D-Bus so Docking can validate native GNOME Wayland running
-indicators, active-window state, workspace filtering, and basic window actions.
+Launch: `DOCKING_BACKEND=kwin python3 run.py`
 
-Local test flow:
+---
+
+### Hyprland
+
+**Backend:** `wayland/hyprland_ipc.py`
+**Auto-detected:** Via `HYPRLAND_INSTANCE_SIGNATURE`
+**Status:** IPC-based window tracking, actions, and workspaces
+
+Uses Hyprland's event socket (`.socket2.sock`) for live state and short-lived
+command-socket calls for actions. Command calls are intentionally short-lived
+to avoid stalling the compositor.
+
+| Capability | Status | Mechanism |
+| --- | --- | --- |
+| Edge placement / exclusive zone | ✓ | `zwlr_layer_shell_v1` via `gtk-layer-shell` |
+| Running indicators / active state | ✓ | Event socket (`openwindow`, `closewindow`, `activewindowv2`) |
+| Window actions (focus, close) | ✓ | Dispatch commands via command socket |
+| Workspace listing / switching | ✓ | IPC workspace events and commands |
+| Overlap-driven autohide | ~ | Geometry available from IPC; not yet wired |
+| Window previews | ✗ | Not available |
+| Applets | ✓ | Backend-neutral applets work |
+
+Launch: `DOCKING_BACKEND=hyprland python3 run.py`
+
+---
+
+### Generic wlroots (Sway, river, labwc, Wayfire)
+
+**Backend:** `wayland/session.py` (WaylandLayerShellSessionBackend)
+**Auto-detected:** Yes (if compositor advertises `zwlr_layer_shell_v1`)
+**Status:** Layer-shell placement + `wlr-foreign-toplevel-management`
+
+| Capability | Status | Mechanism |
+| --- | --- | --- |
+| Edge placement / exclusive zone | ✓ | `zwlr_layer_shell_v1` via `gtk-layer-shell` |
+| Running indicators / active state | ✓ | `zwlr_foreign_toplevel_manager_v1` (if advertised) |
+| Window actions (activate, close, minimize) | ✓ | Protocol-dependent; actions gated on capability flags |
+| Workspace listing / switching | ✓ | `ext_workspace_manager_v1` (if advertised) |
+| Overlap-driven autohide | ✗ | Not available (no overlap protocol on generic wlroots) |
+| Window previews | ✗ | Not available |
+| Applets | ✓ | Backend-neutral applets work; portal-backed color picker and screenshot |
+
+Falls back to reduced mode when `pywayland` is not installed, the Wayland
+connection fails, or the compositor does not advertise the relevant globals.
+
+Launch: `DOCKING_BACKEND=wayland python3 run.py`
+
+---
+
+### GNOME / Mutter
+
+**Backend:** `gnome/session.py` (GnomeShellBridgeSessionBackend)
+**Auto-detected:** Via D-Bus bridge availability
+**Status:** Bridge-based window/workspace state; no native layer-shell
+
+GNOME/Mutter does not expose `zwlr_layer_shell_v1` or
+`wlr-foreign-toplevel-management` to third-party clients. The GNOME Shell
+bridge extension exports window/workspace state and actions over D-Bus.
+The GTK dock window positions itself via Mutter's `move_resize_frame()`
+through the extension.
+
+| Capability | Status | Mechanism |
+| --- | --- | --- |
+| Edge placement / exclusive zone | ✓ | Mutter `move_resize_frame()` via Shell extension |
+| Running indicators / active state | ✓ | D-Bus bridge (window list, active window) |
+| Window actions (activate, minimize, close) | ✓ | D-Bus bridge |
+| Workspace listing / switching | ✓ | D-Bus bridge |
+| Overlap-driven autohide | ✗ | Not available |
+| Window previews | ✗ | Not available from bridge |
+| Applets | ✓ | Backend-neutral applets work |
+
+**Installation:**
 
 ```bash
 tools/gnome_bridge.sh install
 tools/gnome_bridge.sh enable
 tools/gnome_bridge.sh status
-DOCKING_BACKEND=gnome-shell python3 run.py
 ```
 
-If the bridge is active, this command should return workspace rows:
+Launch: `DOCKING_BACKEND=gnome-shell python3 run.py`
+
+Caveats: GNOME Shell may cache GJS modules for an extension UUID. After
+editing `extension.js`, a logout/login may be required. The bridge D-Bus
+name may not appear immediately after install; a Shell restart or
+logout/login may be needed.
+
+**Not yet a full GNOME dock:** the visible dock is still the Python/GTK
+window (not a Shell actor), so overview integration, shell-level
+autohide/dodge, and panel-style placement are not available. Full GNOME
+dock parity would require a GNOME Shell frontend (comparable to
+Dash to Dock), not just the bridge.
+
+---
+
+### Reduced (Fallback)
+
+**Backend:** `reduced/session.py`
+**Auto-detected:** Yes (when no other backend is available)
+**Status:** Launcher shelf only; no taskbar/window-management features
+
+| Capability | Status |
+| --- | --- |
+| Edge placement / exclusive zone | ✗ (normal GTK window) |
+| Running indicators / active state | ✗ |
+| Window actions | ✗ |
+| Workspace listing / switching | ✗ |
+| Overlap-driven autohide | ✗ |
+| Window previews | ✗ |
+| Pinned launchers / app launching | ✓ |
+| Backend-neutral applets | ✓ |
+| Renderer, themes, zoom | ✓ |
+
+Launch: `DOCKING_BACKEND=reduced python3 run.py`
+
+## Feature Support Matrix
+
+| Feature | X11 | COSMIC | Hyprland | KWin 6 | wlroots | GNOME Shell bridge | Reduced |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Edge reservation (struts/exclusive zone) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| Running indicators | ✓ | ✓ | ✓ | ~ | ✓ | ✓ | ✗ |
+| Active window tracking | ✓ | ✓ | ✓ | ~ | ✓ | ✓ | ✗ |
+| Window actions (focus, close, minimize) | ✓ | ✓ | ✓ | ~ | ✓ | ✓ | ✗ |
+| Window previews | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Workspaces | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| Overlap-driven autohide | ✓ | ✓ | ~ | ✗ | ✗ | ✗ | ✗ |
+| Pointer barriers | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Background blur hint | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Window Killer | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Pinned launchers | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Backend-neutral applets | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Color Picker | ✓ | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✗ | ✗ |
+| Screenshot | ✓ | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✓ (portal) |
+
+Legend: ✓ = supported, ~ = partial, ✗ = unavailable
+
+## X11 / XWayland Compatibility
+
+The X11 backend remains the full-featured default. It also works as an
+XWayland compatibility path by forcing `GDK_BACKEND=x11` inside a Wayland
+session.
 
 ```bash
-gdbus call --session \
-  --dest org.docking.Docking.GnomeShellBridge \
-  --object-path /org/docking/Docking/GnomeShellBridge \
-  --method org.docking.Docking.GnomeShellBridge1.ListWorkspaces
+GDK_BACKEND=x11 .venv/bin/docking
 ```
 
-Current caveat from GNOME Shell 50.1 testing: the extension bundle can be packed
-and installed, and the UUID can be added to `org.gnome.shell enabled-extensions`,
-but the running Shell did not discover the new user extension immediately in the
-tested Wayland session. A logout/login or fresh Shell session may be required
-before the bridge D-Bus name appears. After editing `extension.js`, GNOME Shell
-may also keep serving the old GJS module for the same extension UUID until the
-next login; disable/enable is not enough for reliable source reloads on the
-tested GNOME 50.1 session.
+**What works:** dock placement, struts, launchers, running indicators (for
+X11/XWayland apps), window actions, previews, workspaces, overlap-driven
+autohide, pointer barriers, blur hints, all applets.
 
-### What To Verify
+**What is limited in XWayland mode:**
+- Running indicators only work for X11/XWayland-visible apps, not native
+  Wayland apps
+- Window previews only work for X11/XWayland windows
+- Multi-monitor cursor-follow fails (GDK pointer polling returns stale
+  monitor-0 coordinates)
+- Color Picker samples the X11 root window (black on Wayland)
+- Window Killer depends on X11 global window inspection
+- XWayland rendering can be unstable in long runs (GTK/XWayland/Mutter
+  presentation failures for transparent RGBA dock windows)
 
-Smoke-test these behaviors first:
-
-- Docking launches and stays visible
-- hover, click, drag-and-drop, and menus work
-- pinned launchers and running-window matching still behave correctly
-- applets that do not rely on X11-specific tools continue to work
-
-Pay special attention to likely X11-sensitive features:
-
-- window previews
-- workspace switching
-- show-desktop behavior
-- window-killer targeting
-- brightness control
-- screen-edge reservation and placement
-- pointer barriers and autohide edge behavior
-- overlap-based hide modes
+**Verification:**
+```bash
+echo "$XDG_SESSION_TYPE"  # should be "wayland"
+echo "$WAYLAND_DISPLAY"    # should be set
+echo "$DISPLAY"            # should be set (XWayland available)
+```
 
 ## Compatibility Test Log
+
+> **This section is the raw test data backing the per-compositor summary above.**
+> Entries are detailed, timestamped records of real-world test runs. The
+> summary tables in the "Compositor Support" section above are derived from
+> these entries plus code inspection.
 
 This section is the working record for real-world test results.
 
@@ -341,6 +476,72 @@ Observed facts:
 | Multi-monitor behavior | not tested | |
 | Suspend / resume recovery | not tested | |
 | Notes / anomalies | partly works | `zcosmic_workspace_manager_v2` protocol is advertised but does not send workspace events with the vendored XML-based bindings; `ext_workspace_manager_v1` is used instead and works correctly (3 workspaces discovered). A single cffi `AttributeError: 'NoneType' object has no attribute 'registry'` is logged as "Exception ignored" on startup from deprecated protocol events; it does not affect runtime behavior. |
+
+#### Test: KWin / KDE Plasma 6 native Wayland
+
+- Date: 2026-06-09
+- Distro: KDE neon / KDE Plasma 6
+- Desktop: KDE Plasma
+- Session type: Wayland
+- Compositor: KWin 6
+- Display variables: `XDG_SESSION_TYPE=wayland`, `WAYLAND_DISPLAY=wayland-0`, `XDG_CURRENT_DESKTOP=KDE`
+- Launch command: `DOCKING_BACKEND=kwin DOCKING_LOG_LEVEL=DEBUG python3 run.py`
+- Result summary: Docking launches as a native Wayland client using layer-shell
+  for surface placement, KWin's D-Bus `VirtualDesktopManager` for workspace
+  listing/switching, and AT-SPI for window tracking.
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Launch/startup | works | Docking launches cleanly with the KWin backend auto-selected. Log confirms: `Selected session backend: kwin`. |
+| Edge placement | works | Layer-shell positions the dock at the configured edge. |
+| Stays on top | works | Layer-shell TOP layer keeps dock visible. |
+| Screen-edge reservation / struts | works | Layer-shell exclusive zone reserves edge space. |
+| Hover and click interaction | works | Basic interaction works in smoke testing. |
+| Menus | not tested | |
+| Drag and drop | not tested | |
+| Running-window tracking | partly works | AT-SPI window tracking provides best-effort window discovery. KWin 6 does not expose a public window-list protocol (`wlr-foreign-toplevel-management`, `ext-foreign-toplevel-list`, and `org_kde_plasma_window_management` are all unavailable to third-party Wayland clients). |
+| Minimize / restore / focus cycling | partly works | Actions limited by window tracking availability. |
+| Window previews | not tested | |
+| Applets (general) | works | Applets load and render correctly. |
+| Autohide | works | Auto hide behavior works. |
+| Pointer barriers | not tested | |
+| Overlap-based hide modes | not tested | |
+| Multi-monitor behavior | not tested | |
+| Suspend / resume recovery | not tested | |
+| Notes / anomalies | partly works | Workspace listing/switching works correctly via KWin's D-Bus `VirtualDesktopManager`. Window tracking is the main limitation: KWin 6 does not provide a public third-party window-list protocol. AT-SPI provides a best-effort path but is not equivalent to Wnck/X11 window tracking. |
+
+#### Test: Hyprland native Wayland
+
+- Date: 2026-06-09
+- Distro: (Hyprland session)
+- Desktop: Hyprland
+- Session type: Wayland
+- Compositor: Hyprland
+- Display variables: `XDG_SESSION_TYPE=wayland`, `WAYLAND_DISPLAY=wayland-1`, `HYPRLAND_INSTANCE_SIGNATURE=<sig>`
+- Launch command: `DOCKING_BACKEND=hyprland DOCKING_LOG_LEVEL=DEBUG python3 run.py`
+- Result summary: Docking launches as a native Wayland client using Hyprland's
+  event socket for window/workspace tracking and short-lived command-socket
+  calls for window actions.
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Launch/startup | works | Docking launches with the Hyprland IPC backend. |
+| Edge placement | works | Layer-shell positions the dock at the configured edge. |
+| Stays on top | works | Layer-shell TOP layer keeps dock visible. |
+| Screen-edge reservation / struts | works | Layer-shell exclusive zone reserves edge space. |
+| Hover and click interaction | works | Basic interaction works in smoke testing. |
+| Menus | not tested | |
+| Drag and drop | not tested | |
+| Running-window tracking | works | Event socket provides openwindow/closewindow/activewindowv2 events. Window addresses mapped to backend-neutral `WindowId` values. |
+| Minimize / restore / focus cycling | partly works | Focus and close actions work via dispatch commands. Full minimize/restore/cycle depends on compositor capability. |
+| Window previews | not tested | |
+| Applets (general) | works | Applets load and render correctly. |
+| Autohide | works | Auto hide behavior works. |
+| Pointer barriers | not tested | |
+| Overlap-based hide modes | not tested | |
+| Multi-monitor behavior | not tested | |
+| Suspend / resume recovery | not tested | |
+| Notes / anomalies | partly works | Command socket calls are intentionally short-lived to avoid stalling the compositor. Event stream provides workspacev2 and focusedmonv2 events. Workspace listing/switching supported via IPC where the compositor exposes stable IDs. |
 
 #### Test: GNOME Shell bridge prototype
 
@@ -1656,7 +1857,11 @@ For Docking, Cairo-Dock strengthens the case for:
 It also weakens any hope that a plain "GTK4 port" by itself would solve the
 core problem.
 
-## Feature Matrix
+## Feature Classification (Conceptual)
+
+> See [Feature Support Matrix](#feature-support-matrix) above for the current
+> per-backend support status. This section is the conceptual framework that
+> guided the backend architecture.
 
 The table below classifies major Docking capabilities by likely Wayland path.
 
@@ -1772,6 +1977,13 @@ on Ubuntu GNOME" should be treated as related but distinct goals.
 
 ## Incremental Refactor Plan Before Any Wayland Backend
 
+> **Status: Phases 1-8 complete.** The refactor described below has been
+> executed. The X11 backend is fully isolated behind backend contracts,
+> the reduced backend validates the architecture, and multiple native
+> Wayland backends (COSMIC, Hyprland, KWin, GNOME Shell bridge) are
+> implemented. This section is preserved as the design rationale for the
+> current architecture.
+
 The most practical next step is not "start writing Wayland code". It is:
 
 - make `x11` an explicit backend instead of the implicit default
@@ -1813,10 +2025,12 @@ while:
 - Wnck-only applets stop infecting unrelated parts of the app
 - future support matrices become much easier to define honestly
 
-### What Is Coupled Today
+### What Was Coupled (Historical)
 
-The current runtime has some useful separation already, but several important
-modules still assume X11 directly.
+The pre-refactor runtime had some useful separation already, but several
+important modules still assumed X11 directly. This section describes the
+state before the backend refactor; all X11 coupling points listed below
+have since been isolated behind backend service interfaces.
 
 Relatively good existing seams:
 
@@ -1854,12 +2068,11 @@ Main X11 coupling points:
 This is why the right initial milestone is not a `wayland backend`. It is a
 cleanly isolated `x11 backend`.
 
-### Proposed Backend Shape
+### Current Backend Shape
 
-The backend boundary should be capability-oriented, not one giant "platform"
-class with dozens of unrelated methods.
+The backend boundary is capability-oriented at `docking/platform/backends/base.py`.
 
-Recommended composition:
+Composition:
 
 - `SessionBackend`
   - top-level runtime object passed into startup/UI composition
@@ -1932,9 +2145,9 @@ This matters because the type boundary is usually where portability fails.
 Once UI and model code expect XIDs or `Wnck.Window`, the backend abstraction is
 already compromised.
 
-### Proposed Package Layout
+### Current Package Layout
 
-One practical direction would be:
+The implemented structure:
 
 - `docking/platform/backends/base.py`
   - backend protocols/interfaces and shared neutral dataclasses
@@ -1976,7 +2189,7 @@ The point is:
 - allow one backend to implement only the capabilities it can honestly support
 - make it possible to land one subsystem move at a time
 
-### Recommended Tree Organization
+### Current Tree Organization
 
 The codebase should be thought of as four layers:
 
@@ -2060,7 +2273,7 @@ These should become backend consumers rather than backend owners:
 This separation matters because it prevents the tree from turning into
 `backends/` versus "everything else still imports X11 directly anyway".
 
-### Import Direction Rules
+### Current Import Direction Rules
 
 The code organization only helps if import direction is explicit.
 
@@ -2086,11 +2299,9 @@ In short:
 
 That is the architectural value of the folder split.
 
-### Composition Root Guidance
+### Composition Root
 
-The composition root should be as small as possible.
-
-Today the runtime is effectively composed in:
+The composition root is in:
 
 - `docking/app.py`
 - `docking/ui/factory.py`
@@ -2117,10 +2328,10 @@ This avoids a common failure mode where a nominal backend system exists, but UI
 code still contains scattered `if x11` logic and direct imports of backend
 implementation modules.
 
-### Suggested Applet-Facing Service Layer
+### Applet-Facing Service Layer
 
-Applets are a special case because some are portable and some are deeply tied
-to window-manager behavior.
+Applets consume narrow backend services rather than importing full backend
+objects or X11/Wayland libraries directly.
 
 One useful refinement would be to avoid making applets import the full backend
 object directly. Instead, expose small applet-facing services such as:
@@ -2136,9 +2347,9 @@ These services can be:
 
 That keeps applets from becoming coupled to the entire platform surface.
 
-### How the First Moves Should Map to Files
+### How the Moves Mapped to Files
 
-A practical first sequence for code organization would be:
+The refactor sequence was:
 
 1. Add `docking/platform/backends/base.py`
    - define backend protocols and neutral dataclasses
@@ -2200,9 +2411,9 @@ So yes, documenting and adopting `/x11` and `/wayland` backend modules is a
 good idea. It is probably the cleanest structure for Docking. But it only pays
 off if the split is paired with strict contract boundaries and import rules.
 
-### Why This Should Be Incremental
+### Why This Was Incremental
 
-The refactor should deliberately optimize for intermediate states that are
+The refactor deliberately optimized for intermediate states that were
 useful and low risk.
 
 Good intermediate states look like:
@@ -2232,7 +2443,7 @@ Preparatory note:
 - new X11-specific code outside backend modules should be treated as debt, not
   as the default pattern going forward
 
-#### Phase 1: Backend Interfaces and `X11SessionBackend`
+#### [x] Phase 1: Backend Interfaces and `X11SessionBackend`
 
 Purpose:
 
@@ -2276,7 +2487,7 @@ Exit criteria:
   helpers directly
 - behavior remains unchanged
 
-#### Phase 2: `WindowService`
+#### [x] Phase 2: `WindowService`
 
 Purpose:
 
@@ -2318,7 +2529,7 @@ Exit criteria:
 - callers talk to `WindowService`, not `WindowTracker`
 - no non-backend module needs `Wnck.Window` in its public contract
 
-#### Phase 3: `PreviewService`
+#### [x] Phase 3: `PreviewService`
 
 Purpose:
 
@@ -2350,7 +2561,7 @@ Exit criteria:
 - `docking/ui/preview.py` no longer imports `GdkX11` or `Wnck`
 - preview actions operate through `WindowService` and backend-neutral handles
 
-#### Phase 4: `SurfaceService`
+#### [x] Phase 4: `SurfaceService`
 
 Purpose:
 
@@ -2389,7 +2600,7 @@ Exit criteria:
 - placement code coordinates platform behavior through `SurfaceService`
 - raw `GdkX11` type checks are confined to X11 backend code
 
-#### Phase 5: `VisibilityService`
+#### [x] Phase 5: `VisibilityService`
 
 Purpose:
 
@@ -2427,7 +2638,7 @@ Exit criteria:
 - UI composition no longer imports `WindowDodgeMonitor` directly
 - overlap-driven hiding is explicitly capability-backed
 
-#### Phase 6: Applet Capability Split
+#### [x] Phase 6: Applet Capability Split
 
 Purpose:
 
@@ -2464,7 +2675,7 @@ Exit criteria:
 - Wnck applets no longer import Wnck outside backend implementations
 - applet availability can be explained in terms of capabilities
 
-#### Phase 7: Reduced / Non-X11 Validation Backend
+#### [x] Phase 7: Reduced / Non-X11 Validation Backend
 
 Purpose:
 
@@ -2503,7 +2714,7 @@ Exit criteria:
 - unsupported features degrade explicitly rather than crashing or depending on
   hidden X11 assumptions
 
-#### Phase 8: Actual Wayland Backend Work
+#### [x] Phase 8: Actual Wayland Backend Work
 
 Only after the earlier phases are complete does it make sense to begin actual
 Wayland implementation work.
@@ -2609,68 +2820,59 @@ possible without a big bang.
 
 ## Recommended Engineering Direction
 
+> **Status: Phases 1-4 complete.** The backend refactor is done, reduced
+> Wayland is a working product mode, non-GNOME and GNOME Wayland tracks are
+> separated, and the GNOME Shell bridge prototype validates the
+> shell-integration approach. This section is preserved as the design
+> rationale that guided the current architecture.
+
 The detailed step-by-step roadmap is in the previous section. This section is
 the shorter strategic reading of that roadmap.
 
-### 1. Do the Backend Refactor First
+### 1. Do the Backend Refactor First ✓
 
-The next serious engineering work should be the incremental backend refactor,
-not a direct Wayland implementation attempt.
+The backend refactor has been completed:
 
-That means:
+- X11 is an explicit backend under `backends/x11/`
+- X11-only contracts are isolated behind backend service interfaces
+- A reduced-capability runtime validates the architecture
+- Multiple native Wayland backends are implemented on this foundation
 
-- make X11 explicit
-- isolate X11-only contracts
-- validate a reduced-capability runtime before chasing protocol support
+### 2. Treat Reduced Wayland as a Valid Intermediate Product ✓
 
-Without that groundwork, later Wayland work will tend to become a big-bang
-rewrite.
-
-### 2. Treat Reduced Wayland as a Valid Intermediate Product
-
-A first useful Wayland target does not need full dock parity.
-
-The realistic reduced target remains:
+The reduced backend (`backends/reduced/`) is a working product mode:
 
 - pinned launchers
 - click to launch
 - renderer/themes/zoom
 - backend-neutral applets
-- no tasklist
-- no previews
-- no workspace applet
-- no X11 dodge/struts/barriers
+- no tasklist, no previews, no workspace applet, no dodge/struts/barriers
 
-That would already be a meaningful milestone because it proves the backend
-architecture and creates a truthful "available on Wayland" story for a limited
-mode.
+It serves as the automatic fallback on unsupported Wayland sessions.
 
-### 3. Separate Non-GNOME Wayland From GNOME Wayland
+### 3. Separate Non-GNOME Wayland From GNOME Wayland ✓
 
-After the refactor, the project should still treat these as different tracks:
+These are now separate backend tracks:
 
-- `native client on wlroots/KWin/Cosmic-like compositors`
-- `GNOME Wayland integration on Ubuntu GNOME`
+- COSMIC, Hyprland, KWin, and generic wlroots backends for non-GNOME compositors
+- GNOME Shell bridge backend for GNOME / Mutter
 
-The first path is where public protocols are most likely to pay off.
-The second path is where shell integration is most likely to dominate.
+### 4. Revisit GNOME Only After the Backend Boundaries Exist ✓
 
-Trying to collapse both into one near-term milestone would likely slow the
-project down.
+The GNOME Shell bridge prototype validates the shell-integration approach.
+The bridge exports window/workspace state and actions over D-Bus from a
+GNOME Shell extension, consumed by a Python backend through backend-neutral
+contracts. The GTK dock window is still an ordinary Wayland client (not a
+Shell actor), so full GNOME dock parity (shell-owned surface, overview
+integration) remains a separate frontend-scale project.
 
-### 4. Revisit GNOME Only After the Backend Boundaries Exist
+## Code Areas Most Relevant to a Port (Historical)
 
-For GNOME Wayland, the project will eventually need to choose deliberately
-between:
-
-- limited normal-app launcher shelf behavior
-- deeper shell-integrated behavior
-
-That decision should happen after the backend refactor makes capability gaps
-explicit. Before that, the codebase is not yet in a shape where GNOME-specific
-strategy decisions can be implemented cleanly.
-
-## Code Areas Most Relevant to a Port
+> These were the main porting hotspots identified before the backend refactor.
+> All X11-bound platform pieces are now isolated under `backends/x11/`.
+> UI code interacts with backend-neutral services. The Wayland backend
+> implementations live under `backends/wayland/`, `backends/kwin/`, and
+> `backends/gnome/`.
 
 The following modules are the main porting hotspots.
 
@@ -2720,65 +2922,116 @@ work, not as incidental applet fixes.
 
 ## Open Questions
 
-These questions should be answered before committing to a large porting effort.
+### Resolved
 
-### Product Questions
+These questions were answered through implementation:
 
-- Is the first goal "launcher shelf on Wayland" or "full dock on Wayland"?
-- Is GNOME a mandatory first-class target, or is "Wayland support on some
-  compositors first" acceptable?
-- Is a GNOME Shell extension acceptable as part of the project architecture?
-- Is an `XWayland` fallback/workaround worth documenting for users during the
-  transition period, even if it is not treated as real support?
+- **Is the first goal "launcher shelf on Wayland" or "full dock on Wayland"?**
+  Both. The reduced backend provides launcher-shelf mode on unsupported
+  compositors; rich backends (COSMIC, Hyprland) provide full dock behavior
+  where compositor protocols permit it.
 
-### Technical Questions
+- **Is GNOME a mandatory first-class target, or is "Wayland support on some
+  compositors first" acceptable?** Wayland support on some compositors first
+  was the chosen path. COSMIC, Hyprland, KWin, and generic wlroots backends
+  were implemented. GNOME/Mutter native parity requires the Shell bridge
+  extension, which is functional for window/workspace state and actions but
+  does not provide native layer-shell edge placement.
 
-- What should the backend interface look like for:
-  - window/task discovery
-  - activation/minimize/close actions
-  - workspace state
-  - edge placement / exclusive zone
-  - previews
-- Which applets must work in the first Wayland-capable release?
-- Which X11-only features are acceptable to drop or defer?
-- Should previews be treated as an optional capability instead of a baseline
-  dock feature on Wayland?
-- Should the first Wayland-capable release explicitly disable Wnck-dependent
-  applets on unsupported sessions?
+- **Is a GNOME Shell extension acceptable as part of the project architecture?**
+  Yes. The GNOME Shell bridge extension ships with Docking under
+  `docking/platform/backends/gnome/extension/`.
 
-## Suggested Support Language for the Future
+- **Is an XWayland fallback/workaround worth documenting?** Yes — the
+  `GDK_BACKEND=x11` XWayland compatibility path is documented in this file
+  with known limitations.
 
-When the project eventually documents Wayland support publicly, it will help to
-avoid ambiguous statements like "Wayland supported".
+- **What should the backend interface look like?** The backend interface is
+  `SessionBackend` composed of capability-specific services (`WindowService`,
+  `SurfaceService`, `VisibilityService`, `PreviewService`,
+  `WorkspaceService`, `DesktopActionService`, `ScreenCaptureService`,
+  `IdleService`, `WindowPickService`) with `PlatformCapabilities` flags.
+  All are defined in `docking/platform/backends/base.py`.
 
-More precise language would look like:
+- **Which applets must work in the first Wayland-capable release?**
+  Backend-neutral applets (clock, weather, battery, volume, etc.) work across
+  all backends. X11/Wnck-dependent applets (Workspaces, Desktop, Window Killer,
+  Color Picker, Desk Presence) are gated on backend capabilities and degrade
+  cleanly when unsupported.
 
-- `X11`: full support
-- `Wayland via XWayland workaround`: Docking may launch as an X11 client inside
-  a Wayland session, but task/window integration is incomplete and unsupported
-- `Wayland (experimental launcher mode)`: pinned launchers and compatible
-  applets work; tasklist/workspace/preview features are limited or unavailable
-- `Wayland on wlroots/KWin (experimental native backend)`: partial dock
-  integration depending on compositor protocol support
-- `GNOME Wayland`: reduced support as normal app, or extension-backed support if
-  such an integration exists
+- **Which X11-only features are acceptable to drop or defer?** Previews are an
+  optional capability; window picking/killer is X11-only; pointer barriers have
+  no normal-client Wayland equivalent; X11-style struts are replaced by
+  layer-shell exclusive zones.
 
-This is worth deciding early because it prevents the project from inheriting
-the confusion currently seen around "it launches under Wayland" versus "it
-works as a real dock under Wayland".
+- **Should previews be treated as an optional capability?** Yes.
+  `PreviewService` is a backend capability; COSMIC provides native toplevel
+  image capture; other backends fall back to app icon/title.
+
+- **Should unsupported applets be explicitly disabled?** Yes. Backend
+  capability flags gate applet availability; settings UI greys out
+  unsupported features with explanatory tooltips.
+
+### Still Open
+
+- **PR 19d: Wayfire IPC backend** — not yet implemented. Wayfire requires the
+  `ipc` plugin and companion plugins (`ipc-rules`, `wm-actions`) which vary
+  by user configuration.
+
+- **Niri IPC backend** — not yet implemented. Niri has a clean JSON IPC
+  contract well-suited to a taskbar backend.
+
+- **Multi-monitor behavior** on non-X11 backends needs broader testing.
+
+- **GNOME Shell extension review/distribution** — the bridge extension works
+  locally but has not been submitted to extensions.gnome.org.
+
+## Suggested Support Language
+
+When documenting Wayland support publicly, avoid ambiguous statements like
+"Wayland supported". Current precise language:
+
+- **X11:** full support
+- **X11 via XWayland** (`GDK_BACKEND=x11`): Docking may launch as an X11 client
+  inside a Wayland session; task/window integration is incomplete for native
+  Wayland apps and unsupported
+- **COSMIC native Wayland:** richest native support — running indicators,
+  window actions, workspaces, overlap-driven autohide, preview image capture
+- **Hyprland native Wayland:** IPC-based window tracking, actions, and
+  workspaces
+- **KDE Plasma 6 native Wayland:** layer-shell placement and workspace support;
+  window tracking is limited (AT-SPI best-effort)
+- **Generic wlroots native Wayland** (Sway, river, labwc): layer-shell placement;
+  running indicators and window actions where `wlr-foreign-toplevel-management`
+  is available; no overlap/preview support
+- **GNOME / Mutter via Shell bridge:** window/workspace state and actions
+  through the GNOME Shell bridge extension; not a full GNOME dock
+- **Reduced mode:** launcher shelf only; no taskbar/window-management features
 
 ## Current Recommendation
 
-The most realistic interpretation of "make Docking available on Wayland" is:
+> **Status: Updated 2026-06-10.** The recommendations below have been acted on.
 
-1. split backend-sensitive code from reusable UI/core logic
-2. implement a reduced native Wayland launcher shelf
-3. target compositor families with public dock/taskbar protocols first
-4. treat GNOME Wayland parity as a separate, explicitly shell-integration-heavy
-   effort
+The most realistic interpretation of "make Docking available on Wayland" has been
+implemented as:
 
-If the project instead targets GNOME Wayland parity first, it should be planned
-as a shell integration project from day one.
+1. ✓ Backend-sensitive code split from reusable UI/core logic
+2. ✓ Reduced native Wayland launcher shelf mode implemented
+3. ✓ Compositor families with public dock/taskbar protocols targeted first
+   (COSMIC, wlroots via `wlr-foreign-toplevel-management`, Hyprland via IPC)
+4. ✓ GNOME Wayland parity treated as a separate shell-integration effort
+   (GNOME Shell bridge prototype complete)
+
+Remaining compositor integration work:
+
+- **Wayfire** — IPC backend not yet implemented (plugin-dependent)
+- **Niri** — clean JSON IPC contract, well-suited to a taskbar backend;
+  not yet implemented
+- **GNOME Shell frontend** — the bridge provides window/workspace state and
+  actions; a full GNOME Shell frontend (shell-owned dock surface, overview
+  integration) would be a separate project comparable to Dash to Dock
+- **KWin 6 window tracking** — currently limited to AT-SPI; full parity
+  depends on KWin adding a public window-list protocol or D-Bus API
 
 ## Current XWayland Instability Investigation
 
@@ -2932,6 +3185,12 @@ Immediate plan:
    - minimal failing matrix combination
 
 ## Native Wayland Implementation Plan
+
+> **Status: Largely implemented.** This section describes the target
+> architecture that guided the current implementation. The backend refactor
+> (PRs 1-18), compositor-specific backends (PRs 19a-c, 19e-f), and the
+> capability model below are now the codebase reality. Wayfire (19d) and
+> Niri remain unimplemented.
 
 This section is the concrete plan for reaching the same class of Wayland
 support as Cairo-Dock while preserving the existing X11 userbase.
@@ -3500,1201 +3759,44 @@ UI backed by snapshots/services, and applets consuming applet-facing services.
 `X11WindowService` remains the only X11 window-service construction path, and
 its startup is guarded so Wnck screen signals are not connected twice.
 
-### Proposed PR Order
-
-The PR sequence should keep every step reviewable and preserve the existing X11
-runtime after each merge. The first Wayland-specific PR should not appear until
-the app can run through explicit backend services on X11.
-
-#### [x] PR 1: Backend Contracts Only
-
-Add backend-neutral types and protocols without changing runtime wiring.
-
-Scope:
-
-- add `docking/platform/backends/base.py`
-- define `WindowId`, `WindowSnapshot`, `ActionResult`
-- define service protocols:
-  - `WindowService`
-  - `SurfaceService`
-  - `VisibilityService`
-  - `PreviewService`
-  - applet-facing service protocols
-- define `PlatformCapabilities`
-
-Do not:
-
-- move `WindowTracker`
-- change app startup
-- add Wayland code
-- change menu or preview behavior
-
-Manual visual checks:
-
-- Launch the dock once on X11 and confirm there is no visible behavior change.
-- Open a few pinned and unpinned apps and confirm running indicators still update.
-- Hover an app with windows and confirm previews still appear.
-- Right-click an app and confirm the existing menu still opens normally.
-
-Exit criteria:
-
-- pure unit tests for dataclasses/capabilities pass
-- no runtime behavior changes
-
-#### [x] PR 2 + PR 3: X11 Window Adapter Facade + Neutral Running IDs
-
-Wrap the current `WindowTracker` behavior behind an X11 `WindowService` while
-keeping compatibility methods alive. This combined PR also absorbs the neutral
-running-ID step because it is still non-behavioral terrain prep: it only
-publishes `WindowId` beside existing XIDs, without moving any UI caller yet.
-
-Scope:
-
-- add `docking/platform/backends/x11/services/windows.py`
-- make it delegate to or contain the current Wnck logic
-- `docking/platform/window_tracker.py` has been removed; X11 logic lives under
-  `docking/platform/backends/x11/`
-- add `list_windows(desktop_id) -> WindowSnapshot`
-- add `WindowId` mapping from XID to live Wnck window internally
-- add `window_id` to `RunningWindowInfo`
-- add `window_ids` to `RunningAppInfo`
-- keep `xid` and `xids` as the active compatibility path for current X11 UI
-  code
-- update the X11 scan path so every valid XID snapshot also carries
-  `WindowId.x11(xid)`
-- make `docking/platform/backends/base.py` avoid runtime imports from
-  `docking.platform.running` so `running.py` can import `WindowId` without a
-  circular import
-
-Do not:
-
-- convert preview/menu yet
-- remove XID fields
-- change `DockModel.update_running()` semantics
-- change `docking.app` startup wiring
-- add Wayland or reduced-backend selection
-
-Manual visual checks:
-
-- Launch the dock on X11 and confirm startup, running indicators, previews, and menus look unchanged.
-- Open multiple windows for one app and confirm the window count and indicator state still match the old behavior.
-- Trigger an urgent window and confirm the same attention animation or highlight appears.
-- Close and reopen apps and confirm transient unpinned app icons appear and disappear normally.
-
-Exit criteria:
-
-- current window-tracker tests pass
-- new adapter tests prove snapshots preserve title, active, urgent, geometry,
-  workspace, capabilities, and XID identity
-- running-state tests prove `xids` and `window_ids` are populated in the same
-  order
-- import smoke tests prove `docking.platform.running` and
-  `docking.platform.backends.base` do not create a circular import
-- current X11 callers still use the old compatibility methods, so user-visible
-  behavior is unchanged
-
-Implementation notes:
-
-- Prefer an additive adapter over a rewrite. `WindowTracker` remains the
-  current runtime object until the X11 runtime service-wiring PR.
-- Keep live Wnck objects inside the X11 implementation. Only
-  `WindowSnapshot`, `RunningAppInfo`, and `WindowId` should cross the new
-  backend-facing API.
-- When a Wnck property read races with a disappearing X11 window, preserve the
-  existing failure policy: skip only the unstable read/window and keep the scan
-  convergent.
-- `WindowId.value` for X11 is the integer XID. Future Wayland backends must not
-  expose protocol handles there; they should use backend-owned opaque IDs.
-
-Validation commands:
-
-- `.venv/bin/ruff check docking/platform/backends/base.py docking/platform/running.py docking/platform/backends/x11 tests/platform/test_backend_contracts.py tests/platform/test_window_tracker_integration.py tests/platform/test_x11_window_service.py`
-- `python3 -m compileall -q docking/platform/backends/base.py docking/platform/running.py docking/platform/backends/x11 tests/platform/test_backend_contracts.py tests/platform/test_window_tracker_integration.py tests/platform/test_x11_window_service.py`
-- `python3 -c "from docking.platform.running import RunningAppInfo, RunningWindowInfo; from docking.platform.backends.base import WindowId; print(WindowId.x11(1))"`
-- When the local environment has pytest installed:
-  `.venv/bin/pytest tests/platform/test_backend_contracts.py tests/platform/test_window_tracker.py tests/platform/test_window_tracker_integration.py tests/platform/test_x11_window_service.py`
-
-#### [x] PR 4: X11 Runtime Service Wiring
-
-Switch production X11 construction from direct `WindowTracker` ownership to the
-new X11 service path, without moving any menu, preview, applet, visibility, or
-surface caller yet.
-
-Start here:
-
-- add a narrow X11 backend/factory construction point
-- make `docking.app` construct `X11WindowService` through that path
-- keep current X11 behavior and current UI compatibility methods available
-- make `WindowTracker._init_screen()` idempotent before calling service startup
-- update startup/factory tests so the X11 service path is covered
-
-Do not:
-
-- migrate menu or preview callers yet
-- add native Wayland or reduced-backend selection
-- change `DockModel.update_running()` semantics
-- thread environment checks beyond the construction point
-
-Manual visual checks:
-
-- Run the X11 service path.
-- Watch for duplicate updates: flickering indicators, duplicated menu rows, repeated preview refreshes, or doubled close and activate behavior.
-- Test left-click actions for running apps: focus, cycle, most-recent, minimize, and close-focused.
-- Right-click running apps and confirm open-window rows, close, and close-all still affect the correct windows.
-- Hover apps with one and multiple windows and confirm previews still map to the correct windows.
-
-Exit criteria:
-
-- X11 startup uses `X11WindowService`
-- current X11 UI tests still pass unchanged
-- no duplicate Wnck signal connection is possible
-
-#### [x] PR 5: Menu Window Rows Use Snapshots
-
-Remove Wnck/XID assumptions from open-window menu rows. This is the first
-planned UI consumer migration after the combined PR 2 + PR 3 and the X11 runtime
-service-wiring PR, even though X11 behavior should remain visually identical.
-
-Start here:
-
-- inspect `docking/ui/menu.py`, especially open-window row creation, row
-  activation, and close-button handlers
-- inject or pass the window service that already has `list_windows()`,
-  `activate(WindowId)`, and `close(WindowId)`
-- use `WindowSnapshot.title` for labels and `WindowSnapshot.id` for actions
-- preserve current sorting, empty-state behavior, close-button visibility, and
-  menu teardown behavior
-- update tests in `tests/ui/test_menu_integration.py` so they assert
-  `WindowSnapshot` and `WindowId` usage instead of fake Wnck objects where
-  possible
-- add a focused regression test that an X11 snapshot with XID 7 still calls the
-  X11 adapter close/activate path for `WindowId.x11(7)`
-
-Do not:
-
-- touch preview popup behavior
-- remove XID fields from running state
-- change app startup/backend selection
-- add native Wayland-specific menu behavior
-
-Manual visual checks:
-
-- Right-click apps with zero, one, and multiple windows and confirm menu layout and separators are unchanged.
-- Confirm open-window rows show the right titles, sorted in the expected order.
-- Activate each listed window from the menu and confirm the correct window is focused.
-- Use per-window close buttons and Close or Close All, including with stale or just-closed windows.
-- Check long window titles for truncation, spacing, and menu width regressions.
-
-Exit criteria:
-
-- menu tests no longer need live/fake Wnck windows for open-window rows
-- close/activate menu behavior remains unchanged on X11
-- unsupported or empty `list_windows()` produces the current no-window menu
-  behavior rather than a crash
-
-#### [x] PR 6: Preview Popup Uses `PreviewService`
-
-Remove direct `GdkX11`/`Wnck` usage from backend-neutral preview UI while
-keeping the X11 capture path internally unchanged.
-
-Start here:
-
-- inspect `docking/ui/preview.py` and identify every XID, Wnck, and GdkX11
-  boundary
-- add `docking/platform/backends/x11/services/previews.py`
-- move current X11 capture helpers under `docking/platform/backends/x11/impl/preview_capture.py`
-- expose capture through `PreviewService.capture(WindowId, ...)`
-- make `PreviewPopup` consume `WindowSnapshot` or `WindowId` instead of raw XID
-  lists
-- preserve icon/title fallback behavior for windows where capture returns
-  `None`
-- keep X11 screenshot/capture error handling defensive; disappearing windows
-  should drop a preview, not crash hover UI
-- update `tests/ui/test_preview_popup_integration.py` and visual preview cases
-  to use snapshots/service fakes
-
-Do not:
-
-- add native Wayland capture portals yet
-- change thumbnail sizing or timing policy unless required by the service
-  boundary
-- remove XID fields from running state
-
-Manual visual checks:
-
-- Hover apps with one, two, and many windows and confirm preview thumbnails still appear in the right order.
-- Click a preview and confirm it activates the intended window.
-- Close a window while the preview is open and confirm the popup degrades without crashing or stale thumbnails.
-- Check preview sizing, title labels, icon fallback, hover timing, and dismissal behavior.
-- Test minimized windows and windows on other workspaces if the current X11 behavior supports them.
-
-Exit criteria:
-
-- `docking/ui/preview.py` no longer imports `GdkX11` or `Wnck`
-- preview behavior remains the same on X11
-- tests cover stale/not-found `WindowId` handling
-
-#### [x] PR 7: Complete Session Backend Shape With X11 Only
-
-Complete the X11 `SessionBackend` shape after the first runtime service wiring
-and after menu/preview can consume services. Production still selects only the
-X11 backend.
-
-Start here:
-
-- add or expand `docking/platform/backends/x11/session.py`
-- add or expand `docking/platform/backends/selection.py`
-- complete `X11SessionBackend` with:
-  - `name == "x11"`
-  - `display_server == DisplayServer.X11`
-  - X11 `WindowService`
-  - X11 `PreviewService`
-- make `docking.app` pass the service objects needed by migrated UI callers into
-  `build_dock_window`
-- keep imports lazy enough that native Wayland startup does not import X11-only
-  modules before backend selection
-- update `tests/test_app.py`, `tests/ui/test_factory.py`, and smoke tests to
-  build/fake a session backend
-
-Do not:
-
-- add native Wayland backend
-- change applets yet
-- make `GDK_BACKEND=wayland` claim support
-
-Manual visual checks:
-
-- Launch the dock on X11 and confirm startup order feels unchanged: dock appears, applets start, updates run, and window state populates.
-- Confirm all already-migrated menu and preview flows still work through the session backend.
-- Check logs for backend selection clarity without noisy warnings during normal X11 startup.
-
-Exit criteria:
-
-- startup behavior is unchanged on X11
-- tests can construct a fake/reduced session backend for UI wiring
-- `docking.app` no longer directly decides individual X11 services
-
-#### [x] PR 8: Visibility Service
-
-Move dodge monitor creation behind the session backend.
-
-Start here:
-
-- inspect `docking/platform/backends/x11/impl/dodge.py` and
-  `docking/ui/factory.py`
-- add `docking/platform/backends/x11/services/visibility.py`
-- wrap current `WindowDodgeMonitor` construction behind `VisibilityService`
-- teach the factory to request a visibility monitor from
-  `backend.visibility.create_monitor(...)`
-- support `None` cleanly for unsupported or reduced backends
-- use `PlatformCapabilities` for broad overlap support rather than probing X11
-  helpers from UI code
-- preserve all current X11 hide-mode semantics and signal timing
-
-Do not:
-
-- change dodge math
-- add Wayland overlap protocols
-- change surface placement or struts
-
-Manual visual checks:
-
-- Test every hide mode, especially dodge-active, dodge-any, dodge-maximized, autohide, and always-visible.
-- Move, maximize, minimize, and close windows near the dock edge and confirm reveal and hide timing is unchanged.
-- Move the dock between screen edges and monitors and confirm overlap detection still follows the correct edge.
-- Check pressure reveal, pointer barriers, and hover reveal if enabled.
-- Confirm unsupported or reduced visibility paths do not leave the dock stuck hidden or stuck visible.
-
-Exit criteria:
-
-- `docking.ui.factory` no longer imports `WindowDodgeMonitor`
-- X11 dodge tests still pass
-- unsupported visibility service can run without crashing
-
-#### [x] PR 9: Surface Service
-
-Move struts, barriers, blur hints, and platform surface hooks behind
-`SurfaceService`.
-
-Start here:
-
-- inspect `docking/platform/backends/x11/impl/struts.py`, pointer barriers, blur helpers, and
-  `DockPlacementController`
-- add `docking/platform/backends/x11/services/surface.py`
-- move X11 strut/barrier/blur calls behind service methods while keeping
-  placement math in the existing placement controller
-- make input-region support capability-driven
-- keep X11-specific imports under the X11 backend or explicit transitional
-  shims
-- add tests that unsupported reservation/input-region operations are no-ops,
-  not crashes
-
-Do not:
-
-- add layer-shell yet
-- rewrite placement math unless required to preserve behavior
-- change always-visible/autohide semantics
-
-Manual visual checks:
-
-- Check dock placement on bottom, top, left, and right positions.
-- Verify edge distance, additional distance, strut reservation, blur hint, keep-above behavior, and rounded-edge rendering.
-- Maximize windows near the dock and confirm reserved space is still correct.
-- Test multi-monitor placement and monitor switching.
-- Check autohide and reveal geometry after changing icon size, zoom, distance, and position settings.
-
-Exit criteria:
-
-- raw `GdkX11` checks are confined to X11 backend code or transitional shims
-- X11 placement, strut, barrier, and blur tests still pass
-
-#### [x] PR 10: Applet Service Extraction
-
-Move Wnck/X11 applet dependencies behind applet-facing services.
-
-Start here:
-
-- inventory X11/Wnck usage in Desktop, Workspaces, Window Killer,
-  Desk Presence, Color Picker, Screenshot, Caffeine, and any applet that shells
-  out to X11 tools
-- add X11 implementations for `WorkspaceService`, `DesktopActionService`,
-  `WindowPickService`, `IdleService`, and `ScreenCaptureService` only where the
-  current applet really needs them
-- migrate one applet family at a time, starting with the smallest one
-- add explicit unsupported states so applets can hide actions, disable buttons,
-  or show a concise unavailable state instead of crashing
-- keep service APIs narrow; do not expose raw Wnck windows to applets
-
-Do not:
-
-- attempt full native Wayland applet parity
-- make applet UI depend on compositor names directly
-- remove X11 helper paths until each applet has tests
-
-Manual visual checks:
-
-- Review each migrated applet menu, tooltip, icon state, and click behavior on X11.
-- For Desktop, Workspaces, Window Killer, Desk Presence, Color Picker, Screenshot, and Caffeine, confirm the platform-specific action still works.
-- Confirm unsupported-service states are clear and do not crash the applet popup or menu.
-- Check applet ordering, anchoring, and startup behavior after enabling or disabling migrated applets.
-- Verify translated and long labels still fit in applet menus and dialogs.
-
-Exit criteria:
-
-- applets keep current X11 behavior
-- backend-neutral applet loading can skip or disable unsupported actions
-- tests cover at least one unsupported-service path
-
-#### [x] PR 11: Cleanup Transitional X11 APIs
-
-Remove compatibility methods only after all UI callers and tests use neutral
-backend APIs.
-
-Start here:
-
-- remove or deprecate `get_xids_for`, `activate_xid`, `close_xid` from
-  backend-neutral call paths
-- keep XID internals inside X11 backend where still useful
-- update documentation and support language
-- search the repo for `get_xids_for`, `get_windows_for`, `activate_xid`,
-  `close_xid`, raw `Wnck.Window`, and raw XID usage before deleting anything
-- preserve any X11-only internals that the X11 backend still needs for previews
-  or diagnostics
-
-Manual visual checks:
-
-- Run a full X11 smoke pass: startup, running indicators, click actions, menus, previews, hide modes, and applets.
-- Open and close multiple app windows quickly and confirm no stale XID or window assumptions remain visible.
-- Compare the cleaned path against behavior from before cleanup for menu rows, previews, and click actions.
-- Confirm no unsupported Wayland or reduced backend UI regresses after compatibility methods are removed.
-
-Exit criteria:
-
-- no backend-neutral UI module depends on Wnck windows or XIDs
-- X11 backend remains fully supported
-
-#### [x] PR 12: X11 Parity Hardening After Service Split
-
-Fix the remaining confirmed X11 behavior and lifecycle issues found after PRs
-8-11 before using a reduced backend to validate Wayland assumptions.
-
-Completed scope:
-
-- fixed dodge overlap geometry so `VisibilityService` receives the actual dock
-  band/background rect in screen coordinates, not the full GTK toplevel
-  rectangle used for transparent structural space
-- made `DockPlacementController.on_destroy()` stop active-display polling as
-  well as idle reposition callbacks and screen signal handlers
-- made Window Killer avoid resolving the PID twice after a pick by killing the
-  selected/logged PID directly through the picker service
-- made `WorkspacesApplet.start()` idempotent so duplicate starts cannot leak
-  `active-workspace-changed` watches
-- kept the completed `Current Workspace Only` surface-scope behavior covered by
-  tests and manual checks
-
-Do not:
-
-- change X11 hide-mode math beyond correcting the rectangle being observed
-- add native Wayland or reduced-backend selection yet
-- remove X11 cached-XID internals unless a focused parity test proves they are
-  the bug
-- add new speculative service APIs unless a confirmed caller needs them
-
-Manual visual checks:
-
-- Test intelligent/window-dodge/dodge-active/dodge-maximized with windows near
-  transparent parts of the GTK toplevel but outside the visible dock band.
-- Toggle `Current Workspace Only` across multiple workspaces and confirm the
-  completed surface-scope behavior still makes the shelf appear on the intended
-  workspaces immediately.
-- Enable active-display follow, destroy/quit the dock, and confirm no polling
-  callbacks continue after shutdown.
-- Use Window Killer on a normal window and on a window that closes while picking
-  to confirm logs and kill targets stay coherent.
-- Add/remove/start Workspaces applet and switch workspaces repeatedly; confirm
-  only one workspace-change callback is active.
-
-Exit criteria:
-
-- X11 behavior is unchanged except for confirmed bug fixes
-- focused tests cover dodge rect source, workspace scope stickiness,
-  active-display cleanup, Window Killer PID ownership, and Workspaces applet
-  watch idempotency
-- full non-visual suite and the usual X11 manual smoke pass both pass
-
-#### [x] PR 13: Reduced Backend
-
-Add a backend with no taskbar powers to validate that X11 assumptions are no
-longer leaking through normal UI.
-
-Start here:
-
-- add `docking/platform/backends/reduced/session.py`
-- provide no-op services for windows, previews, visibility, workspaces, and
-  applet-specific platform actions
-- add a test/dev selection path, preferably an environment variable such as
-  `DOCKING_BACKEND=reduced`, but keep production auto-detection unchanged
-- verify pinned launchers, rendering, menus without window rows, no-preview
-  hover behavior, and backend-neutral applets
-- assert `PlatformCapabilities` is honest: false for taskbar powers, true only
-  for what the reduced backend actually supports
-
-Do not:
-
-- ship it as user-facing native Wayland support yet unless explicitly labeled
-  reduced/experimental
-- import X11 modules from the reduced backend
-- silently pretend taskbar/window actions succeeded
-
-Manual visual checks:
-
-- Force the reduced backend and confirm the dock starts with pinned launchers and backend-neutral applets.
-- Confirm running indicators, window rows, previews, dodge modes, and unsupported actions disappear or disable cleanly.
-- Check right-click menus for pinned apps: launch, pin, and remove actions should still be usable where applicable.
-- Confirm no X11-only errors leak into the UI and logs explain the reduced capabilities.
-- Switch back to X11 and confirm full behavior returns.
-
-Exit criteria:
-
-- Docking can start without Wnck task powers
-- unsupported features degrade intentionally
-- reduced-backend tests prove no accidental X11 imports
-
-#### [x] PR 14: Native Wayland Detection Stub
-
-Only after the reduced backend works, add native Wayland detection that selects
-a reduced/no-op backend when unsupported.
-
-Scope:
-
-- detect GTK Wayland display
-- avoid importing X11-only backend modules for native Wayland
-- log protocol/dependency limitations clearly
-- select reduced backend on GNOME/Mutter native Wayland
-- select X11 backend for X11 and XWayland sessions exactly as today
-
-Do not:
-
-- add layer-shell or foreign-toplevel yet
-- run X11 fallback code in native Wayland unless explicitly under XWayland
-- claim current-open-app support on compositors without a toplevel protocol
-
-Manual visual checks:
-
-- Start under native Wayland and confirm Docking enters reduced mode instead of crashing.
-- Start under X11 or XWayland and confirm the X11 backend is still selected and behavior is unchanged.
-- Confirm unsupported taskbar and window features are hidden, disabled, or clearly unavailable on native Wayland.
-- Check logs for a concise backend and capability explanation without noisy repeated warnings.
-
-Exit criteria:
-
-- Docking does not crash on native Wayland startup
-- X11 remains unchanged
-- logs and capability flags explain reduced mode
-
-#### [x] PR 15: Layer-Shell Surface Backend
-
-Add native Wayland dock-surface placement for compositors that support
-layer-shell.
-
-Research findings:
-
-- Native Wayland does not require rebuilding the shelf UI from scratch. The
-  existing GTK window/widgets/rendering can remain the shelf; what changes is
-  the surface role and placement path.
-- `wlr-layer-shell` is the right primitive for dock/panel surfaces: anchors,
-  layer choice, margins, keyboard mode, and exclusive zones.
-- `gtk-layer-shell` is the right GTK3 integration point because the layer-shell
-  role must be assigned before the GTK window is first mapped.
-- `gtk-layer-shell` makes the GTK window a layer-shell surface instead of an
-  ordinary `xdg_toplevel` application window. That is what enables native
-  panel/dock placement, edge reservation, and non-Alt-Tab-like behavior on
-  supporting compositors.
-- Layer-shell does not provide taskbar data. Running/active application
-  indicators need a separate foreign-toplevel or compositor-specific window
-  service.
-- Reimplementing `gtk-layer-shell` inside Docking would still depend on the
-  compositor advertising `zwlr_layer_shell_v1`, while adding fragile GTK/GDK
-  Wayland pointer plumbing.
-- GNOME/Mutter native Wayland should remain reduced unless Mutter exposes a
-  supported third-party shell-component path or Docking grows a GNOME Shell
-  extension.
-
-Completed scope:
-
-- added `WaylandLayerShellSessionBackend` for native Wayland layer-shell mode
-- added `WaylandLayerShellSurfaceService`, which imports `GtkLayerShell` only
-  inside the Wayland backend path and assigns the layer-shell role before map
-- maps existing `PlacementRequest` and `ReservationRequest` data onto
-  layer-shell anchors, monitor selection, size, and exclusive zones without
-  changing X11 placement code
-- reuses reduced window, preview, and visibility services so PR15 only claims
-  surface placement/reservation support
-- keeps fallback to reduced mode when `GtkLayerShell` is unavailable or the
-  compositor does not advertise layer-shell support
-- documents the optional system dependency in the README and packaging notes
-- adds focused tests for layer-shell surface calls, backend selection/fallback,
-  and X11 import isolation
-
-Do not:
-
-- add taskbar/window tracking yet
-- make `gtk-layer-shell` a hard dependency for X11 users
-- import layer-shell modules in X11 sessions
-- hand-roll raw Wayland surface role setup unless `gtk-layer-shell` proves
-  impossible to package
-
-Manual visual checks:
-
-- On a layer-shell compositor, check dock anchoring on all four edges and all configured monitors.
-- Maximize windows and confirm exclusive zones reserve space correctly.
-- Toggle autohide and always-visible modes and confirm reveal or hide geometry stays aligned to the layer-shell edge.
-- Check fallback behavior when layer-shell is missing, especially on GNOME or Mutter native Wayland.
-- Verify X11 placement, struts, and blur behavior are unchanged.
-
-Exit criteria:
-
-- native Wayland dock can reserve edge space on a supported layer-shell
-  compositor
-- GNOME native Wayland remains reduced/unsupported with a clear log
-- X11 placement tests remain unchanged
-
-#### [x] PR 16: Generic Foreign-Toplevel Window Service
-
-Add basic opened-app context for compositors that expose foreign-toplevel
-management.
-
-Research findings:
-
-- `zwlr_foreign_toplevel_manager_v1` is the best current generic taskbar
-  protocol when action support is needed.
-- It can provide app ID, title, active/minimized/maximized/fullscreen state,
-  output enter/leave, parent, close events, activate, close, minimize,
-  maximize, and fullscreen requests.
-- This is the generic native-Wayland path for running dots and active
-  application indicators: aggregate foreign toplevel handles by compositor
-  `app_id`, match those app IDs to Docking desktop IDs, and mark the matching
-  shelf item as running/active.
-- Multiple windows for the same app are represented as multiple toplevel handles
-  with the same matched desktop ID, so the same backend state can power counts,
-  window menus, and active-window highlighting.
-- The active indicator comes from the toplevel `activated` state, not from
-  layer-shell or from the dock surface.
-- It does not provide reliable window geometry, workspace membership, PID,
-  stacking order, or window-at-point picking.
-- `ext_foreign_toplevel_list_v1` is newer and gives stable mapped-toplevel
-  handles with app/title/identifier metadata, but it is intentionally minimal
-  and does not itself provide taskbar actions.
-- KWin/Plasma should not be treated as part of this generic path:
-  `zwlr_foreign_toplevel_manager_v1` is not the rich Plasma taskbar API.
-
-Completed scope:
-
-- added a lazy foreign-toplevel protocol adapter/probe behind optional imports;
-  missing Python bindings or compositor support keep the reduced window service
-  active
-- vendored the wlroots `wlr-foreign-toplevel-management-unstable-v1.xml` source
-  and generated PyWayland binding so the missing protocol module is available
-  from Docking's source tree
-- kept the live registry/event-loop bridge separate; without optional
-  `pywayland` runtime support and a concrete adapter, the backend still falls
-  back to reduced window state
-- added `WaylandForeignToplevelWindowService`, which owns protocol handles
-  internally and exposes only backend-neutral `WindowId` and `WindowSnapshot`
-  values
-- tracks app ID, title, active/minimized/maximized/fullscreen state, output
-  enter/leave, parent, and closed/done events through a fakeable protocol-event
-  surface
-- added `WaylandAppIdMatcher` for Wayland app IDs, including direct desktop IDs,
-  reverse-DNS-style IDs, Flatpak-style IDs, and executable-style aliases without
-  changing X11 WM_CLASS matching
-- aggregates matched toplevels into `RunningAppInfo` and publishes them through
-  `DockModel.update_running()` so existing running dots, active indicators, and
-  instance counts work from the same model path as X11
-- implements basic activate, close, minimize, close-all, activate-most-recent,
-  and toggle-focus actions when the protocol adapter exposes them
-- keeps geometry, dodge, PID, stacking, preview, and workspace capability flags
-  false unless a later backend actually provides those facts
-- updates the Wayland session so foreign-toplevel support upgrades only the
-  `windows` service; layer-shell surface, reduced previews, and reduced
-  visibility remain unchanged
-
-Do not:
-
-- claim geometry/dodge/workspace parity
-- add compositor-specific Plasma, COSMIC, Hyprland, Niri, or Wayfire code here
-- change X11 matching behavior
-- infer unsupported capabilities from titles, app IDs, or output-enter events
-
-Manual visual checks:
-
-- On a supported compositor, open apps and confirm running indicators appear and clear correctly.
-- Open multiple windows for one app and confirm counts, active state, and basic actions match compositor capability.
-- Test activate, close, minimize, and maximize where supported; unsupported actions should be disabled or no-op visibly safely.
-- Check app matching for common desktop IDs, Flatpak apps, and apps with unusual app IDs.
-- Confirm X11 behavior is unchanged after the generic Wayland service lands.
-
-Exit criteria:
-
-- running indicators and basic window actions work on at least one supported
-  compositor
-- unsupported compositors continue reduced mode with clear logs
-- geometry, workspace, preview, PID, and dodge features remain capability-gated
-
-#### [x] PR 17: Standard Workspace, Idle, and Portal Services
-
-Add portable Wayland services only where standard protocols or portals exist.
-
-Research findings:
-
-- `ext_workspace_v1` can enumerate workspace groups/workspaces and request
-  activate/deactivate/remove/assign where the compositor advertises those
-  capabilities.
-- Workspace support is still compositor-dependent and should be optional, not a
-  requirement for the generic foreign-toplevel backend.
-- XDG desktop portal `Screenshot` can provide user-mediated screenshots and
-  `PickColor`; it cannot be used as a silent arbitrary-window preview backend.
-- `ext_idle_notify_v1` can report idled/resumed transitions, but it is not a
-  direct replacement for XScreenSaver-style exact idle seconds.
-- Pointer barriers have no normal-client equivalent to X11 global barriers;
-  Wayland pointer constraints and relative pointer protocols are focused on
-  surfaces with pointer focus, not global dock edge barriers.
-
-Completed scope:
-
-- vendored `ext-workspace-v1.xml` and generated PyWayland protocol bindings
-  alongside the other Wayland protocol artifacts
-- added `WaylandWorkspaceService`, a fakeable `WorkspaceService` driven by
-  standard workspace protocol events and capability-gated activate requests
-- wired the Wayland session so `workspaces` upgrades only when a live workspace
-  adapter is available; otherwise it remains `None`
-- added `WaylandPortalColorPickerService` using XDG Desktop Portal
-  `PickColor` as the native Wayland `ScreenCaptureService` path
-- wired portal-backed color picking into the Wayland session when Gio/portal
-  dependencies are available
-- kept idle support unavailable because the current `IdleService` contract
-  requires exact `idle_seconds()`, while `ext-idle-notify-v1` provides
-  threshold-based idled/resumed notifications instead
-- added focused tests for workspace events, active workspace watchers,
-  activation behavior, color conversion/cancel handling, and session
-  capabilities
-
-Do not:
-
-- force workspaces into the generic foreign-toplevel service
-- claim current-workspace filtering for windows unless the backend can map
-  windows to workspaces
-- use portals for background, silent, per-window previews
-- claim pointer-barrier parity on native Wayland
-
-Manual visual checks:
-
-- On compositors with `ext_workspace_v1`, confirm workspace list and activation behavior matches advertised capabilities.
-- On compositors without workspace protocol support, confirm the Workspaces applet degrades cleanly.
-- Test portal color picking under native Wayland and confirm the user-mediated flow is acceptable.
-- Confirm X11 workspace, idle, and color-picking behavior is unchanged.
-
-Exit criteria:
-
-- standard workspace support works where the compositor advertises it
-- portal-backed color picking replaces X11-root sampling on native Wayland
-- unsupported services remain absent or reduced with clear capability flags
-
-#### [x] PR 18: Wayland Protocol Runtime Adapter
-
-Turn the vendored protocol bindings and PR16-17 service state machines into a
-live native Wayland backend by adding the missing PyWayland registry/event-loop
-adapter.
-
-Completed scope:
-
-- added `pywayland` as an optional `wayland` extra in `pyproject.toml`, not as a
-  default X11 dependency
-- added `WaylandProtocolRuntime`, owned by the Wayland session backend
-- uses a separate `pywayland.client.Display` connection for protocol clients
-  rather than borrowing GTK's internal Wayland connection
-- binds `wl_registry` and discovers advertised globals
-- binds `zwlr_foreign_toplevel_manager_v1` when present and forwards events into
-  `WaylandForeignToplevelWindowService`
-- binds `ext_workspace_manager_v1` when present and forwards events into
-  `WaylandWorkspaceService`
-- integrates `display.get_fd()` with the GLib main loop using a removable source
-- dispatches pending events and flushes outgoing requests without blocking GTK
-- logs which live protocol services are available at runtime startup
-- runtime shutdown removes GLib sources, stops protocol managers, and closes the
-  Wayland display connection
-- existing reduced fallback remains when `pywayland` is missing, the Wayland
-  connection fails, or the compositor does not advertise relevant globals
-- added unit tests for registry binding, fd dispatch, fd error handling, and
-  fail-closed startup behavior
-
-Do not:
-
-- add compositor-specific socket/IPC backends yet
-- reuse GTK's internal `wl_display` through `ctypes` in the first implementation
-- make `pywayland` mandatory for X11 users
-- expose raw Wayland protocol handles to UI code
-- block startup if foreign-toplevel or workspace globals are missing
-
-Manual visual checks:
-
-- On a compositor exposing `zwlr_foreign_toplevel_manager_v1`, open/focus/close
-  apps and confirm running dots, active indicators, instance counts, and window
-  menu rows update from live protocol events.
-- On a compositor exposing `ext_workspace_manager_v1`, confirm the Workspaces
-  applet lists/activates workspaces and active-workspace watches fire.
-- Start on native Wayland without one or both globals and confirm Docking keeps
-  the layer-shell surface and reduced behavior for the missing service.
-- Start on X11 and confirm no PyWayland/protocol runtime import happens.
-- Quit/restart Docking repeatedly and confirm no GLib fd watchers or protocol
-  connections leak.
-
-Exit criteria:
-
-- native Wayland can show live running/active app state on a compositor with
-  foreign-toplevel support
-- native Wayland can show live workspace state on a compositor with
-  `ext_workspace_v1`
-- missing globals and missing `pywayland` fall back cleanly
-- X11 and reduced backends remain unaffected
-
-#### [ ] PR 19: Compositor-Specific Rich Backends
-
-Add richer compositor-specific integrations after the generic layer-shell,
-foreign-toplevel, workspace, portal, and protocol-runtime paths are stable.
-
-Research findings:
-
-- KWin/Plasma has the richest taskbar protocol in
-  `org_kde_plasma_window_management`, including UUIDs, app IDs, title/state,
-  attention, skip-taskbar, geometry, client geometry, PID, virtual desktops,
-  stacking order, icons, show desktop, and richer actions. It is explicitly a
-  private desktop implementation detail and only one client can bind it, so it
-  must be treated as a risky trusted-integration path, not a generic backend.
-- KWin scripting can expose window/workspace state through JavaScript and D-Bus,
-  but it is also a Plasma-specific trusted bridge.
-- COSMIC exposes promising protocols for toplevel info, toplevel management,
-  workspaces, overlap notification, and image capture; it is a strong candidate
-  for rich native parity.
-- Hyprland exposes practical JSON IPC for clients, workspaces, events, and
-  dispatch actions. This can provide rich behavior, but it is specific to that
-  compositor.
-- Niri exposes JSON IPC through `$NIRI_SOCKET`, including windows, workspaces,
-  event streams, focus, and close actions.
-- Wayfire exposes IPC via plugins and `pywayfire`; capabilities depend on
-  enabled plugins such as `ipc` and `ipc-rules`.
-- GNOME/Mutter native Wayland remains a separate GNOME Shell extension project
-  if full parity is desired.
-
-Backend-specific findings:
-
-- COSMIC is the strongest protocol-first rich backend candidate. Its
-  `cosmic-protocols` set includes toplevel info, toplevel management,
-  workspace extensions, overlap notification, and image-capture-source
-  extensions. `zcosmic_toplevel_manager_v1` exposes capability-gated close,
-  activate, maximize, minimize, fullscreen, sticky, and move-to-workspace
-  requests. `zcosmic_overlap_notify_v1` is especially important for Docking
-  because it can notify a layer-shell client when toplevels or other layer
-  surfaces overlap the dock surface, which is much closer to native dodge
-  behavior than generic foreign-toplevel can provide.
-- Hyprland is an IPC-first backend candidate. It exposes two UNIX sockets under
-  `$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/`: one synchronous
-  hyprctl-like command socket and one event stream socket. The event stream
-  reports workspace, focused monitor, active window, open/close window,
-  move-window, title, urgent, fullscreen, pin, and minimized events. Its JSON
-  `hyprctl -j` queries can provide current clients/workspaces, while dispatch
-  commands can focus or close windows by address. The main risk is that the
-  command socket is synchronous and can freeze Hyprland if clients hold it open.
-- Niri is an IPC-first backend with the cleanest JSON contract. It exposes a
-  UNIX socket via `$NIRI_SOCKET`; requests and replies are newline-delimited
-  JSON. It has explicit `Windows`, `Workspaces`, `FocusedWindow`,
-  `FocusedOutput`, `PickWindow`, `PickColor`, and `EventStream` requests. The
-  event stream provides current state up front and then streams updates, making
-  it well suited to a taskbar backend. Window/workspace actions can target
-  stable IDs, but clients should not batch unrelated requests and assume
-  consistency between them.
-- Wayfire is IPC-first but plugin-dependent. Its IPC socket exists only when the
-  `ipc` plugin is enabled, and useful window-management methods depend on
-  companion plugins such as `ipc-rules`, `wm-actions`, or other extensions. The
-  `pywayfire` package can provide a Python-facing wrapper with methods such as
-  `list_views()`, `set_focus()`, `close_view()`, `set_view_minimized()`,
-  workspace operations, scale/expo actions, and event watching where the
-  required plugins are enabled. This can be rich, but availability varies by
-  user configuration.
-- KWin/Plasma has two possible paths. The private
-  `org_kde_plasma_window_management` protocol is closest to X11/libwnck parity,
-  but it is explicitly an implementation detail, warns regular clients not to
-  use it, and allows only one client to bind it. A KWin script bridge is a
-  higher-level alternative: JavaScript/QML scripts run inside KWin, use the
-  global `workspace` object to access client lists, active windows, stacking
-  order, geometry, and signals, and could expose a D-Bus contract to Docking.
-  The bridge is safer than competing for the private protocol but creates a
-  Plasma-specific install/configuration surface.
-- GNOME/Mutter remains extension-first. A normal Python GTK client cannot
-  become a full GNOME dock by adding compositor IPC. Full parity belongs in a
-  GNOME Shell extension/frontend or, at minimum, a Shell extension bridge that
-  exposes Mutter window/workspace state over D-Bus.
-- Generic wlroots compositors such as Sway, river, and labwc should stay on the
-  standard layer-shell plus foreign-toplevel path unless they expose a richer
-  stable IPC. Do not add per-compositor backends where the generic protocol
-  backend already gives equivalent behavior.
-
-Capability summary:
-
-| Backend path | Running state | Actions | Workspaces | Geometry/dodge | Previews/capture | Risk |
-| --- | --- | --- | --- | --- | --- | --- |
-| COSMIC protocols | strong | strong | strong | strongest via overlap notify | promising via image-capture protocols | protocol churn while COSMIC matures |
-| Hyprland IPC | strong | strong | strong | geometry available from client IPC | compositor-specific only | socket protocol and synchronous command caveats |
-| Niri IPC | strong | medium/strong | strong | geometry/layout data available | pick/color/cast APIs, preview still separate | JSON contract evolves with niri |
-| Wayfire IPC | medium/strong | medium/strong | medium/strong | possible via view data/plugins | plugin-dependent | user plugin configuration |
-| KWin private protocol | strongest | strongest | strong | strong | icons/private data available | private API, one-client binding |
-| KWin script bridge | strong | strong | strong | strong | bridge-defined | extra install/runtime component |
-| GNOME Shell extension | strongest on GNOME | strongest on GNOME | strongest on GNOME | strongest on GNOME | shell-defined | second frontend/version maintenance |
-
-Start here:
-
-- choose one compositor-specific backend at a time based on available test
-  hardware/session access
-- add explicit detection and capability flags for each backend
-- prefer public standard protocols over compositor-specific IPC when both offer
-  equivalent capability
-- isolate each backend so missing sockets, missing protocol globals, missing
-  desktop-file permissions, or disabled compositor plugins cannot affect X11 or
-  other Wayland backends
-- document each backend's trust and stability model
-- implement each backend as an adapter that feeds the same existing service
-  contracts: `WindowService`, `WorkspaceService`, `VisibilityService`, and
-  optional capture/action services
-- keep backend-specific identifiers private and expose only `WindowId`,
-  `WindowSnapshot`, `WorkspaceSnapshot`, and capability flags to UI code
-- prefer event streams over polling where the compositor provides them, but add
-  a startup full-state snapshot so the dock can recover after missed events
-- add one manual smoke profile per compositor because CI will not cover these
-  runtime integrations reliably
-
-Candidate order:
-
-- COSMIC first if a COSMIC test session is available, because its protocol set
-  most directly maps to Docking's missing native Wayland features.
-- Niri next if JSON socket integration is preferred, because its event stream
-  and typed request/response model are clean and taskbar-oriented.
-- Hyprland next if broader user impact is preferred, but isolate the synchronous
-  command socket carefully and avoid long-lived command connections.
-- Wayfire after that, gated on `ipc`/`ipc-rules`/needed plugin availability.
-- KWin/Plasma only after choosing between private protocol access and a KWin
-  script/D-Bus bridge.
-- GNOME Shell extension as a separate frontend/bridge track, not as a normal
-  Python GTK backend.
-
-##### [ ] PR 19a: Common Compositor IPC Scaffolding
-
-Add shared infrastructure for compositor-specific socket/IPC backends without
-adding a concrete compositor integration yet.
-
-Start here:
-
-- add a small internal IPC adapter interface for request/response calls,
-  event-stream subscriptions, reconnect, shutdown, and diagnostics
-- support newline-delimited JSON socket protocols because Niri and several
-  compositor tools use that shape
-- add text event parsing helpers for Hyprland-style `EVENT>>DATA` streams
-- add lifecycle ownership for background event readers so they stop cleanly when
-  the session backend stops
-- add logging conventions that include compositor name, socket path, capability
-  flags, and fallback reason
-- add test fakes for event streams and request/reply sockets so compositor
-  backends can be tested without running the compositor
-- document the expected contract between compositor adapters and existing
-  `WindowService`, `WorkspaceService`, and `VisibilityService` implementations
-
-Do not:
-
-- add compositor-specific behavior here
-- make any IPC package a hard dependency
-- expose compositor socket payloads to UI code
-- let IPC failures affect X11, generic Wayland, or reduced backends
-
-Manual visual checks:
-
-- Force each existing backend and confirm behavior is unchanged.
-- Simulate a missing socket/dependency and confirm Docking falls back with one
-  clear log line.
-- Start and stop Docking repeatedly and confirm no background reader remains.
-
-Exit criteria:
-
-- compositor IPC adapters can be unit-tested with fake sockets/events
-- service code can consume normalized events without knowing the compositor
-- no existing backend imports compositor-specific IPC modules at startup
-
-##### [ ] PR 19b: COSMIC Rich Protocol Backend
-
-Add the first protocol-first rich backend if a COSMIC Wayland test session is
-available.
-
-Start here:
-
-- bind COSMIC toplevel info and management protocols only when advertised
-- map COSMIC toplevel handles to backend-neutral `WindowId` values
-- track app ID, title, active/minimized/maximized/fullscreen/sticky state,
-  outputs, and workspace links where the protocols expose them
-- implement capability-gated close, activate, maximize, minimize, fullscreen,
-  sticky, and move-to-workspace actions
-- add COSMIC workspace support through COSMIC workspace extensions and/or
-  `ext_workspace_v1` where appropriate
-- add COSMIC overlap-notify support as a native `VisibilityService` for
-  layer-shell dock overlap/dodge behavior
-- evaluate image-capture-source support for previews, but keep previews
-  disabled unless a reliable toplevel capture path is confirmed
-
-Do not:
-
-- assume COSMIC protocols are stable across releases without version checks
-- use COSMIC overlap notifications on non-COSMIC compositors
-- enable preview capability until real image capture is implemented
-- replace generic foreign-toplevel behavior on non-COSMIC sessions
-
-Manual visual checks:
-
-- On COSMIC Wayland, verify running dots, active app state, window counts, and
-  menu rows.
-- Test activate, close, minimize, maximize, fullscreen, and sticky actions only
-  when the compositor advertises the capability.
-- Move windows across workspaces/outputs and confirm Docking tracks expected
-  state.
-- Test dodge/autohide against overlapping toplevels using COSMIC overlap
-  notifications.
-- Start on non-COSMIC Wayland and confirm this backend does not activate.
-
-Exit criteria:
-
-- COSMIC reaches richer-than-generic taskbar behavior through capability flags
-- overlap-driven hide modes work natively on COSMIC
-- missing or changed COSMIC protocol globals fall back cleanly
-
-##### [ ] PR 19c: Hyprland IPC Backend
-
-Add a Hyprland-specific backend using its command and event sockets.
-
-Start here:
-
-- detect Hyprland through `HYPRLAND_INSTANCE_SIGNATURE` and expected socket paths
-- read initial state using short-lived `hyprctl -j`-style client queries for
-  clients, active window, workspaces, and monitors
-- subscribe to `.socket2.sock` for `openwindow`, `closewindow`,
-  `activewindowv2`, `windowtitlev2`, `movewindowv2`, `workspacev2`,
-  `focusedmonv2`, `urgent`, `fullscreen`, `pin`, and `minimized` events
-- map Hyprland window addresses to backend-neutral `WindowId` values
-- implement actions through short-lived command socket/dispatch calls such as
-  `focuswindow address:<addr>` and `closewindow address:<addr>`
-- expose workspace support from Hyprland workspace data where the IPC provides
-  stable IDs/names
-- use client geometry/workspace data for capability-gated geometry and dodge
-  experiments only after basic taskbar behavior is stable
-
-Do not:
-
-- keep the synchronous command socket open
-- parse human-readable `hyprctl` output when JSON is available
-- assume event stream data alone is complete; always reconcile with a startup
-  snapshot
-- claim preview support
-
-Manual visual checks:
-
-- On Hyprland, open/close/focus apps and confirm indicators update from events.
-- Rename/move windows and confirm title/workspace state converges.
-- Test focus and close actions by window address.
-- Restart Hyprland or kill the socket reader and confirm Docking degrades or
-  reconnects without hanging the compositor.
-
-Exit criteria:
-
-- Hyprland running indicators, active state, and basic actions work from IPC
-- socket failures never freeze Hyprland or Docking
-- geometry/workspace capabilities are advertised only after verified
-
-##### [ ] PR 19d: Wayfire IPC Backend
-
-Add a Wayfire-specific backend through `pywayfire` or direct Wayfire IPC.
-
-Start here:
-
-- detect Wayfire through `WAYFIRE_SOCKET` and confirm the `ipc` plugin is active
-- load `pywayfire` lazily, or fall back to a direct JSON socket adapter if the
-  package is unavailable
-- read initial view/workspace/output state with `list_views()` and related IPC
-  calls
-- subscribe to Wayfire IPC watch/events where available
-- map Wayfire view IDs to backend-neutral `WindowId` values
-- implement focus, close, minimize, fullscreen, sticky, show-desktop, and
-  workspace actions only when the installed plugins expose them
-- gate scale/expo and other Wayfire-specific extras behind optional applet or
-  desktop-action capabilities
-
-Do not:
-
-- assume users have `ipc-rules`, `wm-actions`, `grid`, scale, expo, or extra
-  plugins enabled
-- make `pywayfire` a hard dependency for non-Wayfire users
-- expose Wayfire-specific actions in generic UI unless capability-gated
-
-Manual visual checks:
-
-- Start with only `ipc` enabled and confirm graceful reduced capability logging.
-- Enable `ipc-rules`/needed plugins and confirm views, focus, close, minimize,
-  and workspace behavior.
-- Toggle scale/expo integrations only if explicitly supported.
-- Start on non-Wayfire sessions and confirm no Wayfire imports or sockets are
-  used.
-
-Exit criteria:
-
-- Wayfire backend activates only when required socket/plugins are available
-- taskbar actions match the installed plugin capability set
-- missing plugins degrade without noisy repeated errors
-
-##### [ ] PR 19e: KWin / Plasma Decision and Backend
-
-Decide and implement the Plasma integration path: private Wayland protocol or
-KWin script bridge.
-
-Start here:
-
-- run a decision spike comparing `org_kde_plasma_window_management` against a
-  KWin script/D-Bus bridge
-- verify whether a third-party Docking process can bind the private protocol on
-  current Plasma, including any desktop-file permission requirements
-- test whether binding conflicts with `plasmashell` or other task manager
-  components
-- if private protocol is accepted, implement a Plasma protocol backend with
-  UUIDs, app IDs, title/state, attention, skip-taskbar, geometry, client
-  geometry, PID, virtual desktops, stacking order, icons, show desktop, and
-  richer actions
-- if script bridge is accepted, package a KWin script that exposes a narrow
-  D-Bus API and implement Docking's Python backend as a D-Bus client
-- document the selected trust model and installation path
-
-Do not:
-
-- use the private protocol without an explicit decision about its maintenance
-  and one-client binding risks
-- ship a script bridge that exposes arbitrary code execution
-- make Plasma-specific assumptions in generic Wayland services
-
-Manual visual checks:
-
-- On Plasma Wayland, verify running indicators, active windows, attention,
-  window menu rows, workspace filtering, and show-desktop.
-- Move windows between virtual desktops and monitors and confirm state follows.
-- Test activate, close, minimize, maximize, fullscreen, sticky/above, and
-  workspace actions where supported.
-- Start with `plasmashell` running normally and confirm Docking does not break
-  Plasma's own task manager.
-
-Exit criteria:
-
-- one Plasma integration path is chosen and documented
-- Plasma backend reaches the closest native Wayland parity target
-- non-Plasma Wayland and X11 backends remain unaffected
-
-##### [ ] PR 19f: GNOME Shell Extension Prototype
-
-Prototype the GNOME track separately from the normal Python GTK backend.
-
-Start here:
-
-- choose bridge-first or frontend-first based on the GNOME Shell extension
-  support section above
-- for bridge-first, expose read-only window/workspace state over D-Bus from a
-  GNOME Shell extension and consume it from a Docking backend
-- for frontend-first, build a minimal Shell `St`/Clutter dock surface that owns
-  placement and reads existing Docking settings/model data through a narrow IPC
-  or generated data contract
-- define how configuration, icons, desktop matching, and theme tokens are shared
-  without importing Python into GNOME Shell
-- add GNOME Shell version metadata and a version test matrix
-- keep GNOME extension packaging separate from the Python package even if it
-  lives in the same repository
-
-Do not:
-
-- try to make a normal GTK Wayland window behave like a GNOME Shell dock
-- expose arbitrary shell evaluation over D-Bus
-- mix GTK widgets into the Shell extension runtime
-- block X11 or layer-shell releases on GNOME extension compatibility
-
-Manual visual checks:
-
-- On GNOME Wayland, enable the prototype extension and confirm it loads/unloads
-  cleanly.
-- For bridge mode, verify running and active window state reaches Docking
-  without shell log spam.
-- For frontend mode, verify shell actor placement, monitor behavior, app
-  indicators, and workspace behavior.
-- Disable/re-enable the extension and confirm signals, actors, and timers are
-  cleaned up.
-
-Exit criteria:
-
-- a clear GNOME integration direction is validated
-- the prototype does not destabilize `gnome-shell`
-- shared-code/data boundaries are documented before expanding the extension
-
-Manual visual checks:
-
-- On each supported optional compositor, confirm only that compositor-specific path activates.
-- Check running indicators, workspace behavior, overlap or dodge behavior, previews where available, and supported actions against that compositor capability.
-- Start on unsupported compositors and confirm the app falls back to generic or reduced behavior cleanly.
-- Confirm missing optional dependencies produce clear logs and no visible startup breakage.
-- Re-test X11, layer-shell, generic foreign-toplevel, and reduced paths after each optional backend is added.
-
-Exit criteria:
-
-- each compositor extension is capability-gated and does not affect X11 or
-  other Wayland backends
-- richer features such as geometry, workspace filtering, previews, PID, and
-  dodge are enabled only by backends that actually expose those facts
+### Completed PR Order (Historical)
+
+The PR sequence below was designed to keep every step reviewable and preserve
+the existing X11 runtime after each merge. All PRs 1-18 and sub-PRs 19a-c,
+19e-f are merged. Wayfire (19d) and Niri remain unimplemented.
+
+#### PR Summary
+
+All backend-refactor PRs (1-18) and compositor-specific PRs (19a-c, 19e-f)
+are merged. Each step preserved the existing X11 runtime while isolating
+platform-specific behavior behind backend contracts.
+
+| PR | Scope | Key Deliverable |
+| --- | --- | --- |
+| 1 | Backend contracts | `base.py`: `SessionBackend`, `WindowService`, `SurfaceService`, `VisibilityService`, `PreviewService`, `PlatformCapabilities`, `WindowId`, `WindowSnapshot`, `ActionResult` |
+| 2-3 | X11 window adapter | `X11WindowService` wrapping Wnck tracker; `WindowId` and `window_ids` alongside existing XIDs |
+| 4 | X11 runtime wiring | `docking.app` constructs `X11SessionBackend`; Wnck signal connection made idempotent |
+| 5 | Menu window rows | `MenuHandler` uses `WindowSnapshot` / `WindowId` instead of Wnck windows / XIDs |
+| 6 | Preview popup | `PreviewPopup` uses `PreviewService` / `WindowSnapshot`; `GdkX11`/`Wnck` removed from `docking/ui/preview.py` |
+| 7 | Session backend shape | `X11SessionBackend` complete with all services; `selection.py` added; `docking.app` wires backend once |
+| 8 | Visibility service | `WindowDodgeMonitor` behind `VisibilityService`; `docking.ui.factory` no longer imports dodge directly |
+| 9 | Surface service | Struts, barriers, blur hints, input-region behind `SurfaceService`; `GdkX11` checks confined to X11 backend |
+| 10 | Applet services | `WorkspaceService`, `DesktopActionService`, `WindowPickService`, `IdleService`, `ScreenCaptureService` extracted; Wnck-dependent applets consume backend services |
+| 11 | Cleanup | Transitional X11 compatibility APIs removed from backend-neutral paths |
+| 12 | X11 hardening | Dodge geometry fix; active-display polling cleanup on destroy; Window Killer PID ownership; Workspaces applet watch idempotency |
+| 13 | Reduced backend | `ReducedSessionBackend` with no-op services; validates architecture; `DOCKING_BACKEND=reduced` |
+| 14 | Wayland detection | GTK Wayland display detection; native Wayland selects reduced/no-op; X11 unchanged |
+| 15 | Layer-shell surface | `WaylandLayerShellSessionBackend`; `gtk-layer-shell` integration for native dock surface placement |
+| 16 | Foreign-toplevel | `WaylandForeignToplevelWindowService`; `wlr-foreign-toplevel-management` via vendored protocol + `pywayland`; `WaylandAppIdMatcher` |
+| 17 | Workspace/idle/portal | `WaylandWorkspaceService` via `ext_workspace_v1`; `WaylandPortalColorPickerService` via XDG Desktop Portal |
+| 18 | Protocol runtime | `WaylandProtocolRuntime` with separate `pywayland` `Display`, `wl_registry` binding, GLib fd integration, event dispatch |
+| 19a | COSMIC backend | `CosmicSessionBackend` with native toplevel info/management, workspaces, overlap notify, image-capture previews |
+| 19b | Hyprland backend | IPC event socket for windows/workspaces; short-lived command socket for actions; `hyprctl -j` snapshots |
+| 19c | KWin backend | `KWinSessionBackend` with D-Bus `VirtualDesktopManager` for workspaces, AT-SPI window tracking, layer-shell surface |
+| 19e | GNOME bridge | GNOME Shell extension (`extension.js`) + Python `GnomeShellBridgeSessionBackend`; D-Bus window/workspace/action bridge |
+| 19f | — | Extension loads, D-Bus state export, backend integration complete |
+
+**Not yet implemented:** Wayfire IPC backend (PR 19d), Niri IPC backend.
 
 ### Advance Research Findings Before More Wayland Work
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=docking
-pkgver=1.29.0
+pkgver=2.0.0
 pkgrel=1
 pkgdesc="A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo"
 arch=('x86_64' 'aarch64')

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,395 +1,787 @@
+docking (2.0.0-1) stable; urgency=medium
+
+  * First-class Wayland support across all packaging formats
+  * Remove GDK_BACKEND=x11 forcing from all launcher wrappers
+  * Add native Wayland dependencies (gtk-layer-shell, pywayland)
+  * AppImage: bundle GtkLayerShell and libwayland runtime libraries
+  * Debian: vendor pywayland per Python minor version
+  * Flatpak: bundle gtk-layer-shell module and pywayland
+  * RPM: add gtk-layer-shell and pywayland dependencies
+  * Snap: add Wayland build and stage packages
+  * Arch: add python-pywayland and gtk-layer-shell dependencies
+  * Nix: add gtk-layer-shell and pywayland dependencies
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 10 Jun 2026 20:30:00 +0200
+
 docking (1.29.0-1) stable; urgency=medium
+  * Add experimental Wayland runtime support
+  * Add reduced session backend
+  * Refactor X11 backend service layout
+  * Move X11 dodge monitor behind visibility service
+  * Complete X11 session backend shape
+  * Route preview popup through preview service
+  * Use window snapshots for menu window rows
+  * Wire X11 runtime through window service
+  * Add X11 window service facade
+  * Add platform backend contracts
 
-  * Release 1.29.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 04 Jun 2026 20:13:26 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 06 Jun 2026 10:43:49 +0200
 
 docking (1.28.0-1) stable; urgency=medium
+  * Stop tracking architecture notes
+  * Add battery power and peripheral details
+  * Add Caffeine applet
 
-  * Release 1.28.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 30 May 2026 23:30:25 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 30 May 2026 23:38:52 +0200
 
 docking (1.27.0-1) stable; urgency=medium
+  * Move pressure threshold help to info tooltip
+  * Bump ty from 0.0.37 to 0.0.40
+  * Bump ruff from 0.15.13 to 0.15.15
+  * Add Last.fm applet
+  * Add indicator fill and active item theme styles
 
-  * Release 1.27.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 30 May 2026 00:07:58 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 30 May 2026 00:18:17 +0200
 
 docking (1.26.0-1) stable; urgency=medium
+  * Add optional alphabetical sorting for context menu window list
+  * Add Crypto applet
+  * Add Docker applet
 
-  * Release 1.26.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 28 May 2026 19:43:41 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 28 May 2026 18:52:52 +0100
 
 docking (1.25.1-1) stable; urgency=medium
+  * Tighten settings slider widths
+  * Fix system monitor tooltip translations
+  * Show Currency FX chart interval in tooltip
+  * Add UV index to weather applet
 
-  * Release 1.25.1.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 24 May 2026 00:51:20 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 24 May 2026 00:01:45 +0100
 
 docking (1.25.0-1) stable; urgency=medium
+  * Add pressure reveal support
+  * Add distance from edge setting
 
-  * Release 1.25.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 22 May 2026 20:36:26 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 23 May 2026 14:31:56 +0100
 
 docking (1.24.1-1) stable; urgency=medium
+  * Group renderer state inputs
+  * Detect network applet state changes
+  * Adopt shared applet HTTP helpers
+  * Dispatch indicator rendering by style
+  * Use position enum for folder stack placement
+  * Add shared applet text and HTTP helpers
+  * Add shared math clamp helpers
+  * Simplify environment and XDG path helpers
 
-  * Release 1.24.1.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 22 May 2026 20:35:10 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 23 May 2026 00:08:41 +0100
 
 docking (1.24.0-1) stable; urgency=medium
+  * Convert bundled themes to nested schema
+  * Document theme schema naming conventions
+  * Support full nested theme schema
+  * Rename theme horizontal padding field
+  * Add theme migration infrastructure
 
-  * Release 1.24.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 21 May 2026 20:36:28 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 21 May 2026 19:46:47 +0100
 
 docking (1.23.1-1) stable; urgency=medium
+  * Keep dragged indicators under cursor
+  * Propagate runtime theme updates
+  * Use relative freshness update labels
 
-  * Release 1.23.1.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 19 May 2026 21:17:31 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 19 May 2026 20:40:20 +0100
 
 docking (1.23.0-1) stable; urgency=medium
+  * Snap count badge geometry to pixels
+  * Add window count indicator display modes
+  * Raise running indicator dot cap
+  * Bump ruff from 0.15.12 to 0.15.13
+  * Bump ty from 0.0.34 to 0.0.37
+  * Add GPL header to docking Python files
 
-  * Release 1.23.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Mon, 18 May 2026 21:26:58 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Mon, 18 May 2026 20:40:10 +0100
 
 docking (1.22.0-1) stable; urgency=medium
+  * Add Alarm applet
+  * Add README project badges
+  * Add Sunrise applet
+  * Tighten test None narrowing
+  * Require TLS 1.2 for Cert Watch checks
 
-  * Release 1.22.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 17 May 2026 01:25:18 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 17 May 2026 00:40:00 +0100
 
 docking (1.21.0-1) stable; urgency=medium
+  * Update translations
+  * Fix HiDPI pointer barrier placement
+  * Add USB Watch applet
+  * Bundle NetworkManager in Flatpak
 
-  * Release 1.21.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 16 May 2026 00:31:36 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 15 May 2026 23:42:31 +0100
 
 docking (1.20.0-1) stable; urgency=medium
+  * Refactor AI usage backends
+  * Update Flatpak integration
 
-  * Release 1.20.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 14 May 2026 00:18:48 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 13 May 2026 23:31:18 +0100
 
 docking (1.19.0-1) stable; urgency=medium
+  * Deduplicate Flatpak runtime detection
+  * Improve Flatpak launcher integration
+  * Prepare applets for Flatpak runtime
+  * Apply section 4 running-app code patch
 
-  * Release 1.19.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 13 May 2026 00:29:25 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 12 May 2026 23:41:32 +0100
 
 docking (1.18.0-1) stable; urgency=medium
+  * Load custom themes from user config
+  * Add system icon source option for supported applets
+  * Add "Always on Top" hide mode
+  * Fix ty type-checking warnings
+  * Refactor folder stack handling
 
-  * Release 1.18.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 08 May 2026 11:40:46 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 08 May 2026 10:47:27 +0100
 
 docking (1.17.0-1) stable; urgency=medium
+  * Add KDE trash support
+  * Add sysfs thermals backend
+  * Improve applet selector autocomplete
+  * Bump ty from 0.0.32 to 0.0.34
+  * Add update release checks
 
-  * Release 1.17.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 06 May 2026 21:31:57 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 06 May 2026 21:39:36 +0200
 
 docking (1.16.0-1) stable; urgency=medium
+  * Release: bump version to 1.16.0
+  * Add dark pill dock theme
+  * Apply applet usability updates
 
-  * Release 1.16.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 30 Apr 2026 20:52:10 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 30 Apr 2026 21:17:47 +0200
 
 docking (1.15.0-1) stable; urgency=medium
+  * Release: bump version to 1.15.0
+  * Fit applet icon labels within badge bounds
+  * Clarify compact network speed units
+  * Add Hacker News and Thermals applets
 
-  * Release 1.15.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 29 Apr 2026 20:29:50 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 29 Apr 2026 20:38:02 +0200
 
 docking (1.14.1-1) stable; urgency=medium
+  * Release: bump version to 1.14.1
+  * Poll Codex sessions in AI usage applet
+  * Fix keyboard layout backend selection on MATE
 
-  * Release 1.14.1.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 29 Apr 2026 09:41:52 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 29 Apr 2026 09:51:03 +0200
 
 docking (1.14.0-1) stable; urgency=medium
+  * Release: bump version to 1.14.0
+  * Add Currency FX and Mic Shield applets
+  * Refactor gobject-introspection placement in default.nix
 
-  * Release 1.14.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 28 Apr 2026 20:23:54 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 28 Apr 2026 22:32:20 +0200
 
 docking (1.13.0-1) stable; urgency=medium
+  * Release: bump version to 1.13.0
+  * Add Caps Lock applet
+  * Relax i18n catalog completeness checks
+  * Add Drag Share applet
+  * Bump ruff from 0.15.11 to 0.15.12
+  * Bump ty from 0.0.22 to 0.0.32
+  * Add Cam Shield applet
 
-  * Release 1.13.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 28 Apr 2026 09:07:50 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 28 Apr 2026 09:18:03 +0200
 
 docking (1.12.1-1) stable; urgency=medium
+  * Use xz compression for deb packages
+  * Add Cairo-Dock-inspired New Year greeting
 
-  * Release 1.12.1.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 25 Apr 2026 12:15:34 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 25 Apr 2026 12:21:31 +0200
 
 docking (1.12.0-1) stable; urgency=medium
+  * Release: bump version to 1.12.0
+  * Add APOD, Cert Watch, Desk Presence, and Speedtest applets
+  * Cache folder stack content and thumbnails
 
-  * Release 1.12.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 24 Apr 2026 21:14:20 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 24 Apr 2026 22:52:42 +0200
 
 docking (1.11.0-1) stable; urgency=medium
+  * Release: bump version to 1.11.0
+  * Add folder stack unfold behavior setting
+  * Add Unity LauncherEntry overlays
+  * Bump ruff from 0.15.9 to 0.15.10
+  * Refactor worktree cleanups
 
-  * Release 1.11.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 23 Apr 2026 23:48:01 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 23 Apr 2026 23:59:01 +0200
 
 docking (1.10.0-1) stable; urgency=medium
+  * Release: bump version to 1.10.0
+  * Docs: document i18n update workflow
+  * Skip Bluetooth logs for missing optional values
+  * Match transient launchers by WM_CLASS aliases
+  * Add most-recent left-click action
+  * Ci: isolate Python 3.14 smoke test files
+  * Test: expand headless coverage harnesses
 
-  * Release 1.10.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 21 Apr 2026 20:26:28 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 21 Apr 2026 20:26:55 +0200
 
 docking (1.9.13-1) stable; urgency=medium
+  * Avoid blocking Bluetooth applet startup
 
-  * Release 1.9.13.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Mon, 20 Apr 2026 22:05:58 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Mon, 20 Apr 2026 22:06:35 +0200
 
 docking (1.9.12-1) stable; urgency=medium
+  * Fix preferences IM warnings and bump to 1.9.12
+  * Retry transient AppImage apt failures
+  * Adjust theme screenshot layout in README
+  * Add theme screenshots to README
+  * Remove unused shelf transform sizes
+  * Improve dock performance instrumentation and caching
 
-  * Release 1.9.12.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Mon, 20 Apr 2026 21:57:05 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Mon, 20 Apr 2026 21:58:32 +0200
 
 docking (1.9.11-1) stable; urgency=medium
+  * Fix dock window integration test stub
+  * Document XWayland freeze investigation
+  * Investigate XWayland redraw issues
 
-  * Release 1.9.11.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 11 Apr 2026 08:41:44 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 12 Apr 2026 19:45:48 +0200
 
 docking (1.9.10-1) stable; urgency=medium
+  * Fix Nix and AppImage launcher packaging
+  * Fix packaging CI checks
+  * Align package launchers on Wayland
+  * Force Debian launches to use X11 backend on Wayland
 
-  * Release 1.9.10.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 10 Apr 2026 00:13:27 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 11 Apr 2026 08:29:38 +0200
 
 docking (1.9.9-1) stable; urgency=medium
+  * Align placement test formatting with pinned Ruff
+  * Apply Wayland compatibility fixes and bump version to 1.9.9
 
-  * Release 1.9.9.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 08 Apr 2026 23:49:57 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 09 Apr 2026 00:08:36 +0200
 
 docking (1.9.8-1) stable; urgency=medium
+  * Align session test formatting with pinned Ruff
+  * Fix session applet lock action and bump version to 1.9.8
 
-  * Release 1.9.8.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 08 Apr 2026 01:45:47 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 08 Apr 2026 23:42:30 +0200
 
 docking (1.9.7-1) stable; urgency=medium
+  * Fix Debian packaging for Python 3.10+ and bump 1.9.7
 
-  * Release 1.9.7.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 08 Apr 2026 01:37:44 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 08 Apr 2026 01:38:22 +0200
 
 docking (1.9.6-1) stable; urgency=medium
+  * Pin ruff and ty and align keyboardlayout formatting
+  * Add keyboard layout tools and bump version to 1.9.6
+  * Expand Bluetooth applet menu and bump version to 1.9.5
 
-  * Release 1.9.6.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 08 Apr 2026 01:09:39 +0200
-
-docking (1.9.5-1) stable; urgency=medium
-
-  * Release 1.9.5.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 08 Apr 2026 01:03:24 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 08 Apr 2026 01:15:48 +0200
 
 docking (1.9.4-1) stable; urgency=medium
+  * Expand network applet menu and bump version to 1.9.4
 
-  * Release 1.9.4.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 08 Apr 2026 00:49:34 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 08 Apr 2026 00:50:10 +0200
 
 docking (1.9.3-1) stable; urgency=medium
+  * Add volume settings menu and bump version to 1.9.3
 
-  * Release 1.9.3.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 08 Apr 2026 00:17:16 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 08 Apr 2026 00:17:57 +0200
 
 docking (1.9.2-1) stable; urgency=medium
+  * Add battery time estimates and fix deb entrypoint
 
-  * Release 1.9.2.
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 07 Apr 2026 21:36:57 +0200
 
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 07 Apr 2026 21:34:36 +0200
+docking (1.9.1-1) stable; urgency=medium
+  * Refresh architecture and weather docs, fix weather city dialog, and bump vers...
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 05 Apr 2026 11:20:55 +0200
+
+docking (1.9.0-1) stable; urgency=medium
+  * Seed starter dock on first run and bump version to 1.9.0
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 05 Apr 2026 10:59:42 +0200
+
+docking (1.8.2-1) stable; urgency=medium
+  * Reorganize preferences tabs and bump version to 1.8.2
+  * Add transparency slider
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 04 Apr 2026 16:19:25 +0200
+
+docking (1.8.1-1) stable; urgency=medium
+  * Fix support menu link and bump version to 1.8.1
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 04 Apr 2026 13:31:05 +0200
+
+docking (1.8.0-1) stable; urgency=medium
+  * Add clock alarms and seconds display
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 04 Apr 2026 10:13:05 +0200
+
+docking (1.7.0-1) stable; urgency=medium
+  * Add configurable app click actions and bump version to 1.7.0
+  * Skip CI for website-only changes
+  * Document x64 and arm64 release assets
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 04 Apr 2026 01:14:02 +0200
 
 docking (1.6.0-1) stable; urgency=medium
+  * Fix ARM64 Arch CI image
+  * Fix remaining ARM64 package builders
+  * Fix ARM64 packaging CI jobs
+  * Add ARM64 package builds and bump version to 1.6.0
+  * Improve desktop candidate matching
 
-  * Release 1.6.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 03 Apr 2026 22:23:00 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 03 Apr 2026 23:51:08 +0200
 
 docking (1.5.0-1) stable; urgency=medium
+  * Add X11 blur region hint and bump version to 1.5.0
 
-  * Release 1.5.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 03 Apr 2026 22:06:31 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 03 Apr 2026 22:08:13 +0200
 
 docking (1.4.1-1) stable; urgency=medium
+  * Fix keyboard layout switching on MATE and bump version to 1.4.1
 
-  * Release 1.4.1.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 03 Apr 2026 08:52:13 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 03 Apr 2026 08:52:31 +0200
 
 docking (1.4.0-1) stable; urgency=medium
+  * Harden config persistence and dock startup layout
+  * Clarify applet rendering and state comments
+  * Add visual regression and BDD interaction coverage
+  * Add paper and candy themes
+  * Refresh README and website docs
 
-  * Release 1.4.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 02 Apr 2026 21:14:17 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 02 Apr 2026 21:16:46 +0200
 
 docking (1.3.1-1) stable; urgency=medium
+  * Fix external drop targeting and bump version to 1.3.1
 
-  * Release 1.3.1.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 31 Mar 2026 20:41:44 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 31 Mar 2026 20:42:15 +0200
 
 docking (1.3.0-1) stable; urgency=medium
+  * Improve exception logging and bump version to 1.3.0
+  * Constantize applet UI and fetch defaults
 
-  * Release 1.3.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 31 Mar 2026 19:27:44 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 31 Mar 2026 19:32:36 +0200
 
 docking (1.2.9-1) stable; urgency=medium
+  * Refine screen position helpers and bump version to 1.2.9
+  * Move display helpers out of runtime
+  * Remove dead UI helpers and add test-only code scan
+  * Add vulture dead code checks
+  * Remove stale UI helpers and normalize dashes
 
-  * Release 1.2.9.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 31 Mar 2026 00:58:08 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 31 Mar 2026 00:58:35 +0200
 
 docking (1.2.8-1) stable; urgency=medium
+  * Simplify dock UI helpers and bump version to 1.2.8
 
-  * Release 1.2.8.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 29 Mar 2026 22:59:01 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 29 Mar 2026 22:59:19 +0200
 
 docking (1.2.7-1) stable; urgency=medium
+  * Reconcile hide mode changes immediately and bump version to 1.2.7
 
-  * Release 1.2.7.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 29 Mar 2026 19:38:39 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 29 Mar 2026 19:39:12 +0200
 
 docking (1.2.6-1) stable; urgency=medium
+  * Tighten dock window autohide contracts and bump version to 1.2.6
 
-  * Release 1.2.6.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 29 Mar 2026 15:28:08 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 29 Mar 2026 15:28:45 +0200
 
 docking (1.2.5-1) stable; urgency=medium
+  * Simplify dock window assembly and bump version to 1.2.5
+  * Add folder stacks popup
 
-  * Release 1.2.5.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 29 Mar 2026 14:56:48 +0200
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 29 Mar 2026 14:57:07 +0200
 
 docking (1.2.4-1) stable; urgency=medium
+  * Refine applet popups and bump version to 1.2.4
 
-  * Release 1.2.4.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 28 Mar 2026 13:26:33 +0100
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 28 Mar 2026 13:26:56 +0100
 
 docking (1.2.3-1) stable; urgency=medium
+  * Make applet discovery metadata-only and bump version to 1.2.3
+  * Skip CI for docs and site-only changes
+  * Remove simplification plan from repo
 
-  * Release 1.2.3.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 28 Mar 2026 13:04:32 +0100
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 28 Mar 2026 13:05:03 +0100
 
 docking (1.2.2-1) stable; urgency=medium
+  * Refine dock model listeners and bump version to 1.2.2
+  * Document AI Usage applet
 
-  * Release 1.2.2.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 27 Mar 2026 22:31:19 +0100
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 27 Mar 2026 22:31:49 +0100
 
 docking (1.2.1-1) stable; urgency=medium
+  * Fix aiusage Codex hook state lookup
+  * Rename loggers and bump version to 1.2.1
+  * Add AI usage applet and bump version to 1.2.0
 
-  * Release 1.2.1.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 27 Mar 2026 21:36:27 +0100
-
-docking (1.2.0-1) stable; urgency=medium
-
-  * Release 1.2.0.
-
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 27 Mar 2026 21:15:27 +0100
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 27 Mar 2026 21:58:46 +0100
 
 docking (1.1.2-1) stable; urgency=medium
+  * Mark Debian release stable and bump version to 1.1.2
 
-  * Release 1.1.2.
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 27 Mar 2026 00:06:23 +0100
 
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 27 Mar 2026 00:06:06 +0100
+docking (1.1.1-1) stable; urgency=medium
+  * Update 1.1.1 release metadata
+  * Update stale README applet and theme counts
 
-docking (1.1.1-1) unstable; urgency=medium
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 27 Mar 2026 00:04:07 +0100
 
-  * Release 1.1.1.
+docking (1.1.0-1) stable; urgency=medium
+  * Release 1.1.0
+  * Increase coverage and add dock hide regression tests
+  * Expand long-form module documentation
 
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 27 Mar 2026 00:03:50 +0100
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 26 Mar 2026 22:59:37 +0100
 
-docking (0.1.42-1) unstable; urgency=medium
+docking (1.0.0-1) stable; urgency=medium
+  * Sync locale catalogs
+  * Release 1.0.0
+  * Polish Docking website carousel interactions
+  * Update Docking website interactions and applet carousel
 
-  * Release 0.1.42.
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 26 Mar 2026 00:20:35 +0100
 
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 14 Mar 2026 00:44:25 +0100
+docking (0.1.45-1) stable; urgency=medium
+  * Rename system monitor applet and release 0.1.45
+  * Refine Docking website color system
+  * Add initial Docking website landing page
+  * Stabilize UI GI fallback mocks
+  * Fix settings GI fallback mock
+  * Lazy-load UI package exports
+  * Install pycairo in Python 3.14 smoke lanes
+  * Use smoke tests for Python 3.14 lanes
+  * Add Python 3.14 CI coverage
+  * Decouple applet catalog from imports
 
-docking (0.1.41-1) unstable; urgency=medium
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 22 Mar 2026 12:47:51 +0100
 
-  * Release 0.1.41.
+docking (0.1.44-1) stable; urgency=medium
+  * Fix app bootstrap import test stubs
+  * Harden CI test dependencies
+  * Fix UI test GI and dodge monitor isolation
+  * Guard applet polling workers
+  * Fix today in history day rollover
+  * Disconnect dodge window handlers on stop
+  * Persist dock model pin order changes
+  * Rename applet present method
+  * Expand Ruff lint coverage
 
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 14 Mar 2026 00:28:53 +0100
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Mon, 16 Mar 2026 00:08:59 +0100
 
-docking (0.1.39-1) unstable; urgency=medium
+docking (0.1.43-1) stable; urgency=medium
+  * Add today in history applet
+  * Add openSUSE Wnck typelib
+  * Add openSUSE GI typelibs
+  * Use Xvfb directly in openSUSE smoke
+  * Use venv for openSUSE smoke job
+  * Harden openSUSE smoke setup
+  * Fix openSUSE smoke dependencies
+  * Add openSUSE smoke CI job
+  * Add Fedora smoke CI job
 
-  * Release 0.1.39.
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 14 Mar 2026 23:38:09 +0100
 
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 10 Mar 2026 23:51:46 +0100
+docking (0.1.42-1) stable; urgency=medium
+  * Sync package data declarations
+  * Add random trivia applet
+  * Fix type-check warnings
+  * Add stretch coach applet
+  * Add Launchpad PPA packaging scaffolding
+  * Replace magic numbers with named constants
+  * Remove legacy autohide config compatibility
 
-docking (0.1.37-1) unstable; urgency=medium
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 14 Mar 2026 00:47:27 +0100
 
-  * Release 0.1.37.
+docking (0.1.40-1) stable; urgency=medium
+  * Add autohide dodge and bump version to 0.1.40
+  * Add application menu search
 
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 08 Mar 2026 23:15:18 +0100
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 11 Mar 2026 20:34:18 +0100
 
-docking (0.1.36-1) unstable; urgency=medium
+docking (0.1.39-1) stable; urgency=medium
+  * Add new applets and bump version to 0.1.39
+  * Add targeted UI coverage tests
+  * Tighten preferences dialog layout
+  * Rewrite architecture documentation
 
-  * Release 0.1.36.
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 10 Mar 2026 23:54:51 +0100
 
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 08 Mar 2026 22:58:40 +0100
+docking (0.1.38-1) stable; urgency=medium
+  * Fix autohide jump and bump version to 0.1.38
+  * Add shared applet worker service
 
-docking (0.1.35-1) unstable; urgency=medium
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Mon, 09 Mar 2026 23:59:25 +0100
 
+docking (0.1.37-1) stable; urgency=medium
+  * Enable stricter Ruff checks
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 08 Mar 2026 23:15:43 +0100
+
+docking (0.1.36-1) stable; urgency=medium
+  * Harden config normalization and exception logging
+  * Refactor settings bindings
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 08 Mar 2026 22:58:54 +0100
+
+docking (0.1.35-1) stable; urgency=medium
   * Release 0.1.35.
 
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 08 Mar 2026 22:26:57 +0100
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 08 Mar 2026 22:27:04 +0100
 
-docking (0.1.34-1) unstable; urgency=medium
+docking (0.1.34-1) stable; urgency=medium
+  * Fix snap build asset source paths
+  * Fix snap desktop asset install paths
+  * Harden headless tool and applet tests
+  * Improve packaging and release tooling
+  * Update README header image
 
-  * Release 0.1.34.
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 08 Mar 2026 22:26:23 +0100
 
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 08 Mar 2026 12:19:23 +0100
+docking (0.1.33-1) stable; urgency=medium
+  * Refresh app icons and fix network device selection
 
-docking (0.1.33-1) unstable; urgency=medium
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 08 Mar 2026 11:21:33 +0100
 
-  * Release 0.1.33.
+docking (0.1.32-1) stable; urgency=medium
+  * Include applet catalog assets in packages
 
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 08 Mar 2026 11:55:51 +0100
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 08 Mar 2026 01:43:04 +0100
 
-docking (0.1.18-1) unstable; urgency=medium
+docking (0.1.31-1) stable; urgency=medium
+  * Use generated applet catalog icons
+  * Add dock preferences window
 
-  * Release 0.1.18.
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 08 Mar 2026 01:41:05 +0100
 
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 05 Mar 2026 20:00:00 +0100
+docking (0.1.30-1) stable; urgency=medium
+  * Refine dock component assembly and bluetooth polling
 
-docking (0.1.0-1) unstable; urgency=medium
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 07 Mar 2026 23:57:52 +0100
 
-  * Initial release
-  * 9 applets: clock, trash, desktop, CPU monitor, battery, weather,
-    clipboard, applications, network
-  * Parabolic zoom, window previews, autohide, drag-and-drop
-  * 6 themes, multi-position support (bottom/top/left/right)
-  * Desktop actions (quicklists) in right-click menus
-  * Urgent glow animation when dock is hidden
+docking (0.1.29-1) stable; urgency=medium
+  * Normalize dock window tracker naming
+  * Refine dock runtime assembly
 
- -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 25 Feb 2026 14:00:00 +0000
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 07 Mar 2026 20:50:49 +0100
+
+docking (0.1.28-1) stable; urgency=medium
+  * Refine dock interaction cleanup
+  * Split dock layout from zoom module
+  * Expand module documentation and pointer scenarios
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 07 Mar 2026 20:26:09 +0100
+
+docking (0.1.27-1) stable; urgency=medium
+  * Keep dock visible after drag drop
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 07 Mar 2026 19:17:59 +0100
+
+docking (0.1.26-1) stable; urgency=medium
+  * Remove dock window interaction wrappers
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 07 Mar 2026 19:13:34 +0100
+
+docking (0.1.25-1) stable; urgency=medium
+  * Simplify dock geometry builder
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 07 Mar 2026 18:59:32 +0100
+
+docking (0.1.24-1) stable; urgency=medium
+  * Decompose DockWindow collaborators
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 07 Mar 2026 18:40:19 +0100
+
+docking (0.1.23-1) stable; urgency=medium
+  * Refine dock geometry boundaries
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 07 Mar 2026 17:48:32 +0100
+
+docking (0.1.22-1) stable; urgency=medium
+  * Refine preview autohide behavior
+  * Tighten internal attribute access
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 07 Mar 2026 00:37:48 +0100
+
+docking (0.1.21-1) stable; urgency=medium
+  * Make edge spacing theme-owned
+  * Update README to match current config and locale count
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 07 Mar 2026 00:07:17 +0100
+
+docking (0.1.20-1) stable; urgency=medium
+  * Apply docking changes and bump version to 0.1.20
+  * Group icon menu options and refresh i18n catalogs
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 06 Mar 2026 20:03:46 +0100
+
+docking (0.1.19-1) stable; urgency=medium
+  * Sync i18n catalogs for tooltip toggle
+  * Add tooltip toggle setting and bump version to 0.1.19
+  * Add 70 locale catalogs and complete existing translations
+  * Consolidate translation tooling into unified i18n script
+  * Ignore compiled gettext .mo catalogs
+  * Enforce strict i18n checks and update display menu translations
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 06 Mar 2026 01:17:26 +0100
+
+docking (0.1.18-1) stable; urgency=medium
+  * Apply all-features updates and bump version to 0.1.18
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Fri, 06 Mar 2026 00:02:25 +0100
+
+docking (0.1.17-1) stable; urgency=medium
+  * Fix(snap): use CRAFT_PART_SRC for translation compile script
+  * Feat: apply plank quick wins and bump version to 0.1.17
+  * Feat(i18n): add gettext translations, compile step, and bump 0.1.16
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 05 Mar 2026 23:35:33 +0100
+
+docking (0.1.15-1) stable; urgency=medium
+  * Test: raise coverage to 95% and bump version to 0.1.15
+  * Test: expand log and config branch coverage
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 05 Mar 2026 01:15:24 +0100
+
+docking (0.1.14-1) stable; urgency=medium
+  * Fix preview title chip width and bump version to 0.1.14
+  * Keep power profile documentation in code; remove standalone doc file
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 05 Mar 2026 00:44:35 +0100
+
+docking (0.1.13-1) stable; urgency=medium
+  * Add Power Profiles applet with backend fallbacks and extensive docs; bump 0.1.13
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 05 Mar 2026 00:40:27 +0100
+
+docking (0.1.12-1) stable; urgency=medium
+  * Add Bluetooth applet and harden BlueZ power/discovery flow; bump 0.1.12
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Thu, 05 Mar 2026 00:27:02 +0100
+
+docking (0.1.11-1) stable; urgency=medium
+  * Style: apply ruff formatting in notifications files
+  * Feat: add notifications applet with history and bump version to 0.1.11
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 04 Mar 2026 23:54:40 +0100
+
+docking (0.1.10-1) stable; urgency=medium
+  * Feat: add multi-monitor dock selection and bump version to 0.1.10
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 04 Mar 2026 20:45:32 +0100
+
+docking (0.1.9-1) stable; urgency=medium
+  * Fix: reconcile autohide after menu close and bump version to 0.1.9
+  * Docs: add brightness/color/moon applet sections and screenshots
+  * Fix: configure about dialog license metadata
+  * Chore: remove committed patch artifact
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 04 Mar 2026 20:30:02 +0100
+
+docking (0.1.8-1) stable; urgency=medium
+  * Feat: apply patch changes and bump release version to 0.1.8
+  * Docs: update latest release installation links
+  * Ci: ignore arch debug package in release normalization
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 04 Mar 2026 19:57:28 +0100
+
+docking (0.1.7-1) stable; urgency=medium
+  * Ci: harden release asset normalization for latest aliases
+  * Ci: add stable latest release asset aliases
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 04 Mar 2026 00:28:34 +0100
+
+docking (0.1.6-1) stable; urgency=medium
+  * Ci: standardize release assets and bump version to 0.1.6
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 04 Mar 2026 00:16:08 +0100
+
+docking (0.1.5-1) stable; urgency=medium
+  * Add music applet improvements and timed screenshot captures
+  * Raise tests to 95% coverage and expand applet/UI coverage
+  * Extract About dialog module and commit current WIP
+  * Docs: expand architecture narratives for core dock modules
+  * Create custom Cairo icons for applets visual identity
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 04 Mar 2026 00:03:34 +0100
+
+docking (0.1.4-1) stable; urgency=medium
+  * Refactor applets into modular packages and migrate weather applet
+  * Refine applet icons and harden preview/window error handling
+  * Apply preview segfault patch with merge conflict resolution
+  * Extract DockItem to core and stabilize runtime imports
+  * Standardize exception logging across runtime modules
+  * Increase coverage to 80% with applet and model integration tests
+  * Refine Session applet with Cairo user-avatar icon
+  * Improve Snap metadata and icon wiring for lint warnings
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Tue, 03 Mar 2026 00:20:23 +0100
+
+docking (0.1.3-1) stable; urgency=medium
+  * Fix Arch build by syncing PKGBUILD pkgver with project version
+  * Increase test coverage to 75% with app/platform/ui tests and add Debian autop...
+  * Fix Codecov workflow condition by using env token guard
+  * Fix Nix build inputs and relax weather deps for CI reproducibility
+  * Require CODECOV_TOKEN for coverage upload in CI
+  * Polish README badge and layout tweaks
+  * Add Python version badge to README
+  * Add CI/release/coverage badges and publish coverage to Codecov
+  * Adjust applet categories and add Nix packaging with CI artifacts
+  * Make Arch source tarball fallback work without git metadata
+  * Add Arch package CI/release artifacts and standardize package descriptions
+  * Consolidate typed applet identity and category metadata
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 01 Mar 2026 20:59:53 +0100
+
+docking (0.1.2-1) stable; urgency=medium
+  * Rename CI Ubuntu test job id to test-ubuntu
+  * Replace raw applet id strings with AppletId constants
+  * Centralize applet IDs and reuse them in Applets category mapping
+  * Group Applets submenu by categories and fix RPM arch packaging
+  * Fix Snap asset sourcing and stabilize RPM Python install layout
+  * Fix Snap asset path resolution and RPM install fallback
+  * Fix Snap build paths and add initial RPM packaging pipeline
+  * Fix Snap/AppImage CI packaging failures
+  * Center README header image with valid CSS
+  * Expand integration coverage and add AppImage artifact pipeline
+  * Add Snap packaging and CI build/release integration
+  * Refresh README to match current architecture, applets, packaging, and CI
+  * Improve repository hygiene and CI execution model
+  * Harden desktop launcher execution by removing shell=True
+  * Harden CI and developer workflow with coverage gates, security scans, and dep...
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 01 Mar 2026 19:22:02 +0100
+
+docking (0.1.1-1) stable; urgency=medium
+  * Add Quote applet, improve hydration visuals, and publish CI coverage artifacts
+  * Fix Flatpak AppStream icon lookup during compose
+  * Fix Flatpak builder option compatibility
+  * Fix Flatpak builder networking in CI and local script
+  * Fix Flatpak CI permissions by using user-scoped remotes
+  * Add Flatpak packaging and CI build artifact
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sun, 01 Mar 2026 01:25:42 +0100
+
+docking (0.1.0-1) stable; urgency=medium
+  * Fix release version parsing for Python 3.10 runners
+  * Fix CI YAML syntax error in release version check
+  * Make CI release automation master-only with version gating
+  * Another adjustement
+  * Remove visible borders from README title table
+  * Use table layout for README title icon alignment
+  * Tune README title icon alignment via local render loop
+  * Fine-tune README title icon vertical alignment
+  * Align README title icon using trimmed header asset
+  * Refresh WM_CLASS mapping on each window scan
+  * Fix weather API typing issues flagged by ty
+  * Application image and update on applet
+  * Fix Debian CI glibc mismatch by using Python base images
+  * Add Debian matrix CI coverage alongside Ubuntu jobs
+  * Use workspace-local artifacts path for deb build/upload/release
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Sat, 28 Feb 2026 23:59:53 +0100
+

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -5,7 +5,7 @@ let
 in
 pyPkgs.buildPythonApplication rec {
   pname = "docking";
-  version = "1.29.0";
+  version = "2.0.0";
   format = "pyproject";
 
   src = ../..;

--- a/packaging/rpm/docking.spec
+++ b/packaging/rpm/docking.spec
@@ -1,5 +1,5 @@
 Name:           docking
-Version:        %{?pkg_version}%{!?pkg_version:1.29.0}
+Version:        %{?pkg_version}%{!?pkg_version:2.0.0}
 Release:        1%{?dist}
 Summary:        A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo
 
@@ -102,209 +102,554 @@ fi
 /usr/share/icons/hicolor
 
 %changelog
-* Thu Jun 04 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.29.0-1
-- Release 1.29.0.
+
+* Sat Jun 06 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.29.0-1
+- Add experimental Wayland runtime support
+- Add reduced session backend
+- Refactor X11 backend service layout
+- Move X11 dodge monitor behind visibility service
+- Complete X11 session backend shape
+- Route preview popup through preview service
+- Use window snapshots for menu window rows
+- Wire X11 runtime through window service
+- Add X11 window service facade
+- Add platform backend contracts
 
 * Sat May 30 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.28.0-1
-- Release 1.28.0.
+- Stop tracking architecture notes
+- Add battery power and peripheral details
+- Add Caffeine applet
 
 * Sat May 30 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.27.0-1
-- Release 1.27.0.
+- Move pressure threshold help to info tooltip
+- Bump ty from 0.0.37 to 0.0.40
+- Bump ruff from 0.15.13 to 0.15.15
+- Add Last.fm applet
+- Add indicator fill and active item theme styles
 
 * Thu May 28 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.26.0-1
-- Release 1.26.0.
+- Add optional alphabetical sorting for context menu window list
+- Add Crypto applet
+- Add Docker applet
 
 * Sun May 24 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.25.1-1
-- Release 1.25.1.
+- Tighten settings slider widths
+- Fix system monitor tooltip translations
+- Show Currency FX chart interval in tooltip
+- Add UV index to weather applet
 
-* Fri May 22 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.25.0-1
-- Release 1.25.0.
+* Sat May 23 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.25.0-1
+- Add pressure reveal support
+- Add distance from edge setting
 
-* Fri May 22 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.24.1-1
-- Release 1.24.1.
+* Sat May 23 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.24.1-1
+- Group renderer state inputs
+- Detect network applet state changes
+- Adopt shared applet HTTP helpers
+- Dispatch indicator rendering by style
+- Use position enum for folder stack placement
+- Add shared applet text and HTTP helpers
+- Add shared math clamp helpers
+- Simplify environment and XDG path helpers
 
 * Thu May 21 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.24.0-1
-- Release 1.24.0.
+- Convert bundled themes to nested schema
+- Document theme schema naming conventions
+- Support full nested theme schema
+- Rename theme horizontal padding field
+- Add theme migration infrastructure
 
 * Tue May 19 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.23.1-1
-- Release 1.23.1.
+- Keep dragged indicators under cursor
+- Propagate runtime theme updates
+- Use relative freshness update labels
 
 * Mon May 18 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.23.0-1
-- Release 1.23.0.
+- Snap count badge geometry to pixels
+- Add window count indicator display modes
+- Raise running indicator dot cap
+- Bump ruff from 0.15.12 to 0.15.13
+- Bump ty from 0.0.34 to 0.0.37
+- Add GPL header to docking Python files
 
 * Sun May 17 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.22.0-1
-- Release 1.22.0.
+- Add Alarm applet
+- Add README project badges
+- Add Sunrise applet
+- Tighten test None narrowing
+- Require TLS 1.2 for Cert Watch checks
 
-* Sat May 16 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.21.0-1
-- Release 1.21.0.
+* Fri May 15 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.21.0-1
+- Update translations
+- Fix HiDPI pointer barrier placement
+- Add USB Watch applet
+- Bundle NetworkManager in Flatpak
 
-* Thu May 14 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.20.0-1
-- Release 1.20.0.
+* Wed May 13 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.20.0-1
+- Refactor AI usage backends
+- Update Flatpak integration
 
-* Wed May 13 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.19.0-1
-- Release 1.19.0.
+* Tue May 12 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.19.0-1
+- Deduplicate Flatpak runtime detection
+- Improve Flatpak launcher integration
+- Prepare applets for Flatpak runtime
+- Apply section 4 running-app code patch
 
 * Fri May 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.18.0-1
-- Release 1.18.0.
+- Load custom themes from user config
+- Add system icon source option for supported applets
+- Add "Always on Top" hide mode
+- Fix ty type-checking warnings
+- Refactor folder stack handling
 
 * Wed May 06 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.17.0-1
-- Release 1.17.0.
+- Add KDE trash support
+- Add sysfs thermals backend
+- Improve applet selector autocomplete
+- Bump ty from 0.0.32 to 0.0.34
+- Add update release checks
 
 * Thu Apr 30 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.16.0-1
-- Release 1.16.0.
+- Release: bump version to 1.16.0
+- Add dark pill dock theme
+- Apply applet usability updates
 
 * Wed Apr 29 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.15.0-1
-- Release 1.15.0.
+- Release: bump version to 1.15.0
+- Fit applet icon labels within badge bounds
+- Clarify compact network speed units
+- Add Hacker News and Thermals applets
 
 * Wed Apr 29 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.14.1-1
-- Release 1.14.1.
+- Release: bump version to 1.14.1
+- Poll Codex sessions in AI usage applet
+- Fix keyboard layout backend selection on MATE
 
 * Tue Apr 28 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.14.0-1
-- Release 1.14.0.
+- Release: bump version to 1.14.0
+- Add Currency FX and Mic Shield applets
+- Refactor gobject-introspection placement in default.nix
 
 * Tue Apr 28 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.13.0-1
-- Release 1.13.0.
+- Release: bump version to 1.13.0
+- Add Caps Lock applet
+- Relax i18n catalog completeness checks
+- Add Drag Share applet
+- Bump ruff from 0.15.11 to 0.15.12
+- Bump ty from 0.0.22 to 0.0.32
+- Add Cam Shield applet
 
 * Sat Apr 25 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.12.1-1
-- Release 1.12.1.
+- Use xz compression for deb packages
+- Add Cairo-Dock-inspired New Year greeting
 
 * Fri Apr 24 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.12.0-1
-- Release 1.12.0.
+- Release: bump version to 1.12.0
+- Add APOD, Cert Watch, Desk Presence, and Speedtest applets
+- Cache folder stack content and thumbnails
 
 * Thu Apr 23 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.11.0-1
-- Release 1.11.0.
+- Release: bump version to 1.11.0
+- Add folder stack unfold behavior setting
+- Add Unity LauncherEntry overlays
+- Bump ruff from 0.15.9 to 0.15.10
+- Refactor worktree cleanups
 
 * Tue Apr 21 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.10.0-1
-- Release 1.10.0.
+- Release: bump version to 1.10.0
+- Docs: document i18n update workflow
+- Skip Bluetooth logs for missing optional values
+- Match transient launchers by WM_CLASS aliases
+- Add most-recent left-click action
+- Ci: isolate Python 3.14 smoke test files
+- Test: expand headless coverage harnesses
 
 * Mon Apr 20 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.13-1
-- Release 1.9.13.
+- Avoid blocking Bluetooth applet startup
 
 * Mon Apr 20 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.12-1
-- Release 1.9.12.
+- Fix preferences IM warnings and bump to 1.9.12
+- Retry transient AppImage apt failures
+- Adjust theme screenshot layout in README
+- Add theme screenshots to README
+- Remove unused shelf transform sizes
+- Improve dock performance instrumentation and caching
 
-* Sat Apr 11 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.11-1
-- Release 1.9.11.
+* Sun Apr 12 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.11-1
+- Fix dock window integration test stub
+- Document XWayland freeze investigation
+- Investigate XWayland redraw issues
 
-* Fri Apr 10 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.10-1
-- Release 1.9.10.
+* Sat Apr 11 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.10-1
+- Fix Nix and AppImage launcher packaging
+- Fix packaging CI checks
+- Align package launchers on Wayland
+- Force Debian launches to use X11 backend on Wayland
 
-* Wed Apr 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.9-1
-- Release 1.9.9.
+* Thu Apr 09 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.9-1
+- Align placement test formatting with pinned Ruff
+- Apply Wayland compatibility fixes and bump version to 1.9.9
 
 * Wed Apr 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.8-1
-- Release 1.9.8.
+- Align session test formatting with pinned Ruff
+- Fix session applet lock action and bump version to 1.9.8
 
 * Wed Apr 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.7-1
-- Release 1.9.7.
+- Fix Debian packaging for Python 3.10+ and bump 1.9.7
 
 * Wed Apr 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.6-1
-- Release 1.9.6.
-
-* Wed Apr 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.5-1
-- Release 1.9.5.
+- Pin ruff and ty and align keyboardlayout formatting
+- Add keyboard layout tools and bump version to 1.9.6
+- Expand Bluetooth applet menu and bump version to 1.9.5
 
 * Wed Apr 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.4-1
-- Release 1.9.4.
+- Expand network applet menu and bump version to 1.9.4
 
 * Wed Apr 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.3-1
-- Release 1.9.3.
+- Add volume settings menu and bump version to 1.9.3
 
 * Tue Apr 07 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.2-1
-- Release 1.9.2.
+- Add battery time estimates and fix deb entrypoint
+
+* Sun Apr 05 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.1-1
+- Refresh architecture and weather docs, fix weather city dialog, and bump vers...
+
+* Sun Apr 05 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.9.0-1
+- Seed starter dock on first run and bump version to 1.9.0
+
+* Sat Apr 04 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.8.2-1
+- Reorganize preferences tabs and bump version to 1.8.2
+- Add transparency slider
+
+* Sat Apr 04 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.8.1-1
+- Fix support menu link and bump version to 1.8.1
+
+* Sat Apr 04 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.8.0-1
+- Add clock alarms and seconds display
+
+* Sat Apr 04 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.7.0-1
+- Add configurable app click actions and bump version to 1.7.0
+- Skip CI for website-only changes
+- Document x64 and arm64 release assets
 
 * Fri Apr 03 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.6.0-1
-- Release 1.6.0.
+- Fix ARM64 Arch CI image
+- Fix remaining ARM64 package builders
+- Fix ARM64 packaging CI jobs
+- Add ARM64 package builds and bump version to 1.6.0
+- Improve desktop candidate matching
 
 * Fri Apr 03 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.5.0-1
-- Release 1.5.0.
+- Add X11 blur region hint and bump version to 1.5.0
 
 * Fri Apr 03 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.4.1-1
-- Release 1.4.1.
+- Fix keyboard layout switching on MATE and bump version to 1.4.1
 
 * Thu Apr 02 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.4.0-1
-- Release 1.4.0.
+- Harden config persistence and dock startup layout
+- Clarify applet rendering and state comments
+- Add visual regression and BDD interaction coverage
+- Add paper and candy themes
+- Refresh README and website docs
 
 * Tue Mar 31 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.3.1-1
-- Release 1.3.1.
+- Fix external drop targeting and bump version to 1.3.1
 
 * Tue Mar 31 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.3.0-1
-- Release 1.3.0.
+- Improve exception logging and bump version to 1.3.0
+- Constantize applet UI and fetch defaults
 
 * Tue Mar 31 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.2.9-1
-- Release 1.2.9.
+- Refine screen position helpers and bump version to 1.2.9
+- Move display helpers out of runtime
+- Remove dead UI helpers and add test-only code scan
+- Add vulture dead code checks
+- Remove stale UI helpers and normalize dashes
 
 * Sun Mar 29 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.2.8-1
-- Release 1.2.8.
+- Simplify dock UI helpers and bump version to 1.2.8
 
 * Sun Mar 29 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.2.7-1
-- Release 1.2.7.
+- Reconcile hide mode changes immediately and bump version to 1.2.7
 
 * Sun Mar 29 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.2.6-1
-- Release 1.2.6.
+- Tighten dock window autohide contracts and bump version to 1.2.6
 
 * Sun Mar 29 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.2.5-1
-- Release 1.2.5.
+- Simplify dock window assembly and bump version to 1.2.5
+- Add folder stacks popup
 
 * Sat Mar 28 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.2.4-1
-- Release 1.2.4.
+- Refine applet popups and bump version to 1.2.4
 
 * Sat Mar 28 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.2.3-1
-- Release 1.2.3.
+- Make applet discovery metadata-only and bump version to 1.2.3
+- Skip CI for docs and site-only changes
+- Remove simplification plan from repo
 
 * Fri Mar 27 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.2.2-1
-- Release 1.2.2.
+- Refine dock model listeners and bump version to 1.2.2
+- Document AI Usage applet
 
 * Fri Mar 27 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.2.1-1
-- Release 1.2.1.
-
-* Fri Mar 27 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.2.0-1
-- Release 1.2.0.
+- Fix aiusage Codex hook state lookup
+- Rename loggers and bump version to 1.2.1
+- Add AI usage applet and bump version to 1.2.0
 
 * Fri Mar 27 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.1.2-1
-- Release 1.1.2.
+- Mark Debian release stable and bump version to 1.1.2
 
 * Fri Mar 27 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.1.1-1
-- Release 1.1.1.
+- Update 1.1.1 release metadata
+- Update stale README applet and theme counts
 
 * Thu Mar 26 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.1.0-1
-- Release 1.1.0.
+- Release 1.1.0
+- Increase coverage and add dock hide regression tests
+- Expand long-form module documentation
 
 * Thu Mar 26 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.0.0-1
-- Release 1.0.0.
+- Sync locale catalogs
+- Release 1.0.0
+- Polish Docking website carousel interactions
+- Update Docking website interactions and applet carousel
+
+* Sun Mar 22 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.45-1
+- Rename system monitor applet and release 0.1.45
+- Refine Docking website color system
+- Add initial Docking website landing page
+- Stabilize UI GI fallback mocks
+- Fix settings GI fallback mock
+- Lazy-load UI package exports
+- Install pycairo in Python 3.14 smoke lanes
+- Use smoke tests for Python 3.14 lanes
+- Add Python 3.14 CI coverage
+- Decouple applet catalog from imports
+
+* Mon Mar 16 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.44-1
+- Fix app bootstrap import test stubs
+- Harden CI test dependencies
+- Fix UI test GI and dodge monitor isolation
+- Guard applet polling workers
+- Fix today in history day rollover
+- Disconnect dodge window handlers on stop
+- Persist dock model pin order changes
+- Rename applet present method
+- Expand Ruff lint coverage
 
 * Sat Mar 14 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.43-1
-- Release 0.1.43.
+- Add today in history applet
+- Add openSUSE Wnck typelib
+- Add openSUSE GI typelibs
+- Use Xvfb directly in openSUSE smoke
+- Use venv for openSUSE smoke job
+- Harden openSUSE smoke setup
+- Fix openSUSE smoke dependencies
+- Add openSUSE smoke CI job
+- Add Fedora smoke CI job
 
 * Sat Mar 14 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.42-1
-- Release 0.1.42.
-
-* Sat Mar 14 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.41-1
-- Release 0.1.41.
+- Sync package data declarations
+- Add random trivia applet
+- Fix type-check warnings
+- Add stretch coach applet
+- Add Launchpad PPA packaging scaffolding
+- Replace magic numbers with named constants
+- Remove legacy autohide config compatibility
 
 * Wed Mar 11 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.40-1
-- Release 0.1.40.
+- Add autohide dodge and bump version to 0.1.40
+- Add application menu search
 
 * Tue Mar 10 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.39-1
-- Release 0.1.39.
+- Add new applets and bump version to 0.1.39
+- Add targeted UI coverage tests
+- Tighten preferences dialog layout
+- Rewrite architecture documentation
+
+* Mon Mar 09 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.38-1
+- Fix autohide jump and bump version to 0.1.38
+- Add shared applet worker service
 
 * Sun Mar 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.37-1
-- Release 0.1.37.
+- Enable stricter Ruff checks
 
 * Sun Mar 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.36-1
-- Release 0.1.36.
+- Harden config normalization and exception logging
+- Refactor settings bindings
 
 * Sun Mar 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.35-1
 - Release 0.1.35.
 
 * Sun Mar 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.34-1
-- Release 0.1.34.
+- Fix snap build asset source paths
+- Fix snap desktop asset install paths
+- Harden headless tool and applet tests
+- Improve packaging and release tooling
+- Update README header image
 
 * Sun Mar 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.33-1
-- Release 0.1.33.
+- Refresh app icons and fix network device selection
 
-* Thu Mar 05 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.18-1
-- Release 0.1.18.
+* Sun Mar 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.32-1
+- Include applet catalog assets in packages
+
+* Sun Mar 08 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.31-1
+- Use generated applet catalog icons
+- Add dock preferences window
+
+* Sat Mar 07 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.30-1
+- Refine dock component assembly and bluetooth polling
+
+* Sat Mar 07 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.29-1
+- Normalize dock window tracker naming
+- Refine dock runtime assembly
+
+* Sat Mar 07 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.28-1
+- Refine dock interaction cleanup
+- Split dock layout from zoom module
+- Expand module documentation and pointer scenarios
+
+* Sat Mar 07 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.27-1
+- Keep dock visible after drag drop
+
+* Sat Mar 07 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.26-1
+- Remove dock window interaction wrappers
+
+* Sat Mar 07 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.25-1
+- Simplify dock geometry builder
+
+* Sat Mar 07 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.24-1
+- Decompose DockWindow collaborators
+
+* Sat Mar 07 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.23-1
+- Refine dock geometry boundaries
+
+* Sat Mar 07 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.22-1
+- Refine preview autohide behavior
+- Tighten internal attribute access
+
+* Sat Mar 07 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.21-1
+- Make edge spacing theme-owned
+- Update README to match current config and locale count
+
+* Fri Mar 06 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.20-1
+- Apply docking changes and bump version to 0.1.20
+- Group icon menu options and refresh i18n catalogs
+
+* Fri Mar 06 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.19-1
+- Sync i18n catalogs for tooltip toggle
+- Add tooltip toggle setting and bump version to 0.1.19
+- Add 70 locale catalogs and complete existing translations
+- Consolidate translation tooling into unified i18n script
+- Ignore compiled gettext .mo catalogs
+- Enforce strict i18n checks and update display menu translations
+
+* Fri Mar 06 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.18-1
+- Apply all-features updates and bump version to 0.1.18
+
+* Thu Mar 05 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.17-1
+- Fix(snap): use CRAFT_PART_SRC for translation compile script
+- Feat: apply plank quick wins and bump version to 0.1.17
+- Feat(i18n): add gettext translations, compile step, and bump 0.1.16
+
+* Thu Mar 05 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.15-1
+- Test: raise coverage to 95% and bump version to 0.1.15
+- Test: expand log and config branch coverage
+
+* Thu Mar 05 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.14-1
+- Fix preview title chip width and bump version to 0.1.14
+- Keep power profile documentation in code; remove standalone doc file
+
+* Thu Mar 05 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.13-1
+- Add Power Profiles applet with backend fallbacks and extensive docs; bump 0.1.13
+
+* Thu Mar 05 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.12-1
+- Add Bluetooth applet and harden BlueZ power/discovery flow; bump 0.1.12
+
+* Wed Mar 04 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.11-1
+- Style: apply ruff formatting in notifications files
+- Feat: add notifications applet with history and bump version to 0.1.11
+
+* Wed Mar 04 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.10-1
+- Feat: add multi-monitor dock selection and bump version to 0.1.10
+
+* Wed Mar 04 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.9-1
+- Fix: reconcile autohide after menu close and bump version to 0.1.9
+- Docs: add brightness/color/moon applet sections and screenshots
+- Fix: configure about dialog license metadata
+- Chore: remove committed patch artifact
+
+* Wed Mar 04 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.8-1
+- Feat: apply patch changes and bump release version to 0.1.8
+- Docs: update latest release installation links
+- Ci: ignore arch debug package in release normalization
+
+* Wed Mar 04 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.7-1
+- Ci: harden release asset normalization for latest aliases
+- Ci: add stable latest release asset aliases
+
+* Wed Mar 04 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.6-1
+- Ci: standardize release assets and bump version to 0.1.6
+
+* Wed Mar 04 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.5-1
+- Add music applet improvements and timed screenshot captures
+- Raise tests to 95% coverage and expand applet/UI coverage
+- Extract About dialog module and commit current WIP
+- Docs: expand architecture narratives for core dock modules
+- Create custom Cairo icons for applets visual identity
+
+* Tue Mar 03 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.4-1
+- Refactor applets into modular packages and migrate weather applet
+- Refine applet icons and harden preview/window error handling
+- Apply preview segfault patch with merge conflict resolution
+- Extract DockItem to core and stabilize runtime imports
+- Standardize exception logging across runtime modules
+- Increase coverage to 80% with applet and model integration tests
+- Refine Session applet with Cairo user-avatar icon
+- Improve Snap metadata and icon wiring for lint warnings
+
+* Sun Mar 01 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.3-1
+- Fix Arch build by syncing PKGBUILD pkgver with project version
+- Increase test coverage to 75% with app/platform/ui tests and add Debian autop...
+- Fix Codecov workflow condition by using env token guard
+- Fix Nix build inputs and relax weather deps for CI reproducibility
+- Require CODECOV_TOKEN for coverage upload in CI
+- Polish README badge and layout tweaks
+- Add Python version badge to README
+- Add CI/release/coverage badges and publish coverage to Codecov
+- Adjust applet categories and add Nix packaging with CI artifacts
+- Make Arch source tarball fallback work without git metadata
+
+* Sun Mar 01 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.2-1
+- Rename CI Ubuntu test job id to test-ubuntu
+- Replace raw applet id strings with AppletId constants
+- Centralize applet IDs and reuse them in Applets category mapping
+- Group Applets submenu by categories and fix RPM arch packaging
+- Fix Snap asset sourcing and stabilize RPM Python install layout
+- Fix Snap asset path resolution and RPM install fallback
+- Fix Snap build paths and add initial RPM packaging pipeline
+- Fix Snap/AppImage CI packaging failures
+- Center README header image with valid CSS
+- Expand integration coverage and add AppImage artifact pipeline
 
 * Sun Mar 01 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.1-1
-- Initial RPM packaging.
+- Add Quote applet, improve hydration visuals, and publish CI coverage artifacts
+- Fix Flatpak AppStream icon lookup during compose
+- Fix Flatpak builder option compatibility
+- Fix Flatpak builder networking in CI and local script
+- Fix Flatpak CI permissions by using user-scoped remotes
+- Add Flatpak packaging and CI build artifact
+
+* Sat Feb 28 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 0.1.0-1
+- Fix release version parsing for Python 3.10 runners
+- Fix CI YAML syntax error in release version check
+- Make CI release automation master-only with version gating
+- Another adjustement
+- Remove visible borders from README title table
+- Use table layout for README title icon alignment
+- Tune README title icon alignment via local render loop
+- Fine-tune README title icon vertical alignment
+- Align README title icon using trimmed header asset
+- Refresh WM_CLASS mapping on each window scan
+

--- a/packaging/snap/snapcraft.yaml
+++ b/packaging/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: docking
 title: Docking
 base: core22
-version: "1.29.0"
+version: "2.0.0"
 summary: Feature-rich Linux dock in Python with GTK 3 and Cairo
 description: |
   A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docking"
-version = "1.29.0"
+version = "2.0.0"
 description = "A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo"
 requires-python = ">=3.10"
 license = {text = "GPL-3.0-or-later"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # The canonical config is in pyproject.toml.
 [metadata]
 name = docking
-version = 1.29.0
+version = 2.0.0
 [options]
 packages = find:
 python_requires = >=3.10


### PR DESCRIPTION
## Summary

Bump version from 1.29.0 to 2.0.0 and rewrite Debian/RPM changelogs from
git history with meaningful per-release entries.

## Why 2.0.0

The major version bump reflects the removal of `GDK_BACKEND=x11` forcing
and the addition of native Wayland dependencies across all packaging
formats — a significant change in platform support posture.

## Changes

### Version bump
- `docking/__init__.py`: `__version__ = "2.0.0"`
- `pyproject.toml`: `version = "2.0.0"`
- `setup.cfg`: `version = 2.0.0`
- `packaging/arch/PKGBUILD`: `pkgver=2.0.0`
- `packaging/nix/default.nix`: `version = "2.0.0"`
- `packaging/snap/snapcraft.yaml`: `version: "2.0.0"`
- `packaging/rpm/docking.spec`: `Version: 2.0.0`

### Changelog rewrite
- **Debian** (`packaging/deb/debian/changelog`): Rewrote all 105 version
  entries from git history with actual commit messages instead of generic
  "Release X.Y.Z" placeholders. Added v2.0.0 entry at the top.
- **RPM** (`packaging/rpm/docking.spec`): Same — `%changelog` section now
  contains per-release change summaries extracted from git history.

## Dependencies

This PR is the versioning counterpart to #170 (Wayland packaging changes).
The two should be merged in sequence: #170 first, then this one.

## Post-merge

After merging, tag and push:
```bash
git tag -a v2.0.0 -m "v2.0.0: First-class Wayland support"
git push origin v2.0.0
```