### PR TITLE
Improve Niri workspace, desktop, and idle services

### DIFF
--- a/docking/applets/workspaces/applet.py
+++ b/docking/applets/workspaces/applet.py
@@ -134,7 +134,8 @@ class WorkspacesApplet(Applet):
             next_num,
             count,
         )
-        service.activate(str(next_num))
+        if 0 <= next_num < len(workspaces):
+            service.activate(workspaces[next_num].id)
 
     def on_scroll(self, direction_up: bool) -> None:
         """Switch workspace on scroll."""
@@ -159,7 +160,8 @@ class WorkspacesApplet(Applet):
             next_num,
             count,
         )
-        service.activate(str(next_num))
+        if 0 <= next_num < len(workspaces):
+            service.activate(workspaces[next_num].id)
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         service = self._workspace_service

--- a/docking/platform/backends/wayland/idle.py
+++ b/docking/platform/backends/wayland/idle.py
@@ -1,0 +1,66 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Approximate Wayland idle-time service backed by ext-idle-notify-v1."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+from docking.platform.backends.base import IdleService
+
+
+class WaylandIdleService(IdleService):
+    """Estimate idle seconds from ext-idle-notify-v1 resumed events.
+
+    The protocol is threshold/event based rather than a direct idle-duration
+    query. Docking uses a zero-time input idle notification and treats every
+    resumed event as user activity, so ``idle_seconds()`` is best-effort.
+    """
+
+    def __init__(
+        self,
+        *,
+        protocol: object,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._protocol = protocol
+        self._clock = clock
+        self._started = False
+        self._last_activity = 0.0
+        self._known = False
+
+    def start(self) -> None:
+        self._started = True
+        self._last_activity = self._clock()
+        start = getattr(self._protocol, "start", None)
+        if callable(start):
+            start(self)
+
+    def stop(self) -> None:
+        stop = getattr(self._protocol, "stop", None)
+        if callable(stop):
+            stop()
+        self._started = False
+        self._last_activity = 0.0
+        self._known = False
+
+    def idle_seconds(self) -> float | None:
+        if not self._started or not self._known:
+            return None
+        return max(0.0, self._clock() - self._last_activity)
+
+    def idled(self) -> None:
+        """Called by the protocol adapter when the seat is idle."""
+        self._known = True
+
+    def resumed(self) -> None:
+        """Called by the protocol adapter when user activity resumes."""
+        self._last_activity = self._clock()
+        self._known = True

--- a/docking/platform/backends/wayland/niri_ipc.py
+++ b/docking/platform/backends/wayland/niri_ipc.py
@@ -39,6 +39,7 @@ from gi.repository import GdkPixbuf
 from docking.log import get_logger
 from docking.platform.backends.base import (
     ActionResult,
+    DesktopActionService,
     DisplayServer,
     PreviewImage,
     PreviewService,
@@ -47,6 +48,8 @@ from docking.platform.backends.base import (
     WindowId,
     WindowService,
     WindowSnapshot,
+    WorkspaceService,
+    WorkspaceSnapshot,
 )
 from docking.platform.backends.wayland.toplevels import WaylandAppIdMatcher
 from docking.platform.running import RunningAppInfo, RunningWindowInfo
@@ -63,6 +66,12 @@ _NIRI_WINDOW_EVENTS = {
     "WindowClosed",
     "WindowFocusChanged",
     "WindowUrgencyChanged",
+    "WorkspacesChanged",
+    "WorkspaceActivated",
+    "WorkspaceActiveWindowChanged",
+}
+
+_NIRI_WORKSPACE_EVENTS = {
     "WorkspacesChanged",
     "WorkspaceActivated",
     "WorkspaceActiveWindowChanged",
@@ -99,6 +108,24 @@ class NiriWindowRecord:
     @property
     def window_id(self) -> WindowId:
         return WindowId(backend=DisplayServer.WAYLAND, value=str(self.id))
+
+
+@dataclass(frozen=True)
+class NiriWorkspaceRecord:
+    """Backend-neutral projection of one Niri workspace."""
+
+    id: int
+    idx: int
+    name: str
+    output: str
+    active: bool
+    focused: bool
+    number: int
+    active_window_id: int | None = None
+
+    @property
+    def snapshot_id(self) -> str:
+        return str(self.id)
 
 
 # ---------------------------------------------------------------------------
@@ -562,6 +589,191 @@ class NiriWindowService(WindowService):
         return next((r for r in records if r.active), records[0])
 
 
+class NiriWorkspaceService(WorkspaceService):
+    """WorkspaceService backed by Niri IPC workspace snapshots and actions."""
+
+    def __init__(
+        self,
+        *,
+        client: NiriIpcClient,
+        event_stream_factory: Callable[
+            [Callable[[NiriEvent], None]], NiriEventStream | None
+        ]
+        | None = None,
+    ) -> None:
+        self._client = client
+        self._event_stream_factory = event_stream_factory
+        self._event_stream: NiriEventStream | None = None
+        self._records: dict[str, NiriWorkspaceRecord] = {}
+        self._watchers: dict[int, Callable[[], None]] = {}
+        self._next_watch_id = 1
+        self._active_ids: tuple[str, ...] = ()
+
+    def start(self) -> None:
+        self._refresh_workspaces()
+        if self._event_stream_factory is not None:
+            self._event_stream = self._event_stream_factory(self._on_event)
+            if self._event_stream is not None:
+                self._event_stream.start()
+
+    def stop(self) -> None:
+        if self._event_stream is not None:
+            self._event_stream.stop()
+            self._event_stream = None
+        self._records.clear()
+        self._watchers.clear()
+        self._active_ids = ()
+
+    def list_workspaces(self) -> Sequence[WorkspaceSnapshot]:
+        return tuple(
+            WorkspaceSnapshot(
+                id=record.snapshot_id,
+                number=record.number,
+                name=record.name,
+                active=record.focused,
+            )
+            for record in sorted(self._records.values(), key=_workspace_sort_key)
+        )
+
+    def active_workspace(self) -> WorkspaceSnapshot | None:
+        for workspace in self.list_workspaces():
+            if workspace.active:
+                return workspace
+        return None
+
+    def activate(self, workspace_id: str) -> ActionResult:
+        record = self._resolve_workspace(workspace_id)
+        if record is None:
+            return ActionResult.NOT_FOUND
+        return _focus_niri_workspace(client=self._client, record=record)
+
+    def watch_active_workspace(self, on_change: Callable[[], None]) -> object | None:
+        watch_id = self._next_watch_id
+        self._next_watch_id += 1
+        self._watchers[watch_id] = on_change
+        return watch_id
+
+    def unwatch_active_workspace(self, handle: object) -> None:
+        if isinstance(handle, int):
+            self._watchers.pop(handle, None)
+
+    def _on_event(self, event: NiriEvent) -> None:
+        if event.name not in _NIRI_WORKSPACE_EVENTS:
+            return
+        if event.name == "WorkspacesChanged":
+            workspaces_raw = event.data.get("workspaces")
+            if isinstance(workspaces_raw, list):
+                self._replace_workspaces(workspaces_raw)
+            return
+        self._refresh_workspaces()
+
+    def _refresh_workspaces(self) -> None:
+        workspaces_raw = self._client.ok_data({"Workspaces": None}, "Workspaces")
+        if isinstance(workspaces_raw, list):
+            self._replace_workspaces(workspaces_raw)
+
+    def _replace_workspaces(self, items: list[Any]) -> None:
+        records: list[NiriWorkspaceRecord] = []
+        for item in items:
+            if not isinstance(item, Mapping):
+                continue
+            record = _record_from_workspace(item, number=len(records))
+            if record is not None:
+                records.append(record)
+        self._records = {record.snapshot_id: record for record in records}
+        self._notify_if_active_changed()
+
+    def _notify_if_active_changed(self) -> None:
+        active_ids = tuple(
+            record.snapshot_id
+            for record in sorted(self._records.values(), key=_workspace_sort_key)
+            if record.focused
+        )
+        if active_ids == self._active_ids:
+            return
+        self._active_ids = active_ids
+        for callback in tuple(self._watchers.values()):
+            callback()
+
+    def _resolve_workspace(self, workspace_id: str) -> NiriWorkspaceRecord | None:
+        record = self._records.get(workspace_id)
+        if record is not None:
+            return record
+        for candidate in self._records.values():
+            if str(candidate.number) == workspace_id or candidate.name == workspace_id:
+                return candidate
+        return None
+
+
+class NiriDesktopActionService(DesktopActionService):
+    """DesktopActionService that focuses an empty Niri workspace."""
+
+    def __init__(self, *, client: NiriIpcClient) -> None:
+        self._client = client
+        self._restore_by_output: dict[str, str] = {}
+
+    def start(self) -> None:
+        """No persistent runtime resources."""
+
+    def stop(self) -> None:
+        self._restore_by_output.clear()
+
+    def show_desktop(self, show: bool | None = None) -> ActionResult:
+        records = self._list_workspaces()
+        focused = next((record for record in records if record.focused), None)
+        if focused is None:
+            return ActionResult.NOT_FOUND
+
+        wants_show = focused.active_window_id is not None if show is None else show
+        if wants_show:
+            if focused.active_window_id is not None:
+                self._restore_by_output[focused.output] = focused.snapshot_id
+            empty = self._empty_workspace_for_output(
+                records=records,
+                output=focused.output,
+                exclude_id=focused.snapshot_id,
+            )
+            if empty is None:
+                return ActionResult.NOT_FOUND
+            return _focus_niri_workspace(client=self._client, record=empty)
+
+        restore_id = self._restore_by_output.pop(focused.output, "")
+        restore = next(
+            (record for record in records if record.snapshot_id == restore_id),
+            None,
+        )
+        if restore is None:
+            return ActionResult.OK
+        return _focus_niri_workspace(client=self._client, record=restore)
+
+    def _list_workspaces(self) -> tuple[NiriWorkspaceRecord, ...]:
+        workspaces_raw = self._client.ok_data({"Workspaces": None}, "Workspaces")
+        if not isinstance(workspaces_raw, list):
+            return ()
+        records: list[NiriWorkspaceRecord] = []
+        for item in workspaces_raw:
+            if not isinstance(item, Mapping):
+                continue
+            record = _record_from_workspace(item, number=len(records))
+            if record is not None:
+                records.append(record)
+        return tuple(records)
+
+    def _empty_workspace_for_output(
+        self,
+        *,
+        records: Sequence[NiriWorkspaceRecord],
+        output: str,
+        exclude_id: str,
+    ) -> NiriWorkspaceRecord | None:
+        for record in records:
+            if record.output != output or record.snapshot_id == exclude_id:
+                continue
+            if record.active_window_id is None:
+                return record
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Public loaders
 # ---------------------------------------------------------------------------
@@ -582,6 +794,29 @@ def load_niri_window_service(*, model, launcher) -> NiriWindowService | None:
             callback=callback,
         ),
     )
+
+
+def load_niri_workspace_service() -> NiriWorkspaceService | None:
+    """Return a Niri WorkspaceService when the IPC socket is detectable."""
+    socket_path = _niri_socket_path()
+    if socket_path is None or not socket_path.exists():
+        return None
+    client = NiriIpcClient(socket_path=socket_path)
+    return NiriWorkspaceService(
+        client=client,
+        event_stream_factory=lambda callback: NiriEventStream(
+            socket_path=socket_path,
+            callback=callback,
+        ),
+    )
+
+
+def load_niri_desktop_action_service() -> NiriDesktopActionService | None:
+    """Return Niri desktop actions when the IPC socket is detectable."""
+    socket_path = _niri_socket_path()
+    if socket_path is None or not socket_path.exists():
+        return None
+    return NiriDesktopActionService(client=NiriIpcClient(socket_path=socket_path))
 
 
 def load_niri_preview_service() -> NiriPreviewService | None:
@@ -837,6 +1072,48 @@ def _record_from_window(
         workspace_id=workspace_id,
         geometry=geometry,
     )
+
+
+def _record_from_workspace(
+    item: Mapping[str, Any],
+    *,
+    number: int,
+) -> NiriWorkspaceRecord | None:
+    workspace_id = item.get("id")
+    idx = item.get("idx")
+    if not isinstance(workspace_id, int) or not isinstance(idx, int):
+        return None
+    name = str(item.get("name") or "").strip()
+    output = str(item.get("output") or "").strip()
+    active_window_id = item.get("active_window_id")
+    if not isinstance(active_window_id, int):
+        active_window_id = None
+    return NiriWorkspaceRecord(
+        id=workspace_id,
+        idx=idx,
+        name=name,
+        output=output,
+        active=bool(item.get("is_active", False)),
+        focused=bool(item.get("is_focused", False)),
+        number=number,
+        active_window_id=active_window_id,
+    )
+
+
+def _workspace_sort_key(record: NiriWorkspaceRecord) -> tuple[int, int]:
+    return (record.number, record.id)
+
+
+def _focus_niri_workspace(
+    *,
+    client: NiriIpcClient,
+    record: NiriWorkspaceRecord,
+) -> ActionResult:
+    if record.output:
+        monitor = client.action({"FocusMonitor": {"output": record.output}})
+        if monitor is not ActionResult.OK:
+            return monitor
+    return client.action({"FocusWorkspace": {"reference": {"Index": record.idx}}})
 
 
 def _geometry_from_niri_window(item: Mapping[str, Any]) -> Rect | None:

--- a/docking/platform/backends/wayland/niri_session.py
+++ b/docking/platform/backends/wayland/niri_session.py
@@ -32,12 +32,16 @@ from docking.platform.backends.reduced.services import (
     ReducedVisibilityService,
     ReducedWindowService,
 )
+from docking.platform.backends.wayland.idle import WaylandIdleService
 from docking.platform.backends.wayland.niri_ipc import (
+    NiriDesktopActionService,
     NiriScreenCaptureService,
     NiriWindowService,
     _niri_socket_path,
+    load_niri_desktop_action_service,
     load_niri_preview_service,
     load_niri_window_service,
+    load_niri_workspace_service,
 )
 from docking.platform.backends.wayland.portals import (
     WaylandPortalColorPickerService,
@@ -62,6 +66,8 @@ class NiriRuntimeServices:
     visibility: ReducedVisibilityService
     workspaces: WorkspaceService | None
     screen_capture: ScreenCaptureService | None
+    desktop_actions: DesktopActionService | None
+    idle: IdleService | None
     protocol_runtime: WaylandProtocolRuntime | None
 
 
@@ -91,15 +97,26 @@ class NiriSessionBackend(SessionBackend):
         if windows is None:
             windows = ReducedWindowService()
 
-        workspace_protocol = runtime.workspace_protocol if runtime is not None else None
-        workspaces = (
-            WaylandWorkspaceService(protocol=workspace_protocol)
-            if workspace_protocol is not None
-            else None
-        )
+        workspaces = load_niri_workspace_service()
+        if workspaces is None:
+            workspace_protocol = (
+                runtime.workspace_protocol if runtime is not None else None
+            )
+            workspaces = (
+                WaylandWorkspaceService(protocol=workspace_protocol)
+                if workspace_protocol is not None
+                else None
+            )
 
         niri_previews = load_niri_preview_service()
         previews: PreviewService = niri_previews or ReducedPreviewService()
+        desktop_actions = load_niri_desktop_action_service()
+        idle_protocol = runtime.idle_protocol if runtime is not None else None
+        idle: IdleService | None = (
+            WaylandIdleService(protocol=idle_protocol)
+            if idle_protocol is not None
+            else None
+        )
 
         # Prefer Niri's native PickColor IPC over the XDG desktop portal.
         if screen_capture is None:
@@ -116,6 +133,8 @@ class NiriSessionBackend(SessionBackend):
             visibility=ReducedVisibilityService(),
             workspaces=workspaces,
             screen_capture=screen_capture,
+            desktop_actions=desktop_actions,
+            idle=idle,
             protocol_runtime=runtime,
         )
 
@@ -149,10 +168,15 @@ class NiriSessionBackend(SessionBackend):
             supports_current_workspace_filter=tracks_windows,
             supports_workspace_list=supports_workspaces,
             supports_workspace_switch=supports_workspaces,
+            supports_show_desktop=isinstance(
+                self._services.desktop_actions,
+                NiriDesktopActionService,
+            ),
             supports_layer_shell=True,
             supports_screen_reservation=True,
             supports_input_region=True,
             supports_screen_color_pick=supports_color_pick,
+            supports_idle_time=isinstance(self._services.idle, WaylandIdleService),
         )
 
     @property
@@ -177,7 +201,7 @@ class NiriSessionBackend(SessionBackend):
 
     @property
     def desktop_actions(self) -> DesktopActionService | None:
-        return None
+        return self._services.desktop_actions
 
     @property
     def screen_capture(self) -> ScreenCaptureService | None:
@@ -185,7 +209,7 @@ class NiriSessionBackend(SessionBackend):
 
     @property
     def idle(self) -> IdleService | None:
-        return None
+        return self._services.idle
 
     @property
     def window_picker(self) -> WindowPickService | None:
@@ -198,12 +222,20 @@ class NiriSessionBackend(SessionBackend):
         self._services.visibility.start()
         if self._services.workspaces is not None:
             self._services.workspaces.start()
+        if self._services.desktop_actions is not None:
+            self._services.desktop_actions.start()
         if self._services.screen_capture is not None:
             self._services.screen_capture.start()
+        if self._services.idle is not None:
+            self._services.idle.start()
 
     def stop(self) -> None:
+        if self._services.idle is not None:
+            self._services.idle.stop()
         if self._services.screen_capture is not None:
             self._services.screen_capture.stop()
+        if self._services.desktop_actions is not None:
+            self._services.desktop_actions.stop()
         if self._services.workspaces is not None:
             self._services.workspaces.stop()
         self._services.visibility.stop()

--- a/docking/platform/backends/wayland/runtime.py
+++ b/docking/platform/backends/wayland/runtime.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 from docking.log import get_logger
 
 if TYPE_CHECKING:
+    from docking.platform.backends.wayland.idle import WaylandIdleService
     from docking.platform.backends.wayland.previews import (
         WaylandPreviewHandleTracker,
     )
@@ -340,6 +341,85 @@ class WorkspaceProtocolAdapter:
         self.available = False
 
 
+class IdleProtocolAdapter:
+    """Adapter for ext-idle-notify-v1 idle state events."""
+
+    def __init__(self) -> None:
+        self._notifier = None
+        self._seat = None
+        self._notification = None
+        self._flush: Callable[[], None] | None = None
+        self._service: WaylandIdleService | None = None
+        self.available = False
+
+    def set_flush_callback(self, callback: Callable[[], None] | None) -> None:
+        self._flush = callback
+
+    def bind(self, *, registry, name: int, version: int) -> None:
+        from pywayland.protocol.ext_idle_notify_v1 import ExtIdleNotifierV1
+
+        bind_version = min(version, ExtIdleNotifierV1.version)
+        self._notifier = registry.bind(name, ExtIdleNotifierV1, bind_version)
+        self.available = True
+        self._maybe_create_notification()
+
+    def bind_seat(self, *, registry, name: int, version: int) -> None:
+        from pywayland.protocol.wayland import WlSeat
+
+        self._seat = registry.bind(name, WlSeat, min(version, WlSeat.version))
+        self._maybe_create_notification()
+
+    def start(self, service: WaylandIdleService) -> None:
+        self._service = service
+        self._maybe_create_notification()
+
+    def stop(self) -> None:
+        notification = self._notification
+        if notification is not None:
+            destroy = getattr(notification, "destroy", None)
+            if callable(destroy):
+                destroy()
+        notifier = self._notifier
+        if notifier is not None:
+            destroy = getattr(notifier, "destroy", None)
+            if callable(destroy):
+                destroy()
+        self._notifier = None
+        self._seat = None
+        self._notification = None
+        self._flush = None
+        self._service = None
+        self.available = False
+
+    def _maybe_create_notification(self) -> None:
+        if (
+            self._notification is not None
+            or self._notifier is None
+            or self._seat is None
+            or self._service is None
+        ):
+            return
+        create = getattr(self._notifier, "get_input_idle_notification", None)
+        if not callable(create):
+            create = getattr(self._notifier, "get_idle_notification", None)
+        if not callable(create):
+            return
+        notification = create(0, self._seat)
+        notification.dispatcher["idled"] = lambda _notification: self._on_idled()
+        notification.dispatcher["resumed"] = lambda _notification: self._on_resumed()
+        self._notification = notification
+        if self._flush is not None:
+            self._flush()
+
+    def _on_idled(self) -> None:
+        if self._service is not None:
+            self._service.idled()
+
+    def _on_resumed(self) -> None:
+        if self._service is not None:
+            self._service.resumed()
+
+
 class PreviewProtocolAdapter:
     """Adapter for generic Wayland toplevel preview capture protocols."""
 
@@ -594,6 +674,7 @@ class WaylandProtocolRuntime:
         workspace_adapter: WorkspaceProtocolAdapter | None = None,
         preview_adapter: PreviewProtocolAdapter | None = None,
         hyprland_preview_adapter: HyprlandPreviewProtocolAdapter | None = None,
+        idle_adapter: IdleProtocolAdapter | None = None,
         cosmic_toplevel_adapter: object | None = None,
         cosmic_workspace_adapter: object | None = None,
         cosmic_overlap_adapter: object | None = None,
@@ -611,6 +692,7 @@ class WaylandProtocolRuntime:
         self.hyprland_previews = (
             hyprland_preview_adapter or HyprlandPreviewProtocolAdapter()
         )
+        self.idle = idle_adapter or IdleProtocolAdapter()
         self.cosmic_toplevel = cosmic_toplevel_adapter or CosmicToplevelAdapter()
         self.cosmic_workspace = cosmic_workspace_adapter or CosmicWorkspaceAdapter()
         self.cosmic_overlap = cosmic_overlap_adapter or CosmicOverlapAdapter()
@@ -636,6 +718,10 @@ class WaylandProtocolRuntime:
         return (
             self.hyprland_previews if self.hyprland_previews.capture_available else None
         )
+
+    @property
+    def idle_protocol(self) -> object | None:
+        return self.idle if self.idle.available else None
 
     @property
     def cosmic_toplevel_protocol(self) -> object | None:
@@ -665,6 +751,7 @@ class WaylandProtocolRuntime:
             self.workspaces.set_flush_callback(display.flush)
             self.previews.set_flush_callback(display.flush)
             self.hyprland_previews.set_flush_callback(display.flush)
+            self.idle.set_flush_callback(display.flush)
             self.cosmic_toplevel.set_flush_callback(display.flush)
             self.cosmic_workspace.set_flush_callback(display.flush)
             self.cosmic_overlap.set_flush_callback(display.flush)
@@ -696,6 +783,7 @@ class WaylandProtocolRuntime:
         self.workspaces.stop()
         self.previews.stop()
         self.hyprland_previews.stop()
+        self.idle.stop()
         self.cosmic_toplevel.stop()
         self.cosmic_workspace.stop()
         self.cosmic_overlap.stop()
@@ -723,6 +811,11 @@ class WaylandProtocolRuntime:
                 version=version,
             )
             self.cosmic_toplevel.bind_seat(
+                registry=registry,
+                name=name,
+                version=version,
+            )
+            self.idle.bind_seat(
                 registry=registry,
                 name=name,
                 version=version,
@@ -789,6 +882,8 @@ class WaylandProtocolRuntime:
                 name=name,
                 version=version,
             )
+        elif interface == "ext_idle_notifier_v1":
+            self.idle.bind(registry=registry, name=name, version=version)
 
     def _install_glib_watch(
         self, *, factories: WaylandProtocolFactories, display

--- a/tests/applets/test_workspaces.py
+++ b/tests/applets/test_workspaces.py
@@ -12,9 +12,18 @@ from docking.platform.backends.base import WorkspaceSnapshot
 
 
 def _workspace(
-    number: int, *, name: str = "", active: bool = False
+    number: int,
+    *,
+    workspace_id: str | None = None,
+    name: str = "",
+    active: bool = False,
 ) -> WorkspaceSnapshot:
-    return WorkspaceSnapshot(id=str(number), number=number, name=name, active=active)
+    return WorkspaceSnapshot(
+        id=workspace_id or str(number),
+        number=number,
+        name=name,
+        active=active,
+    )
 
 
 class TestRenderGrid:
@@ -105,6 +114,21 @@ class TestWorkspacesBehavior:
         # Then
         service.activate.assert_called_once_with("2")
 
+    def test_on_clicked_activates_next_workspace_by_snapshot_id(self):
+        # Given
+        applet = WorkspacesApplet(48)
+        service = MagicMock()
+        service.list_workspaces.return_value = [
+            _workspace(0, workspace_id="first"),
+            _workspace(1, workspace_id="second", active=True),
+            _workspace(2, workspace_id="target"),
+        ]
+        applet.set_services(AppletServices(workspaces=service))
+        # When
+        applet.on_clicked()
+        # Then
+        service.activate.assert_called_once_with("target")
+
     def test_on_clicked_no_screen_or_active_is_safe(self):
         # Given
         applet = WorkspacesApplet(48)
@@ -135,6 +159,21 @@ class TestWorkspacesBehavior:
         applet.on_scroll(direction_up=False)
         # Then
         service.activate.assert_called_once_with("1")
+
+    def test_on_scroll_activates_workspace_by_snapshot_id(self):
+        # Given
+        applet = WorkspacesApplet(48)
+        service = MagicMock()
+        service.list_workspaces.return_value = [
+            _workspace(0, workspace_id="previous"),
+            _workspace(1, workspace_id="current", active=True),
+            _workspace(2, workspace_id="next"),
+        ]
+        applet.set_services(AppletServices(workspaces=service))
+        # When
+        applet.on_scroll(direction_up=True)
+        # Then
+        service.activate.assert_called_once_with("previous")
 
     def test_get_menu_items_builds_radios_for_workspaces(self):
         # Given

--- a/tests/platform/test_niri_ipc.py
+++ b/tests/platform/test_niri_ipc.py
@@ -15,14 +15,18 @@ from docking.platform.backends.base import (
     WindowId,
 )
 from docking.platform.backends.wayland.niri_ipc import (
+    NiriDesktopActionService,
     NiriEvent,
     NiriPreviewService,
     NiriWindowService,
+    NiriWorkspaceService,
     _niri_socket_path,
     _parse_event_line,
     _parse_response,
     _wait_for_nonempty_file,
+    load_niri_desktop_action_service,
     load_niri_preview_service,
+    load_niri_workspace_service,
 )
 
 
@@ -162,6 +166,19 @@ class FakeEventStream:
 
     def emit(self, name: str, data: dict) -> None:
         self.callback(NiriEvent(name=name, data=data))
+
+
+class KeyedFakeIpcClient:
+    def __init__(self, data: dict[str, object]) -> None:
+        self.data = data
+        self.actions: list[dict] = []
+
+    def ok_data(self, payload: object, key: str):
+        return self.data.get(key)
+
+    def action(self, action_payload: dict) -> ActionResult:
+        self.actions.append(action_payload)
+        return ActionResult.OK
 
 
 # ---------------------------------------------------------------------------
@@ -487,6 +504,247 @@ def test_niri_window_service_close_all_not_found():
 
 
 # ---------------------------------------------------------------------------
+# Workspace service tests
+# ---------------------------------------------------------------------------
+
+
+def test_niri_workspace_service_lists_and_activates_workspaces():
+    client = KeyedFakeIpcClient(
+        {
+            "Workspaces": [
+                {
+                    "id": 1,
+                    "idx": 1,
+                    "name": None,
+                    "output": "HDMI-A-1",
+                    "is_active": True,
+                    "is_focused": True,
+                },
+                {
+                    "id": 3,
+                    "idx": 2,
+                    "name": None,
+                    "output": "HDMI-A-1",
+                    "is_active": False,
+                    "is_focused": False,
+                },
+                {
+                    "id": 2,
+                    "idx": 1,
+                    "name": None,
+                    "output": "eDP-1",
+                    "is_active": True,
+                    "is_focused": False,
+                },
+            ]
+        }
+    )
+    service = NiriWorkspaceService(client=client)
+
+    service.start()
+
+    workspaces = service.list_workspaces()
+    assert [workspace.id for workspace in workspaces] == ["1", "3", "2"]
+    assert [workspace.number for workspace in workspaces] == [0, 1, 2]
+    assert service.active_workspace() == workspaces[0]
+
+    assert service.activate("3") is ActionResult.OK
+    assert client.actions == [
+        {"FocusMonitor": {"output": "HDMI-A-1"}},
+        {"FocusWorkspace": {"reference": {"Index": 2}}},
+    ]
+
+
+def test_niri_workspace_service_notifies_on_workspace_events():
+    stream: FakeEventStream | None = None
+
+    def stream_factory(callback):
+        nonlocal stream
+        stream = FakeEventStream(callback)
+        return stream
+
+    client = KeyedFakeIpcClient(
+        {
+            "Workspaces": [
+                {
+                    "id": 1,
+                    "idx": 1,
+                    "output": "HDMI-A-1",
+                    "is_focused": True,
+                }
+            ]
+        }
+    )
+    service = NiriWorkspaceService(
+        client=client,
+        event_stream_factory=stream_factory,
+    )
+    changed: list[str] = []
+    watch = service.watch_active_workspace(lambda: changed.append("changed"))
+
+    service.start()
+    assert stream is not None
+    assert changed == ["changed"]
+
+    stream.emit(
+        "WorkspacesChanged",
+        {
+            "workspaces": [
+                {
+                    "id": 1,
+                    "idx": 1,
+                    "output": "HDMI-A-1",
+                    "is_focused": False,
+                },
+                {
+                    "id": 3,
+                    "idx": 2,
+                    "output": "HDMI-A-1",
+                    "is_focused": True,
+                },
+            ]
+        },
+    )
+    assert changed == ["changed", "changed"]
+
+    service.unwatch_active_workspace(watch)
+    stream.emit(
+        "WorkspacesChanged",
+        {
+            "workspaces": [
+                {
+                    "id": 1,
+                    "idx": 1,
+                    "output": "HDMI-A-1",
+                    "is_focused": True,
+                }
+            ]
+        },
+    )
+    assert changed == ["changed", "changed"]
+
+
+# ---------------------------------------------------------------------------
+# Desktop action service tests
+# ---------------------------------------------------------------------------
+
+
+def test_niri_desktop_action_service_focuses_empty_workspace_on_current_output():
+    client = KeyedFakeIpcClient(
+        {
+            "Workspaces": [
+                {
+                    "id": 1,
+                    "idx": 1,
+                    "output": "HDMI-A-1",
+                    "is_focused": True,
+                    "active_window_id": 6,
+                },
+                {
+                    "id": 3,
+                    "idx": 2,
+                    "output": "HDMI-A-1",
+                    "is_focused": False,
+                    "active_window_id": None,
+                },
+                {
+                    "id": 2,
+                    "idx": 1,
+                    "output": "eDP-1",
+                    "is_focused": False,
+                    "active_window_id": None,
+                },
+            ]
+        }
+    )
+    service = NiriDesktopActionService(client=client)
+
+    assert service.show_desktop() is ActionResult.OK
+
+    assert client.actions == [
+        {"FocusMonitor": {"output": "HDMI-A-1"}},
+        {"FocusWorkspace": {"reference": {"Index": 2}}},
+    ]
+
+
+def test_niri_desktop_action_service_restores_previous_workspace_on_toggle():
+    client = KeyedFakeIpcClient(
+        {
+            "Workspaces": [
+                {
+                    "id": 1,
+                    "idx": 1,
+                    "output": "HDMI-A-1",
+                    "is_focused": True,
+                    "active_window_id": 6,
+                },
+                {
+                    "id": 3,
+                    "idx": 2,
+                    "output": "HDMI-A-1",
+                    "is_focused": False,
+                    "active_window_id": None,
+                },
+            ]
+        }
+    )
+    service = NiriDesktopActionService(client=client)
+
+    assert service.show_desktop() is ActionResult.OK
+    client.actions.clear()
+    client.data["Workspaces"] = [
+        {
+            "id": 1,
+            "idx": 1,
+            "output": "HDMI-A-1",
+            "is_focused": False,
+            "active_window_id": 6,
+        },
+        {
+            "id": 3,
+            "idx": 2,
+            "output": "HDMI-A-1",
+            "is_focused": True,
+            "active_window_id": None,
+        },
+    ]
+
+    assert service.show_desktop() is ActionResult.OK
+
+    assert client.actions == [
+        {"FocusMonitor": {"output": "HDMI-A-1"}},
+        {"FocusWorkspace": {"reference": {"Index": 1}}},
+    ]
+
+
+def test_niri_desktop_action_service_ignores_empty_workspaces_on_other_outputs():
+    client = KeyedFakeIpcClient(
+        {
+            "Workspaces": [
+                {
+                    "id": 1,
+                    "idx": 1,
+                    "output": "HDMI-A-1",
+                    "is_focused": True,
+                    "active_window_id": 6,
+                },
+                {
+                    "id": 2,
+                    "idx": 1,
+                    "output": "eDP-1",
+                    "is_focused": False,
+                    "active_window_id": None,
+                },
+            ]
+        }
+    )
+    service = NiriDesktopActionService(client=client)
+
+    assert service.show_desktop() is ActionResult.NOT_FOUND
+    assert client.actions == []
+
+
+# ---------------------------------------------------------------------------
 # Preview service tests
 # ---------------------------------------------------------------------------
 
@@ -608,3 +866,13 @@ def test_wait_for_nonempty_file_times_out_for_missing_file():
 def test_load_niri_preview_service_returns_none_without_env():
     with patch.dict("os.environ", {}, clear=True):
         assert load_niri_preview_service() is None
+
+
+def test_load_niri_workspace_service_returns_none_without_env():
+    with patch.dict("os.environ", {}, clear=True):
+        assert load_niri_workspace_service() is None
+
+
+def test_load_niri_desktop_action_service_returns_none_without_env():
+    with patch.dict("os.environ", {}, clear=True):
+        assert load_niri_desktop_action_service() is None

--- a/tests/platform/test_wayland_layer_shell_session.py
+++ b/tests/platform/test_wayland_layer_shell_session.py
@@ -75,6 +75,7 @@ def _empty_runtime() -> SimpleNamespace:
         workspace_protocol=None,
         preview_protocol=None,
         hyprland_preview_protocol=None,
+        idle_protocol=None,
         stop=MagicMock(),
     )
 
@@ -146,6 +147,7 @@ def test_wayland_layer_shell_session_uses_wayland_previews_when_available():
             workspace_protocol=None,
             preview_protocol=preview_protocol,
             hyprland_preview_protocol=None,
+            idle_protocol=None,
             stop=MagicMock(),
         ),
     )
@@ -174,6 +176,7 @@ def test_wayland_layer_shell_session_uses_hyprland_previews_when_available():
             workspace_protocol=None,
             preview_protocol=None,
             hyprland_preview_protocol=hyprland_preview_protocol,
+            idle_protocol=None,
             stop=MagicMock(),
         ),
     )

--- a/tests/platform/test_wayland_protocol_runtime.py
+++ b/tests/platform/test_wayland_protocol_runtime.py
@@ -10,12 +10,14 @@ import pytest
 pytest.importorskip("pywayland")
 
 from pywayland.protocol.ext_foreign_toplevel_list_v1 import ExtForeignToplevelListV1
+from pywayland.protocol.ext_idle_notify_v1 import ExtIdleNotifierV1
 from pywayland.protocol.ext_image_capture_source_v1 import (
     ExtForeignToplevelImageCaptureSourceManagerV1,
 )
 from pywayland.protocol.ext_image_copy_capture_v1 import ExtImageCopyCaptureManagerV1
 from pywayland.protocol.wayland import WlSeat, WlShm
 
+from docking.platform.backends.wayland.idle import WaylandIdleService
 from docking.platform.backends.wayland.protocols.ext_workspace_v1.ext_workspace_manager_v1 import (
     ExtWorkspaceManagerV1,
 )
@@ -27,6 +29,7 @@ from docking.platform.backends.wayland.protocols.wlr_foreign_toplevel_management
 )
 from docking.platform.backends.wayland.runtime import (
     ForeignToplevelProtocolAdapter,
+    IdleProtocolAdapter,
     PreviewProtocolAdapter,
     WaylandProtocolFactories,
     WaylandProtocolRuntime,
@@ -43,6 +46,13 @@ class FakeProxy:
         self.dispatcher: dict[str, object] = {}
         self.stop = MagicMock()
         self.commit = MagicMock()
+        self.destroy = MagicMock()
+        self.notifications: list[tuple[int, object, FakeHandle]] = []
+
+    def get_input_idle_notification(self, timeout: int, seat: object) -> FakeHandle:
+        notification = FakeHandle()
+        self.notifications.append((timeout, seat, notification))
+        return notification
 
 
 class FakeRegistry:
@@ -186,6 +196,8 @@ def test_wayland_protocol_runtime_binds_known_globals_and_installs_watch():
         (10, ZwlrForeignToplevelManagerV1, ZwlrForeignToplevelManagerV1.version),
         (11, ExtWorkspaceManagerV1, ExtWorkspaceManagerV1.version),
         (12, WlSeat, WlSeat.version),
+        (12, WlSeat, WlSeat.version),
+        (12, WlSeat, WlSeat.version),
     ]
     assert glib.watch is not None
 
@@ -213,6 +225,7 @@ def test_wayland_protocol_runtime_binds_preview_protocol_set():
 
     assert runtime.preview_protocol is runtime.previews
     assert registry.bound == [
+        (20, ExtForeignToplevelListV1, ExtForeignToplevelListV1.version),
         (20, ExtForeignToplevelListV1, ExtForeignToplevelListV1.version),
         (
             21,
@@ -248,6 +261,24 @@ def test_wayland_protocol_runtime_binds_hyprland_preview_protocol():
         ),
         (31, WlShm, WlShm.version),
         (31, WlShm, WlShm.version),
+    ]
+
+
+def test_wayland_protocol_runtime_binds_idle_protocol():
+    glib = FakeGLib()
+    runtime = WaylandProtocolRuntime(factories=_factories(glib))
+
+    assert runtime.start() is True
+    registry = FakeDisplay.registry
+    registry.dispatcher["global"](registry, 40, "ext_idle_notifier_v1", 99)
+    registry.dispatcher["global"](registry, 41, "wl_seat", 99)
+
+    assert runtime.idle_protocol is runtime.idle
+    assert registry.bound == [
+        (40, ExtIdleNotifierV1, ExtIdleNotifierV1.version),
+        (41, WlSeat, WlSeat.version),
+        (41, WlSeat, WlSeat.version),
+        (41, WlSeat, WlSeat.version),
     ]
 
 
@@ -319,6 +350,58 @@ def test_workspace_adapter_replays_initial_events_after_service_start():
     assert active.id == "workspace-a"
     assert active.name == "Code"
     assert service.activate("workspace-a") is not None
+
+
+def test_idle_protocol_adapter_creates_notification_and_forwards_events():
+    registry = FakeRegistry()
+    adapter = IdleProtocolAdapter()
+    service = MagicMock()
+    flush = MagicMock()
+    adapter.set_flush_callback(flush)
+
+    adapter.bind(registry=registry, name=10, version=99)
+    adapter.bind_seat(registry=registry, name=11, version=99)
+    adapter.start(service)
+
+    notifier = registry.proxies["ext_idle_notifier_v1"]
+    seat = registry.proxies["wl_seat"]
+    assert len(notifier.notifications) == 1
+    timeout, notification_seat, notification = notifier.notifications[0]
+    assert timeout == 0
+    assert notification_seat is seat
+    flush.assert_called_once_with()
+
+    notification.dispatcher["idled"](notification)
+    notification.dispatcher["resumed"](notification)
+
+    service.idled.assert_called_once_with()
+    service.resumed.assert_called_once_with()
+
+
+def test_wayland_idle_service_estimates_idle_seconds():
+    now = 10.0
+
+    def clock() -> float:
+        return now
+
+    protocol = MagicMock()
+    service = WaylandIdleService(protocol=protocol, clock=clock)
+
+    service.start()
+    assert service.idle_seconds() is None
+
+    service.idled()
+    now = 15.5
+    assert service.idle_seconds() == 5.5
+
+    service.resumed()
+    now = 18.0
+    assert service.idle_seconds() == 2.5
+
+    service.stop()
+    protocol.start.assert_called_once_with(service)
+    protocol.stop.assert_called_once_with()
+    assert service.idle_seconds() is None
 
 
 def test_workspace_adapter_flushes_activation_commit():

--- a/website/index.html
+++ b/website/index.html
@@ -365,7 +365,7 @@
             <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">Compatibility: one dock across Linux desktops</h2>
             <p class="mt-4 text-lg leading-8 text-slate-300">Docking selects the best backend for the current session and falls back cleanly when a compositor does not expose every window-management feature.</p>
           </div>
-          <div class="rounded-full border border-white/15 bg-gradient-to-r from-skyline/8 to-ember/8 px-5 py-3 text-sm text-slate-200 backdrop-blur-xl">X11, GNOME, KDE Plasma, COSMIC, wlroots, and fallback sessions</div>
+          <div class="rounded-full border border-white/15 bg-gradient-to-r from-skyline/8 to-ember/8 px-5 py-3 text-sm text-slate-200 backdrop-blur-xl">X11, GNOME, KDE Plasma, COSMIC, Niri, wlroots, and fallback sessions</div>
         </div>
 
         <div class="mt-10 overflow-hidden rounded-[2rem] border border-white/12 bg-gradient-to-br from-skyline/10 via-white/[0.04] to-ember/8 shadow-soft backdrop-blur-2xl">
@@ -422,6 +422,18 @@
               </div>
               <div class="text-sm font-medium text-slate-200">COSMIC protocols</div>
               <p class="text-sm leading-7 text-slate-300">Native layer-shell placement with COSMIC toplevel, workspace, overlap, and preview protocol paths where available.</p>
+            </article>
+
+            <article class="grid gap-4 px-5 py-5 md:grid-cols-[1fr_1fr_1.6fr] md:items-center" data-environment="niri" data-status="native">
+              <div>
+                <div class="flex items-center gap-3">
+                  <span class="rounded-full border border-sky-300/20 bg-skyline/14 px-3 py-1 text-xs font-semibold text-blue-100">Native</span>
+                  <h3 class="text-lg font-semibold text-white">Niri Wayland</h3>
+                </div>
+                <p class="mt-2 text-sm text-slate-400">Niri compositor sessions</p>
+              </div>
+              <div class="text-sm font-medium text-slate-200">Niri IPC backend</div>
+              <p class="text-sm leading-7 text-slate-300">Layer-shell placement, window tracking with titles, previews, workspace switching, Show Desktop, idle time, and color picker — via native Niri IPC.</p>
             </article>
 
             <article class="grid gap-4 px-5 py-5 md:grid-cols-[1fr_1fr_1.6fr] md:items-center" data-environment="wlroots" data-status="partial">


### PR DESCRIPTION
## Summary
- add Niri IPC workspace service and switch the Workspaces applet by backend workspace IDs
- add Niri desktop action support by focusing/restoring empty workspaces
- add approximate Wayland idle support via ext-idle-notify-v1 and expose it for Niri