### PR TITLE
Fix logout 'Caller does not belong to any known session' on KDE Wayland

### DIFF
--- a/docking/applets/session/state.py
+++ b/docking/applets/session/state.py
@@ -100,9 +100,17 @@ def lock_screen() -> bool:
 
 def _run(*, cmd: list[str], action: str) -> None:
     """Run a session/power command, logging failures."""
-    resolved_cmd = flatpak.host_command(cmd) or cmd
+    # Resolve session-id placeholder for loginctl commands.
+    resolved_cmd = list(cmd)
+    if resolved_cmd[0:2] == ["loginctl", "terminate-session"] and resolved_cmd[2] == "":
+        session_id = (os.environ.get("XDG_SESSION_ID") or "").strip()
+        resolved_cmd[2] = session_id
+    resolved_cmd = flatpak.host_command(resolved_cmd) or resolved_cmd
+    # Remove empty arguments so loginctl auto-detects the calling session
+    # when XDG_SESSION_ID is not available.
+    resolved_cmd = [a for a in resolved_cmd if a != ""]
     try:
-        subprocess.Popen(resolved_cmd, start_new_session=True)
+        subprocess.Popen(resolved_cmd)
     except OSError as exc:
         log.bind(action=action).warning(f"Failed to run {cmd}: {exc}")
 


### PR DESCRIPTION
## Problem

Clicking Log Out in the Session applet on KDE Wayland produced:

    Failed to issue method call: Caller does not belong to any known session.

The logout action had a hardcoded empty string as the session ID placeholder
(`["loginctl", "terminate-session", ""]`) that was never resolved to the
actual session, unlike the lock screen which already resolves `XDG_SESSION_ID`.

## Fix

In `_run()`:
- Resolve `XDG_SESSION_ID` for `terminate-session` commands (same pattern
  `lock_screen` already uses for `lock-session`)
- Filter remaining empty arguments so `loginctl` auto-detects the calling
  session when `XDG_SESSION_ID` is not available
- Remove `start_new_session=True` from `Popen` — `setsid()` can interfere
  with logind session association