### PR TITLE
Add connector-based monitor targeting

### DIFF
--- a/docking/core/config.py
+++ b/docking/core/config.py
@@ -713,6 +713,13 @@ def _normalize_pref_map(raw: object) -> dict[str, dict[str, Any]]:
     return result
 
 
+def _normalize_optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 @dataclass
 class Config:
     """Dock configuration with sensible defaults."""
@@ -729,6 +736,10 @@ class Config:
     position: str = DEFAULT_POSITION
     # Target monitor index (-1 means "primary monitor")
     monitor_index: int = DEFAULT_MONITOR_INDEX
+    # Stable monitor connector/output name when the backend can expose one.
+    # ``monitor_index`` remains the fallback for older configs and sessions
+    # where GDK cannot report a connector.
+    monitor_connector: str | None = None
     # Dock hide behavior (see HideMode enum)
     hide_mode: str = DEFAULT_HIDE_MODE
     # Delay in ms before the dock starts hiding after cursor leaves (Plank default: 0)
@@ -833,6 +844,7 @@ class Config:
                 minimum=DEFAULT_MONITOR_INDEX,
             ),
         )
+        self.monitor_connector = _normalize_optional_text(self.monitor_connector)
         self.hide_mode = _normalize_hide_mode(self.hide_mode)
         self.hide_delay_ms = _normalize_int(
             self.hide_delay_ms,

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-06-13 20:38+0200\n"
+"POT-Creation-Date: 2026-06-15 14:04+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -114,7 +114,7 @@ msgstr ""
 #: docking/applets/runcommand/applet.py:121
 #: docking/applets/runcommand/applet.py:339
 #: docking/applets/sunrise/applet.py:188 docking/applets/trash/applet.py:127
-#: docking/applets/weather/applet.py:271 docking/ui/diagnostics.py:344
+#: docking/applets/weather/applet.py:271 docking/ui/diagnostics.py:342
 msgid "Cancel"
 msgstr ""
 
@@ -308,7 +308,7 @@ msgstr ""
 
 #: docking/applets/apod/applet.py:119 docking/applets/apod/state.py:119
 #: docking/applets/apod/state.py:138 docking/applets/certwatch/applet.py:147
-#: docking/applets/certwatch/state.py:325 docking/ui/diagnostics.py:102
+#: docking/applets/certwatch/state.py:325 docking/ui/diagnostics.py:101
 msgid "Checks"
 msgstr ""
 
@@ -339,7 +339,7 @@ msgstr ""
 #: docking/applets/hackernews/applet.py:205
 #: docking/applets/lastfm/applet.py:198 docking/applets/micshield/applet.py:131
 #: docking/applets/moon/applet.py:137 docking/applets/quote/applet.py:105
-#: docking/applets/systemtray/applet.py:136
+#: docking/applets/systemtray/applet.py:142
 #: docking/applets/thermals/applet.py:157
 #: docking/applets/todayinhistory/applet.py:112
 #: docking/applets/trivia/applet.py:128 docking/applets/weather/applet.py:188
@@ -379,7 +379,7 @@ msgstr ""
 msgid "Power Settings"
 msgstr ""
 
-#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:470
+#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:496
 msgid "Mouse"
 msgstr ""
 
@@ -635,11 +635,11 @@ msgstr ""
 msgid "Discovering: {state}"
 msgstr ""
 
-#: docking/applets/bluetooth/state.py:165 docking/ui/diagnostics.py:393
+#: docking/applets/bluetooth/state.py:165 docking/ui/diagnostics.py:391
 msgid "Yes"
 msgstr ""
 
-#: docking/applets/bluetooth/state.py:165 docking/ui/diagnostics.py:393
+#: docking/applets/bluetooth/state.py:165 docking/ui/diagnostics.py:391
 msgid "No"
 msgstr ""
 
@@ -784,7 +784,7 @@ msgstr ""
 #: docking/applets/camshield/state.py:192
 #: docking/applets/deskpresence/state.py:185
 #: docking/applets/micshield/state.py:193 docking/applets/music/state.py:95
-#: docking/applets/powerprofiles/state.py:150 docking/ui/diagnostics.py:398
+#: docking/applets/powerprofiles/state.py:150 docking/ui/diagnostics.py:396
 msgid "Unknown"
 msgstr ""
 
@@ -1195,7 +1195,7 @@ msgid "Week total at desk: {d}"
 msgstr ""
 
 #: docking/applets/desktop/applet.py:40
-#: docking/applets/workspaces/applet.py:101 docking/ui/diagnostics.py:148
+#: docking/applets/workspaces/applet.py:101 docking/ui/diagnostics.py:147
 msgid "Desktop"
 msgstr ""
 
@@ -1349,7 +1349,7 @@ msgid "{verb} every {interval}"
 msgstr ""
 
 #: docking/applets/freshness.py:42 docking/applets/freshness.py:49
-#: docking/ui/settings.py:222
+#: docking/ui/settings.py:224
 msgid "Updates"
 msgstr ""
 
@@ -1506,7 +1506,7 @@ msgstr ""
 msgid "Scrobbler Settings"
 msgstr ""
 
-#: docking/applets/lastfm/applet.py:381 docking/ui/diagnostics.py:343
+#: docking/applets/lastfm/applet.py:381 docking/ui/diagnostics.py:341
 msgid "Save"
 msgstr ""
 
@@ -2035,7 +2035,7 @@ msgid "Run with file"
 msgstr ""
 
 #: docking/applets/runcommand/applet.py:340
-#: docking/applets/systemtray/applet.py:248 docking/ui/menu.py:467
+#: docking/applets/systemtray/applet.py:254 docking/ui/menu.py:462
 msgid "Open"
 msgstr ""
 
@@ -2076,7 +2076,7 @@ msgstr ""
 msgid "Invert Color"
 msgstr ""
 
-#: docking/applets/session/applet.py:41 docking/ui/diagnostics.py:149
+#: docking/applets/session/applet.py:41 docking/ui/diagnostics.py:148
 msgid "Session"
 msgstr ""
 
@@ -2368,37 +2368,37 @@ msgstr ""
 msgid "Disk: {usage}"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:51
+#: docking/applets/systemtray/applet.py:52
 msgid "System Tray"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:80
+#: docking/applets/systemtray/applet.py:81
 #, python-brace-format
 msgid "System Tray: {n} legacy item(s)"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:121
+#: docking/applets/systemtray/applet.py:127
 msgid "Activate"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:126
+#: docking/applets/systemtray/applet.py:132
 msgid "Context Menu"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:184
+#: docking/applets/systemtray/applet.py:190
 msgid "D-Bus unavailable"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:193
+#: docking/applets/systemtray/applet.py:199
 #, python-brace-format
 msgid "Legacy X11 tray is active with {n} item(s)."
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:197
+#: docking/applets/systemtray/applet.py:203
 msgid "Legacy X11 tray is active and waiting for tray apps."
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:205
+#: docking/applets/systemtray/applet.py:211
 #, python-brace-format
 msgid ""
 "No StatusNotifier apps are registered. Legacy tray icons are currently owned "
@@ -2406,79 +2406,79 @@ msgid ""
 "Docking to host them."
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:211
+#: docking/applets/systemtray/applet.py:217
 msgid ""
 "No tray applications are registered. Use Start Legacy Tray from the applet "
 "menu for older X11 tray apps."
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:255
+#: docking/applets/systemtray/applet.py:261
 msgid "Menu"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:302
+#: docking/applets/systemtray/applet.py:308
 msgid "Release Legacy Tray"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:306
+#: docking/applets/systemtray/applet.py:312
 #, python-brace-format
 msgid "Legacy X11 tray active: {n} item(s)"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:315
+#: docking/applets/systemtray/applet.py:321
 msgid "Take Over Legacy Tray"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:319
+#: docking/applets/systemtray/applet.py:325
 #, python-brace-format
 msgid "Legacy X11 tray owned by {owner}"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:327
+#: docking/applets/systemtray/applet.py:333
 msgid "Start Legacy Tray"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:337
+#: docking/applets/systemtray/applet.py:349
 msgid "Unknown X11 tray error"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:343
+#: docking/applets/systemtray/applet.py:355
 msgid "Could not start the legacy tray"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:350
+#: docking/applets/systemtray/applet.py:362
 msgid "another tray"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:356
+#: docking/applets/systemtray/applet.py:368
 msgid "Take over the legacy tray?"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:358
+#: docking/applets/systemtray/applet.py:370
 msgid "Take Over"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:361
+#: docking/applets/systemtray/applet.py:373
 #, python-brace-format
 msgid ""
 "Docking will replace {owner} as the X11 system tray host. Existing legacy "
 "tray apps may need to be restarted before they dock into Docking."
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:423
+#: docking/applets/systemtray/applet.py:436
 msgid "Menu Item"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:468
+#: docking/applets/systemtray/applet.py:481
 msgid "System Tray unavailable"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:470
+#: docking/applets/systemtray/applet.py:483
 #, python-brace-format
 msgid "System Tray host: {n} item(s)"
 msgstr ""
 
-#: docking/applets/systemtray/applet.py:471
+#: docking/applets/systemtray/applet.py:484
 #: docking/applets/systemtray/state.py:158
 #, python-brace-format
 msgid "System Tray: {n} item(s)"
@@ -2798,131 +2798,131 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: docking/ui/diagnostics.py:72 docking/ui/menu.py:622
+#: docking/ui/diagnostics.py:71 docking/ui/menu.py:617
 msgid "Diagnostics"
 msgstr ""
 
-#: docking/ui/diagnostics.py:94
+#: docking/ui/diagnostics.py:93
 msgid "Overview"
 msgstr ""
 
-#: docking/ui/diagnostics.py:98
+#: docking/ui/diagnostics.py:97
 msgid "Features"
 msgstr ""
 
-#: docking/ui/diagnostics.py:106 docking/ui/diagnostics.py:224
+#: docking/ui/diagnostics.py:105 docking/ui/diagnostics.py:223
 msgid "Environment"
 msgstr ""
 
-#: docking/ui/diagnostics.py:110
+#: docking/ui/diagnostics.py:109
 msgid "Report"
 msgstr ""
 
-#: docking/ui/diagnostics.py:117
+#: docking/ui/diagnostics.py:116
 msgid "Refresh"
 msgstr ""
 
-#: docking/ui/diagnostics.py:119
+#: docking/ui/diagnostics.py:118
 msgid "Copy Report"
 msgstr ""
 
-#: docking/ui/diagnostics.py:121
+#: docking/ui/diagnostics.py:120
 msgid "Save Report..."
 msgstr ""
 
-#: docking/ui/diagnostics.py:123 docking/ui/menu.py:506
+#: docking/ui/diagnostics.py:122 docking/ui/menu.py:501
 msgid "Close"
 msgstr ""
 
-#: docking/ui/diagnostics.py:146 docking/ui/dock_window.py:401
+#: docking/ui/diagnostics.py:145 docking/ui/dock_window.py:402
 msgid "Docking"
 msgstr ""
 
-#: docking/ui/diagnostics.py:147
+#: docking/ui/diagnostics.py:146
 msgid "OS"
 msgstr ""
 
-#: docking/ui/diagnostics.py:150
+#: docking/ui/diagnostics.py:149
 msgid "Selected Backend"
 msgstr ""
 
-#: docking/ui/diagnostics.py:151
+#: docking/ui/diagnostics.py:150
 msgid "Display Server"
 msgstr ""
 
-#: docking/ui/diagnostics.py:152
+#: docking/ui/diagnostics.py:151
 msgid "GTK Backend"
 msgstr ""
 
-#: docking/ui/diagnostics.py:153
+#: docking/ui/diagnostics.py:152
 msgid "Forced Backend"
 msgstr ""
 
-#: docking/ui/diagnostics.py:153
+#: docking/ui/diagnostics.py:152
 msgid "None"
 msgstr ""
 
-#: docking/ui/diagnostics.py:154
+#: docking/ui/diagnostics.py:153
 msgid "XWayland"
 msgstr ""
 
-#: docking/ui/diagnostics.py:155
+#: docking/ui/diagnostics.py:154
 msgid "X11 Compositor"
 msgstr ""
 
-#: docking/ui/diagnostics.py:162
+#: docking/ui/diagnostics.py:161
 msgid "Warnings"
 msgstr ""
 
-#: docking/ui/diagnostics.py:166
+#: docking/ui/diagnostics.py:165
 msgid "No compatibility warnings detected."
 msgstr ""
 
-#: docking/ui/diagnostics.py:192
+#: docking/ui/diagnostics.py:191
 msgid "Runtime"
 msgstr ""
 
-#: docking/ui/diagnostics.py:196
+#: docking/ui/diagnostics.py:195
 msgid "Python"
 msgstr ""
 
-#: docking/ui/diagnostics.py:197
+#: docking/ui/diagnostics.py:196
 msgid "GTK"
 msgstr ""
 
-#: docking/ui/diagnostics.py:198
+#: docking/ui/diagnostics.py:197
 msgid "Backend Class"
 msgstr ""
 
-#: docking/ui/diagnostics.py:199
+#: docking/ui/diagnostics.py:198
 msgid "Wayland Session"
 msgstr ""
 
-#: docking/ui/diagnostics.py:200
+#: docking/ui/diagnostics.py:199
 msgid "X11 GTK Backend"
 msgstr ""
 
-#: docking/ui/diagnostics.py:206
+#: docking/ui/diagnostics.py:205
 msgid "Monitors"
 msgstr ""
 
-#: docking/ui/diagnostics.py:210
+#: docking/ui/diagnostics.py:209
 msgid "primary"
 msgstr ""
 
-#: docking/ui/diagnostics.py:210
+#: docking/ui/diagnostics.py:209
 msgid "secondary"
 msgstr ""
 
-#: docking/ui/diagnostics.py:220
+#: docking/ui/diagnostics.py:219
 msgid "Monitor details unavailable."
 msgstr ""
 
-#: docking/ui/diagnostics.py:340
+#: docking/ui/diagnostics.py:338
 msgid "Save Diagnostics Report"
 msgstr ""
 
-#: docking/ui/diagnostics.py:360
+#: docking/ui/diagnostics.py:358
 msgid "Failed to save diagnostics report."
 msgstr ""
 
@@ -2969,68 +2969,68 @@ msgstr ""
 msgid "%d More in Folder"
 msgstr ""
 
-#: docking/ui/menu.py:408
+#: docking/ui/menu.py:403
 msgid "Icon"
 msgstr ""
 
-#: docking/ui/menu.py:410
+#: docking/ui/menu.py:405
 msgid "Docking Icon"
 msgstr ""
 
-#: docking/ui/menu.py:411
+#: docking/ui/menu.py:406
 msgid "System Icon"
 msgstr ""
 
-#: docking/ui/menu.py:454 docking/ui/menu.py:474 docking/ui/menu.py:490
-#: docking/ui/menu.py:538
+#: docking/ui/menu.py:449 docking/ui/menu.py:469 docking/ui/menu.py:485
+#: docking/ui/menu.py:533
 msgid "Remove from Dock"
 msgstr ""
 
-#: docking/ui/menu.py:497
+#: docking/ui/menu.py:492
 msgid "Keep in Dock"
 msgstr ""
 
-#: docking/ui/menu.py:506
+#: docking/ui/menu.py:501
 msgid "Close All"
 msgstr ""
 
-#: docking/ui/menu.py:523
+#: docking/ui/menu.py:518
 msgid "Sort By"
 msgstr ""
 
-#: docking/ui/menu.py:531
+#: docking/ui/menu.py:526
 msgid "Show Hidden Files"
 msgstr ""
 
-#: docking/ui/menu.py:568
+#: docking/ui/menu.py:563
 msgid "Add Applet"
 msgstr ""
 
-#: docking/ui/menu.py:606
+#: docking/ui/menu.py:601
 msgid "No Applets Available"
 msgstr ""
 
-#: docking/ui/menu.py:613
+#: docking/ui/menu.py:608
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:627 docking/ui/settings.py:195
+#: docking/ui/menu.py:622 docking/ui/settings.py:197
 msgid "Preferences"
 msgstr ""
 
-#: docking/ui/menu.py:632
+#: docking/ui/menu.py:627
 msgid "About"
 msgstr ""
 
-#: docking/ui/menu.py:637
+#: docking/ui/menu.py:632
 msgid "Get Support"
 msgstr ""
 
-#: docking/ui/menu.py:644
+#: docking/ui/menu.py:639
 msgid "Quit"
 msgstr ""
 
-#: docking/ui/menu.py:682
+#: docking/ui/menu.py:677
 msgid "Window"
 msgstr ""
 
@@ -3039,285 +3039,299 @@ msgstr ""
 msgid "Happy new year {year} !!!"
 msgstr ""
 
-#: docking/ui/placement.py:243
+#: docking/ui/placement.py:269
 #, python-brace-format
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-#: docking/ui/settings.py:219
+#: docking/ui/settings.py:221
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:220 docking/ui/settings.py:479
+#: docking/ui/settings.py:222 docking/ui/settings.py:505
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:221
+#: docking/ui/settings.py:223
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:245
+#: docking/ui/settings.py:247
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:246
+#: docking/ui/settings.py:248
 msgid "Always on Top"
 msgstr ""
 
-#: docking/ui/settings.py:247
+#: docking/ui/settings.py:249
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:248
+#: docking/ui/settings.py:250
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:249
+#: docking/ui/settings.py:251
 msgid "Dodge Active"
 msgstr ""
 
-#: docking/ui/settings.py:250
+#: docking/ui/settings.py:252
 msgid "Dodge Windows"
 msgstr ""
 
-#: docking/ui/settings.py:251
+#: docking/ui/settings.py:253
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:262
+#: docking/ui/settings.py:264
 msgid "Toggle Focus"
 msgstr ""
 
-#: docking/ui/settings.py:263
+#: docking/ui/settings.py:265
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:264
+#: docking/ui/settings.py:266
 msgid "Most Recent Window"
 msgstr ""
 
-#: docking/ui/settings.py:271
+#: docking/ui/settings.py:273
 msgid "New Window"
 msgstr ""
 
-#: docking/ui/settings.py:272
+#: docking/ui/settings.py:274
 msgid "Minimize Windows"
 msgstr ""
 
-#: docking/ui/settings.py:273
+#: docking/ui/settings.py:275
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:280
+#: docking/ui/settings.py:282
 msgid "Click"
 msgstr ""
 
-#: docking/ui/settings.py:281
+#: docking/ui/settings.py:283
 msgid "Hover"
 msgstr ""
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:290
 msgid "Default"
 msgstr ""
 
-#: docking/ui/settings.py:289
+#: docking/ui/settings.py:291
 msgid "Alphabetical"
 msgstr ""
 
-#: docking/ui/settings.py:306
+#: docking/ui/settings.py:308
 msgid "Daily"
 msgstr ""
 
-#: docking/ui/settings.py:307
+#: docking/ui/settings.py:309
 msgid "Weekly"
 msgstr ""
 
-#: docking/ui/settings.py:357
+#: docking/ui/settings.py:330
+msgid ""
+"When Follow Cursor is enabled, the dock follows the pointer across monitors. "
+"The selected monitor is kept as the fallback."
+msgstr ""
+
+#: docking/ui/settings.py:376
 msgid "Added on top of the theme's own distance from the edge."
 msgstr ""
 
-#: docking/ui/settings.py:397
+#: docking/ui/settings.py:416
 msgid ""
 "Pixels of cursor pressure against the edge required to reveal a hidden dock. "
 "Higher values mean the dock will not reveal as easily."
 msgstr ""
 
-#: docking/ui/settings.py:407
+#: docking/ui/settings.py:426
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:409
+#: docking/ui/settings.py:428
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:410
+#: docking/ui/settings.py:429
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:411
+#: docking/ui/settings.py:430
 msgid "Transparency"
 msgstr ""
 
-#: docking/ui/settings.py:412
+#: docking/ui/settings.py:431
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:413
+#: docking/ui/settings.py:432
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:414
+#: docking/ui/settings.py:433
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:415
+#: docking/ui/settings.py:434
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:421
+#: docking/ui/settings.py:440
 msgid "Placement"
 msgstr ""
 
-#: docking/ui/settings.py:423
+#: docking/ui/settings.py:442
 msgid "Position"
 msgstr ""
 
-#: docking/ui/settings.py:424
+#: docking/ui/settings.py:443
 msgid "Extra Distance from Edge"
 msgstr ""
 
-#: docking/ui/settings.py:425
-msgid "Follow Cursor"
-msgstr ""
-
-#: docking/ui/settings.py:426
+#: docking/ui/settings.py:444
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:431
+#: docking/ui/settings.py:449 docking/ui/settings.py:452
+msgid "Monitor"
+msgstr ""
+
+#: docking/ui/settings.py:451
+msgid "Follow Cursor"
+msgstr ""
+
+#: docking/ui/settings.py:457
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:433
+#: docking/ui/settings.py:459
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:434
+#: docking/ui/settings.py:460
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:435
+#: docking/ui/settings.py:461
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:472
+#: docking/ui/settings.py:498
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:473
+#: docking/ui/settings.py:499
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:474
+#: docking/ui/settings.py:500
 msgid "Window List Sort"
 msgstr ""
 
-#: docking/ui/settings.py:481
+#: docking/ui/settings.py:507
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:482
+#: docking/ui/settings.py:508
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:483
+#: docking/ui/settings.py:509
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:484
+#: docking/ui/settings.py:510
 msgid "Pressure Reveal"
 msgstr ""
 
-#: docking/ui/settings.py:485
+#: docking/ui/settings.py:511
 msgid "Pressure Threshold"
 msgstr ""
 
-#: docking/ui/settings.py:490
+#: docking/ui/settings.py:516
 msgid "Folder Stacks"
 msgstr ""
 
-#: docking/ui/settings.py:492
+#: docking/ui/settings.py:518
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:566
+#: docking/ui/settings.py:592
 msgid "Check Now"
 msgstr ""
 
-#: docking/ui/settings.py:568
+#: docking/ui/settings.py:594
 msgid "View Releases"
 msgstr ""
 
-#: docking/ui/settings.py:580
+#: docking/ui/settings.py:606
 msgid "Update Checks"
 msgstr ""
 
-#: docking/ui/settings.py:582
+#: docking/ui/settings.py:608
 msgid "Check Automatically"
 msgstr ""
 
-#: docking/ui/settings.py:583
+#: docking/ui/settings.py:609
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:584
+#: docking/ui/settings.py:610
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:585
+#: docking/ui/settings.py:611
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:1020
+#: docking/ui/settings.py:928
+msgid "Primary Display"
+msgstr ""
+
+#: docking/ui/settings.py:1069
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:1024
+#: docking/ui/settings.py:1073
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:1026
+#: docking/ui/settings.py:1075
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:1069
+#: docking/ui/settings.py:1148
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1071
+#: docking/ui/settings.py:1150
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1074
+#: docking/ui/settings.py:1153
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:1076
+#: docking/ui/settings.py:1155
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1078
+#: docking/ui/settings.py:1157
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1080
+#: docking/ui/settings.py:1159
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1083
+#: docking/ui/settings.py:1162
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/platform/backends/base.py
+++ b/docking/platform/backends/base.py
@@ -94,6 +94,7 @@ class MonitorSnapshot:
     scale: int = 1
     primary: bool = False
     name: str | None = None
+    connector: str | None = None
 
 
 @dataclass(frozen=True)

--- a/docking/ui/placement.py
+++ b/docking/ui/placement.py
@@ -159,6 +159,7 @@ stack.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import gi
@@ -187,6 +188,15 @@ if TYPE_CHECKING:
 log = get_logger(name="placement")
 
 
+@dataclass(frozen=True)
+class MonitorChoice:
+    """One selectable monitor target for preferences and menus."""
+
+    label: str
+    index: int
+    connector: str | None = None
+
+
 class DockPlacementController:
     """Owns monitor selection, placement, struts, and pointer barriers."""
 
@@ -204,13 +214,19 @@ class DockPlacementController:
         self._geometry_refresh_source: int = 0
 
     def current_monitor_choice(self) -> int:
-        """Current monitor menu selection (-1=primary, >=0 specific monitor)."""
+        """Current configured home monitor (-1=primary, >=0 specific monitor)."""
         display = self._window.get_display()
         if not display:
             return -1
         n_monitors = display.get_n_monitors()
         if n_monitors <= 0:
             return -1
+        configured = self._monitor_for_connector(
+            display=display,
+            connector=getattr(self._window.config, "monitor_connector", None),
+        )
+        if configured is not None:
+            return self._monitor_index(display=display, monitor=configured)
         selected = int(self._window.config.monitor_index)
         if selected == -1:
             return self.primary_monitor_index()
@@ -221,10 +237,18 @@ class DockPlacementController:
     def get_monitor_menu_choices(self) -> list[tuple[str, int]]:
         """Monitor choices for menu display. Empty when only one monitor."""
         display = self._window.get_display()
+        if not display or display.get_n_monitors() <= 1:
+            return []
+        choices = self.get_monitor_choices()
+        return [(choice.label, choice.index) for choice in choices]
+
+    def get_monitor_choices(self) -> list[MonitorChoice]:
+        """Monitor choices with connector identity when GDK exposes it."""
+        display = self._window.get_display()
         if not display:
             return []
         n_monitors = display.get_n_monitors()
-        if n_monitors <= 1:
+        if n_monitors <= 0:
             return []
 
         primary = display.get_primary_monitor() or display.get_monitor(0)
@@ -234,20 +258,26 @@ class DockPlacementController:
                 primary_idx = idx
                 break
 
-        choices: list[tuple[str, int]] = []
+        choices: list[MonitorChoice] = []
         for idx in range(n_monitors):
             monitor = display.get_monitor(idx)
             if monitor is None:
                 continue
             geom = monitor.get_geometry()
+            connector = self._monitor_connector(monitor)
+            model = self._monitor_model(monitor)
             label = _("Display {display}: {width}x{height}").format(
                 display=idx + 1,
                 width=geom.width,
                 height=geom.height,
             )
+            if connector:
+                label += f" - {connector}"
+            elif model:
+                label += f" - {model}"
             if idx == primary_idx:
                 label += f" ({_('Primary')})"
-            choices.append((label, idx))
+            choices.append(MonitorChoice(label=label, index=idx, connector=connector))
         return choices
 
     def primary_monitor_index(self) -> int:
@@ -550,6 +580,13 @@ class DockPlacementController:
         if n_monitors <= 0:
             return None
 
+        configured = self._monitor_for_connector(
+            display=display,
+            connector=getattr(self._window.config, "monitor_connector", None),
+        )
+        if configured is not None:
+            return configured
+
         selected = int(self._window.config.monitor_index)
         if 0 <= selected < n_monitors:
             monitor = display.get_monitor(selected)
@@ -569,6 +606,35 @@ class DockPlacementController:
             if display.get_monitor(idx) is monitor:
                 return idx
         return -1
+
+    @classmethod
+    def _monitor_for_connector(
+        cls, *, display: Gdk.Display, connector: str | None
+    ) -> Gdk.Monitor | None:
+        if not connector:
+            return None
+        try:
+            n_monitors = display.get_n_monitors()
+        except Exception:
+            return None
+        for idx in range(n_monitors):
+            monitor = display.get_monitor(idx)
+            if monitor is not None and cls._monitor_connector(monitor) == connector:
+                return monitor
+        return None
+
+    @staticmethod
+    def _monitor_connector(monitor: Gdk.Monitor) -> str | None:
+        getter = getattr(monitor, "get_connector", None)
+        if not callable(getter):
+            return None
+        text = str(getter() or "").strip()
+        return text or None
+
+    @staticmethod
+    def _monitor_model(monitor: Gdk.Monitor) -> str | None:
+        text = str(monitor.get_model() or "").strip()
+        return text or None
 
     def _monitor_snapshot(
         self,
@@ -599,4 +665,6 @@ class DockPlacementController:
             ),
             scale=self._window.get_scale_factor(),
             primary=primary,
+            name=self._monitor_model(monitor),
+            connector=self._monitor_connector(monitor),
         )

--- a/docking/ui/runtime.py
+++ b/docking/ui/runtime.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from docking.core.theme import Theme
     from docking.ui.dock_window import DockWindow
+    from docking.ui.placement import MonitorChoice
     from docking.ui.update_popup import UpdateCheckController
 
 
@@ -46,6 +47,9 @@ class DockRuntime:
 
     def get_monitor_menu_choices(self) -> list[tuple[str, int]]:
         return self._window.placement.get_monitor_menu_choices()
+
+    def get_monitor_choices(self) -> list[MonitorChoice]:
+        return self._window.placement.get_monitor_choices()
 
     def current_monitor_choice(self) -> int:
         return self._window.placement.current_monitor_choice()

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -159,6 +159,8 @@ class SettingsWindowController:
         self._lock_icons_switch: Any = None
         self._workspace_only_switch: Any = None
         self._active_display_switch: Any = None
+        self._monitor_combo: Any = None
+        self._monitor_info: Any = None
         self._anchor_applets_switch: Any = None
         self._anchor_files_switch: Any = None
         self._zoom_enabled_switch: Any = None
@@ -320,6 +322,23 @@ class SettingsWindowController:
         for pos in Position:
             self._position_combo.append(pos.value, pos.value.capitalize())
 
+        self._monitor_combo = Gtk.ComboBoxText()
+        self._monitor_combo.set_size_request(HIDE_MODE_COMBO_WIDTH_PX, -1)
+        self._monitor_combo.connect("changed", self._on_monitor_combo_changed)
+        self._monitor_info = self._new_info_icon(
+            _(
+                "When Follow Cursor is enabled, the dock follows the pointer "
+                "across monitors. The selected monitor is kept as the fallback."
+            )
+        )
+        monitor_box = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=HIDE_MODE_BOX_SPACING_PX,
+        )
+        monitor_box.set_size_request(TRANSPARENCY_SCALE_WIDTH_PX, -1)
+        monitor_box.pack_start(self._monitor_combo, False, False, 0)
+        monitor_box.pack_start(self._monitor_info, False, False, 0)
+
         self._icon_size_spin = self._new_numeric_spin_button(
             minimum=MIN_ICON_SIZE,
             maximum=MAX_ICON_SIZE,
@@ -422,8 +441,15 @@ class SettingsWindowController:
             rows=[
                 (_("Position"), self._position_combo),
                 (_("Extra Distance from Edge"), additional_distance_box),
-                (_("Follow Cursor"), self._active_display_switch),
                 (_("Current Workspace Only"), self._workspace_only_switch),
+            ],
+        )
+        self._append_section(
+            outer=outer,
+            title=_("Monitor"),
+            rows=[
+                (_("Follow Cursor"), self._active_display_switch),
+                (_("Monitor"), monitor_box),
             ],
         )
         self._append_section(
@@ -887,10 +913,33 @@ class SettingsWindowController:
             }
             for desktop_id, check in self._applet_checks.items():
                 check.set_active(desktop_id in active_ids)
+            self._sync_monitor_combo()
             self._update_updates_status()
         finally:
             self._syncing_widgets = False
         self._update_dependent_sensitivity()
+
+    def _sync_monitor_combo(self) -> None:
+        if self._monitor_combo is None:
+            return
+        self._monitor_combo.remove_all()
+        choices = self._monitor_choices()
+        if not choices:
+            self._monitor_combo.append("-1", _("Primary Display"))
+            self._monitor_combo.set_active_id("-1")
+            return
+        for choice in choices:
+            self._monitor_combo.append(str(choice.index), choice.label)
+        self._monitor_combo.set_active_id(str(self._runtime.current_monitor_choice()))
+
+    def _monitor_choices(self) -> list[Any]:
+        try:
+            choices = self._runtime.get_monitor_choices()
+        except Exception:
+            return []
+        if not isinstance(choices, list):
+            return []
+        return choices
 
     def _rebuild_applet_tab(self) -> None:
         box = self._applets_box
@@ -1032,6 +1081,36 @@ class SettingsWindowController:
     def _on_view_releases(self, _button: Gtk.Button) -> None:
         self._runtime.open_releases_page()
 
+    def _on_monitor_combo_changed(self, widget: Gtk.ComboBoxText) -> None:
+        if self._syncing_widgets:
+            return
+        active_id = widget.get_active_id()
+        if active_id is None:
+            return
+        try:
+            monitor_index = int(active_id)
+        except ValueError:
+            return
+        choices = self._monitor_choices()
+        connector = next(
+            (
+                choice.connector
+                for choice in choices
+                if int(getattr(choice, "index", -2)) == monitor_index
+            ),
+            None,
+        )
+        if (
+            self._config.monitor_index == monitor_index
+            and self._config.monitor_connector == connector
+        ):
+            return
+        self._config.monitor_index = monitor_index
+        self._config.monitor_connector = connector
+        self._config.save()
+        if not self._config.active_display:
+            self._runtime.reposition()
+
     def _apply_runtime_theme(self) -> None:
         theme = Theme.load(self._config.theme, self._config.icon_size).with_opacity(
             self._config.transparency
@@ -1105,6 +1184,8 @@ class SettingsWindowController:
     def _update_dependent_sensitivity(self) -> None:
         if self._zoom_percent_spin is not None:
             self._zoom_percent_spin.set_sensitive(bool(self._config.zoom_enabled))
+        if self._monitor_combo is not None:
+            self._monitor_combo.set_sensitive(not bool(self._config.active_display))
         hide_controls_sensitive = self._config.hide_mode not in (
             "none",
             "always-on-top",

--- a/tests/ui/test_placement.py
+++ b/tests/ui/test_placement.py
@@ -22,6 +22,7 @@ def _make_window(**overrides):
             active_display=False,
             hide_mode="none",
             monitor_index=-1,
+            monitor_connector=None,
             additional_distance_from_edge=0,
             pressure_reveal_enabled=False,
             pressure_threshold=50,
@@ -61,6 +62,24 @@ def _make_controller(window):
         window,
         surface_service=window.surface_service,
     )
+
+
+def _fake_monitor(
+    *,
+    geometry,
+    workarea=None,
+    model: str | None = None,
+    connector: str | None = None,
+):
+    kwargs = {
+        "get_geometry": lambda: geometry,
+        "get_model": lambda: model,
+    }
+    if workarea is not None:
+        kwargs["get_workarea"] = lambda: workarea
+    if connector is not None:
+        kwargs["get_connector"] = lambda: connector
+    return SimpleNamespace(**kwargs)
 
 
 class TestPlacementControllerLifecycle:
@@ -151,7 +170,7 @@ class TestPlacementControllerLifecycle:
     def test_apply_scheduled_reposition_uses_latest_monitor_metrics(self):
         geom = SimpleNamespace(x=0, y=0, width=1920, height=1080)
         work = SimpleNamespace(x=0, y=24, width=1920, height=1056)
-        monitor = SimpleNamespace(get_geometry=lambda: geom, get_workarea=lambda: work)
+        monitor = _fake_monitor(geometry=geom, workarea=work)
         display = SimpleNamespace(
             get_n_monitors=lambda: 1,
             get_primary_monitor=lambda: monitor,
@@ -239,6 +258,28 @@ class TestPlacementControllerGeometry:
 
         assert controller.current_monitor_choice() == 2
 
+    def test_current_monitor_choice_prefers_configured_connector(self):
+        primary = SimpleNamespace(get_connector=lambda: "eDP-1")
+        selected = SimpleNamespace(get_connector=lambda: "DP-1")
+        display = SimpleNamespace(
+            get_n_monitors=lambda: 2,
+            get_primary_monitor=lambda: primary,
+            get_monitor=lambda idx: selected if idx == 1 else primary,
+        )
+        window = _make_window(
+            get_display=lambda: display,
+            config=SimpleNamespace(
+                active_display=False,
+                monitor_index=0,
+                monitor_connector="DP-1",
+                pressure_reveal_enabled=False,
+                pressure_threshold=50,
+            ),
+        )
+        controller = _make_controller(window)
+
+        assert controller.current_monitor_choice() == 1
+
     def test_primary_monitor_index_falls_back_to_zero(self):
         controller = _make_controller(_make_window(get_display=lambda: None))
         assert controller.primary_monitor_index() == 0
@@ -269,7 +310,7 @@ class TestPlacementControllerGeometry:
 
     def test_get_monitor_menu_choices_skips_missing_monitors(self):
         geom1 = SimpleNamespace(width=1920, height=1080)
-        mon1 = SimpleNamespace(get_geometry=lambda: geom1)
+        mon1 = _fake_monitor(geometry=geom1)
         display = SimpleNamespace(
             get_n_monitors=lambda: 2,
             get_primary_monitor=lambda: mon1,
@@ -284,7 +325,7 @@ class TestPlacementControllerGeometry:
     def test_position_dock_horizontal_bottom(self):
         geom = SimpleNamespace(x=0, y=0, width=1920, height=1080)
         work = SimpleNamespace(x=0, y=24, width=1920, height=1056)
-        monitor = SimpleNamespace(get_geometry=lambda: geom, get_workarea=lambda: work)
+        monitor = _fake_monitor(geometry=geom, workarea=work)
         display = SimpleNamespace(
             get_n_monitors=lambda: 1,
             get_primary_monitor=lambda: monitor,
@@ -304,7 +345,7 @@ class TestPlacementControllerGeometry:
     def test_position_dock_bottom_keeps_window_on_screen_edge_with_theme_gap(self):
         geom = SimpleNamespace(x=0, y=0, width=1920, height=1080)
         work = SimpleNamespace(x=0, y=24, width=1920, height=1056)
-        monitor = SimpleNamespace(get_geometry=lambda: geom, get_workarea=lambda: work)
+        monitor = _fake_monitor(geometry=geom, workarea=work)
         display = SimpleNamespace(
             get_n_monitors=lambda: 1,
             get_primary_monitor=lambda: monitor,
@@ -341,7 +382,7 @@ class TestPlacementControllerGeometry:
     def test_position_dock_right_keeps_window_on_screen_edge_with_theme_gap(self):
         geom = SimpleNamespace(x=0, y=0, width=1920, height=1080)
         work = SimpleNamespace(x=0, y=24, width=1920, height=1000)
-        monitor = SimpleNamespace(get_geometry=lambda: geom, get_workarea=lambda: work)
+        monitor = _fake_monitor(geometry=geom, workarea=work)
         display = SimpleNamespace(
             get_n_monitors=lambda: 1,
             get_primary_monitor=lambda: monitor,
@@ -380,12 +421,8 @@ class TestPlacementControllerGeometry:
         work_primary = SimpleNamespace(x=0, y=24, width=1920, height=1056)
         geom_secondary = SimpleNamespace(x=1920, y=0, width=1280, height=1024)
         work_secondary = SimpleNamespace(x=1920, y=24, width=1280, height=1000)
-        primary = SimpleNamespace(
-            get_geometry=lambda: geom_primary, get_workarea=lambda: work_primary
-        )
-        secondary = SimpleNamespace(
-            get_geometry=lambda: geom_secondary, get_workarea=lambda: work_secondary
-        )
+        primary = _fake_monitor(geometry=geom_primary, workarea=work_primary)
+        secondary = _fake_monitor(geometry=geom_secondary, workarea=work_secondary)
         display = SimpleNamespace(
             get_n_monitors=lambda: 2,
             get_primary_monitor=lambda: primary,
@@ -425,7 +462,7 @@ class TestPlacementControllerGeometry:
 
     def test_get_monitor_menu_choices_only_for_multiple_monitors(self):
         geom = SimpleNamespace(width=1920, height=1080)
-        primary = SimpleNamespace(get_geometry=lambda: geom)
+        primary = _fake_monitor(geometry=geom)
         display = SimpleNamespace(
             get_n_monitors=lambda: 1,
             get_primary_monitor=lambda: primary,
@@ -438,8 +475,8 @@ class TestPlacementControllerGeometry:
     def test_get_monitor_menu_choices_does_not_duplicate_primary(self):
         geom1 = SimpleNamespace(width=1920, height=1080)
         geom2 = SimpleNamespace(width=2560, height=1440)
-        mon1 = SimpleNamespace(get_geometry=lambda: geom1)
-        mon2 = SimpleNamespace(get_geometry=lambda: geom2)
+        mon1 = _fake_monitor(geometry=geom1)
+        mon2 = _fake_monitor(geometry=geom2)
         display = SimpleNamespace(
             get_n_monitors=lambda: 2,
             get_primary_monitor=lambda: mon1,
@@ -451,6 +488,33 @@ class TestPlacementControllerGeometry:
 
         labels = [label for label, _ in choices]
         assert labels == ["Display 1: 1920x1080 (Primary)", "Display 2: 2560x1440"]
+
+    def test_get_monitor_choices_includes_connector_when_available(self):
+        geom1 = SimpleNamespace(width=1920, height=1080)
+        geom2 = SimpleNamespace(width=2560, height=1440)
+        mon1 = _fake_monitor(geometry=geom1, model="Built-in", connector="eDP-1")
+        mon2 = _fake_monitor(geometry=geom2, model="Dell", connector="DP-1")
+        display = SimpleNamespace(
+            get_n_monitors=lambda: 2,
+            get_primary_monitor=lambda: mon1,
+            get_monitor=lambda idx: mon1 if idx == 0 else mon2,
+        )
+        controller = _make_controller(_make_window(get_display=lambda: display))
+
+        choices = controller.get_monitor_choices()
+
+        assert choices == [
+            placement_mod.MonitorChoice(
+                label="Display 1: 1920x1080 - eDP-1 (Primary)",
+                index=0,
+                connector="eDP-1",
+            ),
+            placement_mod.MonitorChoice(
+                label="Display 2: 2560x1440 - DP-1",
+                index=1,
+                connector="DP-1",
+            ),
+        ]
 
 
 class TestPlacementControllerStruts:
@@ -492,7 +556,7 @@ class TestPlacementControllerStruts:
     def test_set_struts_calls_surface_reservation(self):
         geom = SimpleNamespace(x=0, y=0, width=1920, height=1080)
         work = SimpleNamespace(x=0, y=0, width=1920, height=1080)
-        monitor = SimpleNamespace(get_geometry=lambda: geom, get_workarea=lambda: work)
+        monitor = _fake_monitor(geometry=geom, workarea=work)
         display = SimpleNamespace(
             get_n_monitors=lambda: 1,
             get_primary_monitor=lambda: monitor,
@@ -531,14 +595,8 @@ class TestPlacementControllerStruts:
         active_geom = SimpleNamespace(x=1920, y=0, width=2560, height=1440)
         primary_work = SimpleNamespace(x=0, y=0, width=1920, height=1080)
         active_work = SimpleNamespace(x=1920, y=0, width=2560, height=1440)
-        primary = SimpleNamespace(
-            get_geometry=lambda: primary_geom,
-            get_workarea=lambda: primary_work,
-        )
-        active = SimpleNamespace(
-            get_geometry=lambda: active_geom,
-            get_workarea=lambda: active_work,
-        )
+        primary = _fake_monitor(geometry=primary_geom, workarea=primary_work)
+        active = _fake_monitor(geometry=active_geom, workarea=active_work)
         display = SimpleNamespace(
             get_n_monitors=lambda: 1,
             get_primary_monitor=lambda: primary,
@@ -621,7 +679,7 @@ class TestPlacementControllerStruts:
     def test_update_barrier_updates_monitor_geometry(self):
         geom = SimpleNamespace(x=100, y=50, width=1280, height=720)
         work = SimpleNamespace(x=100, y=50, width=1280, height=720)
-        monitor = SimpleNamespace(get_geometry=lambda: geom, get_workarea=lambda: work)
+        monitor = _fake_monitor(geometry=geom, workarea=work)
         window = _make_window(
             config=SimpleNamespace(
                 hide_mode="autohide",
@@ -650,7 +708,7 @@ class TestPlacementControllerStruts:
     def test_update_barrier_delivers_scale_to_surface_service(self):
         geom = SimpleNamespace(x=0, y=0, width=1920, height=1080)
         work = SimpleNamespace(x=0, y=0, width=1920, height=1080)
-        monitor = SimpleNamespace(get_geometry=lambda: geom, get_workarea=lambda: work)
+        monitor = _fake_monitor(geometry=geom, workarea=work)
         window = _make_window(
             config=SimpleNamespace(
                 hide_mode="autohide",
@@ -675,7 +733,7 @@ class TestPlacementControllerStruts:
     def test_update_barrier_forwards_display_scale_factor(self, scale):
         geom = SimpleNamespace(x=0, y=0, width=1920, height=1080)
         work = SimpleNamespace(x=0, y=0, width=1920, height=1080)
-        monitor = SimpleNamespace(get_geometry=lambda: geom, get_workarea=lambda: work)
+        monitor = _fake_monitor(geometry=geom, workarea=work)
         window = _make_window(
             config=SimpleNamespace(
                 hide_mode="autohide",
@@ -696,7 +754,7 @@ class TestPlacementControllerStruts:
     def test_update_barrier_enables_pressure_callback_when_configured(self):
         geom = SimpleNamespace(x=0, y=0, width=1920, height=1080)
         work = SimpleNamespace(x=0, y=0, width=1920, height=1080)
-        monitor = SimpleNamespace(get_geometry=lambda: geom, get_workarea=lambda: work)
+        monitor = _fake_monitor(geometry=geom, workarea=work)
         window = _make_window(
             config=SimpleNamespace(
                 hide_mode="autohide",
@@ -720,7 +778,7 @@ class TestPlacementControllerStruts:
     def test_update_barrier_disables_pressure_callback_when_not_configured(self):
         geom = SimpleNamespace(x=0, y=0, width=1920, height=1080)
         work = SimpleNamespace(x=0, y=0, width=1920, height=1080)
-        monitor = SimpleNamespace(get_geometry=lambda: geom, get_workarea=lambda: work)
+        monitor = _fake_monitor(geometry=geom, workarea=work)
         window = _make_window(
             config=SimpleNamespace(
                 hide_mode="autohide",
@@ -899,6 +957,50 @@ class TestPlacementControllerStruts:
             )
         )
         assert controller._resolve_target_monitor(display=display) is fallback
+
+    def test_resolve_target_monitor_prefers_connector_over_index(self):
+        indexed = SimpleNamespace(get_connector=lambda: "eDP-1")
+        connected = SimpleNamespace(get_connector=lambda: "DP-1")
+        display = SimpleNamespace(
+            get_n_monitors=lambda: 2,
+            get_monitor=lambda idx: connected if idx == 1 else indexed,
+            get_primary_monitor=lambda: indexed,
+        )
+        controller = _make_controller(
+            _make_window(
+                config=SimpleNamespace(
+                    active_display=False,
+                    monitor_index=0,
+                    monitor_connector="DP-1",
+                    pressure_reveal_enabled=False,
+                    pressure_threshold=50,
+                )
+            )
+        )
+
+        assert controller._resolve_target_monitor(display=display) is connected
+
+    def test_resolve_target_monitor_falls_back_to_index_when_connector_missing(self):
+        primary = SimpleNamespace(get_connector=lambda: "HDMI-A-1")
+        indexed = SimpleNamespace(get_connector=lambda: "eDP-1")
+        display = SimpleNamespace(
+            get_n_monitors=lambda: 2,
+            get_monitor=lambda idx: indexed if idx == 1 else primary,
+            get_primary_monitor=lambda: primary,
+        )
+        controller = _make_controller(
+            _make_window(
+                config=SimpleNamespace(
+                    active_display=False,
+                    monitor_index=1,
+                    monitor_connector="DP-1",
+                    pressure_reveal_enabled=False,
+                    pressure_threshold=50,
+                )
+            )
+        )
+
+        assert controller._resolve_target_monitor(display=display) is indexed
 
     def test_reposition_updates_input_region_and_redraw(self):
         window = _make_window()

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -225,6 +225,10 @@ class FakeComboBoxText:
     def append(self, item_id: str, text: str) -> None:
         self.items.append((item_id, text))
 
+    def remove_all(self) -> None:
+        self.items.clear()
+        self._active_id = None
+
     def connect(self, signal: str, callback) -> None:
         self.callbacks[signal] = callback
 
@@ -590,6 +594,8 @@ def _config():
         lock_icons=False,
         current_workspace_only=False,
         active_display=False,
+        monitor_index=-1,
+        monitor_connector=None,
         anchor_applets=False,
         anchor_files=False,
         zoom_enabled=True,
@@ -652,6 +658,7 @@ class TestSettingsWindowController:
         assert section_labels == [
             "<b>Look</b>",
             "<b>Placement</b>",
+            "<b>Monitor</b>",
             "<b>Layout</b>",
         ]
         behavior_box = stack.pages[1][0]
@@ -746,10 +753,78 @@ class TestSettingsWindowController:
         assert "Hide Delay" not in appearance_rows
         assert "Unhide Delay" not in appearance_rows
         assert "Open On" not in appearance_rows
+        assert "Follow Cursor" in appearance_rows
+        assert "Monitor" in appearance_rows
         assert "Hide Mode" in behavior_rows
         assert "Hide Delay" in behavior_rows
         assert "Unhide Delay" in behavior_rows
         assert "Open On" in behavior_rows
+
+    def test_monitor_selector_saves_connector_and_repositions(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        runtime = MagicMock()
+        runtime.get_monitor_choices.return_value = [
+            SimpleNamespace(label="Display 1 - eDP-1", index=0, connector="eDP-1"),
+            SimpleNamespace(label="Display 2 - DP-1", index=1, connector="DP-1"),
+        ]
+        runtime.current_monitor_choice.return_value = 0
+        config = _config()
+        controller = settings_mod.SettingsWindowController(
+            parent=object(),
+            runtime=runtime,
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=config,
+        )
+
+        controller.show()
+        controller._monitor_combo.set_active_id("1")
+        controller._monitor_combo.emit_changed()
+
+        assert config.monitor_index == 1
+        assert config.monitor_connector == "DP-1"
+        config.save.assert_called_once()
+        runtime.reposition.assert_called_once()
+
+    def test_follow_cursor_disables_monitor_selector_without_clearing_target(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        runtime = MagicMock()
+        runtime.get_monitor_choices.return_value = [
+            SimpleNamespace(label="Display 1 - eDP-1", index=0, connector="eDP-1"),
+            SimpleNamespace(label="Display 2 - DP-1", index=1, connector="DP-1"),
+        ]
+        runtime.current_monitor_choice.return_value = 1
+        config = _config()
+        config.monitor_index = 1
+        config.monitor_connector = "DP-1"
+        controller = settings_mod.SettingsWindowController(
+            parent=object(),
+            runtime=runtime,
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=config,
+        )
+
+        controller.show()
+        controller._active_display_switch.set_active(True)
+        controller._active_display_switch.emit_notify_active()
+
+        assert config.active_display is True
+        assert config.monitor_index == 1
+        assert config.monitor_connector == "DP-1"
+        assert controller._monitor_combo.sensitive is False
+        runtime.set_active_display.assert_called_once_with(True)
+        runtime.reposition.assert_called_once()
 
     def test_pressure_threshold_uses_info_icon_tooltip(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)


### PR DESCRIPTION
## Summary
- add monitor_connector config support while keeping monitor_index as fallback
- prefer connector-based monitor resolution before index-based placement
- add an Appearance > Monitor section with Follow Cursor and a disabled home-monitor selector while following the pointer across monitors
- include connector/model labels in monitor choices and update tests/i18n template