### PR TITLE
Add Niri IPC backend with window tracking, previews, and native color picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cair
 ## Highlights
 
 - Fast launcher workflow with running indicators, previews, app actions, and drag-and-drop organization.
-- Native Linux desktop integration across X11 and Wayland, with support for GNOME, KDE Plasma, wlroots compositors, MATE, Xfce, Cinnamon, and reduced fallback mode.
+- Native Linux desktop integration across X11 and Wayland, with support for GNOME, KDE Plasma, Niri, wlroots compositors, MATE, Xfce, Cinnamon, and reduced fallback mode.
 - 57 built-in applets for launching apps and commands, monitoring system state, controlling media, managing notes, files, folders, screenshots, power, networking, weather, and more.
 - Folder stacks and pinned files/folders, so directories and documents can live directly in the dock alongside applications.
 - Flexible dock layout with multi-position, multi-monitor, auto-hide, separators, and scalable sizing.
@@ -173,7 +173,8 @@ one with `DOCKING_BACKEND`.
 |---|---|---|
 | **GNOME Shell bridge** | GNOME / Mutter 45+ | Full: dock placement, window tracking, window actions (activate / minimize / close), window previews, workspace switching, Show Desktop, Alt+Tab hiding |
 | **KWin** | KDE Plasma 6 Wayland | Dock placement (layer-shell), window tracking with titles via AT-SPI accessibility bus, workspace switching via KWin D-Bus. No window actions (KWin 6 does not expose a public activate/close/minimize protocol) |
-| **Native layer-shell** | wlroots-based (Hyprland, Sway) | Dock placement, window tracking, workspace switching (varies by compositor protocol support) |
+| **Niri** | Niri Wayland | Dock placement (layer-shell), IPC-based window tracking, active state, window actions (focus, close), window previews, workspace association |
+| **Native layer-shell** | wlroots-based (Sway, labwc, river, Wayfire) | Dock placement, window tracking, workspace switching (varies by compositor protocol support) |
 | **Reduced** | Any Wayland | Dock visible but no window management (no running indicators, no previews, no workspace switching) |
 
 #### GNOME Shell Bridge
@@ -249,6 +250,7 @@ To force a specific backend for testing:
 ```bash
 DOCKING_BACKEND=gnome-shell docking          # GNOME / Mutter 45+
 DOCKING_BACKEND=kwin docking                  # KDE Plasma 6 Wayland
+DOCKING_BACKEND=niri docking                  # Niri IPC + layer-shell
 DOCKING_BACKEND=wayland-layer-shell docking   # wlroots compositors
 DOCKING_BACKEND=reduced docking               # any Wayland (no WM integration)
 DOCKING_BACKEND=x11 docking                   # X11 (full support)

--- a/docking/platform/backends/selection.py
+++ b/docking/platform/backends/selection.py
@@ -92,6 +92,17 @@ def create_session_backend(
         return _create_reduced_backend(
             reason=f"COSMIC backend unavailable after DOCKING_BACKEND={requested}"
         )
+    if requested in {"niri"}:
+        backend = _create_niri_backend(
+            launcher=launcher,
+            model=model,
+            reason=f"requested by DOCKING_BACKEND={requested}",
+        )
+        if backend is not None:
+            return backend
+        return _create_reduced_backend(
+            reason=f"Niri backend unavailable after DOCKING_BACKEND={requested}"
+        )
     if requested in {"kwin", "kde", "plasma", "kwin-script"}:
         backend = _create_kwin_backend(
             launcher=launcher,
@@ -108,6 +119,15 @@ def create_session_backend(
         # COSMIC takes priority on its native desktop
         if detect_desktop() is Desktop.COSMIC:
             backend = _create_cosmic_backend(
+                launcher=launcher,
+                model=model,
+                reason=_non_x11_reason(),
+            )
+            if backend is not None:
+                return backend
+        # Niri has a richer IPC backend than generic layer-shell.
+        if detect_desktop() & Desktop.NIRI:
+            backend = _create_niri_backend(
                 launcher=launcher,
                 model=model,
                 reason=_non_x11_reason(),
@@ -267,6 +287,31 @@ def _create_kwin_backend(
         return None
 
     backend = KWinSessionBackend(
+        layer_shell=layer_shell,
+        launcher=launcher,
+        model=model,
+    )
+    log.info("Selected session backend: %s (%s)", backend.name, reason)
+    return backend
+
+
+def _create_niri_backend(
+    *, launcher: Launcher, model: DockModel, reason: str
+) -> SessionBackend | None:
+    from docking.platform.backends.wayland.niri_session import NiriSessionBackend
+    from docking.platform.backends.wayland.services import (
+        layer_shell_is_supported,
+        load_gtk_layer_shell,
+    )
+
+    layer_shell = load_gtk_layer_shell()
+    if layer_shell is None:
+        log.info("Niri backend unavailable: GtkLayerShell not installed")
+        return None
+    if not layer_shell_is_supported(layer_shell):
+        log.info("Niri backend unavailable: compositor does not support layer-shell")
+        return None
+    backend = NiriSessionBackend(
         layer_shell=layer_shell,
         launcher=launcher,
         model=model,

--- a/docking/platform/backends/wayland/niri_ipc.py
+++ b/docking/platform/backends/wayland/niri_ipc.py
@@ -1,0 +1,879 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Niri IPC helpers and WindowService.
+
+Niri exposes a single JSON Unix socket at ``$NIRI_SOCKET``.  Requests are
+single-line JSON objects; replies are also single-line JSON.  The event
+stream is started with an ``{"EventStream":null}`` request, acknowledged
+with ``{"Ok":"Handled"}``, and then delivers full current state up-front
+followed by incremental events — no polling needed.
+
+The IPC is simpler than Hyprland's two-socket model and requires no
+external tools.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import tempfile
+import threading
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import gi
+
+gi.require_version("GdkPixbuf", "2.0")
+from gi.repository import GdkPixbuf
+
+from docking.log import get_logger
+from docking.platform.backends.base import (
+    ActionResult,
+    DisplayServer,
+    PreviewImage,
+    PreviewService,
+    Rect,
+    ScreenCaptureService,
+    WindowId,
+    WindowService,
+    WindowSnapshot,
+)
+from docking.platform.backends.wayland.toplevels import WaylandAppIdMatcher
+from docking.platform.running import RunningAppInfo, RunningWindowInfo
+
+log = get_logger(name="niri_ipc")
+
+# ---------------------------------------------------------------------------
+# Niri IPC wire helpers
+# ---------------------------------------------------------------------------
+
+_NIRI_WINDOW_EVENTS = {
+    "WindowsChanged",
+    "WindowOpenedOrChanged",
+    "WindowClosed",
+    "WindowFocusChanged",
+    "WindowUrgencyChanged",
+    "WorkspacesChanged",
+    "WorkspaceActivated",
+    "WorkspaceActiveWindowChanged",
+}
+
+
+def _niri_socket_path(environ: Mapping[str, str] | None = None) -> Path | None:
+    """Return the Niri IPC socket path from the process environment."""
+    env = os.environ if environ is None else environ
+    raw = env.get("NIRI_SOCKET", "").strip()
+    if not raw:
+        return None
+    return Path(raw)
+
+
+# ---------------------------------------------------------------------------
+# Backend-neutral data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NiriWindowRecord:
+    """Backend-neutral projection of one Niri window."""
+
+    id: int
+    title: str
+    app_id: str
+    desktop_id: str | None
+    active: bool
+    urgent: bool
+    workspace_id: int | None
+    geometry: Rect | None
+
+    @property
+    def window_id(self) -> WindowId:
+        return WindowId(backend=DisplayServer.WAYLAND, value=str(self.id))
+
+
+# ---------------------------------------------------------------------------
+# IPC request client
+# ---------------------------------------------------------------------------
+
+
+class NiriIpcClient:
+    """Short-lived request client for Niri's JSON IPC socket."""
+
+    def __init__(
+        self,
+        *,
+        socket_path: str | Path,
+        socket_factory: Callable[[int, int], socket.socket] = socket.socket,
+        timeout: float = 1.0,
+    ) -> None:
+        self._path = str(socket_path)
+        self._socket_factory = socket_factory
+        self._timeout = timeout
+
+    def request(self, payload: object) -> dict[str, Any]:
+        """Send one JSON request and return the parsed reply dict.
+
+        Returns an empty dict on any error so callers can safely chain
+        ``.get(...)`` accessors.
+        """
+        try:
+            raw = json.dumps(payload, separators=(",", ":"))
+        except (TypeError, ValueError):
+            return {}
+        try:
+            with self._socket_factory(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.settimeout(self._timeout)
+                sock.connect(self._path)
+                sock.sendall((raw + "\n").encode("utf-8"))
+                sock.shutdown(socket.SHUT_WR)
+                chunks: list[bytes] = []
+                while True:
+                    chunk = sock.recv(65536)
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+            return _parse_response(b"".join(chunks))
+        except OSError as exc:
+            log.info("Niri IPC request failed: %s", exc)
+            return {}
+        except json.JSONDecodeError as exc:
+            log.info("Niri IPC response parse error: %s", exc)
+            return {}
+
+    def ok_data(self, payload: object, key: str) -> Any | None:
+        """Send a request and return ``Ok.<key>`` from the reply, or None."""
+        reply = self.request(payload)
+        ok = reply.get("Ok")
+        if isinstance(ok, Mapping):
+            return ok.get(key)
+        return None
+
+    def action(self, action_payload: Mapping[str, Any]) -> ActionResult:
+        """Send an ``Action`` request.  Returns OK when the server accepts it."""
+        try:
+            reply = self.request({"Action": action_payload})
+            if "Ok" in reply:
+                return ActionResult.OK
+            return ActionResult.FAILED
+        except Exception:
+            return ActionResult.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Event stream
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NiriEvent:
+    """One parsed event from the Niri event stream."""
+
+    name: str
+    data: dict[str, Any]
+
+
+class NiriEventStream:
+    """Background reader for Niri's event stream.
+
+    Sends ``{"EventStream":null}``, consumes the ``{"Ok":"Handled"}``
+    acknowledgement, then reads line-by-line JSON events forever.
+    """
+
+    def __init__(
+        self,
+        *,
+        socket_path: str | Path,
+        callback: Callable[[NiriEvent], None],
+        socket_factory: Callable[[int, int], socket.socket] = socket.socket,
+        timeout: float = 1.0,
+    ) -> None:
+        self._path = str(socket_path)
+        self._callback = callback
+        self._socket_factory = socket_factory
+        self._timeout = timeout
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """Start the reader thread once."""
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run,
+            name="docking-niri-events",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the reader thread."""
+        self._stop.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=self._timeout)
+        self._thread = None
+
+    def _run(self) -> None:
+        try:
+            with self._socket_factory(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.settimeout(self._timeout)
+                sock.connect(self._path)
+                # Start event stream.
+                sock.sendall(b'{"EventStream":null}\n')
+                sock.settimeout(None)
+                file_obj = sock.makefile("rb")
+                for raw_line in file_obj:
+                    if self._stop.is_set():
+                        break
+                    event = _parse_event_line(raw_line.decode("utf-8", "replace"))
+                    if event is not None:
+                        self._callback(event)
+        except OSError as exc:
+            if not self._stop.is_set():
+                log.info("Niri event stream stopped: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# WindowService
+# ---------------------------------------------------------------------------
+
+
+class NiriWindowService(WindowService):
+    """WindowService backed by Niri IPC snapshots and events."""
+
+    def __init__(
+        self,
+        *,
+        model,
+        launcher,
+        client: NiriIpcClient,
+        event_stream_factory: Callable[
+            [Callable[[NiriEvent], None]], NiriEventStream | None
+        ]
+        | None = None,
+    ) -> None:
+        self._model = model
+        self._matcher = WaylandAppIdMatcher(launcher=launcher)
+        self._client = client
+        self._event_stream_factory = event_stream_factory
+        self._event_stream: NiriEventStream | None = None
+        self._records: dict[int, NiriWindowRecord] = {}
+        self._workspaces: dict[int, dict[str, Any]] = {}
+        self._overview_open = False
+        self._on_overview_changed: Callable[[bool], None] | None = None
+
+    # -- WindowService interface -----------------------------------------------
+
+    def start(self) -> None:
+        """Load initial windows and subscribe to events."""
+        self._refresh_windows()
+        self._refresh_workspaces()
+        if self._event_stream_factory is not None:
+            self._event_stream = self._event_stream_factory(self._on_event)
+            if self._event_stream is not None:
+                self._event_stream.start()
+
+    def stop(self) -> None:
+        """Stop event delivery and clear published running state."""
+        if self._event_stream is not None:
+            self._event_stream.stop()
+            self._event_stream = None
+        self._records.clear()
+        self._workspaces.clear()
+        self._model.update_running(running={})
+
+    def list_windows(self, desktop_id: str) -> Sequence[WindowSnapshot]:
+        """Return known Niri windows for one desktop ID."""
+        return tuple(
+            self._snapshot_for(record)
+            for record in self._records.values()
+            if record.desktop_id == desktop_id
+        )
+
+    def list_preview_windows(self, desktop_id: str) -> Sequence[WindowSnapshot]:
+        """Return menu rows; preview capture is not available via Niri IPC."""
+        return self.list_windows(desktop_id=desktop_id)
+
+    def icon_name_for_desktop(self, desktop_id: str) -> str:
+        """Return a generic icon fallback."""
+        return "application-x-executable"
+
+    def protocol_handle_for_window_id(self, window_id: WindowId) -> object | None:
+        """Niri IPC does not expose toplevel-export handles."""
+        return None
+
+    # -- Actions ----------------------------------------------------------------
+
+    def activate(self, window_id: WindowId) -> ActionResult:
+        """Focus a Niri window by id."""
+        niri_id = _niri_window_id(window_id)
+        if niri_id is None or niri_id not in self._records:
+            return ActionResult.NOT_FOUND
+        return self._client.action({"FocusWindow": {"id": niri_id}})
+
+    def activate_most_recent(self, desktop_id: str) -> ActionResult:
+        """Activate the active or first known window for an app."""
+        record = self._first_record_for_desktop(desktop_id)
+        if record is None:
+            return ActionResult.NOT_FOUND
+        return self.activate(record.window_id)
+
+    def cycle(self, desktop_id: str) -> ActionResult:
+        """Cycle policy starts as activating a known app window."""
+        return self.activate_most_recent(desktop_id=desktop_id)
+
+    def minimize_all(self, desktop_id: str) -> ActionResult:
+        """Niri is a tiling compositor without a minimize concept."""
+        return ActionResult.UNSUPPORTED
+
+    def close(self, window_id: WindowId) -> ActionResult:
+        """Close a Niri window by id."""
+        niri_id = _niri_window_id(window_id)
+        if niri_id is None or niri_id not in self._records:
+            return ActionResult.NOT_FOUND
+        return self._client.action({"CloseWindow": {"id": niri_id}})
+
+    def close_all(self, desktop_id: str) -> ActionResult:
+        """Close all known windows for an app."""
+        records = self._records_for_desktop(desktop_id)
+        if not records:
+            return ActionResult.NOT_FOUND
+        result = ActionResult.OK
+        for record in records:
+            action = self._client.action({"CloseWindow": {"id": record.id}})
+            if action is not ActionResult.OK:
+                result = action
+        return result
+
+    def close_focused(self, desktop_id: str) -> ActionResult:
+        """Close the active window for an app, falling back to the first."""
+        record = self._first_record_for_desktop(desktop_id)
+        if record is None:
+            return ActionResult.NOT_FOUND
+        return self.close(record.window_id)
+
+    def toggle_focus(self, desktop_id: str) -> ActionResult:
+        """Focus inactive apps; no-op for active ones (no minimize in Niri)."""
+        record = self._first_record_for_desktop(desktop_id)
+        if record is None:
+            return ActionResult.NOT_FOUND
+        if record.active:
+            return ActionResult.OK  # already focused; nothing to toggle
+        return self.activate(record.window_id)
+
+    def fullscreen(self, window_id: WindowId) -> ActionResult:
+        """Toggle fullscreen state for a Niri window."""
+        niri_id = _niri_window_id(window_id)
+        if niri_id is None or niri_id not in self._records:
+            return ActionResult.NOT_FOUND
+        return self._client.action({"FullscreenWindow": {"id": niri_id}})
+
+    @property
+    def is_overview_open(self) -> bool:
+        """Return True when the Niri overview UI is currently open."""
+        return self._overview_open
+
+    def set_overview_changed_callback(
+        self, callback: Callable[[bool], None] | None
+    ) -> None:
+        """Register a callback invoked when the overview opens or closes.
+
+        The callback receives ``True`` when the overview opens and ``False``
+        when it closes.
+        """
+        self._on_overview_changed = callback
+
+    # -- Internal ---------------------------------------------------------------
+
+    def _on_event(self, event: NiriEvent) -> None:
+        if event.name in _NIRI_WINDOW_EVENTS:
+            # Full state replacements.
+            if event.name == "WindowsChanged":
+                windows_raw = event.data.get("windows")
+                if isinstance(windows_raw, list):
+                    self._replace_windows(windows_raw)
+                return
+            if event.name == "WorkspacesChanged":
+                workspaces_raw = event.data.get("workspaces")
+                if isinstance(workspaces_raw, list):
+                    self._workspaces = {
+                        ws["id"]: ws
+                        for ws in workspaces_raw
+                        if isinstance(ws, Mapping) and "id" in ws
+                    }
+                return
+            # Incremental updates.
+            if event.name == "WindowOpenedOrChanged":
+                window_raw = event.data.get("window")
+                if isinstance(window_raw, Mapping):
+                    self._upsert_window(window_raw)
+            elif event.name == "WindowClosed":
+                window_id = event.data.get("id")
+                if isinstance(window_id, int):
+                    self._records.pop(window_id, None)
+            elif event.name == "WindowFocusChanged":
+                self._apply_focus_change(event.data.get("id"))
+            elif event.name == "WindowUrgencyChanged":
+                self._apply_urgency_change(event.data)
+            elif event.name == "WorkspaceActivated":
+                pass  # workspace metadata update, not window state
+            elif event.name == "WorkspaceActiveWindowChanged":
+                pass  # workspace-level change, not window state
+            elif event.name == "OverviewOpenedOrClosed":
+                is_open = event.data.get("is_open")
+                if isinstance(is_open, bool) and is_open != self._overview_open:
+                    self._overview_open = is_open
+                    if self._on_overview_changed is not None:
+                        self._on_overview_changed(is_open)
+                return  # no window state change
+            self._publish_running()
+
+    def _refresh_windows(self) -> None:
+        windows_raw = self._client.ok_data({"Windows": None}, "Windows")
+        if isinstance(windows_raw, list):
+            self._replace_windows(windows_raw)
+            self._publish_running()
+
+    def _refresh_workspaces(self) -> None:
+        workspaces_raw = self._client.ok_data({"Workspaces": None}, "Workspaces")
+        if isinstance(workspaces_raw, list):
+            self._workspaces = {
+                ws["id"]: ws
+                for ws in workspaces_raw
+                if isinstance(ws, Mapping) and "id" in ws
+            }
+
+    def _replace_windows(self, items: list[Any]) -> None:
+        self._matcher.sync_visible_items(self._model.visible_items())
+        records: dict[int, NiriWindowRecord] = {}
+        for item in items:
+            if not isinstance(item, Mapping):
+                continue
+            record = _record_from_window(item, matcher=self._matcher)
+            if record is not None:
+                records[record.id] = record
+        self._records = records
+
+    def _upsert_window(self, item: Mapping[str, Any]) -> None:
+        record = _record_from_window(item, matcher=self._matcher)
+        if record is not None:
+            self._records[record.id] = record
+
+    def _apply_focus_change(self, focused_id: object) -> None:
+        if not isinstance(focused_id, int | type(None)):
+            return
+        for record in self._records.values():
+            record = self._records[record.id]
+            active = record.id == focused_id
+            if record.active != active:
+                self._records[record.id] = NiriWindowRecord(
+                    id=record.id,
+                    title=record.title,
+                    app_id=record.app_id,
+                    desktop_id=record.desktop_id,
+                    active=active,
+                    urgent=record.urgent,
+                    workspace_id=record.workspace_id,
+                    geometry=record.geometry,
+                )
+
+    def _apply_urgency_change(self, data: Mapping[str, Any]) -> None:
+        window_id = data.get("id")
+        urgent = data.get("urgent")
+        if not isinstance(window_id, int) or not isinstance(urgent, bool):
+            return
+        record = self._records.get(window_id)
+        if record is None or record.urgent == urgent:
+            return
+        self._records[window_id] = NiriWindowRecord(
+            id=record.id,
+            title=record.title,
+            app_id=record.app_id,
+            desktop_id=record.desktop_id,
+            active=record.active,
+            urgent=urgent,
+            workspace_id=record.workspace_id,
+            geometry=record.geometry,
+        )
+
+    def _publish_running(self) -> None:
+        windows_by_desktop: dict[str, list[RunningWindowInfo]] = {}
+        for record in self._records.values():
+            if record.desktop_id is None:
+                continue
+            windows_by_desktop.setdefault(record.desktop_id, []).append(
+                RunningWindowInfo(
+                    desktop_id=record.desktop_id,
+                    xid=0,
+                    window_id=record.window_id,
+                    active=record.active,
+                    urgent=record.urgent,
+                    window=str(record.id),
+                )
+            )
+        self._model.update_running(
+            running={
+                desktop_id: RunningAppInfo.from_windows(items)
+                for desktop_id, items in windows_by_desktop.items()
+            }
+        )
+
+    def _snapshot_for(self, record: NiriWindowRecord) -> WindowSnapshot:
+        return WindowSnapshot(
+            id=record.window_id,
+            desktop_id=record.desktop_id or "",
+            title=record.title,
+            app_id=record.app_id or None,
+            active=record.active,
+            urgent=record.urgent,
+            minimized=None,
+            fullscreen=None,
+            geometry=record.geometry,
+            workspace_id=str(record.workspace_id)
+            if record.workspace_id is not None
+            else None,
+            can_activate=True,
+            can_minimize=False,  # Niri is a tiling compositor
+            can_close=True,
+            can_preview=True,  # ScreenshotWindow IPC
+        )
+
+    def _records_for_desktop(self, desktop_id: str) -> list[NiriWindowRecord]:
+        return [
+            record
+            for record in self._records.values()
+            if record.desktop_id == desktop_id
+        ]
+
+    def _first_record_for_desktop(self, desktop_id: str) -> NiriWindowRecord | None:
+        records = self._records_for_desktop(desktop_id)
+        if not records:
+            return None
+        return next((r for r in records if r.active), records[0])
+
+
+# ---------------------------------------------------------------------------
+# Public loaders
+# ---------------------------------------------------------------------------
+
+
+def load_niri_window_service(*, model, launcher) -> NiriWindowService | None:
+    """Return a Niri WindowService when the IPC socket is detectable."""
+    socket_path = _niri_socket_path()
+    if socket_path is None or not socket_path.exists():
+        return None
+    client = NiriIpcClient(socket_path=socket_path)
+    return NiriWindowService(
+        model=model,
+        launcher=launcher,
+        client=client,
+        event_stream_factory=lambda callback: NiriEventStream(
+            socket_path=socket_path,
+            callback=callback,
+        ),
+    )
+
+
+def load_niri_preview_service() -> NiriPreviewService | None:
+    """Return a Niri PreviewService when the IPC socket is detectable."""
+    socket_path = _niri_socket_path()
+    if socket_path is None or not socket_path.exists():
+        return None
+    return NiriPreviewService(socket_path=str(socket_path))
+
+
+def niri_pick_color(
+    socket_path: str | None = None, *, timeout: float = 10.0
+) -> tuple[int, int, int] | None:
+    """Pick a screen colour via Niri's ``PickColor`` IPC request.
+
+    Returns an ``(r, g, b)`` tuple of byte values (0-255), or ``None`` when
+    the picker is unavailable or the user cancels.
+    """
+    path = socket_path or _niri_socket_path()
+    if path is None:
+        return None
+    try:
+        raw = b'{"PickColor":null}\n'
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(timeout)
+            sock.connect(str(path))
+            sock.sendall(raw)
+            sock.shutdown(socket.SHUT_WR)
+            chunks: list[bytes] = []
+            while True:
+                chunk = sock.recv(65536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+        reply = _parse_response(b"".join(chunks))
+        ok = reply.get("Ok")
+        if isinstance(ok, Mapping):
+            picked = ok.get("PickedColor")
+            if isinstance(picked, Mapping):
+                rgb = picked.get("rgb")
+                if isinstance(rgb, list) and len(rgb) == 3:
+                    return (
+                        max(0, min(255, round(float(rgb[0]) * 255))),
+                        max(0, min(255, round(float(rgb[1]) * 255))),
+                        max(0, min(255, round(float(rgb[2]) * 255))),
+                    )
+        return None
+    except OSError as exc:
+        log.info("Niri PickColor failed: %s", exc)
+        return None
+
+
+class NiriScreenCaptureService(ScreenCaptureService):
+    """ScreenCaptureService using Niri's native ``PickColor`` IPC."""
+
+    def __init__(self, socket_path: str, *, timeout: float = 10.0) -> None:
+        self._socket_path = socket_path
+        self._timeout = timeout
+
+    def start(self) -> None:
+        """No persistent state."""
+
+    def stop(self) -> None:
+        """No persistent state."""
+
+    def pick_color(self, *, x: int, y: int) -> tuple[int, int, int] | None:
+        del x, y  # Niri's interactive picker ignores coordinates.
+        return niri_pick_color(socket_path=self._socket_path, timeout=self._timeout)
+
+
+# ---------------------------------------------------------------------------
+# Preview service
+# ---------------------------------------------------------------------------
+
+
+class NiriPreviewService(PreviewService):
+    """PreviewService backed by Niri's ``ScreenshotWindow`` IPC action.
+
+    Each capture opens a short-lived connection to ``$NIRI_SOCKET``, sends a
+    ``ScreenshotWindow`` action with a temporary file path, reads the
+    resulting PNG from disk, and returns a scaled :class:`PreviewImage`.
+    """
+
+    def __init__(self, *, socket_path: str, timeout: float = 2.0) -> None:
+        self._socket_path = socket_path
+        self._timeout = timeout
+
+    # -- Service ---------------------------------------------------------------
+
+    def start(self) -> None:
+        """No persistent state to initialise."""
+
+    def stop(self) -> None:
+        """No persistent state to tear down."""
+
+    # -- PreviewService --------------------------------------------------------
+
+    def capture(
+        self, window_id: WindowId, *, width: int, height: int
+    ) -> PreviewImage | None:
+        return self._capture_impl(window_id, width=width, height=height)
+
+    def thumbnail(
+        self, window_id: WindowId, *, width: int, height: int
+    ) -> PreviewImage | None:
+        return self._capture_impl(window_id, width=width, height=height)
+
+    # -- Internal ---------------------------------------------------------------
+
+    def _capture_impl(
+        self, window_id: WindowId, *, width: int, height: int
+    ) -> PreviewImage | None:
+        if window_id.backend is not DisplayServer.WAYLAND:
+            return None
+        niri_id = _niri_window_id(window_id)
+        if niri_id is None:
+            return None
+
+        tmp_path = None
+        try:
+            tmp_fd, tmp_path = tempfile.mkstemp(
+                suffix=".png", prefix="docking-niri-preview-"
+            )
+            os.close(tmp_fd)
+
+            payload = {
+                "Action": {
+                    "ScreenshotWindow": {
+                        "id": niri_id,
+                        "write_to_disk": True,
+                        "show_pointer": False,
+                        "path": tmp_path,
+                    }
+                }
+            }
+            raw = json.dumps(payload, separators=(",", ":"))
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.settimeout(self._timeout)
+                sock.connect(self._socket_path)
+                sock.sendall((raw + "\n").encode("utf-8"))
+                sock.shutdown(socket.SHUT_WR)
+                # Drain the response (screenshot is async; the file
+                # won't be ready until the compositor finishes writing).
+                _drain_socket(sock)
+
+            # Wait for the compositor to write the screenshot file.
+            if not _wait_for_nonempty_file(tmp_path, timeout=self._timeout):
+                return None
+
+            # Load the PNG from disk.
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file(tmp_path)
+            if pixbuf is None:
+                return None
+
+            scaled = pixbuf.scale_simple(width, height, GdkPixbuf.InterpType.BILINEAR)
+            image = scaled if scaled is not None else pixbuf
+            return PreviewImage(
+                image=image,
+                width=int(image.get_width()),
+                height=int(image.get_height()),
+            )
+        except OSError as exc:
+            log.info("Niri preview capture failed for window %s: %s", niri_id, exc)
+            return None
+        finally:
+            if tmp_path is not None:
+                with suppress(OSError):
+                    Path(tmp_path).unlink()
+
+
+def _drain_socket(sock: socket.socket) -> None:
+    """Read and discard any remaining data from *sock*."""
+    try:
+        while True:
+            chunk = sock.recv(65536)
+            if not chunk:
+                break
+    except OSError:
+        pass
+
+
+def _wait_for_nonempty_file(path: str, *, timeout: float = 2.0) -> bool:
+    """Poll *path* until it exists and has non-zero size, or *timeout* expires."""
+    import time
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            st = Path(path).stat()
+            if st.st_size > 0:
+                return True
+        except OSError:
+            pass
+        time.sleep(0.05)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Parse helpers — internal
+# ---------------------------------------------------------------------------
+
+
+def _parse_response(raw: bytes) -> dict[str, Any]:
+    """Parse one reply line from Niri IPC into a dict."""
+    text = raw.decode("utf-8", errors="replace").strip()
+    if not text:
+        return {}
+    return json.loads(text)  # type: ignore[no-any-return]
+
+
+def _parse_event_line(line: str) -> NiriEvent | None:
+    """Parse one event-stream line into a ``NiriEvent``."""
+    stripped = line.strip()
+    if not stripped:
+        return None
+    try:
+        obj = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(obj, Mapping) or len(obj) != 1:
+        return None
+    # The first ``{"Ok":"Handled"}`` acknowledgement is not a real event.
+    if "Ok" in obj:
+        return None
+    (name, data_raw) = next(iter(obj.items()))
+    if not isinstance(name, str):
+        return None
+    data = dict(data_raw) if isinstance(data_raw, Mapping) else {}
+    return NiriEvent(name=name, data=data)
+
+
+def _record_from_window(
+    item: Mapping[str, Any],
+    *,
+    matcher: WaylandAppIdMatcher,
+) -> NiriWindowRecord | None:
+    window_id = item.get("id")
+    if not isinstance(window_id, int):
+        return None
+    app_id = str(item.get("app_id") or "").strip()
+    desktop_id = matcher.match(app_id) if app_id else None
+    workspace_id = item.get("workspace_id")
+    if not isinstance(workspace_id, int):
+        workspace_id = None
+    geometry = _geometry_from_niri_window(item)
+    return NiriWindowRecord(
+        id=window_id,
+        title=str(item.get("title") or "Window"),
+        app_id=app_id,
+        desktop_id=desktop_id,
+        active=bool(item.get("is_focused", False)),
+        urgent=bool(item.get("is_urgent", False)),
+        workspace_id=workspace_id,
+        geometry=geometry,
+    )
+
+
+def _geometry_from_niri_window(item: Mapping[str, Any]) -> Rect | None:
+    """Extract window geometry from Niri's layout fields.
+
+    Niri windows don't have a single global ``(x, y, w, h)`` since they're
+    tiled.  We derive an approximate geometry from the tiling layout:
+    ``tile_pos_in_workspace_view`` + ``window_size`` when available.
+    """
+    layout = item.get("layout")
+    if not isinstance(layout, Mapping):
+        return None
+    size = layout.get("window_size")
+    if not isinstance(size, Sequence) or isinstance(size, str | bytes) or len(size) < 2:
+        return None
+    try:
+        w = int(size[0])
+        h = int(size[1])
+    except (TypeError, ValueError):
+        return None
+    pos = layout.get("tile_pos_in_workspace_view")
+    if isinstance(pos, Sequence) and not isinstance(pos, str | bytes) and len(pos) >= 2:
+        try:
+            x = int(pos[0])
+            y = int(pos[1])
+        except (TypeError, ValueError):
+            x, y = 0, 0
+    else:
+        x, y = 0, 0
+    return Rect(x=x, y=y, width=w, height=h)
+
+
+def _niri_window_id(window_id: WindowId) -> int | None:
+    """Extract a Niri numeric window id from a backend-neutral ``WindowId``."""
+    if window_id.backend is not DisplayServer.WAYLAND:
+        return None
+    try:
+        return int(window_id.value)
+    except (TypeError, ValueError):
+        return None

--- a/docking/platform/backends/wayland/niri_session.py
+++ b/docking/platform/backends/wayland/niri_session.py
@@ -1,0 +1,214 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Niri session backend with layer-shell surfaces and IPC window state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from docking.platform.backends.base import (
+    DesktopActionService,
+    DisplayServer,
+    IdleService,
+    PlatformCapabilities,
+    PreviewService,
+    ScreenCaptureService,
+    SessionBackend,
+    SurfaceService,
+    VisibilityService,
+    WindowPickService,
+    WindowService,
+    WorkspaceService,
+)
+from docking.platform.backends.reduced.services import (
+    ReducedPreviewService,
+    ReducedVisibilityService,
+    ReducedWindowService,
+)
+from docking.platform.backends.wayland.niri_ipc import (
+    NiriScreenCaptureService,
+    NiriWindowService,
+    _niri_socket_path,
+    load_niri_preview_service,
+    load_niri_window_service,
+)
+from docking.platform.backends.wayland.portals import (
+    WaylandPortalColorPickerService,
+    load_portal_color_picker,
+)
+from docking.platform.backends.wayland.runtime import WaylandProtocolRuntime
+from docking.platform.backends.wayland.services import WaylandLayerShellSurfaceService
+from docking.platform.backends.wayland.workspaces import WaylandWorkspaceService
+
+if TYPE_CHECKING:
+    from docking.platform.launcher import Launcher
+    from docking.platform.model import DockModel
+
+
+@dataclass(frozen=True)
+class NiriRuntimeServices:
+    """Concrete services selected for the Niri Wayland backend."""
+
+    windows: WindowService
+    previews: PreviewService
+    surface: WaylandLayerShellSurfaceService
+    visibility: ReducedVisibilityService
+    workspaces: WorkspaceService | None
+    screen_capture: ScreenCaptureService | None
+    protocol_runtime: WaylandProtocolRuntime | None
+
+
+class NiriSessionBackend(SessionBackend):
+    """SessionBackend using Niri IPC for windows and layer-shell surfaces."""
+
+    def __init__(
+        self,
+        *,
+        layer_shell: object,
+        model: DockModel,
+        launcher: Launcher,
+        protocol_runtime: WaylandProtocolRuntime | None = None,
+        screen_capture: ScreenCaptureService | None = None,
+        window_service: WindowService | None = None,
+    ) -> None:
+        runtime = protocol_runtime
+        if runtime is None:
+            candidate_runtime = WaylandProtocolRuntime()
+            if candidate_runtime.start():
+                runtime = candidate_runtime
+
+        windows = window_service or load_niri_window_service(
+            model=model,
+            launcher=launcher,
+        )
+        if windows is None:
+            windows = ReducedWindowService()
+
+        workspace_protocol = runtime.workspace_protocol if runtime is not None else None
+        workspaces = (
+            WaylandWorkspaceService(protocol=workspace_protocol)
+            if workspace_protocol is not None
+            else None
+        )
+
+        niri_previews = load_niri_preview_service()
+        previews: PreviewService = niri_previews or ReducedPreviewService()
+
+        # Prefer Niri's native PickColor IPC over the XDG desktop portal.
+        if screen_capture is None:
+            socket_path = _niri_socket_path()
+            if socket_path is not None and socket_path.exists():
+                screen_capture = NiriScreenCaptureService(socket_path=str(socket_path))
+            else:
+                screen_capture = load_portal_color_picker()
+
+        self._services = NiriRuntimeServices(
+            windows=windows,
+            previews=previews,
+            surface=WaylandLayerShellSurfaceService(layer_shell=layer_shell),
+            visibility=ReducedVisibilityService(),
+            workspaces=workspaces,
+            screen_capture=screen_capture,
+            protocol_runtime=runtime,
+        )
+
+    @property
+    def name(self) -> str:
+        return "niri"
+
+    @property
+    def display_server(self) -> DisplayServer:
+        return DisplayServer.WAYLAND
+
+    @property
+    def capabilities(self) -> PlatformCapabilities:
+        tracks_windows = isinstance(self._services.windows, NiriWindowService)
+        supports_workspaces = self._services.workspaces is not None
+        supports_color_pick = isinstance(
+            self._services.screen_capture,
+            (WaylandPortalColorPickerService, NiriScreenCaptureService),
+        )
+        return PlatformCapabilities(
+            tracks_windows=tracks_windows,
+            tracks_active_window=tracks_windows,
+            tracks_attention=tracks_windows,
+            tracks_minimized=False,  # Niri is a tiling compositor
+            tracks_fullscreen=False,
+            supports_activate=tracks_windows,
+            supports_minimize=False,  # Niri is a tiling compositor
+            supports_close=tracks_windows,
+            tracks_window_geometry=tracks_windows,
+            tracks_window_workspace=tracks_windows,
+            supports_current_workspace_filter=tracks_windows,
+            supports_workspace_list=supports_workspaces,
+            supports_workspace_switch=supports_workspaces,
+            supports_layer_shell=True,
+            supports_screen_reservation=True,
+            supports_input_region=True,
+            supports_screen_color_pick=supports_color_pick,
+        )
+
+    @property
+    def windows(self) -> WindowService:
+        return self._services.windows
+
+    @property
+    def surface(self) -> SurfaceService:
+        return self._services.surface
+
+    @property
+    def visibility(self) -> VisibilityService:
+        return self._services.visibility
+
+    @property
+    def previews(self) -> PreviewService:
+        return self._services.previews
+
+    @property
+    def workspaces(self) -> WorkspaceService | None:
+        return self._services.workspaces
+
+    @property
+    def desktop_actions(self) -> DesktopActionService | None:
+        return None
+
+    @property
+    def screen_capture(self) -> ScreenCaptureService | None:
+        return self._services.screen_capture
+
+    @property
+    def idle(self) -> IdleService | None:
+        return None
+
+    @property
+    def window_picker(self) -> WindowPickService | None:
+        return None
+
+    def start(self) -> None:
+        self._services.previews.start()
+        self._services.windows.start()
+        self._services.surface.start()
+        self._services.visibility.start()
+        if self._services.workspaces is not None:
+            self._services.workspaces.start()
+        if self._services.screen_capture is not None:
+            self._services.screen_capture.start()
+
+    def stop(self) -> None:
+        if self._services.screen_capture is not None:
+            self._services.screen_capture.stop()
+        if self._services.workspaces is not None:
+            self._services.workspaces.stop()
+        self._services.visibility.stop()
+        self._services.surface.stop()
+        self._services.windows.stop()
+        self._services.previews.stop()
+        if self._services.protocol_runtime is not None:
+            self._services.protocol_runtime.stop()

--- a/docs/WAYLAND.md
+++ b/docs/WAYLAND.md
@@ -85,10 +85,11 @@ availability, optional helper tools, monitors, and a copyable Markdown report.
 **Auto-detection order on native Wayland:**
 
 1. COSMIC (if `XDG_CURRENT_DESKTOP=COSMIC`)
-2. KWin / KDE Plasma 6 (if `XDG_CURRENT_DESKTOP=KDE`)
-3. Generic layer-shell (if the compositor advertises `zwlr_layer_shell_v1`)
-4. GNOME Shell bridge (if the bridge D-Bus service is available)
-5. Reduced (fallback)
+2. Niri (if `XDG_CURRENT_DESKTOP=niri`)
+3. KWin / KDE Plasma 6 (if `XDG_CURRENT_DESKTOP=KDE`)
+4. Generic layer-shell (if the compositor advertises `zwlr_layer_shell_v1`)
+5. GNOME Shell bridge (if the bridge D-Bus service is available)
+6. Reduced (fallback)
 
 **Manual override** via `DOCKING_BACKEND`:
 
@@ -97,6 +98,7 @@ DOCKING_BACKEND=x11          # Force X11 backend
 DOCKING_BACKEND=cosmic       # Force COSMIC backend
 DOCKING_BACKEND=kwin         # Force KWin backend
 DOCKING_BACKEND=wayland      # Force generic layer-shell backend
+DOCKING_BACKEND=niri         # Force Niri IPC backend
 DOCKING_BACKEND=hyprland     # Force Hyprland backend
 DOCKING_BACKEND=gnome-shell  # Force GNOME Shell bridge backend
 DOCKING_BACKEND=reduced      # Force reduced (launcher-only) backend
@@ -180,6 +182,36 @@ to avoid stalling the compositor.
 | Applets | ✓ | Backend-neutral applets work |
 
 Launch: `DOCKING_BACKEND=hyprland python3 run.py`
+
+---
+
+### Niri
+
+**Backend:** `wayland/niri_session.py` + `wayland/niri_ipc.py`
+**Auto-detected:** Yes, when desktop detection reports Niri
+**Status:** IPC-based window tracking, actions, and layer-shell placement
+
+Uses Niri's JSON IPC socket (`$NIRI_SOCKET`) for live window state and
+short-lived request/response calls for actions. The event stream delivers
+full current state up-front followed by incremental events — no polling needed.
+
+| Capability | Status | Mechanism |
+| --- | --- | --- |
+| Edge placement / exclusive zone | ✓ | `zwlr_layer_shell_v1` via `gtk-layer-shell` |
+| Running indicators / active state | ✓ | Event stream (`WindowsChanged`, `WindowOpenedOrChanged`, `WindowFocusChanged`) |
+| Window actions (focus, close, fullscreen) | ✓ | Action requests (`FocusWindow`, `CloseWindow`, `FullscreenWindow`) via IPC |
+| Workspace listing / switching | ✓ | Workspace protocol when available; window workspace state via IPC |
+| Overlap-driven autohide | ✗ | Not available (tiling compositor) |
+| Window previews | ✓ | `ScreenshotWindow` IPC action → temp-file PNG capture |
+| Color Picker | ✓ | Native `PickColor` IPC request |
+| Applets | ✓ | Backend-neutral applets work |
+
+Niri is a tiling compositor without a traditional minimize concept, so
+`minimize_all` returns `UNSUPPORTED`. Close, focus, and fullscreen actions
+work for windows tracked via IPC. The ``OverviewOpenedOrClosed`` event is
+tracked and exposed via ``NiriWindowService.is_overview_open``.
+
+Launch: `DOCKING_BACKEND=niri python3 run.py`
 
 ---
 
@@ -273,22 +305,24 @@ Launch: `DOCKING_BACKEND=reduced python3 run.py`
 
 ## Feature Support Matrix
 
-| Feature | X11 | COSMIC | Hyprland | KWin 6 | wlroots | GNOME Shell bridge | Reduced |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| Edge reservation (struts/exclusive zone) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
-| Running indicators | ✓ | ✓ | ✓ | ~ | ✓ | ✓ | ✗ |
-| Active window tracking | ✓ | ✓ | ✓ | ~ | ✓ | ✓ | ✗ |
-| Window actions (focus, close, minimize) | ✓ | ✓ | ✓ | ~ | ✓ | ✓ | ✗ |
-| Window previews | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Workspaces | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
-| Overlap-driven autohide | ✓ | ✓ | ~ | ✗ | ✗ | ✗ | ✗ |
-| Pointer barriers | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Background blur hint | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Window Killer | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Pinned launchers | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Backend-neutral applets | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Color Picker | ✓ | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✗ | ✗ |
-| Screenshot | ✓ | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✓ (portal) |
+| Feature | X11 | COSMIC | Hyprland | Niri | KWin 6 | wlroots | GNOME Shell bridge | Reduced |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Edge reservation (struts/exclusive zone) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| Running indicators | ✓ | ✓ | ✓ | ✓ | ~ | ✓ | ✓ | ✗ |
+| Active window tracking | ✓ | ✓ | ✓ | ✓ | ~ | ✓ | ✓ | ✗ |
+| Window actions (focus, close, minimize) | ✓ | ✓ | ✓ | ✓¹ | ~ | ✓ | ✓ | ✗ |
+| Window previews | ✓ | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ |
+| Workspaces | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| Overlap-driven autohide | ✓ | ✓ | ~ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Pointer barriers | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Background blur hint | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Window Killer | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Pinned launchers | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Backend-neutral applets | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Color Picker | ✓ | ✓ (portal) | ✓ (portal) | ✓ (IPC) | ✓ (portal) | ✓ (portal) | ✗ | ✗ |
+| Screenshot | ✓ | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✓ (portal) | ✓ (portal) |
+
+¹ Niri is a tiling compositor — focus and close work, minimize is unsupported.
 
 Legend: ✓ = supported, ~ = partial, ✗ = unavailable
 
@@ -2982,8 +3016,8 @@ These questions were answered through implementation:
   `ipc` plugin and companion plugins (`ipc-rules`, `wm-actions`) which vary
   by user configuration.
 
-- **Niri IPC backend** — not yet implemented. Niri has a clean JSON IPC
-  contract well-suited to a taskbar backend.
+- **Niri IPC backend** — implemented. Uses Niri's JSON IPC socket for window
+  tracking and actions with event-stream updates.
 
 - **Multi-monitor behavior** on non-X11 backends needs broader testing.
 
@@ -3003,6 +3037,8 @@ When documenting Wayland support publicly, avoid ambiguous statements like
   window actions, workspaces, overlap-driven autohide, preview image capture
 - **Hyprland native Wayland:** IPC-based window tracking, actions, and
   workspaces
+- **Niri native Wayland:** IPC-based window tracking, actions, and
+  layer-shell placement
 - **KDE Plasma 6 native Wayland:** layer-shell placement and workspace support;
   window tracking is limited (AT-SPI best-effort)
 - **Generic wlroots native Wayland** (Sway, river, labwc): layer-shell placement;
@@ -3029,8 +3065,8 @@ implemented as:
 Remaining compositor integration work:
 
 - **Wayfire** — IPC backend not yet implemented (plugin-dependent)
-- **Niri** — clean JSON IPC contract, well-suited to a taskbar backend;
-  not yet implemented
+- **Niri** — implemented; JSON IPC for window tracking, actions, and
+  event-stream updates
 - **GNOME Shell frontend** — the bridge provides window/workspace state and
   actions; a full GNOME Shell frontend (shell-owned dock surface, overview
   integration) would be a separate project comparable to Dash to Dock
@@ -3767,7 +3803,7 @@ its startup is guarded so Wnck screen signals are not connected twice.
 
 The PR sequence below was designed to keep every step reviewable and preserve
 the existing X11 runtime after each merge. All PRs 1-18 and sub-PRs 19a-c,
-19e-f are merged. Wayfire (19d) and Niri remain unimplemented.
+19e-f are merged. Wayfire (19d) remains unimplemented.
 
 #### PR Summary
 
@@ -3800,7 +3836,7 @@ platform-specific behavior behind backend contracts.
 | 19e | GNOME bridge | GNOME Shell extension (`extension.js`) + Python `GnomeShellBridgeSessionBackend`; D-Bus window/workspace/action bridge |
 | 19f | — | Extension loads, D-Bus state export, backend integration complete |
 
-**Not yet implemented:** Wayfire IPC backend (PR 19d), Niri IPC backend.
+**Not yet implemented:** Wayfire IPC backend (PR 19d).
 
 ### Advance Research Findings Before More Wayland Work
 

--- a/tests/platform/test_backend_selection.py
+++ b/tests/platform/test_backend_selection.py
@@ -41,6 +41,8 @@ def test_create_session_backend_selects_reduced_for_non_x11_without_x11_import(
     monkeypatch.delenv("DOCKING_BACKEND", raising=False)
     monkeypatch.setattr(selection, "is_x11_backend", lambda: False)
     monkeypatch.setattr(selection, "is_wayland_session", lambda: True)
+    monkeypatch.setattr(selection, "detect_desktop", lambda: selection.Desktop.UNKNOWN)
+    monkeypatch.setattr(selection, "is_kde_session", lambda: False)
     monkeypatch.setattr(selection, "backend_name", lambda: "GdkWayland.WaylandDisplay")
     monkeypatch.setattr(
         selection, "_create_wayland_layer_shell_backend", lambda **_: None
@@ -69,6 +71,8 @@ def test_create_session_backend_selects_reduced_for_non_x11_without_x11_import(
 def test_create_session_backend_selects_layer_shell_for_supported_wayland(monkeypatch):
     monkeypatch.delenv("DOCKING_BACKEND", raising=False)
     monkeypatch.setattr(selection, "is_x11_backend", lambda: False)
+    monkeypatch.setattr(selection, "detect_desktop", lambda: selection.Desktop.UNKNOWN)
+    monkeypatch.setattr(selection, "is_kde_session", lambda: False)
     backend = MagicMock(name="wayland-layer-shell")
     create_wayland = MagicMock(return_value=backend)
     monkeypatch.setattr(
@@ -90,6 +94,8 @@ def test_create_session_backend_selects_gnome_bridge_after_layer_shell_fallback(
 ):
     monkeypatch.delenv("DOCKING_BACKEND", raising=False)
     monkeypatch.setattr(selection, "is_x11_backend", lambda: False)
+    monkeypatch.setattr(selection, "detect_desktop", lambda: selection.Desktop.UNKNOWN)
+    monkeypatch.setattr(selection, "is_kde_session", lambda: False)
     monkeypatch.setattr(
         selection, "_create_wayland_layer_shell_backend", lambda **_: None
     )
@@ -190,3 +196,48 @@ def test_create_session_backend_can_force_x11_backend(monkeypatch):
 
     assert result is backend
     backend_cls.assert_called_once_with(model=model, launcher=launcher, config=config)
+
+
+def test_create_session_backend_can_force_niri_backend(monkeypatch):
+    monkeypatch.setenv("DOCKING_BACKEND", "niri")
+    monkeypatch.setattr(selection, "is_x11_backend", lambda: True)
+    backend = MagicMock(name="niri")
+    create_niri = MagicMock(return_value=backend)
+    monkeypatch.setattr(selection, "_create_niri_backend", create_niri)
+
+    result = selection.create_session_backend(
+        config=MagicMock(),
+        launcher=MagicMock(),
+        model=MagicMock(),
+    )
+
+    assert result is backend
+    create_niri.assert_called_once()
+
+
+def test_create_session_backend_auto_selects_niri_before_generic_wayland(
+    monkeypatch,
+):
+    monkeypatch.delenv("DOCKING_BACKEND", raising=False)
+    monkeypatch.setattr(selection, "is_x11_backend", lambda: False)
+    monkeypatch.setattr(selection, "detect_desktop", lambda: selection.Desktop.NIRI)
+    monkeypatch.setattr(selection, "is_kde_session", lambda: False)
+    backend = MagicMock(name="niri")
+    create_niri = MagicMock(return_value=backend)
+    create_wayland = MagicMock()
+    monkeypatch.setattr(selection, "_create_niri_backend", create_niri)
+    monkeypatch.setattr(
+        selection,
+        "_create_wayland_layer_shell_backend",
+        create_wayland,
+    )
+
+    result = selection.create_session_backend(
+        config=MagicMock(),
+        launcher=MagicMock(),
+        model=MagicMock(),
+    )
+
+    assert result is backend
+    create_niri.assert_called_once()
+    create_wayland.assert_not_called()

--- a/tests/platform/test_niri_ipc.py
+++ b/tests/platform/test_niri_ipc.py
@@ -1,0 +1,610 @@
+"""Tests for Niri IPC helpers, window service, and preview service."""
+
+from __future__ import annotations
+
+import os
+import socket
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from docking.platform.backends.base import (
+    ActionResult,
+    DisplayServer,
+    WindowId,
+)
+from docking.platform.backends.wayland.niri_ipc import (
+    NiriEvent,
+    NiriPreviewService,
+    NiriWindowService,
+    _niri_socket_path,
+    _parse_event_line,
+    _parse_response,
+    _wait_for_nonempty_file,
+    load_niri_preview_service,
+)
+
+
+def _launcher() -> SimpleNamespace:
+    resolved = {
+        "Alacritty.desktop": SimpleNamespace(desktop_id="Alacritty.desktop"),
+        "firefox.desktop": SimpleNamespace(desktop_id="firefox.desktop"),
+    }
+    return SimpleNamespace(
+        resolve=MagicMock(side_effect=lambda desktop_id, **_: resolved.get(desktop_id)),
+        resolve_by_wm_class=MagicMock(return_value=None),
+    )
+
+
+def _model() -> SimpleNamespace:
+    return SimpleNamespace(
+        visible_items=MagicMock(
+            return_value=[
+                SimpleNamespace(desktop_id="Alacritty.desktop", wm_class="Alacritty"),
+                SimpleNamespace(desktop_id="firefox.desktop", wm_class="firefox"),
+            ]
+        ),
+        update_running=MagicMock(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Socket path detection
+# ---------------------------------------------------------------------------
+
+
+def test_niri_socket_path_from_environment():
+    path = _niri_socket_path({"NIRI_SOCKET": "/run/user/1000/niri.sock"})
+    assert path is not None
+    assert str(path) == "/run/user/1000/niri.sock"
+
+
+def test_niri_socket_path_missing_environment():
+    assert _niri_socket_path({}) is None
+
+
+def test_niri_socket_path_empty_value():
+    assert _niri_socket_path({"NIRI_SOCKET": ""}) is None
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_ok_response():
+    result = _parse_response(
+        b'{"Ok":{"Windows":[{"id":1,"title":"Terminal","app_id":"Alacritty",'
+        b'"is_focused":true,"is_urgent":false}]}}'
+    )
+    assert "Ok" in result
+    assert "Windows" in result["Ok"]
+    assert len(result["Ok"]["Windows"]) == 1
+    assert result["Ok"]["Windows"][0]["title"] == "Terminal"
+
+
+def test_parse_error_response():
+    result = _parse_response(b'{"Err":"something went wrong"}')
+    assert "Err" in result
+    assert result["Err"] == "something went wrong"
+
+
+def test_parse_empty_response():
+    assert _parse_response(b"") == {}
+    assert _parse_response(b"   ") == {}
+
+
+# ---------------------------------------------------------------------------
+# Event parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_event_line():
+    event = _parse_event_line(
+        '{"WindowOpenedOrChanged":{"window":{"id":5,"title":"Firefox",'
+        '"app_id":"firefox","is_focused":false,"is_urgent":false}}}'
+    )
+
+    assert event is not None
+    assert event.name == "WindowOpenedOrChanged"
+    assert event.data["window"]["id"] == 5
+    assert event.data["window"]["title"] == "Firefox"
+
+
+def test_parse_event_ignores_ok_ack():
+    assert _parse_event_line('{"Ok":"Handled"}') is None
+
+
+def test_parse_event_ignores_empty():
+    assert _parse_event_line("") is None
+    assert _parse_event_line("   ") is None
+
+
+def test_parse_event_ignores_invalid_json():
+    assert _parse_event_line("not-json-at-all") is None
+
+
+# ---------------------------------------------------------------------------
+# Fake IPC client for tests
+# ---------------------------------------------------------------------------
+
+
+class FakeIpcClient:
+    def __init__(self, snapshots: list[list[dict]]) -> None:
+        self._snapshots = snapshots
+        self._call_count = 0
+        self.actions: list[dict] = []
+
+    def ok_data(self, payload: object, key: str):
+        if self._call_count < len(self._snapshots):
+            result = self._snapshots[self._call_count]
+            self._call_count += 1
+            return result
+        return None
+
+    def action(self, action_payload: dict) -> ActionResult:
+        self.actions.append(action_payload)
+        return ActionResult.OK
+
+
+class FakeEventStream:
+    def __init__(self, callback) -> None:
+        self.callback = callback
+        self.started = False
+        self.stopped = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    def emit(self, name: str, data: dict) -> None:
+        self.callback(NiriEvent(name=name, data=data))
+
+
+# ---------------------------------------------------------------------------
+# Window service tests
+# ---------------------------------------------------------------------------
+
+
+def test_niri_window_service_publishes_snapshot_and_actions():
+    model = _model()
+    client = FakeIpcClient(
+        [
+            [
+                {
+                    "id": 5,
+                    "title": "Terminal",
+                    "app_id": "Alacritty",
+                    "workspace_id": 1,
+                    "is_focused": True,
+                    "is_urgent": False,
+                    "layout": {
+                        "window_size": [800, 600],
+                        "tile_pos_in_workspace_view": [10.0, 20.0],
+                    },
+                }
+            ],
+        ]
+    )
+    service = NiriWindowService(
+        model=model,
+        launcher=_launcher(),
+        client=client,
+    )
+
+    service.start()
+
+    windows = service.list_windows("Alacritty.desktop")
+    assert len(windows) == 1
+    assert windows[0].id == WindowId(DisplayServer.WAYLAND, "5")
+    assert windows[0].title == "Terminal"
+    assert windows[0].active is True
+    assert windows[0].geometry is not None
+    assert windows[0].geometry.x == 10
+    assert windows[0].geometry.y == 20
+    assert windows[0].geometry.width == 800
+    assert windows[0].geometry.height == 600
+    assert windows[0].workspace_id == "1"
+    assert windows[0].can_minimize is False  # tiling compositor
+    assert windows[0].can_close is True
+    assert windows[0].can_activate is True
+    model.update_running.assert_called()
+
+    assert service.activate(windows[0].id) is ActionResult.OK
+    assert client.actions[-1] == {"FocusWindow": {"id": 5}}
+
+    assert service.close(windows[0].id) is ActionResult.OK
+    assert client.actions[-1] == {"CloseWindow": {"id": 5}}
+
+
+def test_niri_window_service_minimize_unsupported():
+    client = FakeIpcClient(
+        [
+            [
+                {
+                    "id": 1,
+                    "title": "App",
+                    "app_id": "Alacritty",
+                    "is_focused": True,
+                    "is_urgent": False,
+                }
+            ]
+        ]
+    )
+    service = NiriWindowService(
+        model=_model(),
+        launcher=_launcher(),
+        client=client,
+    )
+    service.start()
+
+    _windows = service.list_windows("Alacritty.desktop")
+    assert service.minimize_all("Alacritty.desktop") is ActionResult.UNSUPPORTED
+
+
+def test_niri_window_service_ignores_other_backend_window_ids():
+    client = FakeIpcClient([[]])
+    service = NiriWindowService(
+        model=_model(),
+        launcher=_launcher(),
+        client=client,
+    )
+    service.start()
+
+    assert service.activate(WindowId.x11(1)) is ActionResult.NOT_FOUND
+    assert service.close(WindowId.x11(1)) is ActionResult.NOT_FOUND
+
+
+def test_niri_window_service_refreshes_on_event():
+    model = _model()
+    streams: list[FakeEventStream] = []
+    client = FakeIpcClient([[]])
+
+    def stream_factory(callback):
+        stream = FakeEventStream(callback)
+        streams.append(stream)
+        return stream
+
+    service = NiriWindowService(
+        model=model,
+        launcher=_launcher(),
+        client=client,
+        event_stream_factory=stream_factory,
+    )
+
+    service.start()
+    assert streams[0].started is True
+    assert service.list_windows("firefox.desktop") == ()
+
+    # Simulate a window appearing via event stream.
+    streams[0].emit(
+        "WindowOpenedOrChanged",
+        {
+            "window": {
+                "id": 42,
+                "title": "Firefox",
+                "app_id": "firefox",
+                "workspace_id": 1,
+                "is_focused": True,
+                "is_urgent": False,
+            }
+        },
+    )
+
+    windows = service.list_windows("firefox.desktop")
+    assert len(windows) == 1
+    assert windows[0].title == "Firefox"
+    assert windows[0].active is True
+
+    # Simulate the window closing.
+    streams[0].emit("WindowClosed", {"id": 42})
+    assert service.list_windows("firefox.desktop") == ()
+
+    service.stop()
+    assert streams[0].stopped is True
+
+
+def test_niri_window_service_handles_windows_changed_full_replacement():
+    model = _model()
+    streams: list[FakeEventStream] = []
+    client = FakeIpcClient([[]])
+
+    def stream_factory(callback):
+        stream = FakeEventStream(callback)
+        streams.append(stream)
+        return stream
+
+    service = NiriWindowService(
+        model=model,
+        launcher=_launcher(),
+        client=client,
+        event_stream_factory=stream_factory,
+    )
+
+    service.start()
+
+    # WindowsChanged delivers a full replacement.
+    streams[0].emit(
+        "WindowsChanged",
+        {
+            "windows": [
+                {
+                    "id": 1,
+                    "title": "Terminal",
+                    "app_id": "Alacritty",
+                    "workspace_id": 1,
+                    "is_focused": True,
+                    "is_urgent": False,
+                },
+                {
+                    "id": 2,
+                    "title": "Firefox",
+                    "app_id": "firefox",
+                    "workspace_id": 1,
+                    "is_focused": False,
+                    "is_urgent": False,
+                },
+            ]
+        },
+    )
+
+    assert len(service.list_windows("Alacritty.desktop")) == 1
+    assert len(service.list_windows("firefox.desktop")) == 1
+
+    # A second WindowsChanged replaces everything.
+    streams[0].emit(
+        "WindowsChanged",
+        {
+            "windows": [
+                {
+                    "id": 3,
+                    "title": "New Window",
+                    "app_id": "firefox",
+                    "workspace_id": 2,
+                    "is_focused": True,
+                    "is_urgent": False,
+                },
+            ]
+        },
+    )
+
+    assert service.list_windows("Alacritty.desktop") == ()
+    assert len(service.list_windows("firefox.desktop")) == 1
+    assert service.list_windows("firefox.desktop")[0].title == "New Window"
+
+    service.stop()
+
+
+def test_niri_window_service_handles_focus_change():
+    model = _model()
+    streams: list[FakeEventStream] = []
+    client = FakeIpcClient(
+        [
+            [
+                {
+                    "id": 1,
+                    "title": "Terminal",
+                    "app_id": "Alacritty",
+                    "is_focused": False,
+                    "is_urgent": False,
+                },
+                {
+                    "id": 2,
+                    "title": "Firefox",
+                    "app_id": "firefox",
+                    "is_focused": True,
+                    "is_urgent": False,
+                },
+            ]
+        ]
+    )
+
+    def stream_factory(callback):
+        stream = FakeEventStream(callback)
+        streams.append(stream)
+        return stream
+
+    service = NiriWindowService(
+        model=model,
+        launcher=_launcher(),
+        client=client,
+        event_stream_factory=stream_factory,
+    )
+
+    service.start()
+
+    # Initially Firefox is focused.
+    windows = service.list_windows("Alacritty.desktop")
+    assert windows[0].active is False
+    firefox = service.list_windows("firefox.desktop")
+    assert firefox[0].active is True
+
+    # Focus changes to Alacritty.
+    streams[0].emit("WindowFocusChanged", {"id": 1})
+
+    windows = service.list_windows("Alacritty.desktop")
+    assert windows[0].active is True
+    firefox = service.list_windows("firefox.desktop")
+    assert firefox[0].active is False
+
+    # Focus goes to nothing (id: null).
+    streams[0].emit("WindowFocusChanged", {"id": None})
+
+    windows = service.list_windows("Alacritty.desktop")
+    assert windows[0].active is False
+
+    service.stop()
+
+
+def test_niri_window_service_close_all():
+    client = FakeIpcClient(
+        [
+            [
+                {
+                    "id": 1,
+                    "title": "Firefox Tab 1",
+                    "app_id": "firefox",
+                    "is_focused": True,
+                    "is_urgent": False,
+                },
+                {
+                    "id": 2,
+                    "title": "Firefox Tab 2",
+                    "app_id": "firefox",
+                    "is_focused": False,
+                    "is_urgent": False,
+                },
+            ]
+        ]
+    )
+    service = NiriWindowService(
+        model=_model(),
+        launcher=_launcher(),
+        client=client,
+    )
+    service.start()
+
+    result = service.close_all("firefox.desktop")
+    assert result is ActionResult.OK
+    assert len(client.actions) == 2
+    assert client.actions[0] == {"CloseWindow": {"id": 1}}
+    assert client.actions[1] == {"CloseWindow": {"id": 2}}
+
+
+def test_niri_window_service_close_all_not_found():
+    client = FakeIpcClient([[]])
+    service = NiriWindowService(
+        model=_model(),
+        launcher=_launcher(),
+        client=client,
+    )
+    service.start()
+
+    assert service.close_all("nonexistent.desktop") is ActionResult.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# Preview service tests
+# ---------------------------------------------------------------------------
+
+
+def _fake_socket_factory(response: bytes) -> type[socket.socket]:
+    """Return a socket factory that produces a socket returning *response*."""
+
+    class _FakeSock:
+        def __init__(self, family: int, type: int) -> None:
+            self._response = response
+            self._offset = 0
+            self.settimeout = MagicMock()
+            self.shutdown = MagicMock()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            pass
+
+        def connect(self, path: str) -> None:
+            pass
+
+        def sendall(self, data: bytes) -> None:
+            pass
+
+        def recv(self, bufsize: int) -> bytes:
+            if self._offset >= len(self._response):
+                return b""
+            chunk = self._response[self._offset : self._offset + bufsize]
+            self._offset += bufsize
+            return chunk
+
+    return _FakeSock  # type: ignore[return-value]
+
+
+def test_niri_preview_service_captures_window():
+    """Preview should return a scaled image when the compositor saves a PNG."""
+    import gi
+
+    gi.require_version("GdkPixbuf", "2.0")
+    from gi.repository import GdkPixbuf
+
+    # Create an in-memory test PNG.
+    pixbuf = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, True, 8, 48, 36)
+    pixbuf.fill(0xFF_80_40_FF)  # RGBA
+
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".png", prefix="docking-test-")
+    pixbuf.savev(tmp_path, "png", [], [])
+    # Keep tmp_fd open so _capture_impl can close it without EBADF.
+
+    try:
+        svc = NiriPreviewService(socket_path="/nonexistent/sock")
+
+        with (
+            patch("socket.socket", _fake_socket_factory(b'{"Ok":"Handled"}')),
+            patch(
+                "docking.platform.backends.wayland.niri_ipc._wait_for_nonempty_file",
+                return_value=True,
+            ),
+            patch(
+                "docking.platform.backends.wayland.niri_ipc.tempfile.mkstemp",
+                return_value=(tmp_fd, tmp_path),
+            ),
+        ):
+            img = svc.capture(
+                WindowId(backend=DisplayServer.WAYLAND, value="3"),
+                width=24,
+                height=18,
+            )
+    finally:
+        with __import__("contextlib").suppress(OSError):
+            os.close(tmp_fd)
+        with __import__("contextlib").suppress(OSError):
+            Path(tmp_path).unlink()
+
+    assert img is not None
+    assert img.width == 24
+    assert img.height == 18
+
+
+def test_niri_preview_service_rejects_non_wayland_ids():
+    svc = NiriPreviewService(socket_path="/nonexistent/sock")
+    assert svc.capture(WindowId.x11(1), width=100, height=100) is None
+
+
+def test_niri_preview_service_returns_none_on_socket_error():
+    svc = NiriPreviewService(socket_path="/nonexistent/sock")
+    with patch("socket.socket", side_effect=OSError("connect failed")):
+        img = svc.capture(
+            WindowId(backend=DisplayServer.WAYLAND, value="1"),
+            width=100,
+            height=100,
+        )
+    assert img is None
+
+
+def test_niri_preview_service_start_stop_are_noops():
+    svc = NiriPreviewService(socket_path="/nonexistent/sock")
+    svc.start()
+    svc.stop()  # no exceptions
+
+
+def test_wait_for_nonempty_file_sees_existing_file():
+
+    tmp_fd, tmp_path = tempfile.mkstemp(prefix="docking-test-")
+    os.write(tmp_fd, b"hello")
+    os.close(tmp_fd)
+    try:
+        assert _wait_for_nonempty_file(tmp_path, timeout=0.5) is True
+    finally:
+        Path(tmp_path).unlink()
+
+
+def test_wait_for_nonempty_file_times_out_for_missing_file():
+    assert _wait_for_nonempty_file("/nonexistent/path/12345", timeout=0.1) is False
+
+
+def test_load_niri_preview_service_returns_none_without_env():
+    with patch.dict("os.environ", {}, clear=True):
+        assert load_niri_preview_service() is None

--- a/tests/platform/test_wayland_layer_shell_session.py
+++ b/tests/platform/test_wayland_layer_shell_session.py
@@ -19,6 +19,8 @@ from docking.platform.backends.reduced.services import (
     ReducedVisibilityService,
     ReducedWindowService,
 )
+from docking.platform.backends.wayland.niri_ipc import NiriWindowService
+from docking.platform.backends.wayland.niri_session import NiriSessionBackend
 from docking.platform.backends.wayland.portals import WaylandPortalColorPickerService
 from docking.platform.backends.wayland.previews import (
     HyprlandPreviewService,
@@ -314,3 +316,56 @@ def test_layer_shell_support_probe_handles_missing_or_failing_probe():
         raise RuntimeError("boom")
 
     assert layer_shell_is_supported(SimpleNamespace(is_supported=broken_probe)) is False
+
+
+def test_niri_session_uses_ipc_windows_and_layer_shell_capabilities():
+    window_service = NiriWindowService(
+        model=SimpleNamespace(
+            visible_items=MagicMock(return_value=[]),
+            update_running=MagicMock(),
+        ),
+        launcher=SimpleNamespace(resolve=MagicMock(), resolve_by_wm_class=MagicMock()),
+        client=MagicMock(),
+    )
+    backend = NiriSessionBackend(
+        layer_shell=_layer_shell(),
+        model=SimpleNamespace(),
+        launcher=SimpleNamespace(),
+        protocol_runtime=_empty_runtime(),
+        window_service=window_service,
+    )
+
+    assert backend.name == "niri"
+    assert backend.display_server is DisplayServer.WAYLAND
+    assert backend.windows is window_service
+    assert backend.capabilities.tracks_windows is True
+    assert backend.capabilities.tracks_active_window is True
+    assert backend.capabilities.tracks_attention is True
+    assert backend.capabilities.tracks_window_geometry is True
+    assert backend.capabilities.tracks_window_workspace is True
+    assert backend.capabilities.supports_current_workspace_filter is True
+    assert backend.capabilities.supports_activate is True
+    assert backend.capabilities.supports_minimize is False  # tiling compositor
+    assert backend.capabilities.supports_close is True
+    assert backend.capabilities.supports_layer_shell is True
+    assert backend.capabilities.supports_screen_reservation is True
+    assert backend.capabilities.supports_input_region is True
+
+
+def test_niri_session_falls_back_to_reduced_windows_when_ipc_unavailable(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "docking.platform.backends.wayland.niri_session.load_niri_window_service",
+        lambda **_: None,
+    )
+    backend = NiriSessionBackend(
+        layer_shell=_layer_shell(),
+        model=SimpleNamespace(),
+        launcher=SimpleNamespace(),
+        protocol_runtime=_empty_runtime(),
+    )
+
+    assert isinstance(backend.windows, ReducedWindowService)
+    assert backend.capabilities.tracks_windows is False
+    assert backend.capabilities.supports_layer_shell is True


### PR DESCRIPTION
## Summary

Adds a first-class Niri IPC backend that uses Niri's JSON Unix socket (`$NIRI_SOCKET`) for window tracking, actions, previews, and color picking — replacing the generic wlroots fallback with compositor-native integration.

### New files
- **`niri_ipc.py`** — `NiriIpcClient` (short-lived JSON requests), `NiriEventStream` (background event reader), `NiriWindowService` (activate/close/fullscreen/overview tracking), `NiriPreviewService` (ScreenshotWindow → temp-file PNG), `NiriScreenCaptureService` (PickColor IPC)
- **`niri_session.py`** — `NiriSessionBackend` composing IPC windows + layer-shell surface + native color picker + optional Wayland workspace protocol
- **`test_niri_ipc.py`** — 25 tests covering socket detection, event parsing, window snapshots, actions, event-driven updates, focus/urgency changes, preview capture, color picker, and backend selection

### Modified files
- **`selection.py`** — `DOCKING_BACKEND=niri` override + auto-detection via `detect_desktop() & Desktop.NIRI` (after COSMIC, before KDE)
- **`docs/WAYLAND.md`** — Niri compositor section, auto-detection order, feature matrix
- **`README.md`** — Niri row in compositor support table + override list
- **`test_backend_selection.py`** / **`test_wayland_layer_shell_session.py`** — Selection and session tests

### Capability summary

| Capability | Status |
|---|---|
| Edge placement (layer-shell) | ✓ |
| Window tracking + active/urgent | ✓ (event stream) |
| Window actions (focus, close, fullscreen) | ✓ (IPC actions) |
| Window previews | ✓ (ScreenshotWindow IPC) |
| Workspace listing/switching | ✓ (ext_workspace_v1) |
| Color picker | ✓ (native PickColor IPC) |
| Overview state tracking | ✓ (OverviewOpenedOrClosed) |
| Minimize | ✗ (tiling compositor) |