### PR TITLE
Wire Hyprland backend selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ one with `DOCKING_BACKEND`.
 |---|---|---|
 | **GNOME Shell bridge** | GNOME / Mutter 45+ | Full: dock placement, window tracking, window actions (activate / minimize / close), window previews, workspace switching, Show Desktop, Alt+Tab hiding |
 | **KWin** | KDE Plasma 6 Wayland | Dock placement (layer-shell), window tracking with titles via AT-SPI accessibility bus, workspace switching via KWin D-Bus. No window actions (KWin 6 does not expose a public activate/close/minimize protocol) |
-| **Native layer-shell** | wlroots-based (Hyprland, Sway) | Dock placement, window tracking, workspace switching (varies by compositor protocol support) |
+| **Hyprland** | Hyprland Wayland | Dock placement (layer-shell), IPC-based window tracking, active state, window actions, geometry, workspace association, and optional previews |
+| **Native layer-shell** | wlroots-based (Sway, labwc, river, Wayfire) | Dock placement, window tracking, workspace switching (varies by compositor protocol support) |
 | **Reduced** | Any Wayland | Dock visible but no window management (no running indicators, no previews, no workspace switching) |
 
 #### GNOME Shell Bridge
@@ -249,6 +250,7 @@ To force a specific backend for testing:
 ```bash
 DOCKING_BACKEND=gnome-shell docking          # GNOME / Mutter 45+
 DOCKING_BACKEND=kwin docking                  # KDE Plasma 6 Wayland
+DOCKING_BACKEND=hyprland docking              # Hyprland IPC + layer-shell
 DOCKING_BACKEND=wayland-layer-shell docking   # wlroots compositors
 DOCKING_BACKEND=reduced docking               # any Wayland (no WM integration)
 DOCKING_BACKEND=x11 docking                   # X11 (full support)

--- a/docking/platform/backends/selection.py
+++ b/docking/platform/backends/selection.py
@@ -92,6 +92,17 @@ def create_session_backend(
         return _create_reduced_backend(
             reason=f"COSMIC backend unavailable after DOCKING_BACKEND={requested}"
         )
+    if requested in {"hyprland", "hypr"}:
+        backend = _create_hyprland_backend(
+            launcher=launcher,
+            model=model,
+            reason=f"requested by DOCKING_BACKEND={requested}",
+        )
+        if backend is not None:
+            return backend
+        return _create_reduced_backend(
+            reason=f"Hyprland backend unavailable after DOCKING_BACKEND={requested}"
+        )
     if requested in {"kwin", "kde", "plasma", "kwin-script"}:
         backend = _create_kwin_backend(
             launcher=launcher,
@@ -105,6 +116,15 @@ def create_session_backend(
         )
 
     if not is_x11_backend():
+        # Hyprland has a richer IPC backend than generic layer-shell.
+        if detect_desktop() & Desktop.HYPRLAND:
+            backend = _create_hyprland_backend(
+                launcher=launcher,
+                model=model,
+                reason=_non_x11_reason(),
+            )
+            if backend is not None:
+                return backend
         # COSMIC takes priority on its native desktop
         if detect_desktop() is Desktop.COSMIC:
             backend = _create_cosmic_backend(
@@ -234,6 +254,35 @@ def _create_cosmic_backend(
         log.info("COSMIC backend unavailable: compositor does not support layer-shell")
         return None
     backend = CosmicSessionBackend(
+        layer_shell=layer_shell,
+        launcher=launcher,
+        model=model,
+    )
+    log.info("Selected session backend: %s (%s)", backend.name, reason)
+    return backend
+
+
+def _create_hyprland_backend(
+    *, launcher: Launcher, model: DockModel, reason: str
+) -> SessionBackend | None:
+    from docking.platform.backends.wayland.hyprland_session import (
+        HyprlandSessionBackend,
+    )
+    from docking.platform.backends.wayland.services import (
+        layer_shell_is_supported,
+        load_gtk_layer_shell,
+    )
+
+    layer_shell = load_gtk_layer_shell()
+    if layer_shell is None:
+        log.info("Hyprland backend unavailable: GtkLayerShell not installed")
+        return None
+    if not layer_shell_is_supported(layer_shell):
+        log.info(
+            "Hyprland backend unavailable: compositor does not support layer-shell"
+        )
+        return None
+    backend = HyprlandSessionBackend(
         layer_shell=layer_shell,
         launcher=launcher,
         model=model,

--- a/docking/platform/backends/wayland/hyprland_session.py
+++ b/docking/platform/backends/wayland/hyprland_session.py
@@ -1,0 +1,238 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Hyprland session backend with layer-shell surfaces and IPC window state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from docking.platform.backends.base import (
+    DesktopActionService,
+    DisplayServer,
+    IdleService,
+    PlatformCapabilities,
+    PreviewService,
+    ScreenCaptureService,
+    SessionBackend,
+    SurfaceService,
+    VisibilityService,
+    WindowPickService,
+    WindowService,
+    WorkspaceService,
+)
+from docking.platform.backends.reduced.services import (
+    ReducedPreviewService,
+    ReducedVisibilityService,
+    ReducedWindowService,
+)
+from docking.platform.backends.wayland.hyprland_ipc import (
+    HyprlandWindowService,
+    load_hyprland_window_service,
+)
+from docking.platform.backends.wayland.portals import (
+    WaylandPortalColorPickerService,
+    load_portal_color_picker,
+)
+from docking.platform.backends.wayland.previews import (
+    HyprlandPreviewService,
+    WaylandPreviewHandleTracker,
+)
+from docking.platform.backends.wayland.runtime import WaylandProtocolRuntime
+from docking.platform.backends.wayland.services import WaylandLayerShellSurfaceService
+from docking.platform.backends.wayland.workspaces import WaylandWorkspaceService
+
+if TYPE_CHECKING:
+    from docking.platform.launcher import Launcher
+    from docking.platform.model import DockModel
+
+
+@dataclass(frozen=True)
+class HyprlandRuntimeServices:
+    """Concrete services selected for the Hyprland Wayland backend."""
+
+    windows: WindowService
+    previews: PreviewService
+    surface: WaylandLayerShellSurfaceService
+    visibility: ReducedVisibilityService
+    workspaces: WorkspaceService | None
+    screen_capture: ScreenCaptureService | None
+    protocol_runtime: WaylandProtocolRuntime | None
+
+
+class HyprlandSessionBackend(SessionBackend):
+    """SessionBackend using Hyprland IPC for windows and layer-shell surfaces."""
+
+    def __init__(
+        self,
+        *,
+        layer_shell: object,
+        model: DockModel,
+        launcher: Launcher,
+        protocol_runtime: WaylandProtocolRuntime | None = None,
+        screen_capture: ScreenCaptureService | None = None,
+        window_service: WindowService | None = None,
+    ) -> None:
+        runtime = protocol_runtime
+        if runtime is None:
+            candidate_runtime = WaylandProtocolRuntime()
+            if candidate_runtime.start():
+                runtime = candidate_runtime
+
+        windows = window_service or load_hyprland_window_service(
+            model=model,
+            launcher=launcher,
+        )
+        if windows is None:
+            windows = ReducedWindowService()
+
+        foreign_toplevel = (
+            runtime.foreign_toplevel_protocol if runtime is not None else None
+        )
+        preview_handles = None
+        if isinstance(windows, HyprlandWindowService) and foreign_toplevel is not None:
+            preview_handles = WaylandPreviewHandleTracker(
+                model=model,
+                launcher=launcher,
+                protocol=foreign_toplevel,
+            )
+            windows.set_preview_handle_source(preview_handles)
+
+        hyprland_preview_protocol = (
+            runtime.hyprland_preview_protocol if runtime is not None else None
+        )
+        if (
+            hyprland_preview_protocol is not None
+            and isinstance(windows, HyprlandWindowService)
+            and preview_handles is not None
+        ):
+            previews: PreviewService = HyprlandPreviewService(
+                protocol=hyprland_preview_protocol,
+                windows=windows,
+            )
+        else:
+            previews = ReducedPreviewService()
+
+        workspace_protocol = runtime.workspace_protocol if runtime is not None else None
+        workspaces = (
+            WaylandWorkspaceService(protocol=workspace_protocol)
+            if workspace_protocol is not None
+            else None
+        )
+
+        self._services = HyprlandRuntimeServices(
+            windows=windows,
+            previews=previews,
+            surface=WaylandLayerShellSurfaceService(layer_shell=layer_shell),
+            visibility=ReducedVisibilityService(),
+            workspaces=workspaces,
+            screen_capture=screen_capture
+            if screen_capture is not None
+            else load_portal_color_picker(),
+            protocol_runtime=runtime,
+        )
+
+    @property
+    def name(self) -> str:
+        return "hyprland"
+
+    @property
+    def display_server(self) -> DisplayServer:
+        return DisplayServer.WAYLAND
+
+    @property
+    def capabilities(self) -> PlatformCapabilities:
+        tracks_windows = isinstance(self._services.windows, HyprlandWindowService)
+        supports_workspaces = self._services.workspaces is not None
+        supports_color_pick = isinstance(
+            self._services.screen_capture,
+            WaylandPortalColorPickerService,
+        )
+        return PlatformCapabilities(
+            tracks_windows=tracks_windows,
+            tracks_active_window=tracks_windows,
+            tracks_attention=tracks_windows,
+            tracks_minimized=tracks_windows,
+            tracks_fullscreen=tracks_windows,
+            supports_activate=tracks_windows,
+            supports_minimize=tracks_windows,
+            supports_close=tracks_windows,
+            tracks_window_geometry=tracks_windows,
+            tracks_window_workspace=tracks_windows,
+            supports_current_workspace_filter=tracks_windows,
+            supports_workspace_list=supports_workspaces,
+            supports_workspace_switch=supports_workspaces,
+            supports_layer_shell=True,
+            supports_screen_reservation=True,
+            supports_input_region=True,
+            supports_screen_color_pick=supports_color_pick,
+        )
+
+    @property
+    def windows(self) -> WindowService:
+        return self._services.windows
+
+    @property
+    def surface(self) -> SurfaceService:
+        return self._services.surface
+
+    @property
+    def visibility(self) -> VisibilityService:
+        return self._services.visibility
+
+    @property
+    def previews(self) -> PreviewService:
+        return self._services.previews
+
+    @property
+    def workspaces(self) -> WorkspaceService | None:
+        return self._services.workspaces
+
+    @property
+    def desktop_actions(self) -> DesktopActionService | None:
+        return None
+
+    @property
+    def screen_capture(self) -> ScreenCaptureService | None:
+        return self._services.screen_capture
+
+    @property
+    def idle(self) -> IdleService | None:
+        return None
+
+    @property
+    def window_picker(self) -> WindowPickService | None:
+        return None
+
+    def start(self) -> None:
+        self._services.previews.start()
+        self._services.windows.start()
+        self._services.surface.start()
+        self._services.visibility.start()
+        if self._services.workspaces is not None:
+            self._services.workspaces.start()
+        if self._services.screen_capture is not None:
+            self._services.screen_capture.start()
+
+    def stop(self) -> None:
+        if self._services.screen_capture is not None:
+            self._services.screen_capture.stop()
+        if self._services.workspaces is not None:
+            self._services.workspaces.stop()
+        self._services.visibility.stop()
+        self._services.surface.stop()
+        self._services.windows.stop()
+        self._services.previews.stop()
+        if self._services.protocol_runtime is not None:
+            self._services.protocol_runtime.stop()

--- a/docs/WAYLAND.md
+++ b/docs/WAYLAND.md
@@ -80,11 +80,12 @@ and the desktop environment. The selection logic lives in
 
 **Auto-detection order on native Wayland:**
 
-1. COSMIC (if `XDG_CURRENT_DESKTOP=COSMIC`)
-2. KWin / KDE Plasma 6 (if `XDG_CURRENT_DESKTOP=KDE`)
-3. Generic layer-shell (if the compositor advertises `zwlr_layer_shell_v1`)
-4. GNOME Shell bridge (if the bridge D-Bus service is available)
-5. Reduced (fallback)
+1. Hyprland (if `XDG_CURRENT_DESKTOP=Hyprland`)
+2. COSMIC (if `XDG_CURRENT_DESKTOP=COSMIC`)
+3. KWin / KDE Plasma 6 (if `XDG_CURRENT_DESKTOP=KDE`)
+4. Generic layer-shell (if the compositor advertises `zwlr_layer_shell_v1`)
+5. GNOME Shell bridge (if the bridge D-Bus service is available)
+6. Reduced (fallback)
 
 **Manual override** via `DOCKING_BACKEND`:
 
@@ -157,8 +158,8 @@ Launch: `DOCKING_BACKEND=kwin python3 run.py`
 
 ### Hyprland
 
-**Backend:** `wayland/hyprland_ipc.py`
-**Auto-detected:** Via `HYPRLAND_INSTANCE_SIGNATURE`
+**Backend:** `wayland/hyprland_session.py` + `wayland/hyprland_ipc.py`
+**Auto-detected:** Yes, when desktop detection reports Hyprland
 **Status:** IPC-based window tracking, actions, and workspaces
 
 Uses Hyprland's event socket (`.socket2.sock`) for live state and short-lived
@@ -170,9 +171,9 @@ to avoid stalling the compositor.
 | Edge placement / exclusive zone | ✓ | `zwlr_layer_shell_v1` via `gtk-layer-shell` |
 | Running indicators / active state | ✓ | Event socket (`openwindow`, `closewindow`, `activewindowv2`) |
 | Window actions (focus, close) | ✓ | Dispatch commands via command socket |
-| Workspace listing / switching | ✓ | IPC workspace events and commands |
+| Workspace listing / switching | ✓ | Workspace protocol when available; window workspace state via IPC |
 | Overlap-driven autohide | ~ | Geometry available from IPC; not yet wired |
-| Window previews | ✗ | Not available |
+| Window previews | ~ | Hyprland toplevel-export when matching protocol handles are available |
 | Applets | ✓ | Backend-neutral applets work |
 
 Launch: `DOCKING_BACKEND=hyprland python3 run.py`

--- a/tests/platform/test_backend_selection.py
+++ b/tests/platform/test_backend_selection.py
@@ -143,6 +143,50 @@ def test_create_session_backend_can_force_gnome_bridge_backend(monkeypatch):
     create_gnome.assert_called_once()
 
 
+def test_create_session_backend_can_force_hyprland_backend(monkeypatch):
+    monkeypatch.setenv("DOCKING_BACKEND", "hyprland")
+    monkeypatch.setattr(selection, "is_x11_backend", lambda: True)
+    backend = MagicMock(name="hyprland")
+    create_hyprland = MagicMock(return_value=backend)
+    monkeypatch.setattr(selection, "_create_hyprland_backend", create_hyprland)
+
+    result = selection.create_session_backend(
+        config=MagicMock(),
+        launcher=MagicMock(),
+        model=MagicMock(),
+    )
+
+    assert result is backend
+    create_hyprland.assert_called_once()
+
+
+def test_create_session_backend_auto_selects_hyprland_before_generic_wayland(
+    monkeypatch,
+):
+    monkeypatch.delenv("DOCKING_BACKEND", raising=False)
+    monkeypatch.setattr(selection, "is_x11_backend", lambda: False)
+    monkeypatch.setattr(selection, "detect_desktop", lambda: selection.Desktop.HYPRLAND)
+    backend = MagicMock(name="hyprland")
+    create_hyprland = MagicMock(return_value=backend)
+    create_wayland = MagicMock()
+    monkeypatch.setattr(selection, "_create_hyprland_backend", create_hyprland)
+    monkeypatch.setattr(
+        selection,
+        "_create_wayland_layer_shell_backend",
+        create_wayland,
+    )
+
+    result = selection.create_session_backend(
+        config=MagicMock(),
+        launcher=MagicMock(),
+        model=MagicMock(),
+    )
+
+    assert result is backend
+    create_hyprland.assert_called_once()
+    create_wayland.assert_not_called()
+
+
 def test_create_session_backend_can_select_reduced_backend_by_override(monkeypatch):
     monkeypatch.setenv("DOCKING_BACKEND", "reduced")
     monkeypatch.setattr(selection, "is_x11_backend", lambda: True)

--- a/tests/platform/test_wayland_layer_shell_session.py
+++ b/tests/platform/test_wayland_layer_shell_session.py
@@ -19,6 +19,11 @@ from docking.platform.backends.reduced.services import (
     ReducedVisibilityService,
     ReducedWindowService,
 )
+from docking.platform.backends.wayland.hyprland_ipc import (
+    HyprlandSocketPaths,
+    HyprlandWindowService,
+)
+from docking.platform.backends.wayland.hyprland_session import HyprlandSessionBackend
 from docking.platform.backends.wayland.portals import WaylandPortalColorPickerService
 from docking.platform.backends.wayland.previews import (
     HyprlandPreviewService,
@@ -190,6 +195,60 @@ def test_wayland_layer_shell_session_uses_workspace_and_capture_services_when_av
     assert backend.capabilities.supports_workspace_list is True
     assert backend.capabilities.supports_workspace_switch is True
     assert backend.capabilities.supports_screen_color_pick is True
+
+
+def test_hyprland_session_uses_ipc_windows_and_layer_shell_capabilities():
+    window_service = HyprlandWindowService(
+        model=SimpleNamespace(
+            visible_items=MagicMock(return_value=[]),
+            update_running=MagicMock(),
+        ),
+        launcher=SimpleNamespace(resolve=MagicMock(), resolve_by_wm_class=MagicMock()),
+        client=SimpleNamespace(paths=HyprlandSocketPaths(command="", events="")),
+    )
+    backend = HyprlandSessionBackend(
+        layer_shell=_layer_shell(),
+        model=SimpleNamespace(),
+        launcher=SimpleNamespace(),
+        protocol_runtime=_empty_runtime(),
+        window_service=window_service,
+    )
+
+    assert backend.name == "hyprland"
+    assert backend.display_server is DisplayServer.WAYLAND
+    assert backend.windows is window_service
+    assert backend.capabilities.tracks_windows is True
+    assert backend.capabilities.tracks_active_window is True
+    assert backend.capabilities.tracks_attention is True
+    assert backend.capabilities.tracks_window_geometry is True
+    assert backend.capabilities.tracks_window_workspace is True
+    assert backend.capabilities.supports_current_workspace_filter is True
+    assert backend.capabilities.supports_activate is True
+    assert backend.capabilities.supports_minimize is True
+    assert backend.capabilities.supports_close is True
+    assert backend.capabilities.supports_layer_shell is True
+    assert backend.capabilities.supports_screen_reservation is True
+    assert backend.capabilities.supports_input_region is True
+
+
+def test_hyprland_session_falls_back_to_reduced_windows_when_ipc_unavailable(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "docking.platform.backends.wayland.hyprland_session."
+        "load_hyprland_window_service",
+        lambda **_: None,
+    )
+    backend = HyprlandSessionBackend(
+        layer_shell=_layer_shell(),
+        model=SimpleNamespace(),
+        launcher=SimpleNamespace(),
+        protocol_runtime=_empty_runtime(),
+    )
+
+    assert isinstance(backend.windows, ReducedWindowService)
+    assert backend.capabilities.tracks_windows is False
+    assert backend.capabilities.supports_layer_shell is True
 
 
 def test_wayland_layer_shell_session_lifecycle_is_safe():


### PR DESCRIPTION
## Summary
- Add a Hyprland session backend that combines layer-shell surfaces with Hyprland IPC window state
- Wire DOCKING_BACKEND=hyprland / hypr and auto-select Hyprland before generic Wayland layer-shell
- Advertise Hyprland-specific capabilities and document the backend in README and docs/WAYLAND.md
- Add backend selection and session capability tests