### PR TITLE
Bump version to 2.0.1

### DIFF
--- a/docking/__init__.py
+++ b/docking/__init__.py
@@ -38,4 +38,4 @@ In other words, this module is a package marker and metadata boundary, not an
 alternate application entrypoint.
 """
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=docking
-pkgver=2.0.0
+pkgver=2.0.1
 pkgrel=1
 pkgdesc="A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo"
 arch=('x86_64' 'aarch64')

--- a/packaging/deb/debian/changelog
+++ b/packaging/deb/debian/changelog
@@ -1,3 +1,12 @@
+docking (2.0.1-1) stable; urgency=medium
+
+  * Refresh README, packaging docs, and website for v2.0.1
+  * Add GPU utilization summary to System Monitor applet
+  * Fix Opus 4.7/4.8 and Sonnet 4.5/4.6 pricing tiers
+  * Replace getattr calls with direct attribute access in placement.py
+
+ -- Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com>  Wed, 11 Jun 2026 00:00:00 -0000
+
 docking (2.0.0-1) stable; urgency=medium
 
   * First-class Wayland support across all packaging formats

--- a/packaging/nix/default.nix
+++ b/packaging/nix/default.nix
@@ -5,7 +5,7 @@ let
 in
 pyPkgs.buildPythonApplication rec {
   pname = "docking";
-  version = "2.0.0";
+  version = "2.0.1";
   format = "pyproject";
 
   src = ../..;

--- a/packaging/rpm/docking.spec
+++ b/packaging/rpm/docking.spec
@@ -1,5 +1,5 @@
 Name:           docking
-Version:        %{?pkg_version}%{!?pkg_version:2.0.0}
+Version:        %{?pkg_version}%{!?pkg_version:2.0.1}
 Release:        1%{?dist}
 Summary:        A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo
 
@@ -118,6 +118,12 @@ fi
 /usr/share/icons/hicolor
 
 %changelog
+
+* Wed Jun 11 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 2.0.1-1
+- Refresh README, packaging docs, and website for v2.0.1
+- Add GPU utilization summary to System Monitor applet
+- Fix Opus 4.7/4.8 and Sonnet 4.5/4.6 pricing tiers
+- Replace getattr calls with direct attribute access in placement.py
 
 * Sat Jun 06 2026 Eduardo Mucelli Rezende Oliveira <edumucelli@gmail.com> - 1.29.0-1
 - Add experimental Wayland runtime support

--- a/packaging/snap/snapcraft.yaml
+++ b/packaging/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: docking
 title: Docking
 base: core22
-version: "2.0.0"
+version: "2.0.1"
 summary: Feature-rich Linux dock in Python with GTK 3 and Cairo
 description: |
   A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docking"
-version = "2.0.0"
+version = "2.0.1"
 description = "A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cairo"
 requires-python = ">=3.10"
 license = {text = "GPL-3.0-or-later"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # The canonical config is in pyproject.toml.
 [metadata]
 name = docking
-version = 2.0.0
+version = 2.0.1
 [options]
 packages = find:
 python_requires = >=3.10


### PR DESCRIPTION
## Summary

Patch version bump from 2.0.0 to 2.0.1.

### Version bumps

- `pyproject.toml`, `setup.cfg`, `docking/__init__.py`: 2.0.0 → 2.0.1
- `packaging/arch/PKGBUILD`, `packaging/nix/default.nix`, `packaging/snap/snapcraft.yaml`, `packaging/rpm/docking.spec`: 2.0.0 → 2.0.1

### Changelogs

- `packaging/deb/debian/changelog`: add 2.0.1-1 entry
- `packaging/rpm/docking.spec`: add 2.0.1-1 %changelog entry