### PR TITLE
Add Run Application applet

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cair
 
 ## Contents
 
-- [Features](#features)
+- [Highlights](#highlights)
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Running](#running)
@@ -31,23 +31,17 @@ A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cair
 - [Contributing](#contributing)
 - [License](#license)
 
-## Features
+## Highlights
 
-Docking is built around a few core capabilities:
-
-- Fast launcher workflow with running-state indicators and preview interactions.
-- Flexible layout with multi-position, multi-monitor, auto-hide, and drag-and-drop organization.
-- Broad customization through themes, transparency, icon sizing, menu options, and tooltip controls.
-- Native support for pinned files/folders, including left-click folder stacks.
-- Extensible applet surface for system status, productivity, media, and utilities.
-
-Highlights:
-- 56 built-in applets enabled from the dock menu, plus a separate dock separator item.
-- 13 built-in themes with scalable layout values.
-- Desktop-environment integration across MATE, Xfce, KDE, Cinnamon, GNOME, and others.
-- Unity LauncherEntry support for per-app badge counts and progress bars on dock icons.
-- Exports `_DOCKING_BACKGROUND_BLUR_REGION` on X11 so compositors and scripts can read the exact visible shelf rectangle.
-- 74 locale catalogs plus English fallback.
+- Fast launcher workflow with running indicators, previews, app actions, and drag-and-drop organization.
+- Native Linux desktop integration across X11 and Wayland, with support for GNOME, KDE Plasma, wlroots compositors, MATE, Xfce, Cinnamon, and reduced fallback mode.
+- 57 built-in applets for launching apps and commands, monitoring system state, controlling media, managing notes, files, folders, screenshots, power, networking, weather, and more.
+- Folder stacks and pinned files/folders, so directories and documents can live directly in the dock alongside applications.
+- Flexible dock layout with multi-position, multi-monitor, auto-hide, separators, and scalable sizing.
+- Deep customization through 13 built-in themes, transparency, icon sizing, menu behavior, and tooltip controls.
+- Broad release packaging: AppImage, Debian package, RPM, Flatpak, Snap, Arch package, and Nix output.
+- Desktop integration details such as Unity LauncherEntry badge/progress support, X11 background blur region export, and 74 locale catalogs plus English fallback.
+- Extensible Python applet system for adding custom dock-resident tools without changing the core runtime.
 
 ## Requirements
 

--- a/docking/applets/applications/state.py
+++ b/docking/applets/applications/state.py
@@ -16,16 +16,8 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from pathlib import Path
-from typing import NamedTuple
 
-import gi
-
-gi.require_version("Gtk", "3.0")
-from gi.repository import Gio, GLib
-
-from docking.platform.launcher import Launcher
-from docking.platform.launcher import launch as launch_desktop_id
+from docking.applets.apps import ApplicationEntry, all_desktop_app_infos
 
 # FreeDesktop main categories -> display label
 CATEGORY_LABELS: dict[str, str] = {
@@ -60,42 +52,6 @@ CATEGORY_ICONS: dict[str, str] = {
 }
 
 
-class ApplicationEntry(NamedTuple):
-    """Small app-info adapter for Gio and host-parsed desktop files."""
-
-    desktop_id: str
-    name: str
-    categories: str
-    icon_name: str
-    app_info: Gio.DesktopAppInfo | None = None
-
-    def get_id(self) -> str:
-        return self.desktop_id
-
-    def get_display_name(self) -> str:
-        return self.name
-
-    def get_categories(self) -> str:
-        return self.categories
-
-    def get_icon(self) -> Gio.Icon | None:
-        if self.app_info is not None:
-            return self.app_info.get_icon()
-        if not self.icon_name:
-            return None
-        icon_path = Path(self.icon_name)
-        if icon_path.is_absolute():
-            return Gio.FileIcon.new(Gio.File.new_for_path(str(icon_path)))
-        return Gio.ThemedIcon.new(self.icon_name)
-
-    def launch(self, files: list[object], context: object | None) -> None:
-        if self.desktop_id:
-            launch_desktop_id(desktop_id=self.desktop_id)
-            return
-        if self.app_info is not None:
-            self.app_info.launch(files, context)
-
-
 def _map_category(categories: str) -> str:
     """Map FreeDesktop category string to display category."""
     display_cat = "Other"
@@ -115,7 +71,7 @@ def _build_app_categories() -> dict[str, list[ApplicationEntry]]:
     """
     categories: dict[str, list[ApplicationEntry]] = defaultdict(list)
 
-    for app_info in _all_desktop_app_infos():
+    for app_info in all_desktop_app_infos():
         cats = app_info.get_categories() or ""
         categories[_map_category(categories=cats)].append(app_info)
 
@@ -124,101 +80,3 @@ def _build_app_categories() -> dict[str, list[ApplicationEntry]]:
         apps.sort(key=lambda a: (a.get_display_name() or "").lower())
 
     return dict(categories)
-
-
-def _all_desktop_app_infos() -> list[ApplicationEntry]:
-    apps: list[ApplicationEntry] = []
-    seen: set[str] = set()
-
-    for app_info in Gio.AppInfo.get_all():
-        if isinstance(app_info, Gio.DesktopAppInfo):
-            if app_info.get_is_hidden() or app_info.get_nodisplay():
-                continue
-            app_id = app_info.get_id()
-            if app_id:
-                seen.add(app_id)
-            apps.append(
-                ApplicationEntry(
-                    desktop_id=app_id or "",
-                    name=app_info.get_display_name() or app_id or "Unknown",
-                    categories=app_info.get_categories() or "",
-                    icon_name=app_info.get_icon().to_string()
-                    if app_info.get_icon()
-                    else "",
-                    app_info=app_info,
-                )
-            )
-
-    for desktop_dir in Launcher._get_desktop_dirs():
-        for path in desktop_dir.rglob("*.desktop"):
-            if not path.is_file():
-                continue
-            desktop_id = path.relative_to(desktop_dir).as_posix()
-            if desktop_id in seen:
-                continue
-            try:
-                app_info = Gio.DesktopAppInfo.new_from_filename(str(path))
-            except (TypeError, GLib.Error):
-                app_info = None
-            if app_info is None:
-                entry = _entry_from_desktop_file(desktop_id=desktop_id, path=path)
-            else:
-                if app_info.get_is_hidden() or app_info.get_nodisplay():
-                    continue
-                entry = ApplicationEntry(
-                    desktop_id=desktop_id,
-                    name=app_info.get_display_name() or desktop_id,
-                    categories=app_info.get_categories() or "",
-                    icon_name=app_info.get_icon().to_string()
-                    if app_info.get_icon()
-                    else "",
-                    app_info=app_info,
-                )
-            if entry is None:
-                continue
-            seen.add(desktop_id)
-            apps.append(entry)
-
-    return apps
-
-
-def _entry_from_desktop_file(*, desktop_id: str, path: Path) -> ApplicationEntry | None:
-    key_file = GLib.KeyFile()
-    try:
-        key_file.load_from_file(str(path), GLib.KeyFileFlags.NONE)
-    except GLib.Error:
-        return None
-    if _desktop_string(key_file=key_file, key="Type") != "Application":
-        return None
-    if _desktop_bool(key_file=key_file, key="Hidden") or _desktop_bool(
-        key_file=key_file,
-        key="NoDisplay",
-    ):
-        return None
-    return ApplicationEntry(
-        desktop_id=desktop_id,
-        name=_desktop_locale_string(key_file=key_file, key="Name") or desktop_id,
-        categories=_desktop_string(key_file=key_file, key="Categories"),
-        icon_name=_desktop_string(key_file=key_file, key="Icon"),
-    )
-
-
-def _desktop_string(*, key_file: GLib.KeyFile, key: str) -> str:
-    try:
-        return key_file.get_string("Desktop Entry", key).strip()
-    except GLib.Error:
-        return ""
-
-
-def _desktop_locale_string(*, key_file: GLib.KeyFile, key: str) -> str:
-    try:
-        return key_file.get_locale_string("Desktop Entry", key, None).strip()
-    except GLib.Error:
-        return _desktop_string(key_file=key_file, key=key)
-
-
-def _desktop_bool(*, key_file: GLib.KeyFile, key: str) -> bool:
-    try:
-        return bool(key_file.get_boolean("Desktop Entry", key))
-    except GLib.Error:
-        return False

--- a/docking/applets/apps.py
+++ b/docking/applets/apps.py
@@ -1,0 +1,166 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Shared desktop application discovery helpers for applets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gio, GLib
+
+from docking.platform.launcher import Launcher
+from docking.platform.launcher import launch as launch_desktop_id
+
+
+class ApplicationEntry(NamedTuple):
+    """Small app-info adapter for Gio and host-parsed desktop files."""
+
+    desktop_id: str
+    name: str
+    categories: str
+    icon_name: str
+    app_info: Gio.DesktopAppInfo | None = None
+
+    def get_id(self) -> str:
+        return self.desktop_id
+
+    def get_display_name(self) -> str:
+        return self.name
+
+    def get_categories(self) -> str:
+        return self.categories
+
+    def get_icon(self) -> object | None:
+        if self.app_info is not None:
+            return self.app_info.get_icon()
+        if not self.icon_name:
+            return None
+
+        icon_path = Path(self.icon_name)
+        if icon_path.is_absolute():
+            return Gio.FileIcon.new(Gio.File.new_for_path(str(icon_path)))
+        return Gio.ThemedIcon.new(self.icon_name)
+
+    def launch(self, files: list[object], context: object | None) -> None:
+        if self.desktop_id:
+            launch_desktop_id(desktop_id=self.desktop_id)
+            return
+        if self.app_info is not None:
+            self.app_info.launch(files, context)
+
+
+def all_desktop_app_infos() -> list[ApplicationEntry]:
+    """Return launchable desktop applications visible to applet UIs."""
+    apps: list[ApplicationEntry] = []
+    seen: set[str] = set()
+
+    for app_info in Gio.AppInfo.get_all():
+        if isinstance(app_info, Gio.DesktopAppInfo):
+            if app_info.get_is_hidden() or app_info.get_nodisplay():
+                continue
+            app_id = app_info.get_id()
+            if app_id:
+                seen.add(app_id)
+            apps.append(
+                ApplicationEntry(
+                    desktop_id=app_id or "",
+                    name=app_info.get_display_name() or app_id or "Unknown",
+                    categories=app_info.get_categories() or "",
+                    icon_name=app_info.get_icon().to_string()
+                    if app_info.get_icon()
+                    else "",
+                    app_info=app_info,
+                )
+            )
+
+    for desktop_dir in Launcher._get_desktop_dirs():
+        for path in desktop_dir.rglob("*.desktop"):
+            if not path.is_file():
+                continue
+            desktop_id = path.relative_to(desktop_dir).as_posix()
+            if desktop_id in seen:
+                continue
+            try:
+                app_info = Gio.DesktopAppInfo.new_from_filename(str(path))
+            except (TypeError, GLib.Error):
+                app_info = None
+            if app_info is None:
+                entry = _entry_from_desktop_file(desktop_id=desktop_id, path=path)
+            else:
+                if app_info.get_is_hidden() or app_info.get_nodisplay():
+                    continue
+                entry = ApplicationEntry(
+                    desktop_id=desktop_id,
+                    name=app_info.get_display_name() or desktop_id,
+                    categories=app_info.get_categories() or "",
+                    icon_name=app_info.get_icon().to_string()
+                    if app_info.get_icon()
+                    else "",
+                    app_info=app_info,
+                )
+            if entry is None:
+                continue
+            seen.add(desktop_id)
+            apps.append(entry)
+
+    return apps
+
+
+def _entry_from_desktop_file(*, desktop_id: str, path: Path) -> ApplicationEntry | None:
+    key_file = GLib.KeyFile()
+    try:
+        key_file.load_from_file(str(path), GLib.KeyFileFlags.NONE)
+    except GLib.Error:
+        return None
+    if _desktop_string(key_file=key_file, key="Type") != "Application":
+        return None
+    if _desktop_bool(key_file=key_file, key="Hidden") or _desktop_bool(
+        key_file=key_file,
+        key="NoDisplay",
+    ):
+        return None
+    return ApplicationEntry(
+        desktop_id=desktop_id,
+        name=_desktop_locale_string(key_file=key_file, key="Name") or desktop_id,
+        categories=_desktop_string(key_file=key_file, key="Categories"),
+        icon_name=_desktop_string(key_file=key_file, key="Icon"),
+    )
+
+
+def _desktop_string(*, key_file: GLib.KeyFile, key: str) -> str:
+    try:
+        return key_file.get_string("Desktop Entry", key).strip()
+    except GLib.Error:
+        return ""
+
+
+def _desktop_locale_string(*, key_file: GLib.KeyFile, key: str) -> str:
+    try:
+        return key_file.get_locale_string("Desktop Entry", key, None).strip()
+    except GLib.Error:
+        return _desktop_string(key_file=key_file, key=key)
+
+
+def _desktop_bool(*, key_file: GLib.KeyFile, key: str) -> bool:
+    try:
+        return bool(key_file.get_boolean("Desktop Entry", key))
+    except GLib.Error:
+        return False
+
+
+__all__ = ["ApplicationEntry", "all_desktop_app_infos"]

--- a/docking/applets/runcommand/__init__.py
+++ b/docking/applets/runcommand/__init__.py
@@ -11,14 +11,16 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 
-"""Applications applet metadata."""
+"""Applet metadata for the Run Application applet."""
 
 from __future__ import annotations
 
 from docking.applets.identity import AppletCategory, AppletMeta
 
 meta = AppletMeta(
-    id="applications",
-    name="Applications",
+    id="runcommand",
+    name="Run Application",
     category=AppletCategory.LAUNCHER,
 )
+
+__all__ = ["meta"]

--- a/docking/applets/runcommand/applet.py
+++ b/docking/applets/runcommand/applet.py
@@ -1,0 +1,392 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""GTK dialog glue for the Run Application applet."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+gi.require_version("GdkPixbuf", "2.0")
+from gi.repository import GdkPixbuf, Gtk
+
+from docking.applets.apps import all_desktop_app_infos
+from docking.applets.base import Applet
+from docking.applets.popup import prepare_dialog_content
+from docking.applets.runcommand import meta
+from docking.applets.runcommand.render import create_icon
+from docking.applets.runcommand.state import (
+    ApplicationLike,
+    app_command_text,
+    app_description,
+    app_display_name,
+    append_file_argument,
+    launch_application,
+    launch_command,
+    match_application,
+    normalize_history,
+    prefs_payload,
+    updated_history,
+)
+from docking.i18n import _
+
+if TYPE_CHECKING:
+    from docking.core.config import Config
+
+RUN_DIALOG_WIDTH_PX = 575
+RUN_DIALOG_HEIGHT_PX = 355
+RUN_DIALOG_MARGIN_PX = 8
+RUN_DIALOG_SPACING_PX = 6
+LEFT_ICON_PX = 48
+APP_LIST_HEIGHT_PX = 140
+COMMAND_WIDTH_CHARS = 48
+
+
+class RunCommandApplet(Applet):
+    """Alt+F2-style command/application launcher."""
+
+    id = meta.id
+    name = _("Run Application")
+    icon_name = "system-run"
+    supports_system_icon = True
+
+    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+        prefs = config.applet_prefs.get(meta.id, {}) if config else {}
+        self._history = normalize_history(prefs.get("history"))
+        self._dialog: Gtk.Dialog | None = None
+        self._entry_combo: Gtk.ComboBoxText | None = None
+        self._entry: Gtk.Entry | None = None
+        self._terminal_check: Gtk.CheckButton | None = None
+        self._run_button: Gtk.Widget | None = None
+        self._left_icon: Gtk.Image | None = None
+        self._description_label: Gtk.Label | None = None
+        self._apps: list[ApplicationLike] = []
+        self._app_rows: list[Any] = []
+        self._selected_app: ApplicationLike | None = None
+        self._selected_entry_text = ""
+        super().__init__(icon_size=icon_size, config=config)
+        self.present()
+
+    def create_docking_icon(self, size: int) -> GdkPixbuf.Pixbuf | None:
+        return create_icon(size=size)
+
+    def refresh_tooltip(self) -> None:
+        self.item.name = _("Run Application")
+
+    def on_clicked(self) -> None:
+        if self._dialog and self._dialog.get_visible():
+            self._dialog.present()
+            return
+        self._show_dialog()
+
+    def stop(self) -> None:
+        if self._dialog:
+            self._dialog.destroy()
+            self._dialog = None
+        super().stop()
+
+    # -- Dialog ---------------------------------------------------------------
+
+    def _show_dialog(self) -> None:
+        if self._dialog is None:
+            self._dialog = self._create_dialog()
+        self._refresh_app_list()
+        self._sync_entry_history()
+        self._sync_run_state()
+        self._dialog.show_all()
+        self._apply_app_filter(self._entry.get_text() if self._entry else "")
+        self._dialog.present()
+        if self._entry is not None:
+            self._entry.grab_focus()
+
+    def _create_dialog(self) -> Gtk.Dialog:
+        dialog = Gtk.Dialog(
+            title=_("Run Application"),
+            flags=Gtk.DialogFlags.DESTROY_WITH_PARENT,
+        )
+        dialog.add_button(_("Help"), Gtk.ResponseType.HELP)
+        dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
+        dialog.add_button(_("Run"), Gtk.ResponseType.OK)
+        dialog.connect("response", self._on_response)
+        dialog.connect("delete-event", self._on_delete_event)
+        self._run_button = dialog.get_widget_for_response(Gtk.ResponseType.OK)
+
+        content = prepare_dialog_content(
+            dialog=dialog,
+            width=RUN_DIALOG_WIDTH_PX,
+            height=RUN_DIALOG_HEIGHT_PX,
+            spacing=RUN_DIALOG_SPACING_PX,
+            margin=RUN_DIALOG_MARGIN_PX,
+            default_response=Gtk.ResponseType.OK,
+            resizable=False,
+        )
+        content.pack_start(self._build_dialog_content(), True, True, 0)
+        return dialog
+
+    def _build_dialog_content(self) -> Gtk.Box:
+        outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+
+        top = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        outer.pack_start(top, False, False, 0)
+
+        self._left_icon = Gtk.Image.new_from_icon_name(
+            self.icon_name,
+            Gtk.IconSize.DIALOG,
+        )
+        self._left_icon.set_pixel_size(LEFT_ICON_PX)
+        self._left_icon.set_valign(Gtk.Align.START)
+        top.pack_start(self._left_icon, False, False, 0)
+
+        body = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        body.set_hexpand(True)
+        top.pack_start(body, True, True, 0)
+
+        self._entry_combo = Gtk.ComboBoxText.new_with_entry()
+        self._entry_combo.set_entry_text_column(0)
+        self._entry_combo.set_hexpand(True)
+        self._entry = self._entry_combo.get_child()
+        self._entry.set_width_chars(COMMAND_WIDTH_CHARS)
+        self._entry.set_activates_default(True)
+        self._entry.connect("changed", self._on_entry_changed)
+        body.pack_start(self._entry_combo, False, False, 0)
+
+        options_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        self._terminal_check = Gtk.CheckButton(label=_("Run in terminal"))
+        options_row.pack_start(self._terminal_check, False, False, 0)
+        file_button = Gtk.Button(label=_("Run with file..."))
+        file_button.connect("clicked", self._on_run_with_file)
+        options_row.pack_end(file_button, False, False, 0)
+        body.pack_start(options_row, False, False, 0)
+
+        expander = Gtk.Expander(label=_("Show list of known applications"))
+        expander.set_expanded(True)
+        expander.add(self._build_app_list())
+        outer.pack_start(expander, False, False, 0)
+
+        self._description_label = Gtk.Label(
+            label=_("Select an application to view its description."),
+        )
+        self._description_label.set_xalign(0.0)
+        self._description_label.set_line_wrap(True)
+        outer.pack_start(self._description_label, False, False, 0)
+
+        return outer
+
+    def _build_app_list(self) -> Gtk.ScrolledWindow:
+        self._app_list = Gtk.ListBox()
+        self._app_list.set_selection_mode(Gtk.SelectionMode.SINGLE)
+        self._app_list.connect("row-selected", self._on_app_row_selected)
+
+        scroll = Gtk.ScrolledWindow()
+        scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_size_request(-1, APP_LIST_HEIGHT_PX)
+        scroll.add(self._app_list)
+        return scroll
+
+    def _refresh_app_list(self) -> None:
+        if not hasattr(self, "_app_list"):
+            return
+        app_list = self._app_list
+        for child in list(app_list.get_children()):
+            app_list.remove(child)
+
+        self._apps = list(all_desktop_app_infos())
+        self._app_rows = []
+        for app in self._apps:
+            row = Gtk.ListBoxRow()
+            row.app_entry = app  # type: ignore[attr-defined]
+            row.add(self._build_app_row(app))
+            app_list.add(row)
+            self._app_rows.append(row)
+        self._apply_app_filter(self._entry.get_text() if self._entry else "")
+
+    def _build_app_row(self, app: ApplicationLike) -> Gtk.Box:
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        icon = Gtk.Image()
+        gicon = app.get_icon()
+        if gicon is not None:
+            icon.set_from_gicon(gicon, Gtk.IconSize.MENU)
+        icon.set_pixel_size(16)
+        row.pack_start(icon, False, False, 0)
+
+        label = Gtk.Label(label=app_display_name(app))
+        label.set_xalign(0.0)
+        row.pack_start(label, True, True, 0)
+        return row
+
+    def _sync_entry_history(self) -> None:
+        if self._entry_combo is None:
+            return
+        current = self._entry.get_text() if self._entry is not None else ""
+        self._entry_combo.remove_all()
+        for command in self._history:
+            self._entry_combo.append_text(command)
+        if self._entry is not None and current:
+            self._entry.set_text(current)
+
+    def _on_delete_event(self, *_args: object) -> bool:
+        if self._dialog is not None:
+            self._dialog.hide()
+        return True
+
+    def _on_response(self, dialog: Gtk.Dialog, response_id: int) -> None:
+        if response_id == Gtk.ResponseType.OK:
+            self._run_current()
+            return
+        if response_id == Gtk.ResponseType.HELP:
+            self._show_help_dialog()
+            return
+        dialog.hide()
+
+    def _show_help_dialog(self) -> None:
+        parent = self._dialog
+        help_dialog = Gtk.MessageDialog(
+            transient_for=parent,
+            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            message_type=Gtk.MessageType.INFO,
+            buttons=Gtk.ButtonsType.OK,
+            text=_("Run Application"),
+        )
+        help_dialog.format_secondary_text(
+            _("Type a command or select an application to launch it."),
+        )
+        help_dialog.connect("response", lambda dlg, _response: dlg.destroy())
+        help_dialog.show_all()
+
+    # -- Input handling -------------------------------------------------------
+
+    def _on_entry_changed(self, entry: Gtk.Entry) -> None:
+        text = entry.get_text()
+        self._apply_app_filter(text)
+        if self._selected_app is not None and text == self._selected_entry_text:
+            matched = self._selected_app
+        else:
+            matched = match_application(apps=self._apps, text=text)
+            self._selected_app = matched
+            self._selected_entry_text = text if matched is not None else ""
+        self._update_left_icon(matched)
+        if self._description_label is not None:
+            self._description_label.set_text(
+                app_description(matched)
+                if matched is not None
+                else _("Select an application to view its description.")
+            )
+        self._sync_run_state()
+
+    def _apply_app_filter(self, text: str) -> None:
+        query = text.strip().casefold()
+        for row in self._app_rows:
+            app = getattr(row, "app_entry", None)
+            visible = app is not None and _app_matches_filter(app=app, query=query)
+            if visible:
+                row.show()
+            else:
+                row.hide()
+
+    def _on_app_row_selected(self, _listbox: Gtk.ListBox, row: Any) -> None:
+        if row is None:
+            return
+        app = getattr(row, "app_entry", None)
+        if app is None:
+            return
+        self._select_application(app)
+
+    def _select_application(self, app: ApplicationLike) -> None:
+        self._selected_app = app
+        self._selected_entry_text = app_command_text(app)
+        if self._entry is not None:
+            self._entry.set_text(self._selected_entry_text)
+            self._entry.set_position(-1)
+        self._update_left_icon(app)
+        if self._description_label is not None:
+            self._description_label.set_text(app_description(app))
+        self._sync_run_state()
+
+    def _update_left_icon(self, app: ApplicationLike | None) -> None:
+        if self._left_icon is None:
+            return
+        gicon = app.get_icon() if app is not None else None
+        if gicon is not None:
+            self._left_icon.set_from_gicon(gicon, Gtk.IconSize.DIALOG)
+        else:
+            self._left_icon.set_from_icon_name(self.icon_name, Gtk.IconSize.DIALOG)
+        self._left_icon.set_pixel_size(LEFT_ICON_PX)
+
+    def _sync_run_state(self) -> None:
+        if self._run_button is None or self._entry is None:
+            return
+        self._run_button.set_sensitive(bool(self._entry.get_text().strip()))
+
+    def _on_run_with_file(self, _button: Gtk.Button) -> None:
+        dialog = Gtk.FileChooserDialog(
+            title=_("Run with file"),
+            parent=self._dialog,
+            action=Gtk.FileChooserAction.OPEN,
+        )
+        dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
+        dialog.add_button(_("Open"), Gtk.ResponseType.OK)
+        response = dialog.run()
+        if response == Gtk.ResponseType.OK and self._entry is not None:
+            filename = dialog.get_filename()
+            if filename:
+                command = self._entry.get_text()
+                self._entry.set_text(
+                    append_file_argument(command=command, path=filename),
+                )
+                self._entry.set_position(-1)
+        dialog.destroy()
+
+    def _run_current(self) -> None:
+        if self._entry is None:
+            return
+        command = self._entry.get_text().strip()
+        if not command:
+            return
+
+        app = (
+            self._selected_app
+            if self._selected_app is not None and command == self._selected_entry_text
+            else match_application(apps=self._apps, text=command)
+        )
+        run_in_terminal = bool(
+            self._terminal_check and self._terminal_check.get_active()
+        )
+        if run_in_terminal:
+            launched = launch_command(
+                command=app_command_text(app) if app is not None else command,
+                run_in_terminal=True,
+            )
+        elif app is not None:
+            launched = launch_application(app)
+        else:
+            launched = launch_command(
+                command=command,
+                run_in_terminal=False,
+            )
+
+        if launched:
+            self._history = updated_history(history=self._history, command=command)
+            self.save_prefs(prefs=prefs_payload(history=self._history))
+            if self._dialog is not None:
+                self._dialog.hide()
+
+
+def _app_matches_filter(*, app: ApplicationLike, query: str) -> bool:
+    if not query:
+        return True
+    name = app_display_name(app).casefold()
+    command = app_command_text(app).casefold()
+    return query in name or query in command

--- a/docking/applets/runcommand/render.py
+++ b/docking/applets/runcommand/render.py
@@ -1,0 +1,78 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Dock icon rendering for the Run Application applet."""
+
+from __future__ import annotations
+
+import cairo
+import gi
+
+gi.require_version("Gdk", "3.0")
+gi.require_version("GdkPixbuf", "2.0")
+from gi.repository import Gdk, GdkPixbuf
+
+from docking.applets.draw import rounded_rect
+
+
+def create_icon(size: int) -> GdkPixbuf.Pixbuf | None:
+    """Render a compact command prompt icon."""
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, size, size)
+    cr = cairo.Context(surface)
+    cr.set_source_rgba(0, 0, 0, 0)
+    cr.paint()
+
+    pad = size * 0.10
+    x = pad
+    y = size * 0.16
+    width = size - 2 * pad
+    height = size * 0.68
+    radius = size * 0.10
+
+    rounded_rect(cr=cr, x=x, y=y, width=width, height=height, radius=radius)
+    cr.set_source_rgb(0.12, 0.13, 0.15)
+    cr.fill()
+
+    rounded_rect(
+        cr=cr,
+        x=x + size * 0.035,
+        y=y + size * 0.035,
+        width=width - size * 0.07,
+        height=height - size * 0.07,
+        radius=radius * 0.70,
+    )
+    cr.set_source_rgb(0.93, 0.95, 0.93)
+    cr.fill()
+
+    header_h = height * 0.24
+    rounded_rect(cr=cr, x=x, y=y, width=width, height=header_h, radius=radius)
+    cr.set_source_rgb(0.45, 0.58, 0.51)
+    cr.fill()
+    cr.rectangle(x, y + header_h * 0.58, width, header_h * 0.42)
+    cr.fill()
+
+    cr.set_source_rgb(0.10, 0.17, 0.16)
+    cr.set_line_width(max(1.0, size * 0.065))
+    prompt_x = x + width * 0.18
+    prompt_y = y + header_h + height * 0.28
+    cr.move_to(prompt_x, prompt_y - size * 0.10)
+    cr.line_to(prompt_x + size * 0.12, prompt_y)
+    cr.line_to(prompt_x, prompt_y + size * 0.10)
+    cr.stroke()
+
+    cr.set_line_width(max(1.0, size * 0.055))
+    cr.move_to(prompt_x + size * 0.20, prompt_y + size * 0.10)
+    cr.line_to(x + width * 0.78, prompt_y + size * 0.10)
+    cr.stroke()
+
+    return Gdk.pixbuf_get_from_surface(surface, 0, 0, size, size)

--- a/docking/applets/runcommand/state.py
+++ b/docking/applets/runcommand/state.py
@@ -1,0 +1,342 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Command, history, and application matching helpers for Run Application."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import shutil
+import subprocess
+from collections.abc import Callable, Iterable
+from enum import Enum
+from functools import cache
+from typing import Any, NamedTuple, Protocol
+
+from gi.repository import GLib
+
+from docking.applets.runcommand import meta
+from docking.log import get_logger, with_context
+from docking.platform.environment import flatpak
+
+log = with_context(get_logger(name="runcommand"), applet_id=meta.id)
+
+HISTORY_LIMIT = 20
+TERMINAL_LOOKUP_TIMEOUT_SECONDS = 1.5
+
+
+class TerminalMode(str, Enum):
+    ARGV = "argv"
+    COMMAND_STRING = "command_string"
+
+
+class TerminalCandidate(NamedTuple):
+    executable: str
+    exec_prefix: tuple[str, ...]
+    mode: TerminalMode = TerminalMode.ARGV
+
+
+class ResolvedTerminal(NamedTuple):
+    executable: str
+    exec_prefix: tuple[str, ...]
+    mode: TerminalMode
+
+
+TERMINAL_CANDIDATES: tuple[TerminalCandidate, ...] = (
+    TerminalCandidate("x-terminal-emulator", ("-e",)),
+    TerminalCandidate("sensible-terminal", ("-e",)),
+    TerminalCandidate("gnome-terminal", ("--",)),
+    TerminalCandidate("kgx", ("--",)),
+    TerminalCandidate("ptyxis", ("--",)),
+    TerminalCandidate("mate-terminal", ("-e",), TerminalMode.COMMAND_STRING),
+    TerminalCandidate("xfce4-terminal", ("-e",), TerminalMode.COMMAND_STRING),
+    TerminalCandidate("lxterminal", ("-e",), TerminalMode.COMMAND_STRING),
+    TerminalCandidate("qterminal", ("-e",)),
+    TerminalCandidate("konsole", ("-e",)),
+    TerminalCandidate("tilix", ("-e",), TerminalMode.COMMAND_STRING),
+    TerminalCandidate("terminator", ("-e",), TerminalMode.COMMAND_STRING),
+    TerminalCandidate("alacritty", ("-e",)),
+    TerminalCandidate("kitty", ("-e",)),
+    TerminalCandidate("foot", ("-e",)),
+    TerminalCandidate("ghostty", ("-e",)),
+    TerminalCandidate("wezterm", ("start", "--")),
+    TerminalCandidate("terminology", ("-e",), TerminalMode.COMMAND_STRING),
+    TerminalCandidate("deepin-terminal", ("-e",), TerminalMode.COMMAND_STRING),
+    TerminalCandidate("urxvt", ("-e",)),
+    TerminalCandidate("rxvt", ("-e",)),
+    TerminalCandidate("xterm", ("-e",)),
+)
+DESKTOP_EXEC_FIELD_CODES_RE = re.compile(r"%[uUfFdDnNickvm]")
+
+
+class ApplicationLike(Protocol):
+    """Protocol shared by Gio app infos and the Applications applet adapter."""
+
+    app_info: Any
+
+    def get_display_name(self) -> str: ...
+
+    def get_icon(self) -> object | None: ...
+
+    def launch(self, files: list[object], context: object | None) -> None: ...
+
+
+def normalize_history(raw_history: object) -> list[str]:
+    """Return non-empty, de-duplicated history entries."""
+    if not isinstance(raw_history, list):
+        return []
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in raw_history:
+        if not isinstance(value, str):
+            continue
+        command = value.strip()
+        if not command or command in seen:
+            continue
+        result.append(command)
+        seen.add(command)
+        if len(result) >= HISTORY_LIMIT:
+            break
+    return result
+
+
+def updated_history(
+    *,
+    history: Iterable[str],
+    command: str,
+    limit: int = HISTORY_LIMIT,
+) -> list[str]:
+    """Add command at the front while preserving a bounded unique history."""
+    normalized = command.strip()
+    if not normalized:
+        return list(history)[:limit]
+    result = [normalized]
+    result.extend(item for item in history if item != normalized)
+    return result[:limit]
+
+
+def shell_path() -> str:
+    """Return the user's shell, falling back to POSIX sh."""
+    return os.environ.get("SHELL") or "/bin/sh"
+
+
+def build_shell_argv(*, command: str, shell: str | None = None) -> list[str]:
+    """Build argv for shell-compatible Alt+F2 command text."""
+    return [shell or shell_path(), "-lc", command.strip()]
+
+
+@cache
+def _flatpak_host_terminal_name() -> str | None:
+    """Resolve the first host terminal in one sandbox-crossing command."""
+    if flatpak.spawn_path() is None:
+        return None
+
+    names = " ".join(
+        shlex.quote(candidate.executable) for candidate in TERMINAL_CANDIDATES
+    )
+    script = (
+        f"for cmd in {names}; do "
+        'command -v "$cmd" >/dev/null 2>&1 && { printf "%s" "$cmd"; exit 0; }; '
+        "done; exit 1"
+    )
+    cmd = flatpak.host_command(["sh", "-lc", script], sanitize_env=False)
+    if cmd is None:
+        return None
+    try:
+        result = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=TERMINAL_LOOKUP_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    terminal = result.stdout.strip()
+    return terminal or None
+
+
+def resolve_terminal_executable(executable: str) -> str | None:
+    """Resolve a terminal executable locally."""
+    return shutil.which(executable)
+
+
+def find_terminal(
+    resolver: Callable[[str], str | None] | None = None,
+) -> ResolvedTerminal | None:
+    """Return the first available terminal command and its exec prefix."""
+    if resolver is None:
+        host_terminal = _flatpak_host_terminal_name()
+        if host_terminal is not None:
+            for candidate in TERMINAL_CANDIDATES:
+                if candidate.executable == host_terminal:
+                    return ResolvedTerminal(
+                        executable=host_terminal,
+                        exec_prefix=candidate.exec_prefix,
+                        mode=candidate.mode,
+                    )
+        resolver = resolve_terminal_executable
+
+    for candidate in TERMINAL_CANDIDATES:
+        path = resolver(candidate.executable)
+        if path is not None:
+            return ResolvedTerminal(
+                executable=path,
+                exec_prefix=candidate.exec_prefix,
+                mode=candidate.mode,
+            )
+    return None
+
+
+def build_terminal_argv(
+    *,
+    command: str,
+    shell: str | None = None,
+    resolver: Callable[[str], str | None] | None = None,
+) -> list[str] | None:
+    """Build argv for running command in a terminal emulator."""
+    terminal = find_terminal(resolver=resolver)
+    if terminal is None:
+        return None
+    shell_argv = build_shell_argv(command=command, shell=shell)
+    if terminal.mode == TerminalMode.COMMAND_STRING:
+        exec_argv = [shlex.join(shell_argv)]
+    else:
+        exec_argv = shell_argv
+    return [
+        terminal.executable,
+        *terminal.exec_prefix,
+        *exec_argv,
+    ]
+
+
+def launch_command(
+    *,
+    command: str,
+    run_in_terminal: bool,
+    popen: Callable[..., object] = subprocess.Popen,
+    resolver: Callable[[str], str | None] | None = None,
+) -> bool:
+    """Launch command text, returning whether a process was started."""
+    normalized = command.strip()
+    if not normalized:
+        return False
+
+    argv = (
+        build_terminal_argv(command=normalized, resolver=resolver)
+        if run_in_terminal
+        else build_shell_argv(command=normalized)
+    )
+    if argv is None:
+        log.bind(action="launch_command").warning("No terminal emulator found")
+        return False
+    argv = flatpak.host_command(argv) or argv
+
+    try:
+        popen(
+            argv,
+            shell=False,
+            start_new_session=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as exc:
+        log.bind(action="launch_command").warning(
+            "Failed to launch command %s: %s",
+            normalized,
+            exc,
+        )
+        return False
+    return True
+
+
+def append_file_argument(*, command: str, path: str) -> str:
+    """Append a shell-quoted file path to existing command text."""
+    quoted = shlex.quote(path)
+    normalized = command.strip()
+    return f"{normalized} {quoted}" if normalized else quoted
+
+
+def clean_desktop_exec(command: str) -> str:
+    """Remove freedesktop Exec field placeholders from a command line."""
+    return DESKTOP_EXEC_FIELD_CODES_RE.sub("", command).strip()
+
+
+def app_display_name(app: ApplicationLike) -> str:
+    return (app.get_display_name() or "").strip()
+
+
+def app_command_text(app: ApplicationLike) -> str:
+    """Return command text suitable for the dialog entry."""
+    app_info = getattr(app, "app_info", None)
+    commandline = ""
+    get_commandline = getattr(app_info, "get_commandline", None)
+    if callable(get_commandline):
+        commandline = clean_desktop_exec(str(get_commandline() or ""))
+    return commandline or app_display_name(app)
+
+
+def app_description(app: ApplicationLike) -> str:
+    """Return the best available app description/comment."""
+    app_info = getattr(app, "app_info", None)
+    for attr in ("get_description", "get_comment", "get_generic_name"):
+        getter = getattr(app_info, attr, None)
+        if not callable(getter):
+            continue
+        text = str(getter() or "").strip()
+        if text:
+            return text
+    return app_display_name(app)
+
+
+def match_application(
+    *,
+    apps: Iterable[ApplicationLike],
+    text: str,
+) -> ApplicationLike | None:
+    """Match typed text to an application by exact name, then unique prefix."""
+    needle = text.strip().casefold()
+    if not needle:
+        return None
+
+    app_list = list(apps)
+    exact = [app for app in app_list if app_display_name(app).casefold() == needle]
+    if len(exact) == 1:
+        return exact[0]
+
+    prefix = [
+        app for app in app_list if app_display_name(app).casefold().startswith(needle)
+    ]
+    if len(prefix) == 1:
+        return prefix[0]
+    return None
+
+
+def launch_application(app: ApplicationLike) -> bool:
+    """Launch a matched application through its existing adapter."""
+    try:
+        app.launch([], None)
+    except (GLib.Error, OSError) as exc:
+        log.bind(action="launch_application", app=app_display_name(app)).warning(
+            "Failed to launch application: %s",
+            exc,
+        )
+        return False
+    return True
+
+
+def prefs_payload(*, history: Iterable[str]) -> dict[str, list[str]]:
+    return {"history": list(history)[:HISTORY_LIMIT]}

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-06-10 00:19+0200\n"
+"POT-Creation-Date: 2026-06-12 15:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -66,11 +66,11 @@ msgstr ""
 msgid "This week: {value}"
 msgstr ""
 
-#: docking/applets/aiusage/state.py:472
+#: docking/applets/aiusage/state.py:476
 msgid "no usage today"
 msgstr ""
 
-#: docking/applets/aiusage/state.py:476
+#: docking/applets/aiusage/state.py:480
 #, python-brace-format
 msgid "Today: {cost}"
 msgstr ""
@@ -111,6 +111,8 @@ msgstr ""
 
 #: docking/applets/alarm/applet.py:163 docking/applets/clock/applet.py:218
 #: docking/applets/lastfm/applet.py:380 docking/applets/quicknote/applet.py:86
+#: docking/applets/runcommand/applet.py:121
+#: docking/applets/runcommand/applet.py:339
 #: docking/applets/sunrise/applet.py:188 docking/applets/trash/applet.py:127
 #: docking/applets/weather/applet.py:271
 msgid "Cancel"
@@ -376,7 +378,7 @@ msgstr ""
 msgid "Power Settings"
 msgstr ""
 
-#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:468
+#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:470
 msgid "Mouse"
 msgstr ""
 
@@ -932,7 +934,6 @@ msgstr ""
 msgid "Set Alarm"
 msgstr ""
 
-
 #: docking/applets/colorpicker/applet.py:59
 #: docking/applets/colorpicker/applet.py:94
 msgid "Color Picker"
@@ -1347,7 +1348,7 @@ msgid "{verb} every {interval}"
 msgstr ""
 
 #: docking/applets/freshness.py:42 docking/applets/freshness.py:49
-#: docking/ui/settings.py:220
+#: docking/ui/settings.py:222
 msgid "Updates"
 msgstr ""
 
@@ -1992,6 +1993,50 @@ msgstr ""
 msgid "Clear Recent Files"
 msgstr ""
 
+#: docking/applets/runcommand/applet.py:62
+#: docking/applets/runcommand/applet.py:87
+#: docking/applets/runcommand/applet.py:117
+#: docking/applets/runcommand/applet.py:261
+msgid "Run Application"
+msgstr ""
+
+#: docking/applets/runcommand/applet.py:120
+msgid "Help"
+msgstr ""
+
+#: docking/applets/runcommand/applet.py:122
+msgid "Run"
+msgstr ""
+
+#: docking/applets/runcommand/applet.py:167
+msgid "Run in terminal"
+msgstr ""
+
+#: docking/applets/runcommand/applet.py:169
+msgid "Run with file..."
+msgstr ""
+
+#: docking/applets/runcommand/applet.py:174
+msgid "Show list of known applications"
+msgstr ""
+
+#: docking/applets/runcommand/applet.py:180
+#: docking/applets/runcommand/applet.py:285
+msgid "Select an application to view its description."
+msgstr ""
+
+#: docking/applets/runcommand/applet.py:264
+msgid "Type a command or select an application to launch it."
+msgstr ""
+
+#: docking/applets/runcommand/applet.py:335
+msgid "Run with file"
+msgstr ""
+
+#: docking/applets/runcommand/applet.py:340 docking/ui/menu.py:459
+msgid "Open"
+msgstr ""
+
 #: docking/applets/screenshot/applet.py:53
 msgid "Screenshot"
 msgstr ""
@@ -2604,7 +2649,7 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: docking/ui/dock_window.py:397
+#: docking/ui/dock_window.py:398
 msgid "Docking"
 msgstr ""
 
@@ -2668,10 +2713,6 @@ msgstr ""
 msgid "Remove from Dock"
 msgstr ""
 
-#: docking/ui/menu.py:459
-msgid "Open"
-msgstr ""
-
 #: docking/ui/menu.py:489
 msgid "Keep in Dock"
 msgstr ""
@@ -2704,7 +2745,7 @@ msgstr ""
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:615 docking/ui/settings.py:193
+#: docking/ui/menu.py:615 docking/ui/settings.py:195
 msgid "Preferences"
 msgstr ""
 
@@ -2734,281 +2775,280 @@ msgstr ""
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-
-#: docking/ui/settings.py:217
+#: docking/ui/settings.py:219
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:218 docking/ui/settings.py:477
+#: docking/ui/settings.py:220 docking/ui/settings.py:479
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:219
+#: docking/ui/settings.py:221
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:243
+#: docking/ui/settings.py:245
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:244
+#: docking/ui/settings.py:246
 msgid "Always on Top"
 msgstr ""
 
-#: docking/ui/settings.py:245
+#: docking/ui/settings.py:247
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:246
+#: docking/ui/settings.py:248
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:247
+#: docking/ui/settings.py:249
 msgid "Dodge Active"
 msgstr ""
 
-#: docking/ui/settings.py:248
+#: docking/ui/settings.py:250
 msgid "Dodge Windows"
 msgstr ""
 
-#: docking/ui/settings.py:249
+#: docking/ui/settings.py:251
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:262
 msgid "Toggle Focus"
 msgstr ""
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:263
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:264
 msgid "Most Recent Window"
 msgstr ""
 
-#: docking/ui/settings.py:269
+#: docking/ui/settings.py:271
 msgid "New Window"
 msgstr ""
 
-#: docking/ui/settings.py:270
+#: docking/ui/settings.py:272
 msgid "Minimize Windows"
 msgstr ""
 
-#: docking/ui/settings.py:271
+#: docking/ui/settings.py:273
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:280
 msgid "Click"
 msgstr ""
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:281
 msgid "Hover"
 msgstr ""
 
-#: docking/ui/settings.py:286
+#: docking/ui/settings.py:288
 msgid "Default"
 msgstr ""
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:289
 msgid "Alphabetical"
 msgstr ""
 
-#: docking/ui/settings.py:304
+#: docking/ui/settings.py:306
 msgid "Daily"
 msgstr ""
 
-#: docking/ui/settings.py:305
+#: docking/ui/settings.py:307
 msgid "Weekly"
 msgstr ""
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:357
 msgid "Added on top of the theme's own distance from the edge."
 msgstr ""
 
-#: docking/ui/settings.py:395
+#: docking/ui/settings.py:397
 msgid ""
 "Pixels of cursor pressure against the edge required to reveal a hidden dock. "
 "Higher values mean the dock will not reveal as easily."
 msgstr ""
 
-#: docking/ui/settings.py:405
+#: docking/ui/settings.py:407
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:407
+#: docking/ui/settings.py:409
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:408
+#: docking/ui/settings.py:410
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:409
+#: docking/ui/settings.py:411
 msgid "Transparency"
 msgstr ""
 
-#: docking/ui/settings.py:410
+#: docking/ui/settings.py:412
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:411
+#: docking/ui/settings.py:413
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:412
+#: docking/ui/settings.py:414
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:413
+#: docking/ui/settings.py:415
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:419
+#: docking/ui/settings.py:421
 msgid "Placement"
 msgstr ""
 
-#: docking/ui/settings.py:421
+#: docking/ui/settings.py:423
 msgid "Position"
 msgstr ""
 
-#: docking/ui/settings.py:422
+#: docking/ui/settings.py:424
 msgid "Extra Distance from Edge"
 msgstr ""
 
-#: docking/ui/settings.py:423
+#: docking/ui/settings.py:425
 msgid "Follow Cursor"
 msgstr ""
 
-#: docking/ui/settings.py:424
+#: docking/ui/settings.py:426
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:429
+#: docking/ui/settings.py:431
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:431
+#: docking/ui/settings.py:433
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:432
+#: docking/ui/settings.py:434
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:433
+#: docking/ui/settings.py:435
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:470
+#: docking/ui/settings.py:472
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:471
+#: docking/ui/settings.py:473
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:472
+#: docking/ui/settings.py:474
 msgid "Window List Sort"
 msgstr ""
 
-#: docking/ui/settings.py:479
+#: docking/ui/settings.py:481
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:480
+#: docking/ui/settings.py:482
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:481
+#: docking/ui/settings.py:483
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:482
+#: docking/ui/settings.py:484
 msgid "Pressure Reveal"
 msgstr ""
 
-#: docking/ui/settings.py:483
+#: docking/ui/settings.py:485
 msgid "Pressure Threshold"
 msgstr ""
 
-#: docking/ui/settings.py:488
+#: docking/ui/settings.py:490
 msgid "Folder Stacks"
 msgstr ""
 
-#: docking/ui/settings.py:490
+#: docking/ui/settings.py:492
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:529
+#: docking/ui/settings.py:566
 msgid "Check Now"
 msgstr ""
 
-#: docking/ui/settings.py:531
+#: docking/ui/settings.py:568
 msgid "View Releases"
 msgstr ""
 
-#: docking/ui/settings.py:543
+#: docking/ui/settings.py:580
 msgid "Update Checks"
 msgstr ""
 
-#: docking/ui/settings.py:545
+#: docking/ui/settings.py:582
 msgid "Check Automatically"
 msgstr ""
 
-#: docking/ui/settings.py:546
+#: docking/ui/settings.py:583
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:547
+#: docking/ui/settings.py:584
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:548
+#: docking/ui/settings.py:585
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:983
+#: docking/ui/settings.py:1020
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:987
+#: docking/ui/settings.py:1024
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:989
+#: docking/ui/settings.py:1026
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:1032
+#: docking/ui/settings.py:1069
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1034
+#: docking/ui/settings.py:1071
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1037
+#: docking/ui/settings.py:1074
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:1039
+#: docking/ui/settings.py:1076
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1041
+#: docking/ui/settings.py:1078
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1043
+#: docking/ui/settings.py:1080
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1046
+#: docking/ui/settings.py:1083
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/tests/applets/test_applications.py
+++ b/tests/applets/test_applications.py
@@ -5,12 +5,10 @@ from unittest.mock import MagicMock, patch
 
 import docking.applets.applications.applet as applications_applet_mod
 import docking.applets.applications.render as applications_render_mod
+import docking.applets.apps as apps_shared
 from docking.applets.applications.applet import ApplicationsApplet
-from docking.applets.applications.state import (
-    ApplicationEntry,
-    _all_desktop_app_infos,
-    _build_app_categories,
-)
+from docking.applets.applications.state import _build_app_categories
+from docking.applets.apps import ApplicationEntry, all_desktop_app_infos
 
 
 class TestBuildAppCategories:
@@ -25,11 +23,11 @@ class TestBuildAppCategories:
 
         with (
             patch(
-                "docking.applets.applications.state.Gio.AppInfo.get_all",
+                "docking.applets.apps.Gio.AppInfo.get_all",
                 return_value=[mock_app],
             ),
             patch(
-                "docking.applets.applications.state.Launcher._get_desktop_dirs",
+                "docking.applets.apps.Launcher._get_desktop_dirs",
                 return_value=[],
             ),
         ):
@@ -53,11 +51,11 @@ class TestBuildAppCategories:
             encoding="utf-8",
         )
         monkeypatch.setattr(
-            "docking.applets.applications.state.Gio.AppInfo.get_all",
+            "docking.applets.apps.Gio.AppInfo.get_all",
             list,
         )
         monkeypatch.setattr(
-            "docking.applets.applications.state.Launcher._get_desktop_dirs",
+            "docking.applets.apps.Launcher._get_desktop_dirs",
             lambda: [host_apps],
         )
 
@@ -82,22 +80,23 @@ class TestBuildAppCategories:
                 encoding="utf-8",
             )
         monkeypatch.setattr(
-            "docking.applets.applications.state.Gio.AppInfo.get_all",
+            "docking.applets.apps.Gio.AppInfo.get_all",
             list,
         )
         monkeypatch.setattr(
-            "docking.applets.applications.state.Launcher._get_desktop_dirs",
+            "docking.applets.apps.Launcher._get_desktop_dirs",
             lambda: [first_apps, second_apps],
         )
 
-        apps = _all_desktop_app_infos()
+        apps = all_desktop_app_infos()
 
         assert [app.get_id() for app in apps] == ["org.example.Tool.desktop"]
 
     def test_application_entry_launch_uses_launcher_bridge(self, monkeypatch):
         launched: list[str] = []
         monkeypatch.setattr(
-            "docking.applets.applications.state.launch_desktop_id",
+            apps_shared,
+            "launch_desktop_id",
             lambda *, desktop_id: launched.append(desktop_id),
         )
         entry = ApplicationEntry(

--- a/tests/applets/test_runcommand.py
+++ b/tests/applets/test_runcommand.py
@@ -1,0 +1,459 @@
+"""Tests for the Run Application applet."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import docking.applets.runcommand.applet as runcommand_applet_mod
+import docking.applets.runcommand.state as runcommand_state_mod
+from docking.applets import get_applet_catalog, load_applet_class
+from docking.applets.runcommand.applet import RunCommandApplet
+from docking.applets.runcommand.state import (
+    TERMINAL_CANDIDATES,
+    _flatpak_host_terminal_name,
+    app_command_text,
+    append_file_argument,
+    build_shell_argv,
+    build_terminal_argv,
+    launch_command,
+    match_application,
+    normalize_history,
+    updated_history,
+)
+
+
+class _FakeAppInfo:
+    def __init__(self, command: str = "", description: str = "") -> None:
+        self.command = command
+        self.description = description
+
+    def get_commandline(self) -> str:
+        return self.command
+
+    def get_description(self) -> str:
+        return self.description
+
+
+class _FakeApp:
+    def __init__(
+        self,
+        name: str,
+        *,
+        command: str = "",
+        description: str = "",
+        icon: object | None = None,
+    ) -> None:
+        self.name = name
+        self.app_info = _FakeAppInfo(command=command, description=description)
+        self.icon = icon
+        self.launched = False
+
+    def get_display_name(self) -> str:
+        return self.name
+
+    def get_icon(self) -> object | None:
+        return self.icon
+
+    def launch(self, _files: list[object], _context: object | None) -> None:
+        self.launched = True
+
+
+class _FakeEntry:
+    def __init__(self, text: str = "") -> None:
+        self._text = text
+        self.position = None
+        self.focused = False
+
+    def get_text(self) -> str:
+        return self._text
+
+    def set_text(self, text: str) -> None:
+        self._text = text
+
+    def set_position(self, position: int) -> None:
+        self.position = position
+
+    def grab_focus(self) -> None:
+        self.focused = True
+
+
+class _FakeIcon:
+    def __init__(self) -> None:
+        self.gicon = None
+        self.icon_name = None
+        self.pixel_size = None
+
+    def set_from_gicon(self, gicon, _size) -> None:
+        self.gicon = gicon
+
+    def set_from_icon_name(self, icon_name: str, _size) -> None:
+        self.icon_name = icon_name
+
+    def set_pixel_size(self, size: int) -> None:
+        self.pixel_size = size
+
+
+class _FakeLabel:
+    def __init__(self) -> None:
+        self.text = ""
+
+    def set_text(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeButton:
+    def __init__(self) -> None:
+        self.sensitive = None
+
+    def set_sensitive(self, value: bool) -> None:
+        self.sensitive = value
+
+
+class _FakeCheck:
+    def __init__(self, active: bool = False) -> None:
+        self.active = active
+
+    def get_active(self) -> bool:
+        return self.active
+
+
+class _FakeDialog:
+    def __init__(self) -> None:
+        self.hidden = False
+
+    def hide(self) -> None:
+        self.hidden = True
+
+
+class _FakeRow:
+    def __init__(self, app: _FakeApp) -> None:
+        self.app_entry = app
+        self.visible = True
+
+    def show(self) -> None:
+        self.visible = True
+
+    def hide(self) -> None:
+        self.visible = False
+
+
+def _make_applet() -> RunCommandApplet:
+    return RunCommandApplet(48)
+
+
+class TestRunCommandState:
+    def test_normalize_history_filters_deduplicates_and_caps(self):
+        raw = [" firefox ", "", "calc", "firefox", 1, *[f"cmd{i}" for i in range(30)]]
+
+        history = normalize_history(raw)
+
+        assert history[:3] == ["firefox", "calc", "cmd0"]
+        assert len(history) == 20
+
+    def test_updated_history_promotes_command(self):
+        assert updated_history(history=["one", "two"], command=" two ") == [
+            "two",
+            "one",
+        ]
+
+    def test_build_shell_argv(self):
+        assert build_shell_argv(command="echo ok", shell="/bin/zsh") == [
+            "/bin/zsh",
+            "-lc",
+            "echo ok",
+        ]
+
+    def test_build_terminal_argv_uses_first_available_terminal(self):
+        def resolver(name: str) -> str | None:
+            return name if name == "x-terminal-emulator" else None
+
+        assert build_terminal_argv(
+            command="echo ok",
+            shell="/bin/sh",
+            resolver=resolver,
+        ) == [
+            "x-terminal-emulator",
+            "-e",
+            "/bin/sh",
+            "-lc",
+            "echo ok",
+        ]
+
+    def test_build_terminal_argv_supports_multi_arg_terminal_prefix(self):
+        def resolver(name: str) -> str | None:
+            return name if name == "wezterm" else None
+
+        assert build_terminal_argv(
+            command="echo ok",
+            shell="/bin/sh",
+            resolver=resolver,
+        ) == [
+            "wezterm",
+            "start",
+            "--",
+            "/bin/sh",
+            "-lc",
+            "echo ok",
+        ]
+
+    def test_build_terminal_argv_supports_command_string_terminals(self):
+        def resolver(name: str) -> str | None:
+            return name if name == "xfce4-terminal" else None
+
+        assert build_terminal_argv(
+            command="echo ok",
+            shell="/bin/sh",
+            resolver=resolver,
+        ) == [
+            "xfce4-terminal",
+            "-e",
+            "/bin/sh -lc 'echo ok'",
+        ]
+
+    def test_terminal_candidates_cover_common_desktops_and_wayland(self):
+        names = {candidate.executable for candidate in TERMINAL_CANDIDATES}
+
+        assert {
+            "x-terminal-emulator",
+            "gnome-terminal",
+            "kgx",
+            "ptyxis",
+            "konsole",
+            "qterminal",
+            "foot",
+            "kitty",
+            "alacritty",
+            "wezterm",
+            "xterm",
+        }.issubset(names)
+
+    def test_flatpak_host_terminal_lookup_is_cached_single_scan(self, monkeypatch):
+        _flatpak_host_terminal_name.cache_clear()
+        calls = []
+
+        monkeypatch.setattr(
+            runcommand_state_mod.flatpak,
+            "spawn_path",
+            lambda: "/usr/bin/flatpak-spawn",
+        )
+        monkeypatch.setattr(
+            runcommand_state_mod.flatpak,
+            "host_command",
+            lambda cmd, sanitize_env: ["flatpak-spawn", *cmd],
+        )
+
+        def run(cmd, **_kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(stdout="konsole\n")
+
+        monkeypatch.setattr(runcommand_state_mod.subprocess, "run", run)
+
+        assert _flatpak_host_terminal_name() == "konsole"
+        assert _flatpak_host_terminal_name() == "konsole"
+        assert len(calls) == 1
+        _flatpak_host_terminal_name.cache_clear()
+
+    def test_launch_command_rejects_empty_command(self):
+        popen = MagicMock()
+
+        assert launch_command(command=" ", run_in_terminal=False, popen=popen) is False
+        popen.assert_not_called()
+
+    def test_launch_command_starts_shell_process(self, monkeypatch):
+        monkeypatch.setenv("SHELL", "/bin/zsh")
+        popen = MagicMock()
+
+        monkeypatch.setattr(
+            "docking.applets.runcommand.state.flatpak.host_command",
+            lambda argv: None,
+        )
+
+        assert launch_command(command="echo ok", run_in_terminal=False, popen=popen)
+
+        argv = popen.call_args.args[0]
+        assert argv == ["/bin/zsh", "-lc", "echo ok"]
+        assert popen.call_args.kwargs["start_new_session"] is True
+
+    def test_append_file_argument_quotes_path(self):
+        assert append_file_argument(command="atril", path="/tmp/report one.pdf") == (
+            "atril '/tmp/report one.pdf'"
+        )
+
+    def test_app_command_text_removes_desktop_placeholders(self):
+        app = _FakeApp("Atril", command="atril %U")
+
+        assert app_command_text(app) == "atril"
+
+    def test_match_application_exact_then_unique_prefix(self):
+        calc = _FakeApp("Calculator")
+        calendar = _FakeApp("Calendar")
+        firefox = _FakeApp("Firefox")
+
+        assert match_application(apps=[calc, calendar, firefox], text="fire") is firefox
+        assert match_application(apps=[calc, calendar], text="calc") is calc
+        assert match_application(apps=[calc, calendar], text="cal") is None
+
+
+class TestRunCommandApplet:
+    def test_catalog_discovers_applet(self):
+        get_applet_catalog.cache_clear()
+        load_applet_class.cache_clear()
+
+        assert "runcommand" in get_applet_catalog()
+        assert load_applet_class("runcommand") is RunCommandApplet
+
+    def test_creates_with_icon(self):
+        applet = _make_applet()
+        assert applet.item.icon is not None
+
+    def test_renders_at_various_sizes(self):
+        applet = _make_applet()
+        for size in [32, 48, 64]:
+            assert applet.create_icon(size) is not None
+
+    def test_select_application_updates_entry_description_and_icon(self):
+        applet = _make_applet()
+        app = _FakeApp(
+            "Atril Document Viewer",
+            command="atril %U",
+            description="View documents",
+            icon="atril-icon",
+        )
+        applet._entry = _FakeEntry()
+        applet._left_icon = _FakeIcon()
+        applet._description_label = _FakeLabel()
+        applet._run_button = _FakeButton()
+
+        applet._select_application(app)
+
+        assert applet._entry.get_text() == "atril"
+        assert applet._entry.position == -1
+        assert applet._left_icon.gicon == "atril-icon"
+        assert applet._description_label.text == "View documents"
+        assert applet._run_button.sensitive is True
+
+    def test_typing_matching_app_name_updates_left_icon(self):
+        applet = _make_applet()
+        applet._apps = [_FakeApp("Calculator", description="Calculate", icon="calc")]
+        applet._app_rows = [_FakeRow(applet._apps[0])]
+        applet._entry = _FakeEntry("calc")
+        applet._left_icon = _FakeIcon()
+        applet._description_label = _FakeLabel()
+        applet._run_button = _FakeButton()
+
+        applet._on_entry_changed(applet._entry)
+
+        assert applet._selected_app is applet._apps[0]
+        assert applet._left_icon.gicon == "calc"
+        assert applet._description_label.text == "Calculate"
+
+    def test_typing_unknown_text_restores_default_left_icon(self):
+        applet = _make_applet()
+        applet._apps = [_FakeApp("Calculator", icon="calc")]
+        applet._app_rows = [_FakeRow(applet._apps[0])]
+        applet._entry = _FakeEntry("unknown")
+        applet._left_icon = _FakeIcon()
+        applet._description_label = _FakeLabel()
+        applet._run_button = _FakeButton()
+
+        applet._on_entry_changed(applet._entry)
+
+        assert applet._selected_app is None
+        assert applet._left_icon.icon_name == "system-run"
+        assert applet._run_button.sensitive is True
+
+    def test_typing_filters_application_rows_without_resizing_list(self):
+        applet = _make_applet()
+        engrampa = _FakeApp("Engrampa Archive Manager", command="engrampa %U")
+        cairo = _FakeApp("Cairo-Dock", command="cairo-dock")
+        applet._apps = [engrampa, cairo]
+        applet._app_rows = [_FakeRow(engrampa), _FakeRow(cairo)]
+        applet._entry = _FakeEntry("engrampa")
+        applet._left_icon = _FakeIcon()
+        applet._description_label = _FakeLabel()
+        applet._run_button = _FakeButton()
+
+        applet._on_entry_changed(applet._entry)
+
+        assert applet._app_rows[0].visible is True
+        assert applet._app_rows[1].visible is False
+
+    def test_run_current_launches_selected_application(self, monkeypatch):
+        applet = _make_applet()
+        app = _FakeApp("Calculator", command="gnome-calculator")
+        applet._entry = _FakeEntry("gnome-calculator")
+        applet._selected_app = app
+        applet._selected_entry_text = "gnome-calculator"
+        applet._dialog = _FakeDialog()
+        launch = MagicMock(return_value=True)
+        monkeypatch.setattr(runcommand_applet_mod, "launch_application", launch)
+
+        applet._run_current()
+
+        launch.assert_called_once_with(app)
+        assert applet._history == ["gnome-calculator"]
+        assert applet._dialog.hidden is True
+
+    def test_run_current_terminal_mode_overrides_matched_application(self, monkeypatch):
+        applet = _make_applet()
+        app = _FakeApp("Calculator", command="gnome-calculator")
+        applet._entry = _FakeEntry("gnome-calculator")
+        applet._terminal_check = _FakeCheck(active=True)
+        applet._selected_app = app
+        applet._selected_entry_text = "gnome-calculator"
+        applet._dialog = _FakeDialog()
+        launch_command = MagicMock(return_value=True)
+        launch_application = MagicMock(return_value=True)
+        monkeypatch.setattr(runcommand_applet_mod, "launch_command", launch_command)
+        monkeypatch.setattr(
+            runcommand_applet_mod,
+            "launch_application",
+            launch_application,
+        )
+
+        applet._run_current()
+
+        launch_command.assert_called_once_with(
+            command="gnome-calculator",
+            run_in_terminal=True,
+        )
+        launch_application.assert_not_called()
+
+    def test_run_current_launches_shell_command_when_no_app_matches(self, monkeypatch):
+        applet = _make_applet()
+        applet._apps = [_FakeApp("Calculator")]
+        applet._entry = _FakeEntry("echo ok")
+        applet._terminal_check = _FakeCheck(active=True)
+        applet._dialog = _FakeDialog()
+        launch = MagicMock(return_value=True)
+        monkeypatch.setattr(runcommand_applet_mod, "launch_command", launch)
+
+        applet._run_current()
+
+        launch.assert_called_once_with(command="echo ok", run_in_terminal=True)
+        assert applet._history == ["echo ok"]
+        assert applet._dialog.hidden is True
+
+    def test_show_dialog_refreshes_apps_and_history(self, monkeypatch):
+        applet = _make_applet()
+        dialog = SimpleNamespace(
+            show_all=MagicMock(),
+            present=MagicMock(),
+            get_visible=lambda: False,
+        )
+        applet._dialog = dialog
+        applet._entry = _FakeEntry()
+        applet._run_button = _FakeButton()
+        applet._history = ["echo ok"]
+        monkeypatch.setattr(applet, "_refresh_app_list", MagicMock())
+        monkeypatch.setattr(applet, "_sync_entry_history", MagicMock())
+        monkeypatch.setattr(applet, "_apply_app_filter", MagicMock())
+
+        applet._show_dialog()
+
+        applet._refresh_app_list.assert_called_once_with()
+        applet._sync_entry_history.assert_called_once_with()
+        dialog.show_all.assert_called_once_with()
+        applet._apply_app_filter.assert_called_once_with("")
+        dialog.present.assert_called_once_with()

--- a/website/index.html
+++ b/website/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Docking - Open Source Linux Dock with Applets, Themes and Desktop Integration</title>
-  <meta name="description" content="Docking is an open source dock for Linux with X11 and Wayland backends, 56 built-in applets, customizable themes, multi-monitor support, and desktop integration. Written in Python with GTK and Cairo.">
+  <meta name="description" content="Docking is an open source dock for Linux with X11 and Wayland backends, 57 built-in applets, customizable themes, multi-monitor support, and desktop integration. Written in Python with GTK and Cairo.">
   <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/edumucelli/docking/master/packaging/deb/icons/hicolor/32x32/apps/org.docking.Docking.png">
   <link rel="canonical" href="https://docking.cc">
   <meta property="og:title" content="Docking - Open Source Linux Dock with Applets, Themes and Desktop Integration">
-  <meta property="og:description" content="Fast, customizable dock for Linux with X11 and Wayland backends, 56 built-in applets, themes, multi-monitor support, and desktop integration. Written in Python with GTK and Cairo.">
+  <meta property="og:description" content="Fast, customizable dock for Linux with X11 and Wayland backends, 57 built-in applets, themes, multi-monitor support, and desktop integration. Written in Python with GTK and Cairo.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://docking.cc">
   <meta property="og:image" content="https://raw.githubusercontent.com/edumucelli/docking/master/website/hero.png">
@@ -17,7 +17,7 @@
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "Docking",
-    "description": "Open source dock for Linux with X11 and Wayland backends, 56 built-in applets, customizable themes, multi-monitor support, and desktop integration.",
+    "description": "Open source dock for Linux with X11 and Wayland backends, 57 built-in applets, customizable themes, multi-monitor support, and desktop integration.",
     "applicationCategory": "DesktopEnhancement",
     "operatingSystem": "Linux",
     "url": "https://docking.cc",
@@ -308,7 +308,7 @@
               <span class="rounded-full border border-white/12 bg-gradient-to-r from-accent/8 to-accent/5 px-4 py-2">Applet system</span>
               <span class="rounded-full border border-white/12 bg-gradient-to-r from-skyline/8 to-skyline/5 px-4 py-2">Cross desktop environments</span>
               <span class="rounded-full border border-white/12 bg-gradient-to-r from-ember/8 to-ember/5 px-4 py-2">Open source</span>
-              <span class="rounded-full border border-amber-300/18 bg-gradient-to-r from-ember/10 to-accent/6 px-4 py-2">56 Applets</span>
+              <span class="rounded-full border border-amber-300/18 bg-gradient-to-r from-ember/10 to-accent/6 px-4 py-2">57 Applets</span>
               <span class="rounded-full border border-white/12 bg-gradient-to-r from-accent/8 to-accent/5 px-4 py-2">Themeable</span>
               <span class="rounded-full border border-white/12 bg-gradient-to-r from-skyline/8 to-skyline/5 px-4 py-2">Auto-hide</span>
               <span class="rounded-full border border-white/12 bg-gradient-to-r from-ember/8 to-ember/5 px-4 py-2">Multi-monitor</span>
@@ -316,7 +316,7 @@
               <span class="rounded-full border border-white/12 bg-gradient-to-r from-accent/8 to-accent/5 px-4 py-2">Applet system</span>
               <span class="rounded-full border border-white/12 bg-gradient-to-r from-skyline/8 to-skyline/5 px-4 py-2">Cross desktop environments</span>
               <span class="rounded-full border border-white/12 bg-gradient-to-r from-ember/8 to-ember/5 px-4 py-2">Open source</span>
-              <span class="rounded-full border border-amber-300/18 bg-gradient-to-r from-ember/10 to-accent/6 px-4 py-2">56 Applets</span>
+              <span class="rounded-full border border-amber-300/18 bg-gradient-to-r from-ember/10 to-accent/6 px-4 py-2">57 Applets</span>
             </div>
           </div>
         </div>
@@ -336,7 +336,7 @@
           </article>
           <article class="reveal rounded-[2rem] border border-white/12 bg-gradient-to-br from-ember/12 to-ember/6 p-6 shadow-soft backdrop-blur-2xl">
             <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-ember/14 text-amber-100"><svg viewBox="0 0 24 24" class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="4" y="4" width="6" height="6" rx="1.5"></rect><rect x="14" y="4" width="6" height="6" rx="1.5"></rect><rect x="4" y="14" width="6" height="6" rx="1.5"></rect><rect x="14" y="14" width="6" height="6" rx="1.5"></rect></svg></div>
-            <h3 class="mt-5 text-xl font-semibold text-white">Built-in applets (56)</h3>
+            <h3 class="mt-5 text-xl font-semibold text-white">Built-in applets (57)</h3>
             <p class="mt-3 text-sm leading-7 text-slate-300">Ship a dock that already knows how to show system status, weather, media, timers, notes, and more.</p>
           </article>
           <article class="reveal rounded-[2rem] border border-white/12 bg-gradient-to-br from-skyline/12 to-skyline/6 p-6 shadow-soft backdrop-blur-2xl">
@@ -365,11 +365,11 @@
       <section id="applets" class="mx-auto max-w-7xl px-6 py-16 lg:px-8 lg:py-24">
         <div class="reveal flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
           <div class="max-w-3xl">
-            <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">56 built-in applets: useful widgets, already in the dock</h2>
+            <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">57 built-in applets: useful widgets, already in the dock</h2>
             <p class="mt-4 text-lg leading-8 text-slate-300">Small tools with real utility: glanceable information, richer controls, and compact workflow helpers. Browse the full applet catalog without leaving the page.</p>
           </div>
           <div class="flex items-center gap-3 self-start lg:self-auto">
-            <div class="rounded-full border border-white/15 bg-gradient-to-r from-skyline/8 to-ember/8 px-5 py-3 text-sm text-slate-200 backdrop-blur-xl">56 built-in applets, with more room to explore</div>
+            <div class="rounded-full border border-white/15 bg-gradient-to-r from-skyline/8 to-ember/8 px-5 py-3 text-sm text-slate-200 backdrop-blur-xl">57 built-in applets, with more room to explore</div>
             <div class="hidden items-center gap-2 sm:flex">
               <button type="button" data-carousel-target="applets-carousel" data-carousel-direction="prev" class="flex h-11 w-11 items-center justify-center rounded-full border border-white/15 bg-white/10 text-white transition hover:border-white/30 hover:bg-white/14" aria-label="Previous applets">
                 <svg viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="1.8"><path d="m15 18-6-6 6-6"></path></svg>
@@ -426,6 +426,17 @@
               </div>
             </div>
             <p class="mt-4 text-sm leading-7 text-slate-300">A launcher-style entry point for your installed apps.</p>
+          </article>
+          <article class="reveal snap-start shrink-0 basis-[82%] sm:basis-[calc((100%-1.25rem)/2)] lg:basis-[calc((100%-2.5rem)/3)] xl:basis-[calc((100%-5rem)/5)] rounded-[2rem] border border-white/12 bg-gradient-to-br from-skyline/12 to-emerald-400/6 p-5 shadow-soft backdrop-blur-2xl" data-carousel-card>
+            <div class="flex items-center gap-3">
+              <div class="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/12 bg-skyline/10 p-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)]">
+                <img src="https://raw.githubusercontent.com/edumucelli/docking/master/docking/assets/icons/applets/runcommand.png" alt="Run Application applet icon" class="h-full w-full object-contain" loading="lazy">
+              </div>
+              <div>
+                <h3 class="text-lg font-semibold text-white">Run Application</h3>
+              </div>
+            </div>
+            <p class="mt-4 text-sm leading-7 text-slate-300">Alt+F2-style command launcher with app matching, terminal mode, file arguments, and a searchable application list.</p>
           </article>
           <article class="reveal snap-start shrink-0 basis-[82%] sm:basis-[calc((100%-1.25rem)/2)] lg:basis-[calc((100%-2.5rem)/3)] xl:basis-[calc((100%-5rem)/5)] rounded-[2rem] border border-white/12 bg-gradient-to-br from-rose-400/12 to-ember/6 p-5 shadow-soft backdrop-blur-2xl" data-carousel-card>
             <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- add a Run Application applet with Alt+F2-style command launching, app matching, terminal mode, file argument support, and a searchable application list
- expose application discovery through a public helper and refresh gettext strings
- update README and website applet count/copy for the new applet

## Tests
- pre-commit hook: ruff format, ruff check, ty, i18n sync/catalog checks, package-data checks
- full pytest suite: 3646 passed, 1 skipped, 12 deselected