### PR TITLE
Add System Tray applet

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cair
 
 - Fast launcher workflow with running indicators, previews, app actions, and drag-and-drop organization.
 - Native Linux desktop integration across X11 and Wayland, with support for GNOME, KDE Plasma, Niri, wlroots compositors, MATE, Xfce, Cinnamon, and reduced fallback mode.
-- 57 built-in applets for launching apps and commands, monitoring system state, controlling media, managing notes, files, folders, screenshots, power, networking, weather, and more.
+- 58 built-in applets for launching apps and commands, monitoring system state, controlling media, managing notes, files, folders, screenshots, power, networking, weather, and more.
 - Folder stacks and pinned files/folders, so directories and documents can live directly in the dock alongside applications.
 - Flexible dock layout with multi-position, multi-monitor, auto-hide, separators, and scalable sizing.
 - Deep customization through 13 built-in themes, transparency, icon sizing, menu behavior, and tooltip controls.
@@ -888,6 +888,21 @@ Notification center applet with a compact status icon, Do Not Disturb toggle, an
 - **Clear Notifications** -- clear notification history (when available)
 
 **Update interval:** 2 seconds
+
+### System Tray
+
+
+StatusNotifier/AppIndicator host for tray applications such as chat clients, sync tools, background utilities, and desktop services.
+
+**Click:** Show registered tray applications
+**Right-click options:**
+- Registered tray app actions
+- Context menus exposed through DBusMenu when available
+- Refresh Now
+
+The applet uses an existing desktop StatusNotifier watcher when one is available. In sessions without a watcher, Docking can provide the watcher service so tray apps started afterward can register with the dock.
+
+**Update interval:** 3 seconds
 
 ### Session
 

--- a/docking/applets/systemtray/__init__.py
+++ b/docking/applets/systemtray/__init__.py
@@ -1,0 +1,26 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Applet metadata for the System Tray applet."""
+
+from __future__ import annotations
+
+from docking.applets.identity import AppletCategory, AppletMeta
+
+meta = AppletMeta(
+    id="systemtray",
+    name="System Tray",
+    category=AppletCategory.SYSTEM,
+)
+
+__all__ = ["meta"]

--- a/docking/applets/systemtray/applet.py
+++ b/docking/applets/systemtray/applet.py
@@ -1,0 +1,548 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""GTK lifecycle and popup UI for the System Tray applet."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import gi
+
+gi.require_version("GdkPixbuf", "2.0")
+gi.require_version("Gtk", "3.0")
+gi.require_version("Pango", "1.0")
+from gi.repository import GdkPixbuf, GLib, Gtk, Pango
+
+from docking.applets.base import Applet, load_theme_icon
+from docking.applets.menu import disabled_menu_item, menu_sections
+from docking.applets.popup import create_popup_window, show_wrapped_popup
+from docking.applets.systemtray import meta
+from docking.applets.worker import BackgroundWorker
+from docking.i18n import _
+
+from .dbusmenu import DBusMenuClient, DBusMenuItem
+from .render import create_status_tray_icon
+from .state import StatusNotifierBackend, StatusTrayState, TrayItem, tooltip_text
+from .xembed import XEmbedTrayHost
+
+if TYPE_CHECKING:
+    from docking.core.config import Config
+    from docking.core.position import Position
+
+POLL_INTERVAL_S = 3
+
+
+class SystemTrayApplet(Applet):
+    """System tray host for StatusNotifier/AppIndicator items."""
+
+    id = meta.id
+    name = _("System Tray")
+    icon_name = "application-x-executable"
+
+    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+        self._backend = StatusNotifierBackend()
+        self._state = self._backend.get_state()
+        self._timer_id: int = 0
+        self._popup: Gtk.Window | None = None
+        self._item_menu: Gtk.Menu | None = None
+        self._worker = BackgroundWorker()
+        self._legacy_host = XEmbedTrayHost(
+            icon_size=min(32, max(22, icon_size)),
+            on_changed=self._on_legacy_changed,
+        )
+        super().__init__(icon_size=icon_size, config=config)
+        self.present()
+
+    def create_icon(self, size: int):
+        item_count = len(self._state.items)
+        if self._legacy_host.active:
+            item_count += len(self._legacy_host.icons)
+        return create_status_tray_icon(
+            size=size,
+            available=self._state.available,
+            item_count=item_count,
+        )
+
+    def refresh_tooltip(self) -> None:
+        if self._legacy_host.active:
+            self.item.name = _("System Tray: {n} legacy item(s)").format(
+                n=len(self._legacy_host.icons),
+            )
+            return
+        self.item.name = tooltip_text(self._state)
+
+    def start(self, notify: Callable[[], None]) -> None:
+        super().start(notify=notify)
+        self._timer_id = GLib.timeout_add_seconds(POLL_INTERVAL_S, self._tick)
+
+    def stop(self) -> None:
+        if self._timer_id:
+            GLib.source_remove(self._timer_id)
+            self._timer_id = 0
+        if self._popup is not None:
+            self._popup.destroy()
+            self._popup = None
+        self._legacy_host.stop()
+        self._backend.close()
+        super().stop()
+
+    def on_clicked(self) -> None:
+        if self._popup is not None and self._popup.get_visible():
+            self._popup.hide()
+            return
+        if self._legacy_host.active:
+            anchor_x, anchor_y, position = self._legacy_position()
+            self._legacy_host.toggle_visible(
+                anchor_x=anchor_x,
+                anchor_y=anchor_y,
+                position=position,
+            )
+            return
+        self._refresh_now()
+        self._position_legacy_host()
+        self._show_popup()
+
+    def get_menu_items(self) -> list[Gtk.MenuItem]:
+        status: list[Gtk.MenuItem] = [
+            disabled_menu_item(self._menu_header(), gtk=Gtk),
+        ]
+        legacy: list[Gtk.MenuItem] = self._legacy_menu_items()
+        primary: list[Gtk.MenuItem] = []
+        for item in self._state.items[:12]:
+            root = Gtk.MenuItem(label=item.display_title)
+            submenu = Gtk.Menu()
+            activate = Gtk.MenuItem(label=_("Activate"))
+            activate.connect(
+                "activate",
+                lambda _w, identifier=item.identifier: self._on_activate(identifier),
+            )
+            context = Gtk.MenuItem(label=_("Context Menu"))
+            context.connect(
+                "activate",
+                lambda _w, identifier=item.identifier: self._show_item_menu(identifier),
+            )
+            submenu.append(activate)
+            submenu.append(context)
+            root.set_submenu(submenu)
+            primary.append(root)
+
+        refresh = Gtk.MenuItem(label=_("Refresh Now"))
+        refresh.connect("activate", lambda _w: self._refresh_now())
+        return menu_sections(
+            status=status,
+            primary=primary,
+            refresh=[refresh],
+            manage=legacy,
+        )
+
+    def _tick(self) -> bool:
+        self._worker.run_guarded(
+            key="poll",
+            name="systemtray-poll",
+            fn=self._backend.get_state,
+            on_result=self._on_state_result,
+        )
+        return True
+
+    def _refresh_now(self) -> None:
+        self._on_state_result(self._backend.get_state())
+
+    def _on_state_result(self, state: StatusTrayState) -> bool:
+        if state != self._state:
+            self._state = state
+            self.present()
+            if self._popup is not None and self._popup.get_visible():
+                self._show_popup()
+        return False
+
+    def _show_popup(self) -> None:
+        self._position_legacy_host()
+        if self._popup is None:
+            self._popup = create_popup_window()
+        show_wrapped_popup(
+            window=self._popup,
+            content=self._build_popup_content(),
+            anchor=self.popup_anchor,
+        )
+
+    def _build_popup_content(self) -> Gtk.Box:
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        box.set_border_width(10)
+        header = Gtk.Label(label=self._menu_header())
+        header.set_xalign(0)
+        header.get_style_context().add_class("dim-label")
+        box.pack_start(header, False, False, 0)
+
+        if not self._state.available:
+            label = Gtk.Label(label=self._state.error or _("D-Bus unavailable"))
+            label.set_xalign(0)
+            box.pack_start(label, False, False, 0)
+            return box
+
+        if not self._state.items:
+            if self._legacy_host.active:
+                legacy_count = len(self._legacy_host.icons)
+                if legacy_count:
+                    text = _("Legacy X11 tray is active with {n} item(s).").format(
+                        n=legacy_count,
+                    )
+                else:
+                    text = _("Legacy X11 tray is active and waiting for tray apps.")
+                label = Gtk.Label(label=text)
+                label.set_xalign(0)
+                label.set_line_wrap(True)
+                box.pack_start(label, False, False, 0)
+                return box
+            if self._state.legacy_tray_owner:
+                text = _(
+                    "No StatusNotifier apps are registered. Legacy tray icons are "
+                    "currently owned by {owner}. Use Take Over Legacy Tray from the "
+                    "applet menu if you want Docking to host them."
+                ).format(owner=self._state.legacy_tray_owner)
+            else:
+                text = _(
+                    "No tray applications are registered. Use Start Legacy Tray from "
+                    "the applet menu for older X11 tray apps."
+                )
+            label = Gtk.Label(label=text)
+            label.set_xalign(0)
+            label.set_line_wrap(True)
+            box.pack_start(label, False, False, 0)
+            return box
+
+        for item in self._state.items:
+            box.pack_start(self._build_item_row(item), False, False, 0)
+        return box
+
+    def _build_item_row(self, item: TrayItem) -> Gtk.Box:
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        image = Gtk.Image()
+        pixbuf = _load_item_icon(item=item, size=24)
+        if pixbuf is not None:
+            image.set_from_pixbuf(pixbuf)
+        else:
+            image.set_from_icon_name("application-x-executable", Gtk.IconSize.MENU)
+        row.pack_start(image, False, False, 0)
+
+        labels = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+        title = Gtk.Label(label=item.display_title)
+        title.set_xalign(0)
+        title.set_ellipsize(Pango.EllipsizeMode.END)
+        labels.pack_start(title, False, False, 0)
+        detail_text = item.tooltip_text or item.status
+        if detail_text:
+            detail = Gtk.Label(label=detail_text)
+            detail.set_xalign(0)
+            detail.set_ellipsize(Pango.EllipsizeMode.END)
+            detail.get_style_context().add_class("dim-label")
+            labels.pack_start(detail, False, False, 0)
+        row.pack_start(labels, True, True, 0)
+
+        activate = Gtk.Button(label=_("Open"))
+        activate.connect(
+            "clicked",
+            lambda _w, identifier=item.identifier: self._on_activate(identifier),
+        )
+        row.pack_start(activate, False, False, 0)
+
+        menu = Gtk.Button(label=_("Menu"))
+        menu.connect(
+            "clicked",
+            lambda _w, identifier=item.identifier: self._show_item_menu(identifier),
+        )
+        row.pack_start(menu, False, False, 0)
+        return row
+
+    def _on_activate(self, identifier: str) -> None:
+        self._backend.activate(identifier)
+        if self._popup is not None:
+            self._popup.hide()
+        self._refresh_now()
+
+    def _show_item_menu(self, identifier: str) -> None:
+        client = self._backend.menu_client(identifier)
+        if client is None:
+            self._on_context_menu(identifier)
+            return
+        client.about_to_show(0)
+        layout = client.get_layout()
+        if layout is None:
+            self._on_context_menu(identifier)
+            return
+
+        if layout.root.item_id != 0 and client.about_to_show(layout.root.item_id):
+            layout = client.get_layout() or layout
+        menu = self._gtk_menu_from_dbus_menu(root=layout.root, client=client)
+        if menu is None:
+            self._on_context_menu(identifier)
+            return
+
+        if self._popup is not None:
+            self._popup.hide()
+        self._item_menu = menu
+        menu.connect("hide", lambda _w: setattr(self, "_item_menu", None))
+        menu.show_all()
+        menu.popup_at_pointer(None)
+
+    def _on_context_menu(self, identifier: str) -> None:
+        self._backend.context_menu(identifier)
+        if self._popup is not None:
+            self._popup.hide()
+        self._refresh_now()
+
+    def _legacy_menu_items(self) -> list[Gtk.MenuItem]:
+        if self._legacy_host.active:
+            release = Gtk.MenuItem(label=_("Release Legacy Tray"))
+            release.connect("activate", lambda _w: self._release_legacy_tray())
+            return [
+                disabled_menu_item(
+                    _("Legacy X11 tray active: {n} item(s)").format(
+                        n=len(self._legacy_host.icons),
+                    ),
+                    gtk=Gtk,
+                ),
+                release,
+            ]
+
+        if self._state.legacy_tray_owner:
+            take_over = Gtk.MenuItem(label=_("Take Over Legacy Tray"))
+            take_over.connect("activate", lambda _w: self._confirm_take_over_legacy())
+            return [
+                disabled_menu_item(
+                    _("Legacy X11 tray owned by {owner}").format(
+                        owner=self._state.legacy_tray_owner,
+                    ),
+                    gtk=Gtk,
+                ),
+                take_over,
+            ]
+
+        start = Gtk.MenuItem(label=_("Start Legacy Tray"))
+        start.connect("activate", lambda _w: self._start_legacy_tray())
+        return [start]
+
+    def _start_legacy_tray(self, *, force: bool = False) -> None:
+        anchor_x, anchor_y, position = self._legacy_position()
+        if self._legacy_host.start(
+            force=force,
+            anchor_x=anchor_x,
+            anchor_y=anchor_y,
+            position=position,
+        ):
+            self.present()
+            self._refresh_now()
+            return
+
+        message = self._legacy_host.unavailable_reason or _("Unknown X11 tray error")
+        dialog = Gtk.MessageDialog(
+            transient_for=self.popup_anchor.parent if self.popup_anchor else None,
+            flags=Gtk.DialogFlags.MODAL,
+            message_type=Gtk.MessageType.WARNING,
+            buttons=Gtk.ButtonsType.OK,
+            text=_("Could not start the legacy tray"),
+        )
+        dialog.format_secondary_text(message)
+        dialog.run()
+        dialog.destroy()
+
+    def _confirm_take_over_legacy(self) -> None:
+        owner = self._state.legacy_tray_owner or _("another tray")
+        dialog = Gtk.MessageDialog(
+            transient_for=self.popup_anchor.parent if self.popup_anchor else None,
+            flags=Gtk.DialogFlags.MODAL,
+            message_type=Gtk.MessageType.WARNING,
+            buttons=Gtk.ButtonsType.CANCEL,
+            text=_("Take over the legacy tray?"),
+        )
+        dialog.add_button(_("Take Over"), Gtk.ResponseType.OK)
+        dialog.format_secondary_text(
+            _(
+                "Docking will replace {owner} as the X11 system tray host. "
+                "Existing legacy tray apps may need to be restarted before they "
+                "dock into Docking."
+            ).format(owner=owner),
+        )
+        response = dialog.run()
+        dialog.destroy()
+        if response == Gtk.ResponseType.OK:
+            self._start_legacy_tray(force=True)
+
+    def _release_legacy_tray(self) -> None:
+        self._legacy_host.stop()
+        self.present()
+        self._refresh_now()
+
+    def _legacy_position(self) -> tuple[int, int, Position | None]:
+        anchor = self.popup_anchor
+        if anchor is None:
+            return (0, 0, None)
+        return (anchor.x, anchor.y, anchor.position)
+
+    def _position_legacy_host(self) -> None:
+        if not self._legacy_host.active:
+            return
+        anchor_x, anchor_y, position = self._legacy_position()
+        self._legacy_host.position_near(
+            anchor_x=anchor_x,
+            anchor_y=anchor_y,
+            position=position,
+        )
+
+    def _on_legacy_changed(self) -> None:
+        self._position_legacy_host()
+        self.present()
+        if self._popup is not None and self._popup.get_visible():
+            self._show_popup()
+
+    def _gtk_menu_from_dbus_menu(
+        self,
+        *,
+        root: DBusMenuItem,
+        client: DBusMenuClient,
+    ) -> Gtk.Menu | None:
+        menu = Gtk.Menu()
+        for child in root.children:
+            menu_item = self._gtk_menu_item_from_dbus_item(item=child, client=client)
+            if menu_item is not None:
+                menu.append(menu_item)
+        if not menu.get_children():
+            return None
+        return menu
+
+    def _gtk_menu_item_from_dbus_item(
+        self,
+        *,
+        item: DBusMenuItem,
+        client: DBusMenuClient,
+    ) -> Gtk.MenuItem | None:
+        if not item.visible:
+            return None
+        if item.is_separator:
+            return Gtk.SeparatorMenuItem()
+
+        label = item.label or _("Menu Item")
+        if item.toggle_type in {"checkmark", "radio"}:
+            menu_item: Gtk.MenuItem = Gtk.CheckMenuItem(label=label)
+            if isinstance(menu_item, Gtk.CheckMenuItem):
+                menu_item.set_active(item.toggle_state == 1)
+        else:
+            menu_item = Gtk.ImageMenuItem(label=label)
+
+        menu_item.set_sensitive(item.enabled)
+        if item.icon_name:
+            pixbuf = _load_menu_icon(item=item, size=16)
+            if pixbuf is not None and isinstance(menu_item, Gtk.ImageMenuItem):
+                menu_item.set_image(Gtk.Image.new_from_pixbuf(pixbuf))
+                menu_item.set_always_show_image(True)
+
+        if item.children:
+            submenu = Gtk.Menu()
+            for child in item.children:
+                child_item = self._gtk_menu_item_from_dbus_item(
+                    item=child,
+                    client=client,
+                )
+                if child_item is not None:
+                    submenu.append(child_item)
+            menu_item.set_submenu(submenu)
+            submenu.connect(
+                "show",
+                lambda _w, item_id=item.item_id: client.about_to_show(item_id),
+            )
+        else:
+            menu_item.connect(
+                "activate",
+                lambda _w, item_id=item.item_id: self._on_dbus_menu_activate(
+                    client=client,
+                    item_id=item_id,
+                ),
+            )
+        return menu_item
+
+    def _on_dbus_menu_activate(self, *, client: DBusMenuClient, item_id: int) -> None:
+        client.event(item_id)
+        self._refresh_now()
+
+    def _menu_header(self) -> str:
+        if not self._state.available:
+            return _("System Tray unavailable")
+        if self._state.watcher_mode == "host":
+            return _("System Tray host: {n} item(s)").format(n=len(self._state.items))
+        return _("System Tray: {n} item(s)").format(n=len(self._state.items))
+
+
+def _load_item_icon(*, item: TrayItem, size: int) -> GdkPixbuf.Pixbuf | None:
+    icon_name = item.effective_icon_name
+    if not icon_name:
+        return _load_item_pixmap(item=item, size=size)
+    pixbuf = _load_icon_name_or_path(icon_name=icon_name, size=size)
+    if pixbuf is not None:
+        return pixbuf
+    if item.icon_theme_path:
+        themed_path = Path(item.icon_theme_path) / icon_name
+        pixbuf = _load_icon_name_or_path(icon_name=str(themed_path), size=size)
+        if pixbuf is not None:
+            return pixbuf
+    return _load_item_pixmap(item=item, size=size)
+
+
+def _load_item_pixmap(*, item: TrayItem, size: int) -> GdkPixbuf.Pixbuf | None:
+    if item.icon_pixmap is None:
+        return None
+    bytes_ = GLib.Bytes.new(item.icon_pixmap.rgba)
+    pixbuf = GdkPixbuf.Pixbuf.new_from_bytes(
+        bytes_,
+        GdkPixbuf.Colorspace.RGB,
+        True,
+        8,
+        item.icon_pixmap.width,
+        item.icon_pixmap.height,
+        item.icon_pixmap.width * 4,
+    )
+    if item.icon_pixmap.width == size and item.icon_pixmap.height == size:
+        return pixbuf
+    return pixbuf.scale_simple(size, size, GdkPixbuf.InterpType.BILINEAR)
+
+
+def _load_menu_icon(*, item: DBusMenuItem, size: int) -> GdkPixbuf.Pixbuf | None:
+    if item.icon_data:
+        try:
+            loader = GdkPixbuf.PixbufLoader.new()
+            loader.write(item.icon_data)
+            loader.close()
+            pixbuf = loader.get_pixbuf()
+        except GLib.Error:
+            pixbuf = None
+        if pixbuf is not None:
+            return pixbuf.scale_simple(size, size, GdkPixbuf.InterpType.BILINEAR)
+    if item.icon_name:
+        return _load_icon_name_or_path(icon_name=item.icon_name, size=size)
+    return None
+
+
+def _load_icon_name_or_path(*, icon_name: str, size: int) -> GdkPixbuf.Pixbuf | None:
+    path = Path(icon_name)
+    if path.is_absolute() and path.exists():
+        try:
+            return GdkPixbuf.Pixbuf.new_from_file_at_scale(
+                str(path),
+                size,
+                size,
+                True,
+            )
+        except GLib.Error:
+            return None
+    return load_theme_icon(icon_name, size)

--- a/docking/applets/systemtray/dbusmenu.py
+++ b/docking/applets/systemtray/dbusmenu.py
@@ -1,0 +1,181 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""DBusMenu client helpers for StatusNotifier/AppIndicator menus."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import gi
+
+gi.require_version("Gio", "2.0")
+gi.require_version("GLib", "2.0")
+from gi.repository import Gio, GLib
+
+DBUSMENU_IFACE = "com.canonical.dbusmenu"
+DBUSMENU_METHOD_TIMEOUT_MS = 1400
+
+
+@dataclass(frozen=True, slots=True)
+class DBusMenuItem:
+    """One menu item from a DBusMenu layout tree."""
+
+    item_id: int
+    label: str
+    enabled: bool = True
+    visible: bool = True
+    item_type: str = ""
+    icon_name: str = ""
+    icon_data: bytes = b""
+    toggle_type: str = ""
+    toggle_state: int = -1
+    children: tuple[DBusMenuItem, ...] = ()
+
+    @property
+    def is_separator(self) -> bool:
+        return self.item_type == "separator"
+
+
+@dataclass(frozen=True, slots=True)
+class DBusMenuLayout:
+    """Parsed DBusMenu layout."""
+
+    revision: int
+    root: DBusMenuItem
+
+
+class DBusMenuClient:
+    """Small synchronous DBusMenu client used by the tray popup/menu UI."""
+
+    def __init__(
+        self,
+        *,
+        bus: Gio.DBusConnection,
+        service: str,
+        path: str,
+    ) -> None:
+        self._bus = bus
+        self._service = service
+        self._path = path
+
+    def get_layout(self) -> DBusMenuLayout | None:
+        try:
+            result = self._bus.call_sync(
+                self._service,
+                self._path,
+                DBUSMENU_IFACE,
+                "GetLayout",
+                GLib.Variant("(iias)", (0, -1, [])),
+                GLib.VariantType.new("(u(ia{sv}av))"),
+                Gio.DBusCallFlags.NONE,
+                DBUSMENU_METHOD_TIMEOUT_MS,
+                None,
+            )
+        except GLib.Error:
+            return None
+        revision, raw_root = _unpack_variant(result)
+        root = parse_menu_node(raw_root)
+        if root is None:
+            return None
+        return DBusMenuLayout(revision=int(revision), root=root)
+
+    def about_to_show(self, item_id: int) -> bool:
+        try:
+            result = self._bus.call_sync(
+                self._service,
+                self._path,
+                DBUSMENU_IFACE,
+                "AboutToShow",
+                GLib.Variant("(i)", (item_id,)),
+                GLib.VariantType.new("(b)"),
+                Gio.DBusCallFlags.NONE,
+                DBUSMENU_METHOD_TIMEOUT_MS,
+                None,
+            )
+        except GLib.Error:
+            return False
+        unpacked = _unpack_variant(result)
+        return bool(unpacked[0]) if isinstance(unpacked, (tuple, list)) else False
+
+    def event(self, item_id: int, event_id: str = "clicked") -> bool:
+        try:
+            self._bus.call_sync(
+                self._service,
+                self._path,
+                DBUSMENU_IFACE,
+                "Event",
+                GLib.Variant("(isvu)", (item_id, event_id, GLib.Variant("s", ""), 0)),
+                None,
+                Gio.DBusCallFlags.NONE,
+                DBUSMENU_METHOD_TIMEOUT_MS,
+                None,
+            )
+        except GLib.Error:
+            return False
+        return True
+
+
+def parse_menu_node(raw: object) -> DBusMenuItem | None:
+    """Parse one DBusMenu ``(ia{sv}av)`` node after GLib unpacking."""
+    raw = _unpack_variant(raw)
+    if not isinstance(raw, (tuple, list)) or len(raw) != 3:
+        return None
+    item_id, properties, children = raw
+    if not isinstance(properties, dict):
+        properties = {}
+    parsed_children = tuple(
+        child
+        for raw_child in children
+        for child in (parse_menu_node(raw_child),)
+        if child is not None
+    )
+    return DBusMenuItem(
+        item_id=int(item_id),
+        label=_clean_label(str(properties.get("label") or "")),
+        enabled=bool(properties.get("enabled", True)),
+        visible=bool(properties.get("visible", True)),
+        item_type=str(properties.get("type") or ""),
+        icon_name=str(properties.get("icon-name") or ""),
+        icon_data=_icon_data(properties.get("icon-data")),
+        toggle_type=str(properties.get("toggle-type") or ""),
+        toggle_state=int(properties.get("toggle-state", -1)),
+        children=parsed_children,
+    )
+
+
+def _clean_label(label: str) -> str:
+    """Convert DBusMenu mnemonic underscores into GTK labels."""
+    return label.replace("__", "\0").replace("_", "").replace("\0", "_")
+
+
+def _icon_data(value: object) -> bytes:
+    value = _unpack_variant(value)
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, list):
+        return bytes(int(byte) & 0xFF for byte in value)
+    return b""
+
+
+def _unpack_variant(value: object) -> Any:
+    if isinstance(value, GLib.Variant):
+        return _unpack_variant(value.unpack())
+    if isinstance(value, dict):
+        return {key: _unpack_variant(val) for key, val in value.items()}
+    if isinstance(value, tuple):
+        return tuple(_unpack_variant(item) for item in value)
+    if isinstance(value, list):
+        return [_unpack_variant(item) for item in value]
+    return value

--- a/docking/applets/systemtray/render.py
+++ b/docking/applets/systemtray/render.py
@@ -1,0 +1,159 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Rendering helpers for the System Tray applet."""
+
+from __future__ import annotations
+
+import cairo
+import gi
+
+gi.require_version("Gdk", "3.0")
+gi.require_version("GdkPixbuf", "2.0")
+from gi.repository import Gdk, GdkPixbuf
+
+from docking.applets.draw import rounded_rect
+from docking.ui.overlays import draw_count_badge
+
+
+def create_status_tray_icon(
+    *,
+    size: int,
+    available: bool,
+    item_count: int,
+) -> GdkPixbuf.Pixbuf | None:
+    """Render a serving-tray host icon with an item-count badge."""
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, size, size)
+    cr = cairo.Context(surface)
+
+    _draw_cloche(cr=cr, size=size, available=available)
+
+    if available and item_count > 0:
+        badge_size = size * 0.34
+        draw_count_badge(
+            cr=cr,
+            x=size - badge_size - size * 0.03,
+            y=size - badge_size - size * 0.02,
+            width=badge_size,
+            height=badge_size,
+            badge_count=item_count,
+        )
+
+    return Gdk.pixbuf_get_from_surface(surface, 0, 0, size, size)
+
+
+def _draw_cloche(*, cr: cairo.Context, size: int, available: bool) -> None:
+    stroke = max(2.0, size * 0.095)
+    cr.set_line_width(stroke)
+    cr.set_line_join(cairo.LINE_JOIN_ROUND)
+    cr.set_line_cap(cairo.LINE_CAP_ROUND)
+
+    if available:
+        dome_color = (0.94, 0.27, 0.30, 0.98)
+        lip_color = (0.37, 0.82, 0.81, 0.98)
+        outline = (0.18, 0.18, 0.17, 0.98)
+        shine = (1.0, 0.96, 0.92, 0.90)
+    else:
+        dome_color = (0.45, 0.46, 0.48, 0.92)
+        lip_color = (0.58, 0.60, 0.62, 0.92)
+        outline = (0.24, 0.25, 0.26, 0.96)
+        shine = (0.90, 0.91, 0.92, 0.70)
+
+    left = size * 0.13
+    right = size * 0.87
+    base_y = size * 0.70
+    top_y = size * 0.24
+    cx = size * 0.50
+
+    cr.new_path()
+    cr.move_to(left, base_y)
+    cr.curve_to(left, size * 0.45, size * 0.30, top_y, cx, top_y)
+    cr.curve_to(size * 0.70, top_y, right, size * 0.45, right, base_y)
+    cr.close_path()
+    cr.set_source_rgba(*dome_color)
+    cr.fill_preserve()
+    cr.set_source_rgba(*outline)
+    cr.stroke()
+
+    handle_w = size * 0.22
+    handle_h = size * 0.15
+    handle_x = cx - handle_w / 2
+    handle_y = size * 0.11
+    cr.new_path()
+    cr.move_to(handle_x, top_y)
+    cr.line_to(handle_x, handle_y + handle_h)
+    cr.curve_to(handle_x, handle_y, handle_x, handle_y, cx, handle_y)
+    cr.curve_to(
+        handle_x + handle_w,
+        handle_y,
+        handle_x + handle_w,
+        handle_y,
+        handle_x + handle_w,
+        handle_y + handle_h,
+    )
+    cr.line_to(handle_x + handle_w, top_y)
+    cr.set_source_rgba(*dome_color)
+    cr.fill_preserve()
+    cr.set_source_rgba(*outline)
+    cr.stroke()
+
+    slot_w = size * 0.13
+    slot_h = size * 0.05
+    rounded_rect(
+        cr=cr,
+        x=cx - slot_w / 2,
+        y=handle_y + size * 0.04,
+        width=slot_w,
+        height=slot_h,
+        radius=slot_h / 2,
+    )
+    cr.set_source_rgba(*outline)
+    cr.fill()
+
+    base_h = size * 0.13
+    base_x = size * 0.08
+    base_w = size * 0.84
+    rounded_rect(
+        cr=cr,
+        x=base_x,
+        y=base_y - base_h * 0.30,
+        width=base_w,
+        height=base_h,
+        radius=base_h * 0.35,
+    )
+    cr.set_source_rgba(*outline)
+    cr.fill()
+    inset = stroke * 0.45
+    rounded_rect(
+        cr=cr,
+        x=base_x + inset,
+        y=base_y + base_h * 0.02,
+        width=base_w - inset * 2,
+        height=base_h * 0.42,
+        radius=base_h * 0.18,
+    )
+    cr.set_source_rgba(*lip_color)
+    cr.fill()
+
+    cr.set_source_rgba(*shine)
+    cr.set_line_width(max(1.6, size * 0.055))
+    cr.set_line_cap(cairo.LINE_CAP_ROUND)
+    cr.move_to(size * 0.23, size * 0.58)
+    cr.curve_to(
+        size * 0.26, size * 0.46, size * 0.34, size * 0.35, size * 0.44, size * 0.31
+    )
+    cr.stroke()
+    cr.set_line_width(max(1.3, size * 0.04))
+    cr.move_to(size * 0.48, size * 0.30)
+    cr.line_to(size * 0.56, size * 0.29)
+    cr.stroke()

--- a/docking/applets/systemtray/state.py
+++ b/docking/applets/systemtray/state.py
@@ -1,0 +1,703 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""StatusNotifierItem/AppIndicator state and D-Bus helpers."""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+from dataclasses import dataclass
+from typing import Any
+
+import gi
+
+gi.require_version("Gio", "2.0")
+gi.require_version("GLib", "2.0")
+from gi.repository import Gio, GLib
+
+from docking.applets.systemtray import meta
+from docking.i18n import _
+from docking.log import get_logger, with_context
+
+log = with_context(get_logger(name="systemtray"), applet_id=meta.id)
+
+DBUS_SERVICE = "org.freedesktop.DBus"
+DBUS_PATH = "/org/freedesktop/DBus"
+DBUS_IFACE = "org.freedesktop.DBus"
+PROPERTIES_IFACE = "org.freedesktop.DBus.Properties"
+
+WATCHER_SERVICE = "org.kde.StatusNotifierWatcher"
+WATCHER_PATH = "/StatusNotifierWatcher"
+WATCHER_IFACE = "org.kde.StatusNotifierWatcher"
+ITEM_IFACE = "org.kde.StatusNotifierItem"
+DEFAULT_ITEM_PATH = "/StatusNotifierItem"
+METHOD_TIMEOUT_MS = 1200
+
+WATCHER_INTROSPECTION_XML = f"""
+<node>
+  <interface name="{WATCHER_IFACE}">
+    <method name="RegisterStatusNotifierItem">
+      <arg name="service" type="s" direction="in"/>
+    </method>
+    <method name="RegisterStatusNotifierHost">
+      <arg name="service" type="s" direction="in"/>
+    </method>
+    <signal name="StatusNotifierItemRegistered">
+      <arg name="service" type="s"/>
+    </signal>
+    <signal name="StatusNotifierItemUnregistered">
+      <arg name="service" type="s"/>
+    </signal>
+    <signal name="StatusNotifierHostRegistered"/>
+    <signal name="StatusNotifierHostUnregistered"/>
+    <property name="RegisteredStatusNotifierItems" type="as" access="read"/>
+    <property name="IsStatusNotifierHostRegistered" type="b" access="read"/>
+    <property name="ProtocolVersion" type="i" access="read"/>
+  </interface>
+</node>
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class RegisteredItemAddress:
+    """Resolved D-Bus service/path pair for one StatusNotifier item."""
+
+    service: str
+    path: str
+
+    @property
+    def identifier(self) -> str:
+        return f"{self.service}{self.path}"
+
+
+@dataclass(frozen=True, slots=True)
+class TrayIconPixmap:
+    """Raw StatusNotifier icon pixmap converted to RGBA bytes."""
+
+    width: int
+    height: int
+    rgba: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class TrayItem:
+    """Applet-facing snapshot of one StatusNotifier item."""
+
+    identifier: str
+    service: str
+    path: str
+    title: str
+    status: str
+    category: str
+    icon_name: str
+    attention_icon_name: str
+    overlay_icon_name: str
+    icon_theme_path: str
+    icon_pixmap: TrayIconPixmap | None
+    menu_path: str
+    tooltip_title: str
+    tooltip_text: str
+    item_is_menu: bool
+
+    @property
+    def display_title(self) -> str:
+        return self.title or self.tooltip_title or self.service
+
+    @property
+    def effective_icon_name(self) -> str:
+        if self.status.casefold() == "needsattention" and self.attention_icon_name:
+            return self.attention_icon_name
+        return self.icon_name or self.attention_icon_name or self.overlay_icon_name
+
+
+@dataclass(frozen=True, slots=True)
+class StatusTrayState:
+    """Current applet state."""
+
+    available: bool
+    watcher_mode: str
+    items: tuple[TrayItem, ...]
+    error: str = ""
+    legacy_tray_owner: str = ""
+
+
+def unavailable_state(error: str = "") -> StatusTrayState:
+    return StatusTrayState(
+        available=False,
+        watcher_mode="unavailable",
+        items=(),
+        error=error,
+        legacy_tray_owner=legacy_tray_owner_name(),
+    )
+
+
+def tooltip_text(state: StatusTrayState) -> str:
+    if not state.available:
+        if state.error:
+            return _("System Tray: {error}").format(error=state.error)
+        return _("System Tray: D-Bus unavailable")
+    if not state.items:
+        if state.legacy_tray_owner:
+            return _("System Tray: legacy tray owned by {owner}").format(
+                owner=state.legacy_tray_owner
+            )
+        if state.watcher_mode == "host":
+            return _("System Tray: waiting for tray apps")
+        return _("System Tray: no tray apps")
+    lines = [_("System Tray: {n} item(s)").format(n=len(state.items))]
+    for item in state.items[:6]:
+        lines.append(f"- {item.display_title}")
+    if len(state.items) > 6:
+        lines.append(_("and {n} more").format(n=len(state.items) - 6))
+    return "\n".join(lines)
+
+
+def parse_registered_item(
+    value: str,
+    *,
+    default_service: str | None = None,
+) -> RegisteredItemAddress | None:
+    """Parse watcher item identifiers into service/path pairs.
+
+    Common forms are ``org.example.App``, ``org.example.App/StatusNotifierItem``,
+    ``:1.42/StatusNotifierItem``, or a path passed during registration, in which
+    case the D-Bus sender becomes the service.
+    """
+    raw = value.strip()
+    if not raw:
+        return None
+    if raw.startswith("/"):
+        if not default_service:
+            return None
+        return RegisteredItemAddress(service=default_service, path=raw)
+    if "/" not in raw:
+        return RegisteredItemAddress(service=raw, path=DEFAULT_ITEM_PATH)
+    service, suffix = raw.split("/", 1)
+    if not service:
+        return None
+    return RegisteredItemAddress(service=service, path=f"/{suffix}")
+
+
+def tray_item_from_properties(
+    *,
+    address: RegisteredItemAddress,
+    properties: dict[str, Any],
+) -> TrayItem:
+    tooltip_title, tooltip_text_value = _tooltip_parts(properties.get("ToolTip"))
+    pixmap = _best_icon_pixmap(properties.get("IconPixmap"))
+    return TrayItem(
+        identifier=address.identifier,
+        service=address.service,
+        path=address.path,
+        title=str(properties.get("Title") or properties.get("Id") or ""),
+        status=str(properties.get("Status") or "Passive"),
+        category=str(properties.get("Category") or ""),
+        icon_name=str(properties.get("IconName") or ""),
+        attention_icon_name=str(properties.get("AttentionIconName") or ""),
+        overlay_icon_name=str(properties.get("OverlayIconName") or ""),
+        icon_theme_path=str(properties.get("IconThemePath") or ""),
+        icon_pixmap=pixmap,
+        menu_path=str(properties.get("Menu") or ""),
+        tooltip_title=tooltip_title,
+        tooltip_text=tooltip_text_value,
+        item_is_menu=bool(properties.get("ItemIsMenu") or False),
+    )
+
+
+class StatusNotifierBackend:
+    """StatusNotifier watcher/client backend.
+
+    The backend consumes an existing watcher when the desktop provides one. In
+    minimal sessions it owns the watcher name and accepts registrations from
+    tray apps started after Docking.
+    """
+
+    def __init__(self) -> None:
+        self._bus: Gio.DBusConnection | None = None
+        self._host: _StatusNotifierWatcherHost | None = None
+        self._last_items: dict[str, TrayItem] = {}
+        self._registered_with_existing_watcher = False
+
+    def close(self) -> None:
+        if self._host is not None:
+            self._host.close()
+            self._host = None
+
+    def get_state(self) -> StatusTrayState:
+        try:
+            bus = self._connection()
+        except GLib.Error as exc:
+            log.debug("StatusNotifier session bus unavailable: %s", exc)
+            return unavailable_state(_("session bus unavailable"))
+
+        try:
+            if self._host is not None:
+                addresses = self._host.registered_addresses()
+                mode = "host"
+            elif _name_has_owner(bus=bus, name=WATCHER_SERVICE):
+                self._register_with_existing_watcher(bus=bus)
+                addresses = self._existing_watcher_addresses(bus=bus)
+                mode = "watcher"
+            else:
+                host = self._ensure_host(bus=bus)
+                addresses = host.registered_addresses()
+                mode = "host"
+        except GLib.Error as exc:
+            log.debug("StatusNotifier watcher unavailable: %s", exc)
+            return unavailable_state(str(exc))
+
+        items: list[TrayItem] = []
+        for address in addresses:
+            item = _read_item(bus=bus, address=address)
+            if item is not None:
+                items.append(item)
+
+        self._last_items = {item.identifier: item for item in items}
+        items.sort(key=lambda item: item.display_title.casefold())
+        return StatusTrayState(
+            available=True,
+            watcher_mode=mode,
+            items=tuple(items),
+            legacy_tray_owner=legacy_tray_owner_name() if not items else "",
+        )
+
+    def activate(self, identifier: str) -> bool:
+        item = self._last_items.get(identifier)
+        if item is None:
+            return False
+        method = "ContextMenu" if item.item_is_menu else "Activate"
+        return self._call_item_method(item=item, method=method)
+
+    def context_menu(self, identifier: str) -> bool:
+        item = self._last_items.get(identifier)
+        if item is None:
+            return False
+        return self._call_item_method(item=item, method="ContextMenu")
+
+    def menu_client(self, identifier: str):
+        item = self._last_items.get(identifier)
+        if item is None or not item.menu_path:
+            return None
+        from docking.applets.systemtray.dbusmenu import DBusMenuClient
+
+        return DBusMenuClient(
+            bus=self._connection(),
+            service=item.service,
+            path=item.menu_path,
+        )
+
+    def _connection(self) -> Gio.DBusConnection:
+        if self._bus is None:
+            self._bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+        return self._bus
+
+    def _existing_watcher_addresses(
+        self,
+        *,
+        bus: Gio.DBusConnection,
+    ) -> tuple[RegisteredItemAddress, ...]:
+        result = bus.call_sync(
+            WATCHER_SERVICE,
+            WATCHER_PATH,
+            PROPERTIES_IFACE,
+            "Get",
+            GLib.Variant("(ss)", (WATCHER_IFACE, "RegisteredStatusNotifierItems")),
+            GLib.VariantType.new("(v)"),
+            Gio.DBusCallFlags.NONE,
+            METHOD_TIMEOUT_MS,
+            None,
+        )
+        values = _unpack_variant(result)[0]
+        if isinstance(values, GLib.Variant):
+            values = _unpack_variant(values)
+        addresses = [
+            parsed
+            for value in values
+            if isinstance(value, str)
+            for parsed in (parse_registered_item(value),)
+            if parsed is not None
+        ]
+        return tuple(addresses)
+
+    def _register_with_existing_watcher(self, *, bus: Gio.DBusConnection) -> None:
+        if self._registered_with_existing_watcher:
+            return
+        try:
+            bus.call_sync(
+                WATCHER_SERVICE,
+                WATCHER_PATH,
+                WATCHER_IFACE,
+                "RegisterStatusNotifierHost",
+                GLib.Variant("(s)", (bus.get_unique_name() or "org.docking.Docking",)),
+                None,
+                Gio.DBusCallFlags.NONE,
+                METHOD_TIMEOUT_MS,
+                None,
+            )
+        except GLib.Error as exc:
+            log.debug("Failed to register StatusNotifier host: %s", exc)
+        else:
+            self._registered_with_existing_watcher = True
+
+    def _ensure_host(self, *, bus: Gio.DBusConnection) -> _StatusNotifierWatcherHost:
+        if self._host is None:
+            self._host = _StatusNotifierWatcherHost(bus=bus)
+        return self._host
+
+    def _call_item_method(self, *, item: TrayItem, method: str) -> bool:
+        try:
+            self._connection().call_sync(
+                item.service,
+                item.path,
+                ITEM_IFACE,
+                method,
+                GLib.Variant("(ii)", (0, 0)),
+                None,
+                Gio.DBusCallFlags.NONE,
+                METHOD_TIMEOUT_MS,
+                None,
+            )
+        except GLib.Error as exc:
+            log.debug(
+                "StatusNotifier %s failed for %s: %s",
+                method,
+                item.identifier,
+                exc,
+            )
+            return False
+        return True
+
+
+class _StatusNotifierWatcherHost:
+    """Minimal watcher implementation for sessions with no existing watcher."""
+
+    def __init__(self, *, bus: Gio.DBusConnection) -> None:
+        self._bus = bus
+        self._registered: dict[str, RegisteredItemAddress] = {}
+        self._item_senders: dict[str, str] = {}
+        self._items_by_sender: dict[str, set[str]] = {}
+        self._hosts: set[str] = set()
+        node = Gio.DBusNodeInfo.new_for_xml(WATCHER_INTROSPECTION_XML)
+        self._iface = node.interfaces[0]
+        self._registration_id = bus.register_object(
+            WATCHER_PATH,
+            self._iface,
+            self._on_method_call,
+            self._get_property,
+            None,
+        )
+        self._name_owner_subscription_id = bus.signal_subscribe(
+            DBUS_SERVICE,
+            DBUS_IFACE,
+            "NameOwnerChanged",
+            DBUS_PATH,
+            None,
+            Gio.DBusSignalFlags.NONE,
+            self._on_name_owner_changed,
+            None,
+        )
+        self._owner_id = Gio.bus_own_name_on_connection(
+            bus,
+            WATCHER_SERVICE,
+            Gio.BusNameOwnerFlags.NONE,
+            None,
+            None,
+        )
+
+    def close(self) -> None:
+        if self._name_owner_subscription_id:
+            self._bus.signal_unsubscribe(self._name_owner_subscription_id)
+            self._name_owner_subscription_id = 0
+        if self._registration_id:
+            self._bus.unregister_object(self._registration_id)
+            self._registration_id = 0
+        if self._owner_id:
+            Gio.bus_unown_name(self._owner_id)
+            self._owner_id = 0
+
+    def registered_addresses(self) -> tuple[RegisteredItemAddress, ...]:
+        return tuple(self._registered.values())
+
+    def _get_property(
+        self,
+        _connection: Gio.DBusConnection,
+        _sender: str,
+        _object_path: str,
+        _interface_name: str,
+        property_name: str,
+    ) -> GLib.Variant | None:
+        if property_name == "RegisteredStatusNotifierItems":
+            return GLib.Variant("as", tuple(self._registered))
+        if property_name == "IsStatusNotifierHostRegistered":
+            return GLib.Variant("b", bool(self._hosts))
+        if property_name == "ProtocolVersion":
+            return GLib.Variant("i", 0)
+        return None
+
+    def _on_method_call(
+        self,
+        connection: Gio.DBusConnection,
+        sender: str,
+        _object_path: str,
+        _interface_name: str,
+        method_name: str,
+        parameters: GLib.Variant,
+        invocation: Gio.DBusMethodInvocation,
+    ) -> None:
+        if method_name == "RegisterStatusNotifierHost":
+            self._hosts.add(sender)
+            invocation.return_value(None)
+            self._emit_host_registered(connection=connection)
+            return
+        if method_name != "RegisterStatusNotifierItem":
+            invocation.return_dbus_error(
+                "org.docking.Docking.StatusNotifier.UnknownMethod",
+                f"Unknown method: {method_name}",
+            )
+            return
+
+        service = str(_unpack_variant(parameters)[0])
+        address = parse_registered_item(service, default_service=sender)
+        if address is None:
+            invocation.return_dbus_error(
+                "org.docking.Docking.StatusNotifier.InvalidItem",
+                f"Invalid StatusNotifier item: {service}",
+            )
+            return
+        if address.identifier not in self._registered:
+            self._registered[address.identifier] = address
+            self._item_senders[address.identifier] = sender
+            self._items_by_sender.setdefault(sender, set()).add(address.identifier)
+            connection.emit_signal(
+                None,
+                WATCHER_PATH,
+                WATCHER_IFACE,
+                "StatusNotifierItemRegistered",
+                GLib.Variant("(s)", (address.identifier,)),
+            )
+        invocation.return_value(None)
+
+    def _on_name_owner_changed(
+        self,
+        connection: Gio.DBusConnection,
+        _sender_name: str,
+        _object_path: str,
+        _interface_name: str,
+        _signal_name: str,
+        parameters: GLib.Variant,
+        _user_data: object,
+    ) -> None:
+        name, _old_owner, new_owner = _unpack_variant(parameters)
+        if new_owner:
+            return
+        name = str(name)
+        if name in self._hosts:
+            self._hosts.remove(name)
+            connection.emit_signal(
+                None,
+                WATCHER_PATH,
+                WATCHER_IFACE,
+                "StatusNotifierHostUnregistered",
+                None,
+            )
+        for identifier in tuple(self._items_by_sender.pop(name, ())):
+            self._registered.pop(identifier, None)
+            self._item_senders.pop(identifier, None)
+            connection.emit_signal(
+                None,
+                WATCHER_PATH,
+                WATCHER_IFACE,
+                "StatusNotifierItemUnregistered",
+                GLib.Variant("(s)", (identifier,)),
+            )
+
+    def _emit_host_registered(self, *, connection: Gio.DBusConnection) -> None:
+        connection.emit_signal(
+            None,
+            WATCHER_PATH,
+            WATCHER_IFACE,
+            "StatusNotifierHostRegistered",
+            None,
+        )
+
+
+def _name_has_owner(*, bus: Gio.DBusConnection, name: str) -> bool:
+    result = bus.call_sync(
+        DBUS_SERVICE,
+        DBUS_PATH,
+        DBUS_IFACE,
+        "NameHasOwner",
+        GLib.Variant("(s)", (name,)),
+        GLib.VariantType.new("(b)"),
+        Gio.DBusCallFlags.NONE,
+        METHOD_TIMEOUT_MS,
+        None,
+    )
+    return bool(_unpack_variant(result)[0])
+
+
+def _read_item(
+    *,
+    bus: Gio.DBusConnection,
+    address: RegisteredItemAddress,
+) -> TrayItem | None:
+    try:
+        result = bus.call_sync(
+            address.service,
+            address.path,
+            PROPERTIES_IFACE,
+            "GetAll",
+            GLib.Variant("(s)", (ITEM_IFACE,)),
+            GLib.VariantType.new("(a{sv})"),
+            Gio.DBusCallFlags.NONE,
+            METHOD_TIMEOUT_MS,
+            None,
+        )
+    except GLib.Error as exc:
+        log.debug("Failed to read StatusNotifier item %s: %s", address.identifier, exc)
+        return None
+    properties = _unpack_variant(result)[0]
+    if not isinstance(properties, dict):
+        return None
+    return tray_item_from_properties(
+        address=address,
+        properties={
+            str(key): _unpack_variant(value) for key, value in properties.items()
+        },
+    )
+
+
+def _tooltip_parts(value: object) -> tuple[str, str]:
+    if isinstance(value, GLib.Variant):
+        value = _unpack_variant(value)
+    if isinstance(value, (tuple, list)) and len(value) >= 4:
+        return str(value[2] or ""), str(value[3] or "")
+    return "", ""
+
+
+def _best_icon_pixmap(value: object) -> TrayIconPixmap | None:
+    value = _unpack_variant(value)
+    if not isinstance(value, (tuple, list)):
+        return None
+
+    pixmaps: list[TrayIconPixmap] = []
+    for raw_pixmap in value:
+        raw_pixmap = _unpack_variant(raw_pixmap)
+        if not isinstance(raw_pixmap, (tuple, list)) or len(raw_pixmap) != 3:
+            continue
+        width, height, payload = raw_pixmap
+        try:
+            width = int(width)
+            height = int(height)
+        except (TypeError, ValueError):
+            continue
+        if width <= 0 or height <= 0:
+            continue
+        argb = _bytes_from_dbus_array(payload)
+        if len(argb) < width * height * 4:
+            continue
+        pixmaps.append(
+            TrayIconPixmap(
+                width=width,
+                height=height,
+                rgba=_argb_to_rgba(argb[: width * height * 4]),
+            )
+        )
+    if not pixmaps:
+        return None
+    return max(pixmaps, key=lambda pixmap: pixmap.width * pixmap.height)
+
+
+def _bytes_from_dbus_array(value: object) -> bytes:
+    value = _unpack_variant(value)
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, (tuple, list)):
+        return bytes(int(byte) & 0xFF for byte in value)
+    return b""
+
+
+def _argb_to_rgba(argb: bytes) -> bytes:
+    rgba = bytearray(len(argb))
+    for index in range(0, len(argb), 4):
+        alpha = argb[index]
+        red = argb[index + 1]
+        green = argb[index + 2]
+        blue = argb[index + 3]
+        rgba[index : index + 4] = bytes((red, green, blue, alpha))
+    return bytes(rgba)
+
+
+def legacy_tray_owner_name() -> str:
+    """Return the XEmbed system tray selection owner name on X11, if any."""
+    x11 = ctypes.util.find_library("X11")
+    if not x11:
+        return ""
+
+    try:
+        lib = ctypes.CDLL(x11)
+        lib.XOpenDisplay.restype = ctypes.c_void_p
+        lib.XDefaultScreen.argtypes = [ctypes.c_void_p]
+        lib.XDefaultScreen.restype = ctypes.c_int
+        lib.XInternAtom.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+        lib.XInternAtom.restype = ctypes.c_ulong
+        lib.XGetSelectionOwner.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+        lib.XGetSelectionOwner.restype = ctypes.c_ulong
+        lib.XFetchName.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_ulong,
+            ctypes.POINTER(ctypes.c_char_p),
+        ]
+        lib.XFetchName.restype = ctypes.c_int
+        lib.XFree.argtypes = [ctypes.c_void_p]
+        lib.XCloseDisplay.argtypes = [ctypes.c_void_p]
+    except (AttributeError, OSError):
+        return ""
+
+    display = lib.XOpenDisplay(None)
+    if not display:
+        return ""
+
+    try:
+        screen = lib.XDefaultScreen(display)
+        selection = lib.XInternAtom(
+            display,
+            f"_NET_SYSTEM_TRAY_S{screen}".encode(),
+            True,
+        )
+        if not selection:
+            return ""
+        owner = lib.XGetSelectionOwner(display, selection)
+        if not owner:
+            return ""
+        name = ctypes.c_char_p()
+        if lib.XFetchName(display, owner, ctypes.byref(name)) and name.value:
+            value = name.value.decode(errors="replace")
+            lib.XFree(name)
+            return value
+        return f"0x{owner:x}"
+    finally:
+        lib.XCloseDisplay(display)
+
+
+def _unpack_variant(value: object) -> Any:
+    if isinstance(value, GLib.Variant):
+        return _unpack_variant(value.unpack())
+    if isinstance(value, dict):
+        return {key: _unpack_variant(val) for key, val in value.items()}
+    if isinstance(value, tuple):
+        return tuple(_unpack_variant(item) for item in value)
+    if isinstance(value, list):
+        return [_unpack_variant(item) for item in value]
+    return value

--- a/docking/applets/systemtray/xembed.py
+++ b/docking/applets/systemtray/xembed.py
@@ -1,0 +1,646 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Persistent XEmbed system tray host for legacy X11 tray icons."""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+import gi
+
+gi.require_version("Gdk", "3.0")
+gi.require_version("GdkX11", "3.0")
+gi.require_version("GLib", "2.0")
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk, GdkX11, GLib, Gtk
+
+from docking.core.position import Position
+from docking.log import get_logger
+
+log = get_logger("systemtray.xembed")
+
+CLIENT_MESSAGE = 33
+DESTROY_NOTIFY = 17
+SELECTION_CLEAR = 29
+SYSTEM_TRAY_REQUEST_DOCK = 0
+CURRENT_TIME = 0
+STRUCTURE_NOTIFY_MASK = 1 << 17
+GDK_FILTER_CONTINUE = 0
+GDK_FILTER_REMOVE = 1
+PROP_MODE_REPLACE = 0
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyTrayIcon:
+    """One XEmbed tray icon currently docked into Docking."""
+
+    xid: int
+    title: str
+
+
+class XClientMessageData(ctypes.Union):
+    _fields_: ClassVar = [
+        ("b", ctypes.c_char * 20),
+        ("s", ctypes.c_short * 10),
+        ("l", ctypes.c_long * 5),
+    ]
+
+
+class XClientMessageEvent(ctypes.Structure):
+    _fields_: ClassVar = [
+        ("type", ctypes.c_int),
+        ("serial", ctypes.c_ulong),
+        ("send_event", ctypes.c_int),
+        ("display", ctypes.c_void_p),
+        ("window", ctypes.c_ulong),
+        ("message_type", ctypes.c_ulong),
+        ("format", ctypes.c_int),
+        ("data", XClientMessageData),
+    ]
+
+
+class XDestroyWindowEvent(ctypes.Structure):
+    _fields_: ClassVar = [
+        ("type", ctypes.c_int),
+        ("serial", ctypes.c_ulong),
+        ("send_event", ctypes.c_int),
+        ("display", ctypes.c_void_p),
+        ("event", ctypes.c_ulong),
+        ("window", ctypes.c_ulong),
+    ]
+
+
+class XWindowAttributes(ctypes.Structure):
+    _fields_: ClassVar = [
+        ("x", ctypes.c_int),
+        ("y", ctypes.c_int),
+        ("width", ctypes.c_int),
+        ("height", ctypes.c_int),
+        ("border_width", ctypes.c_int),
+        ("depth", ctypes.c_int),
+        ("visual", ctypes.c_void_p),
+        ("root", ctypes.c_ulong),
+        ("class", ctypes.c_int),
+        ("bit_gravity", ctypes.c_int),
+        ("win_gravity", ctypes.c_int),
+        ("backing_store", ctypes.c_int),
+        ("backing_planes", ctypes.c_ulong),
+        ("backing_pixel", ctypes.c_ulong),
+        ("save_under", ctypes.c_int),
+        ("colormap", ctypes.c_ulong),
+        ("map_installed", ctypes.c_int),
+        ("map_state", ctypes.c_int),
+        ("all_event_masks", ctypes.c_long),
+        ("your_event_mask", ctypes.c_long),
+        ("do_not_propagate_mask", ctypes.c_long),
+        ("override_redirect", ctypes.c_int),
+        ("screen", ctypes.c_void_p),
+    ]
+
+
+GdkFilterFunc = ctypes.CFUNCTYPE(
+    ctypes.c_int,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+)
+
+
+class XEmbedTrayHost:
+    """Persistent legacy tray manager, modelled after Cairo-Dock's NaTray."""
+
+    def __init__(self, *, icon_size: int, on_changed: Callable[[], None]) -> None:
+        self._icon_size = max(16, icon_size)
+        self._on_changed = on_changed
+        self._xlib = _load_x11()
+        self._gdk_lib = _load_gdk()
+        self._display: int = 0
+        self._screen = 0
+        self._root = 0
+        self._selection_atom = 0
+        self._manager_atom = 0
+        self._opcode_atom = 0
+        self._message_data_atom = 0
+        self._orientation_atom = 0
+        self._padding_atom = 0
+        self._icon_size_atom = 0
+        self._visual_atom = 0
+        self._colors_atom = 0
+        self._owner_xid = 0
+        self._owner_gdk_window_ptr = 0
+        self._window: Gtk.Window | None = None
+        self._box: Gtk.Box | None = None
+        self._sockets: dict[int, Gtk.Socket] = {}
+        self._titles: dict[int, str] = {}
+        self._filter_ref: Any | None = None
+        self._active = False
+        self._unavailable_reason = ""
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    @property
+    def unavailable_reason(self) -> str:
+        return self._unavailable_reason
+
+    @property
+    def visible(self) -> bool:
+        return bool(self._window is not None and self._window.get_visible())
+
+    @property
+    def icons(self) -> tuple[LegacyTrayIcon, ...]:
+        return tuple(
+            LegacyTrayIcon(xid=xid, title=self._titles.get(xid) or f"0x{xid:x}")
+            for xid in self._sockets
+        )
+
+    def start(
+        self,
+        *,
+        force: bool = False,
+        anchor_x: int = 0,
+        anchor_y: int = 0,
+        position: Position | None = None,
+    ) -> bool:
+        if self._active:
+            self.position_near(anchor_x=anchor_x, anchor_y=anchor_y, position=position)
+            return True
+        if self._xlib is None or self._gdk_lib is None:
+            self._unavailable_reason = "X11 libraries unavailable"
+            return False
+
+        display = Gdk.Display.get_default()
+        if display is None or not isinstance(display, GdkX11.X11Display):
+            self._unavailable_reason = "not running on X11"
+            return False
+
+        self._display = hash(display.get_xdisplay())
+        screen = display.get_default_screen()
+        self._screen = int(screen.get_number())
+        self._root = int(screen.get_root_window().get_xid())
+        self._selection_atom = self._intern_atom(f"_NET_SYSTEM_TRAY_S{self._screen}")
+        self._manager_atom = self._intern_atom("MANAGER")
+        self._opcode_atom = self._intern_atom("_NET_SYSTEM_TRAY_OPCODE")
+        self._message_data_atom = self._intern_atom("_NET_SYSTEM_TRAY_MESSAGE_DATA")
+        self._orientation_atom = self._intern_atom("_NET_SYSTEM_TRAY_ORIENTATION")
+        self._padding_atom = self._intern_atom("_NET_SYSTEM_TRAY_PADDING")
+        self._icon_size_atom = self._intern_atom("_NET_SYSTEM_TRAY_ICON_SIZE")
+        self._visual_atom = self._intern_atom("_NET_SYSTEM_TRAY_VISUAL")
+        self._colors_atom = self._intern_atom("_NET_SYSTEM_TRAY_COLORS")
+
+        owner = self._xlib.XGetSelectionOwner(self._display, self._selection_atom)
+        if owner and not force:
+            self._unavailable_reason = (
+                f"owned by {_window_name(self._xlib, self._display, owner)}"
+            )
+            return False
+
+        self._window = Gtk.Window(type=Gtk.WindowType.POPUP)
+        self._window.set_decorated(False)
+        self._window.set_resizable(False)
+        self._window.set_skip_taskbar_hint(True)
+        self._window.set_skip_pager_hint(True)
+        self._window.set_keep_above(True)
+        self._window.set_type_hint(Gdk.WindowTypeHint.DOCK)
+        self._box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+        self._box.set_border_width(0)
+        self._window.add(self._box)
+        self._window.realize()
+        gdk_window = self._window.get_window()
+        if gdk_window is None or not isinstance(gdk_window, GdkX11.X11Window):
+            self._unavailable_reason = "X11 owner window unavailable"
+            self.stop()
+            return False
+
+        self._owner_xid = int(gdk_window.get_xid())
+        self._owner_gdk_window_ptr = hash(gdk_window)
+        self._set_tray_properties()
+
+        self._xlib.XSetSelectionOwner(
+            self._display,
+            self._selection_atom,
+            self._owner_xid,
+            CURRENT_TIME,
+        )
+        if (
+            self._xlib.XGetSelectionOwner(self._display, self._selection_atom)
+            != self._owner_xid
+        ):
+            self._unavailable_reason = "failed to own tray selection"
+            self.stop()
+            return False
+
+        self._install_filter()
+        self._broadcast_manager()
+        self._active = True
+        self._unavailable_reason = ""
+        self.position_near(anchor_x=anchor_x, anchor_y=anchor_y, position=position)
+        self._window.show_all()
+        return True
+
+    def stop(self) -> None:
+        if self._display and self._selection_atom and self._owner_xid:
+            owner = self._xlib.XGetSelectionOwner(self._display, self._selection_atom)
+            if owner == self._owner_xid:
+                self._xlib.XSetSelectionOwner(
+                    self._display,
+                    self._selection_atom,
+                    0,
+                    CURRENT_TIME,
+                )
+                self._xlib.XFlush(self._display)
+        if self._filter_ref is not None and self._gdk_lib is not None:
+            self._gdk_lib.gdk_window_remove_filter(
+                ctypes.c_void_p(self._owner_gdk_window_ptr),
+                self._filter_ref,
+                None,
+            )
+            self._filter_ref = None
+        for socket in tuple(self._sockets.values()):
+            socket.destroy()
+        self._sockets.clear()
+        self._titles.clear()
+        if self._window is not None:
+            self._window.destroy()
+            self._window = None
+        self._box = None
+        self._owner_xid = 0
+        self._owner_gdk_window_ptr = 0
+        self._active = False
+
+    def position_near(
+        self,
+        *,
+        anchor_x: int = 0,
+        anchor_y: int = 0,
+        position: Position | None = None,
+    ) -> None:
+        if self._window is None:
+            return
+        pref = self._window.get_preferred_size()[1]
+        width = max(pref.width, self._icon_size)
+        height = max(pref.height, self._icon_size)
+        gap = 4
+        if position == Position.TOP:
+            x = anchor_x - width // 2
+            y = anchor_y + gap
+        elif position == Position.LEFT:
+            x = anchor_x + gap
+            y = anchor_y - height // 2
+        elif position == Position.RIGHT:
+            x = anchor_x - width - gap
+            y = anchor_y - height // 2
+        else:
+            x = anchor_x - width // 2
+            y = anchor_y - height - gap
+        screen = self._window.get_screen()
+        x = max(0, min(x, max(0, screen.get_width() - width)))
+        y = max(0, min(y, max(0, screen.get_height() - height)))
+        self._window.move(int(x), int(y))
+
+    def show(self) -> None:
+        if self._window is not None:
+            self._window.show_all()
+
+    def hide(self) -> None:
+        if self._window is not None:
+            self._window.hide()
+
+    def toggle_visible(
+        self,
+        *,
+        anchor_x: int = 0,
+        anchor_y: int = 0,
+        position: Position | None = None,
+    ) -> bool:
+        if not self._active or self._window is None:
+            return False
+        if self.visible:
+            self.hide()
+            return False
+        self.position_near(anchor_x=anchor_x, anchor_y=anchor_y, position=position)
+        self.show()
+        return True
+
+    def _install_filter(self) -> None:
+        self._gdk_lib.gdk_window_add_filter.argtypes = [
+            ctypes.c_void_p,
+            GdkFilterFunc,
+            ctypes.c_void_p,
+        ]
+        self._gdk_lib.gdk_window_add_filter.restype = None
+        self._gdk_lib.gdk_window_remove_filter.argtypes = [
+            ctypes.c_void_p,
+            GdkFilterFunc,
+            ctypes.c_void_p,
+        ]
+        self._gdk_lib.gdk_window_remove_filter.restype = None
+        self._filter_ref = GdkFilterFunc(self._filter)
+        self._gdk_lib.gdk_window_add_filter(
+            ctypes.c_void_p(self._owner_gdk_window_ptr),
+            self._filter_ref,
+            None,
+        )
+
+    def _filter(self, xevent_ptr, _gdk_event_ptr, _user_data) -> int:
+        try:
+            return self._handle_xevent(int(xevent_ptr))
+        except Exception as exc:
+            log.debug("XEmbed tray event handling failed: %s", exc)
+            return GDK_FILTER_CONTINUE
+
+    def _handle_xevent(self, xevent_ptr: int) -> int:
+        if not xevent_ptr:
+            return GDK_FILTER_CONTINUE
+        event_type = ctypes.cast(
+            ctypes.c_void_p(xevent_ptr),
+            ctypes.POINTER(ctypes.c_int),
+        ).contents.value
+        if event_type == CLIENT_MESSAGE:
+            event = ctypes.cast(
+                ctypes.c_void_p(xevent_ptr),
+                ctypes.POINTER(XClientMessageEvent),
+            ).contents
+            if event.message_type == self._opcode_atom:
+                opcode = int(event.data.l[1])
+                if opcode == SYSTEM_TRAY_REQUEST_DOCK:
+                    self._dock_icon(int(event.data.l[2]))
+                    return GDK_FILTER_REMOVE
+                return GDK_FILTER_REMOVE
+            if event.message_type == self._message_data_atom:
+                return GDK_FILTER_REMOVE
+        elif event_type == DESTROY_NOTIFY:
+            event = ctypes.cast(
+                ctypes.c_void_p(xevent_ptr),
+                ctypes.POINTER(XDestroyWindowEvent),
+            ).contents
+            self._remove_icon(int(event.window))
+            return GDK_FILTER_REMOVE
+        elif event_type == SELECTION_CLEAR:
+            GLib.idle_add(self._stop_from_selection_clear)
+            return GDK_FILTER_REMOVE
+        return GDK_FILTER_CONTINUE
+
+    def _stop_from_selection_clear(self) -> bool:
+        self.stop()
+        self._on_changed()
+        return False
+
+    def _dock_icon(self, xid: int) -> None:
+        if not xid or xid in self._sockets or self._box is None:
+            return
+        if not self._foreign_window_exists(xid):
+            log.debug("Ignoring vanished XEmbed tray icon xid=0x%x", xid)
+            return
+        socket = Gtk.Socket()
+        socket.set_size_request(self._icon_size, self._icon_size)
+        self._box.pack_start(socket, False, False, 0)
+        self._box.show_all()
+        socket.realize()
+        socket.connect("plug-removed", lambda _socket, xid=xid: self._remove_icon(xid))
+        x_error = self._trap_x_errors(lambda: socket.add_id(xid))
+        if x_error:
+            log.debug("Failed to add XEmbed tray icon xid=0x%x error=%s", xid, x_error)
+            socket.destroy()
+            return
+        plug_window = None
+
+        def get_plug_window() -> None:
+            nonlocal plug_window
+            plug_window = socket.get_plug_window()
+
+        x_error = self._trap_x_errors(get_plug_window)
+        if x_error or plug_window is None:
+            log.debug(
+                "XEmbed tray icon xid=0x%x did not create a plug window (error=%s)",
+                xid,
+                x_error,
+            )
+            socket.destroy()
+            return
+        self._sockets[xid] = socket
+        self._titles[xid] = _window_name(self._xlib, self._display, xid)
+        self._trap_x_errors(
+            lambda: self._xlib.XSelectInput(self._display, xid, STRUCTURE_NOTIFY_MASK),
+        )
+        self._xlib.XFlush(self._display)
+        if self._window is not None:
+            self._window.resize(1, 1)
+            self._window.show_all()
+        self._on_changed()
+
+    def _remove_icon(self, xid: int) -> None:
+        socket = self._sockets.pop(xid, None)
+        self._titles.pop(xid, None)
+        if socket is not None:
+            socket.destroy()
+            self._on_changed()
+
+    def _broadcast_manager(self) -> None:
+        event = XClientMessageEvent()
+        event.type = CLIENT_MESSAGE
+        event.window = self._root
+        event.message_type = self._manager_atom
+        event.format = 32
+        event.data.l[0] = CURRENT_TIME
+        event.data.l[1] = self._selection_atom
+        event.data.l[2] = self._owner_xid
+        self._xlib.XSendEvent(
+            self._display,
+            self._root,
+            False,
+            STRUCTURE_NOTIFY_MASK,
+            ctypes.byref(event),
+        )
+        self._xlib.XFlush(self._display)
+
+    def _set_tray_properties(self) -> None:
+        self._change_cardinal_property(self._orientation_atom, 0)
+        self._change_cardinal_property(self._padding_atom, 0)
+        self._change_cardinal_property(self._icon_size_atom, self._icon_size)
+        self._set_visual_property()
+        self._set_colors_property()
+
+    def _set_visual_property(self) -> None:
+        if self._window is None:
+            return
+        screen = self._window.get_screen()
+        display = self._window.get_display()
+        visual = None
+        if display.supports_composite():
+            visual = screen.get_rgba_visual()
+        visual = visual or screen.get_system_visual()
+        if visual is None or not isinstance(visual, GdkX11.X11Visual):
+            return
+        xvisual = visual.get_xvisual()
+        visual_id = self._xlib.XVisualIDFromVisual(hash(xvisual))
+        visual_id_atom = self._intern_atom("VISUALID")
+        data = (ctypes.c_ulong * 1)(int(visual_id))
+        self._xlib.XChangeProperty(
+            self._display,
+            self._owner_xid,
+            self._visual_atom,
+            visual_id_atom,
+            32,
+            PROP_MODE_REPLACE,
+            ctypes.cast(data, ctypes.POINTER(ctypes.c_ubyte)),
+            1,
+        )
+
+    def _set_colors_property(self) -> None:
+        data = (ctypes.c_ulong * 12)(
+            0,
+            0,
+            0,
+            0xFFFF,
+            0,
+            0,
+            0xFFFF,
+            0xFFFF,
+            0,
+            0,
+            0xFFFF,
+            0,
+        )
+        cardinal = self._intern_atom("CARDINAL")
+        self._xlib.XChangeProperty(
+            self._display,
+            self._owner_xid,
+            self._colors_atom,
+            cardinal,
+            32,
+            PROP_MODE_REPLACE,
+            ctypes.cast(data, ctypes.POINTER(ctypes.c_ubyte)),
+            12,
+        )
+
+    def _change_cardinal_property(self, atom: int, value: int) -> None:
+        cardinal = self._intern_atom("CARDINAL")
+        data = (ctypes.c_ulong * 1)(int(value))
+        self._xlib.XChangeProperty(
+            self._display,
+            self._owner_xid,
+            atom,
+            cardinal,
+            32,
+            PROP_MODE_REPLACE,
+            ctypes.cast(data, ctypes.POINTER(ctypes.c_ubyte)),
+            1,
+        )
+
+    def _intern_atom(self, name: str) -> int:
+        return int(self._xlib.XInternAtom(self._display, name.encode(), False))
+
+    def _foreign_window_exists(self, xid: int) -> bool:
+        attributes = XWindowAttributes()
+        result = 0
+
+        def check() -> None:
+            nonlocal result
+            result = self._xlib.XGetWindowAttributes(
+                self._display,
+                xid,
+                ctypes.byref(attributes),
+            )
+
+        x_error = self._trap_x_errors(check)
+        return not x_error and bool(result)
+
+    def _trap_x_errors(self, fn: Callable[[], object]) -> int:
+        display = Gdk.Display.get_default()
+        if display is None or not isinstance(display, GdkX11.X11Display):
+            fn()
+            return 0
+        display.error_trap_push()
+        try:
+            fn()
+        except Exception:
+            display.error_trap_pop_ignored()
+            raise
+        return int(display.error_trap_pop())
+
+
+def _load_x11():
+    path = ctypes.util.find_library("X11")
+    if not path:
+        return None
+    lib = ctypes.CDLL(path)
+    lib.XGetSelectionOwner.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+    lib.XGetSelectionOwner.restype = ctypes.c_ulong
+    lib.XSetSelectionOwner.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_ulong,
+        ctypes.c_ulong,
+        ctypes.c_ulong,
+    ]
+    lib.XInternAtom.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+    lib.XInternAtom.restype = ctypes.c_ulong
+    lib.XSendEvent.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_ulong,
+        ctypes.c_int,
+        ctypes.c_long,
+        ctypes.c_void_p,
+    ]
+    lib.XSendEvent.restype = ctypes.c_int
+    lib.XSelectInput.argtypes = [ctypes.c_void_p, ctypes.c_ulong, ctypes.c_long]
+    lib.XGetWindowAttributes.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_ulong,
+        ctypes.POINTER(XWindowAttributes),
+    ]
+    lib.XGetWindowAttributes.restype = ctypes.c_int
+    lib.XVisualIDFromVisual.argtypes = [ctypes.c_void_p]
+    lib.XVisualIDFromVisual.restype = ctypes.c_ulong
+    lib.XChangeProperty.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_ulong,
+        ctypes.c_ulong,
+        ctypes.c_ulong,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.POINTER(ctypes.c_ubyte),
+        ctypes.c_int,
+    ]
+    lib.XFlush.argtypes = [ctypes.c_void_p]
+    lib.XFetchName.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_ulong,
+        ctypes.POINTER(ctypes.c_char_p),
+    ]
+    lib.XFetchName.restype = ctypes.c_int
+    lib.XFree.argtypes = [ctypes.c_void_p]
+    return lib
+
+
+def _load_gdk():
+    path = ctypes.util.find_library("gdk-3")
+    return ctypes.CDLL(path) if path else None
+
+
+def _window_name(xlib, display: int, xid: int) -> str:
+    gdk_display = Gdk.Display.get_default()
+    if isinstance(gdk_display, GdkX11.X11Display):
+        gdk_display.error_trap_push()
+    name = ctypes.c_char_p()
+    result = xlib.XFetchName(display, xid, ctypes.byref(name))
+    if isinstance(gdk_display, GdkX11.X11Display):
+        x_error = gdk_display.error_trap_pop()
+        if x_error:
+            return f"0x{xid:x}"
+    if result and name.value:
+        value = name.value.decode(errors="replace")
+        xlib.XFree(name)
+        return value
+    return f"0x{xid:x}"

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -339,6 +339,7 @@ msgstr ""
 #: docking/applets/hackernews/applet.py:205
 #: docking/applets/lastfm/applet.py:198 docking/applets/micshield/applet.py:131
 #: docking/applets/moon/applet.py:137 docking/applets/quote/applet.py:105
+#: docking/applets/systemtray/applet.py:136
 #: docking/applets/thermals/applet.py:157
 #: docking/applets/todayinhistory/applet.py:112
 #: docking/applets/trivia/applet.py:128 docking/applets/weather/applet.py:188
@@ -2033,7 +2034,8 @@ msgstr ""
 msgid "Run with file"
 msgstr ""
 
-#: docking/applets/runcommand/applet.py:340 docking/ui/menu.py:467
+#: docking/applets/runcommand/applet.py:340
+#: docking/applets/systemtray/applet.py:248 docking/ui/menu.py:467
 msgid "Open"
 msgstr ""
 
@@ -2364,6 +2366,153 @@ msgstr ""
 #: docking/applets/systemmonitor/state.py:184
 #, python-brace-format
 msgid "Disk: {usage}"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:51
+msgid "System Tray"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:80
+#, python-brace-format
+msgid "System Tray: {n} legacy item(s)"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:121
+msgid "Activate"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:126
+msgid "Context Menu"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:184
+msgid "D-Bus unavailable"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:193
+#, python-brace-format
+msgid "Legacy X11 tray is active with {n} item(s)."
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:197
+msgid "Legacy X11 tray is active and waiting for tray apps."
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:205
+#, python-brace-format
+msgid ""
+"No StatusNotifier apps are registered. Legacy tray icons are currently owned "
+"by {owner}. Use Take Over Legacy Tray from the applet menu if you want "
+"Docking to host them."
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:211
+msgid ""
+"No tray applications are registered. Use Start Legacy Tray from the applet "
+"menu for older X11 tray apps."
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:255
+msgid "Menu"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:302
+msgid "Release Legacy Tray"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:306
+#, python-brace-format
+msgid "Legacy X11 tray active: {n} item(s)"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:315
+msgid "Take Over Legacy Tray"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:319
+#, python-brace-format
+msgid "Legacy X11 tray owned by {owner}"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:327
+msgid "Start Legacy Tray"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:337
+msgid "Unknown X11 tray error"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:343
+msgid "Could not start the legacy tray"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:350
+msgid "another tray"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:356
+msgid "Take over the legacy tray?"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:358
+msgid "Take Over"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:361
+#, python-brace-format
+msgid ""
+"Docking will replace {owner} as the X11 system tray host. Existing legacy "
+"tray apps may need to be restarted before they dock into Docking."
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:423
+msgid "Menu Item"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:468
+msgid "System Tray unavailable"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:470
+#, python-brace-format
+msgid "System Tray host: {n} item(s)"
+msgstr ""
+
+#: docking/applets/systemtray/applet.py:471
+#: docking/applets/systemtray/state.py:158
+#, python-brace-format
+msgid "System Tray: {n} item(s)"
+msgstr ""
+
+#: docking/applets/systemtray/state.py:148
+#, python-brace-format
+msgid "System Tray: {error}"
+msgstr ""
+
+#: docking/applets/systemtray/state.py:149
+msgid "System Tray: D-Bus unavailable"
+msgstr ""
+
+#: docking/applets/systemtray/state.py:152
+#, python-brace-format
+msgid "System Tray: legacy tray owned by {owner}"
+msgstr ""
+
+#: docking/applets/systemtray/state.py:156
+msgid "System Tray: waiting for tray apps"
+msgstr ""
+
+#: docking/applets/systemtray/state.py:157
+msgid "System Tray: no tray apps"
+msgstr ""
+
+#: docking/applets/systemtray/state.py:162
+#, python-brace-format
+msgid "and {n} more"
+msgstr ""
+
+#: docking/applets/systemtray/state.py:242
+msgid "session bus unavailable"
 msgstr ""
 
 #: docking/applets/temperature.py:44

--- a/tests/applets/test_systemtray.py
+++ b/tests/applets/test_systemtray.py
@@ -1,0 +1,194 @@
+"""Tests for the System Tray applet helpers."""
+
+from __future__ import annotations
+
+from gi.repository import GLib
+
+from docking.applets.systemtray.dbusmenu import parse_menu_node
+from docking.applets.systemtray.render import create_status_tray_icon
+from docking.applets.systemtray.state import (
+    DEFAULT_ITEM_PATH,
+    RegisteredItemAddress,
+    StatusTrayState,
+    parse_registered_item,
+    tooltip_text,
+    tray_item_from_properties,
+    unavailable_state,
+)
+
+
+class TestRegisteredItemParsing:
+    def test_service_only_uses_default_path(self):
+        address = parse_registered_item("org.example.Tray")
+
+        assert address == RegisteredItemAddress(
+            service="org.example.Tray",
+            path=DEFAULT_ITEM_PATH,
+        )
+
+    def test_service_and_path(self):
+        address = parse_registered_item(":1.42/Tray/Icon")
+
+        assert address == RegisteredItemAddress(service=":1.42", path="/Tray/Icon")
+
+    def test_path_only_uses_sender_service(self):
+        address = parse_registered_item(
+            "/StatusNotifierItem",
+            default_service=":1.99",
+        )
+
+        assert address == RegisteredItemAddress(
+            service=":1.99",
+            path="/StatusNotifierItem",
+        )
+
+    def test_path_only_without_sender_is_invalid(self):
+        assert parse_registered_item("/StatusNotifierItem") is None
+        assert parse_registered_item("") is None
+
+
+class TestTrayItemParsing:
+    def test_tray_item_from_status_notifier_properties(self):
+        item = tray_item_from_properties(
+            address=RegisteredItemAddress(
+                service="org.example.App",
+                path="/StatusNotifierItem",
+            ),
+            properties={
+                "Title": "Example",
+                "Status": "Active",
+                "Category": "ApplicationStatus",
+                "IconName": "example-icon",
+                "AttentionIconName": "example-alert",
+                "IconThemePath": "/tmp/icons",
+                "IconPixmap": [(1, 1, [255, 17, 34, 51])],
+                "Menu": "/Menu",
+                "ToolTip": ("", [], "Tooltip title", "Tooltip body"),
+                "ItemIsMenu": True,
+            },
+        )
+
+        assert item.identifier == "org.example.App/StatusNotifierItem"
+        assert item.display_title == "Example"
+        assert item.effective_icon_name == "example-icon"
+        assert item.menu_path == "/Menu"
+        assert item.icon_theme_path == "/tmp/icons"
+        assert item.icon_pixmap is not None
+        assert item.icon_pixmap.width == 1
+        assert item.icon_pixmap.height == 1
+        assert item.icon_pixmap.rgba == b"\x11\x22\x33\xff"
+        assert item.tooltip_title == "Tooltip title"
+        assert item.tooltip_text == "Tooltip body"
+        assert item.item_is_menu is True
+
+    def test_attention_icon_wins_when_status_needs_attention(self):
+        item = tray_item_from_properties(
+            address=RegisteredItemAddress(service="org.example.App", path="/Item"),
+            properties={
+                "Title": "Example",
+                "Status": "NeedsAttention",
+                "IconName": "normal",
+                "AttentionIconName": "alert",
+            },
+        )
+
+        assert item.effective_icon_name == "alert"
+
+
+class TestTooltipText:
+    def test_unavailable_state_mentions_error(self):
+        assert "session bus unavailable" in tooltip_text(
+            unavailable_state("session bus unavailable")
+        )
+
+    def test_host_waiting_text(self):
+        text = tooltip_text(
+            StatusTrayState(available=True, watcher_mode="host", items=())
+        )
+
+        assert text == "System Tray: waiting for tray apps"
+
+    def test_legacy_tray_owner_text(self):
+        text = tooltip_text(
+            StatusTrayState(
+                available=True,
+                watcher_mode="watcher",
+                items=(),
+                legacy_tray_owner="notification-area-applet",
+            )
+        )
+
+        assert text == "System Tray: legacy tray owned by notification-area-applet"
+
+    def test_lists_item_titles(self):
+        item = tray_item_from_properties(
+            address=RegisteredItemAddress(service="org.example.App", path="/Item"),
+            properties={"Title": "Example", "Status": "Active"},
+        )
+
+        assert "- Example" in tooltip_text(
+            StatusTrayState(available=True, watcher_mode="watcher", items=(item,))
+        )
+
+
+class TestDBusMenuParsing:
+    def test_parse_menu_tree(self):
+        root = parse_menu_node(
+            (
+                0,
+                {},
+                [
+                    (
+                        1,
+                        {
+                            "label": "_Open",
+                            "enabled": True,
+                            "icon-name": "document-open",
+                        },
+                        [],
+                    ),
+                    (2, {"type": "separator"}, []),
+                    (
+                        3,
+                        {
+                            "label": "_Enabled",
+                            "toggle-type": "checkmark",
+                            "toggle-state": 1,
+                            "icon-data": [1, 2, 3],
+                        },
+                        [],
+                    ),
+                ],
+            )
+        )
+
+        assert root is not None
+        assert [child.label for child in root.children] == ["Open", "", "Enabled"]
+        assert root.children[0].icon_name == "document-open"
+        assert root.children[1].is_separator is True
+        assert root.children[2].toggle_type == "checkmark"
+        assert root.children[2].toggle_state == 1
+        assert root.children[2].icon_data == b"\x01\x02\x03"
+
+    def test_parse_glib_variant_node(self):
+        root = parse_menu_node(
+            GLib.Variant(
+                "(ia{sv}av)",
+                (
+                    0,
+                    {"label": GLib.Variant("s", "_Root")},
+                    [],
+                ),
+            )
+        )
+
+        assert root is not None
+        assert root.label == "Root"
+
+
+def test_create_status_tray_icon_dimensions():
+    pixbuf = create_status_tray_icon(size=48, available=True, item_count=3)
+
+    assert pixbuf is not None
+    assert pixbuf.get_width() == 48
+    assert pixbuf.get_height() == 48


### PR DESCRIPTION
## Summary
- Add the System Tray applet under docking.applets.systemtray with StatusNotifier/AppIndicator support and DBusMenu actions
- Add an X11 legacy tray host with explicit start, takeover, hide/show, and release controls
- Update README and website applet catalog/counts for the new applet