### PR TITLE
Add tooltips for settings options

### DIFF
--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-06-15 14:04+0200\n"
+"POT-Creation-Date: 2026-06-15 16:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -379,7 +379,7 @@ msgstr ""
 msgid "Power Settings"
 msgstr ""
 
-#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:496
+#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:562
 msgid "Mouse"
 msgstr ""
 
@@ -1349,7 +1349,7 @@ msgid "{verb} every {interval}"
 msgstr ""
 
 #: docking/applets/freshness.py:42 docking/applets/freshness.py:49
-#: docking/ui/settings.py:224
+#: docking/ui/settings.py:226
 msgid "Updates"
 msgstr ""
 
@@ -3014,7 +3014,7 @@ msgstr ""
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:622 docking/ui/settings.py:197
+#: docking/ui/menu.py:622 docking/ui/settings.py:199
 msgid "Preferences"
 msgstr ""
 
@@ -3044,294 +3044,385 @@ msgstr ""
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-#: docking/ui/settings.py:221
+#: docking/ui/settings.py:223
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:222 docking/ui/settings.py:505
+#: docking/ui/settings.py:224 docking/ui/settings.py:589
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:223
+#: docking/ui/settings.py:225
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:247
+#: docking/ui/settings.py:249
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:248
+#: docking/ui/settings.py:250
 msgid "Always on Top"
 msgstr ""
 
-#: docking/ui/settings.py:249
+#: docking/ui/settings.py:251
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:250
+#: docking/ui/settings.py:252
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:251
+#: docking/ui/settings.py:253
 msgid "Dodge Active"
 msgstr ""
 
-#: docking/ui/settings.py:252
+#: docking/ui/settings.py:254
 msgid "Dodge Windows"
 msgstr ""
 
-#: docking/ui/settings.py:253
+#: docking/ui/settings.py:255
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:264
+#: docking/ui/settings.py:266
 msgid "Toggle Focus"
 msgstr ""
 
-#: docking/ui/settings.py:265
+#: docking/ui/settings.py:267
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:266
+#: docking/ui/settings.py:268
 msgid "Most Recent Window"
 msgstr ""
 
-#: docking/ui/settings.py:273
+#: docking/ui/settings.py:275
 msgid "New Window"
 msgstr ""
 
-#: docking/ui/settings.py:274
+#: docking/ui/settings.py:276
 msgid "Minimize Windows"
 msgstr ""
 
-#: docking/ui/settings.py:275
+#: docking/ui/settings.py:277
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:282
+#: docking/ui/settings.py:284
 msgid "Click"
 msgstr ""
 
-#: docking/ui/settings.py:283
+#: docking/ui/settings.py:285
 msgid "Hover"
 msgstr ""
 
-#: docking/ui/settings.py:290
+#: docking/ui/settings.py:292
 msgid "Default"
 msgstr ""
 
-#: docking/ui/settings.py:291
+#: docking/ui/settings.py:293
 msgid "Alphabetical"
 msgstr ""
 
-#: docking/ui/settings.py:308
+#: docking/ui/settings.py:310
 msgid "Daily"
 msgstr ""
 
-#: docking/ui/settings.py:309
+#: docking/ui/settings.py:311
 msgid "Weekly"
 msgstr ""
 
-#: docking/ui/settings.py:330
+#: docking/ui/settings.py:332
 msgid ""
 "When Follow Cursor is enabled, the dock follows the pointer across monitors. "
 "The selected monitor is kept as the fallback."
 msgstr ""
 
-#: docking/ui/settings.py:376
+#: docking/ui/settings.py:378
 msgid "Added on top of the theme's own distance from the edge."
 msgstr ""
 
-#: docking/ui/settings.py:416
+#: docking/ui/settings.py:418
 msgid ""
 "Pixels of cursor pressure against the edge required to reveal a hidden dock. "
 "Higher values mean the dock will not reveal as easily."
 msgstr ""
 
-#: docking/ui/settings.py:426
+#: docking/ui/settings.py:428
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:428
+#: docking/ui/settings.py:430
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:429
-msgid "Icon Size"
-msgstr ""
-
 #: docking/ui/settings.py:430
-msgid "Transparency"
-msgstr ""
-
-#: docking/ui/settings.py:431
-msgid "Zoom"
+msgid "Choose the dock color palette."
 msgstr ""
 
 #: docking/ui/settings.py:432
-msgid "Zoom Percent"
-msgstr ""
-
-#: docking/ui/settings.py:433
-msgid "Show Tooltips"
+msgid "Icon Size"
 msgstr ""
 
 #: docking/ui/settings.py:434
-msgid "Window Previews"
+msgid "Set the base size of dock icons before zoom is applied."
 msgstr ""
 
-#: docking/ui/settings.py:440
-msgid "Placement"
+#: docking/ui/settings.py:437
+msgid "Transparency"
+msgstr ""
+
+#: docking/ui/settings.py:439
+msgid "Adjust how transparent the dock background is."
 msgstr ""
 
 #: docking/ui/settings.py:442
-msgid "Position"
-msgstr ""
-
-#: docking/ui/settings.py:443
-msgid "Extra Distance from Edge"
+msgid "Zoom"
 msgstr ""
 
 #: docking/ui/settings.py:444
-msgid "Current Workspace Only"
+msgid "Enlarge icons when the pointer hovers over the dock."
 msgstr ""
 
-#: docking/ui/settings.py:449 docking/ui/settings.py:452
-msgid "Monitor"
+#: docking/ui/settings.py:447
+msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:451
-msgid "Follow Cursor"
+#: docking/ui/settings.py:449
+msgid "Set how much hovered icons grow when zoom is enabled."
+msgstr ""
+
+#: docking/ui/settings.py:452
+msgid "Show Tooltips"
+msgstr ""
+
+#: docking/ui/settings.py:454
+msgid "Show item names and details when hovering over dock items."
 msgstr ""
 
 #: docking/ui/settings.py:457
-msgid "Layout"
+msgid "Window Previews"
 msgstr ""
 
 #: docking/ui/settings.py:459
-msgid "Lock Positions"
+msgid "Show window thumbnails when hovering over running apps."
 msgstr ""
 
-#: docking/ui/settings.py:460
-msgid "Anchor Applets to End"
+#: docking/ui/settings.py:462
+msgid "Show Window Counts"
 msgstr ""
 
-#: docking/ui/settings.py:461
-msgid "Anchor Files to End"
+#: docking/ui/settings.py:465
+msgid "Show a number on running app indicators when multiple windows are open."
 msgstr ""
 
-#: docking/ui/settings.py:498
-msgid "Left Click"
+#: docking/ui/settings.py:473
+msgid "Placement"
+msgstr ""
+
+#: docking/ui/settings.py:476
+msgid "Position"
+msgstr ""
+
+#: docking/ui/settings.py:478
+msgid "Choose which screen edge the dock uses."
+msgstr ""
+
+#: docking/ui/settings.py:480
+msgid "Extra Distance from Edge"
+msgstr ""
+
+#: docking/ui/settings.py:482
+msgid "Current Workspace Only"
+msgstr ""
+
+#: docking/ui/settings.py:485
+msgid "Show running windows only from the active workspace when supported."
+msgstr ""
+
+#: docking/ui/settings.py:493 docking/ui/settings.py:503
+msgid "Monitor"
+msgstr ""
+
+#: docking/ui/settings.py:496
+msgid "Follow Cursor"
 msgstr ""
 
 #: docking/ui/settings.py:499
-msgid "Middle Click"
-msgstr ""
-
-#: docking/ui/settings.py:500
-msgid "Window List Sort"
-msgstr ""
-
-#: docking/ui/settings.py:507
-msgid "Hide Mode"
+msgid "Move the dock to the monitor where the pointer is currently located."
 msgstr ""
 
 #: docking/ui/settings.py:508
-msgid "Hide Delay"
-msgstr ""
-
-#: docking/ui/settings.py:509
-msgid "Unhide Delay"
-msgstr ""
-
-#: docking/ui/settings.py:510
-msgid "Pressure Reveal"
+msgid "Layout"
 msgstr ""
 
 #: docking/ui/settings.py:511
-msgid "Pressure Threshold"
+msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:516
-msgid "Folder Stacks"
+#: docking/ui/settings.py:514
+msgid "Prevent dock items from being reordered or removed by drag and drop."
 msgstr ""
 
-#: docking/ui/settings.py:518
-msgid "Open On"
+#: docking/ui/settings.py:519
+msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:592
-msgid "Check Now"
+#: docking/ui/settings.py:521
+msgid "Keep applets grouped at the end of the dock."
 msgstr ""
 
-#: docking/ui/settings.py:594
-msgid "View Releases"
+#: docking/ui/settings.py:524
+msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:606
-msgid "Update Checks"
+#: docking/ui/settings.py:526
+msgid "Keep pinned files and folders grouped at the end of the dock."
 msgstr ""
 
-#: docking/ui/settings.py:608
-msgid "Check Automatically"
+#: docking/ui/settings.py:565
+msgid "Left Click"
+msgstr ""
+
+#: docking/ui/settings.py:568
+msgid ""
+"Choose what happens when clicking a running app with the left mouse button."
+msgstr ""
+
+#: docking/ui/settings.py:573
+msgid "Middle Click"
+msgstr ""
+
+#: docking/ui/settings.py:576
+msgid "Choose what happens when clicking an app with the middle mouse button."
+msgstr ""
+
+#: docking/ui/settings.py:581
+msgid "Window List Sort"
+msgstr ""
+
+#: docking/ui/settings.py:583
+msgid "Choose how open windows are ordered in app context menus."
+msgstr ""
+
+#: docking/ui/settings.py:591
+msgid "Hide Mode"
+msgstr ""
+
+#: docking/ui/settings.py:593
+msgid "Hide Delay"
+msgstr ""
+
+#: docking/ui/settings.py:596
+msgid "Set how long the dock waits before hiding after the pointer leaves."
+msgstr ""
+
+#: docking/ui/settings.py:601
+msgid "Unhide Delay"
+msgstr ""
+
+#: docking/ui/settings.py:604
+msgid "Set how long the dock waits before showing after the pointer returns."
 msgstr ""
 
 #: docking/ui/settings.py:609
+msgid "Pressure Reveal"
+msgstr ""
+
+#: docking/ui/settings.py:612
+msgid ""
+"Require the pointer to push against the screen edge before revealing a "
+"hidden dock."
+msgstr ""
+
+#: docking/ui/settings.py:616
+msgid "Pressure Threshold"
+msgstr ""
+
+#: docking/ui/settings.py:621
+msgid "Folder Stacks"
+msgstr ""
+
+#: docking/ui/settings.py:624
+msgid "Open On"
+msgstr ""
+
+#: docking/ui/settings.py:626
+msgid "Choose whether folder stacks open on click or while hovering."
+msgstr ""
+
+#: docking/ui/settings.py:701
+msgid "Check Now"
+msgstr ""
+
+#: docking/ui/settings.py:703
+msgid "View Releases"
+msgstr ""
+
+#: docking/ui/settings.py:715
+msgid "Update Checks"
+msgstr ""
+
+#: docking/ui/settings.py:717
+msgid "Check Automatically"
+msgstr ""
+
+#: docking/ui/settings.py:718
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:610
+#: docking/ui/settings.py:719
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:611
+#: docking/ui/settings.py:720
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:928
+#: docking/ui/settings.py:1058
 msgid "Primary Display"
 msgstr ""
 
-#: docking/ui/settings.py:1069
+#: docking/ui/settings.py:1199
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:1073
+#: docking/ui/settings.py:1203
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:1075
+#: docking/ui/settings.py:1205
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:1148
+#: docking/ui/settings.py:1278
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1150
+#: docking/ui/settings.py:1280
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1153
+#: docking/ui/settings.py:1283
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:1155
+#: docking/ui/settings.py:1285
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1157
+#: docking/ui/settings.py:1287
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1159
+#: docking/ui/settings.py:1289
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1162
+#: docking/ui/settings.py:1292
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -117,6 +117,8 @@ HIDE_DELAY_STEP_MS = 50
 INFO_POPOVER_PADDING_PX = 8
 log = get_logger("settings")
 
+SettingsRow = tuple[str, Gtk.Widget, str | None]
+
 
 @dataclass
 class _ScalarBinding:
@@ -425,40 +427,104 @@ class SettingsWindowController:
             outer=outer,
             title=_("Look"),
             rows=[
-                (_("Theme"), self._theme_combo),
-                (_("Icon Size"), self._icon_size_spin),
-                (_("Transparency"), transparency_box),
-                (_("Zoom"), self._zoom_enabled_switch),
-                (_("Zoom Percent"), self._zoom_percent_spin),
-                (_("Show Tooltips"), self._tooltips_switch),
-                (_("Window Previews"), self._previews_switch),
-                ("Show Window Counts", self._window_count_numbers_switch),
+                (_("Theme"), self._theme_combo, _("Choose the dock color palette.")),
+                (
+                    _("Icon Size"),
+                    self._icon_size_spin,
+                    _("Set the base size of dock icons before zoom is applied."),
+                ),
+                (
+                    _("Transparency"),
+                    transparency_box,
+                    _("Adjust how transparent the dock background is."),
+                ),
+                (
+                    _("Zoom"),
+                    self._zoom_enabled_switch,
+                    _("Enlarge icons when the pointer hovers over the dock."),
+                ),
+                (
+                    _("Zoom Percent"),
+                    self._zoom_percent_spin,
+                    _("Set how much hovered icons grow when zoom is enabled."),
+                ),
+                (
+                    _("Show Tooltips"),
+                    self._tooltips_switch,
+                    _("Show item names and details when hovering over dock items."),
+                ),
+                (
+                    _("Window Previews"),
+                    self._previews_switch,
+                    _("Show window thumbnails when hovering over running apps."),
+                ),
+                (
+                    _("Show Window Counts"),
+                    self._window_count_numbers_switch,
+                    _(
+                        "Show a number on running app indicators when multiple "
+                        "windows are open."
+                    ),
+                ),
             ],
         )
         self._append_section(
             outer=outer,
             title=_("Placement"),
             rows=[
-                (_("Position"), self._position_combo),
-                (_("Extra Distance from Edge"), additional_distance_box),
-                (_("Current Workspace Only"), self._workspace_only_switch),
+                (
+                    _("Position"),
+                    self._position_combo,
+                    _("Choose which screen edge the dock uses."),
+                ),
+                (_("Extra Distance from Edge"), additional_distance_box, None),
+                (
+                    _("Current Workspace Only"),
+                    self._workspace_only_switch,
+                    _(
+                        "Show running windows only from the active workspace "
+                        "when supported."
+                    ),
+                ),
             ],
         )
         self._append_section(
             outer=outer,
             title=_("Monitor"),
             rows=[
-                (_("Follow Cursor"), self._active_display_switch),
-                (_("Monitor"), monitor_box),
+                (
+                    _("Follow Cursor"),
+                    self._active_display_switch,
+                    _(
+                        "Move the dock to the monitor where the pointer is "
+                        "currently located."
+                    ),
+                ),
+                (_("Monitor"), monitor_box, None),
             ],
         )
         self._append_section(
             outer=outer,
             title=_("Layout"),
             rows=[
-                (_("Lock Positions"), self._lock_icons_switch),
-                (_("Anchor Applets to End"), self._anchor_applets_switch),
-                (_("Anchor Files to End"), self._anchor_files_switch),
+                (
+                    _("Lock Positions"),
+                    self._lock_icons_switch,
+                    _(
+                        "Prevent dock items from being reordered or removed by "
+                        "drag and drop."
+                    ),
+                ),
+                (
+                    _("Anchor Applets to End"),
+                    self._anchor_applets_switch,
+                    _("Keep applets grouped at the end of the dock."),
+                ),
+                (
+                    _("Anchor Files to End"),
+                    self._anchor_files_switch,
+                    _("Keep pinned files and folders grouped at the end of the dock."),
+                ),
             ],
         )
 
@@ -495,27 +561,70 @@ class SettingsWindowController:
             outer=outer,
             title=_("Mouse"),
             rows=[
-                (_("Left Click"), self._left_click_combo),
-                (_("Middle Click"), self._middle_click_combo),
-                (_("Window List Sort"), self._window_list_sort_combo),
+                (
+                    _("Left Click"),
+                    self._left_click_combo,
+                    _(
+                        "Choose what happens when clicking a running app with "
+                        "the left mouse button."
+                    ),
+                ),
+                (
+                    _("Middle Click"),
+                    self._middle_click_combo,
+                    _(
+                        "Choose what happens when clicking an app with the "
+                        "middle mouse button."
+                    ),
+                ),
+                (
+                    _("Window List Sort"),
+                    self._window_list_sort_combo,
+                    _("Choose how open windows are ordered in app context menus."),
+                ),
             ],
         )
         self._append_section(
             outer=outer,
             title=_("Behavior"),
             rows=[
-                (_("Hide Mode"), hide_mode_box),
-                (_("Hide Delay"), self._hide_delay_spin),
-                (_("Unhide Delay"), self._unhide_delay_spin),
-                (_("Pressure Reveal"), self._pressure_reveal_switch),
-                (_("Pressure Threshold"), pressure_threshold_box),
+                (_("Hide Mode"), hide_mode_box, None),
+                (
+                    _("Hide Delay"),
+                    self._hide_delay_spin,
+                    _(
+                        "Set how long the dock waits before hiding after the "
+                        "pointer leaves."
+                    ),
+                ),
+                (
+                    _("Unhide Delay"),
+                    self._unhide_delay_spin,
+                    _(
+                        "Set how long the dock waits before showing after the "
+                        "pointer returns."
+                    ),
+                ),
+                (
+                    _("Pressure Reveal"),
+                    self._pressure_reveal_switch,
+                    _(
+                        "Require the pointer to push against the screen edge "
+                        "before revealing a hidden dock."
+                    ),
+                ),
+                (_("Pressure Threshold"), pressure_threshold_box, None),
             ],
         )
         self._append_section(
             outer=outer,
             title=_("Folder Stacks"),
             rows=[
-                (_("Open On"), self._folder_stack_unfold_combo),
+                (
+                    _("Open On"),
+                    self._folder_stack_unfold_combo,
+                    _("Choose whether folder stacks open on click or while hovering."),
+                ),
             ],
         )
 
@@ -605,22 +714,29 @@ class SettingsWindowController:
             outer=outer,
             title=_("Update Checks"),
             rows=[
-                (_("Check Automatically"), self._update_check_switch),
-                (_("Frequency"), self._update_interval_combo),
-                (_("Status"), self._update_status_label),
-                (_("Actions"), actions),
+                (_("Check Automatically"), self._update_check_switch, None),
+                (_("Frequency"), self._update_interval_combo, None),
+                (_("Status"), self._update_status_label, None),
+                (_("Actions"), actions, None),
             ],
         )
         return outer
 
-    def _build_row(self, *, label: str, widget: Gtk.Widget) -> Gtk.Box:
+    def _build_row(
+        self, *, label: str, widget: Gtk.Widget, tooltip: str | None = None
+    ) -> Gtk.Box:
         row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=ROW_SPACING_PX)
         row.set_size_request(APPEARANCE_ROW_WIDTH_PX, -1)
         title = Gtk.Label(label=label)
         title.set_xalign(0.0)
         title.set_hexpand(True)
         row.pack_start(title, True, True, 0)
-        row.pack_end(widget, False, False, 0)
+        row.pack_end(
+            self._with_info_icon(widget=widget, tooltip=tooltip),
+            False,
+            False,
+            0,
+        )
         return row
 
     def _append_section(
@@ -628,7 +744,7 @@ class SettingsWindowController:
         *,
         outer: Gtk.Box,
         title: str,
-        rows: list[tuple[str, Gtk.Widget]],
+        rows: list[SettingsRow],
     ) -> None:
         section = Gtk.Box(
             orientation=Gtk.Orientation.VERTICAL, spacing=SECTION_SPACING_PX
@@ -640,12 +756,26 @@ class SettingsWindowController:
         )
         content.set_margin_start(SECTION_CONTENT_INSET_PX)
         content.set_margin_end(SECTION_CONTENT_INSET_PX)
-        for label, widget in rows:
+        for label, widget, tooltip in rows:
             content.pack_start(
-                self._build_row(label=label, widget=widget), False, False, 0
+                self._build_row(label=label, widget=widget, tooltip=tooltip),
+                False,
+                False,
+                0,
             )
         section.pack_start(content, False, False, 0)
         outer.pack_start(section, False, False, 0)
+
+    def _with_info_icon(self, *, widget: Gtk.Widget, tooltip: str | None) -> Gtk.Widget:
+        if not tooltip:
+            return widget
+        box = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=HIDE_MODE_BOX_SPACING_PX,
+        )
+        box.pack_start(widget, False, False, 0)
+        box.pack_start(self._new_info_icon(tooltip), False, False, 0)
+        return box
 
     def _build_section_header(self, *, title: str) -> Gtk.Label:
         header = Gtk.Label()

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -91,6 +91,7 @@ class FakeBox:
         self.size_request = None
         self.margin_start = 0
         self.margin_end = 0
+        self.tooltip_text = None
 
     def set_border_width(self, value: int) -> None:
         self.border_width = value
@@ -106,6 +107,9 @@ class FakeBox:
 
     def set_size_request(self, width: int, height: int) -> None:
         self.size_request = (width, height)
+
+    def set_tooltip_text(self, value: str) -> None:
+        self.tooltip_text = value
 
     def pack_start(self, child, *_args) -> None:
         self.children.append(child)
@@ -221,6 +225,7 @@ class FakeComboBoxText:
         self._active_id: str | None = None
         self.callbacks: dict[str, object] = {}
         self.sensitive = True
+        self.tooltip_text = None
 
     def append(self, item_id: str, text: str) -> None:
         self.items.append((item_id, text))
@@ -249,6 +254,9 @@ class FakeComboBoxText:
     def set_sensitive(self, value: bool) -> None:
         self.sensitive = value
 
+    def set_tooltip_text(self, value: str) -> None:
+        self.tooltip_text = value
+
 
 class FakeSpinButton:
     def __init__(self) -> None:
@@ -256,6 +264,7 @@ class FakeSpinButton:
         self.callbacks: dict[str, object] = {}
         self.properties: dict[str, object] = {}
         self.sensitive = True
+        self.tooltip_text = None
 
     @classmethod
     def new_with_range(cls, *_args):
@@ -284,6 +293,9 @@ class FakeSpinButton:
     def set_size_request(self, width: int, height: int) -> None:
         self.size_request = (width, height)
 
+    def set_tooltip_text(self, value: str) -> None:
+        self.tooltip_text = value
+
 
 class FakeScale(FakeSpinButton):
     @classmethod
@@ -305,6 +317,7 @@ class FakeSwitch:
         self._active = False
         self.callbacks: dict[str, object] = {}
         self.sensitive = True
+        self.tooltip_text = None
 
     def connect(self, signal: str, callback, *args) -> None:
         self.callbacks[signal] = (callback, args)
@@ -321,6 +334,9 @@ class FakeSwitch:
 
     def set_sensitive(self, value: bool) -> None:
         self.sensitive = value
+
+    def set_tooltip_text(self, value: str) -> None:
+        self.tooltip_text = value
 
 
 class FakeCheckButton(FakeSwitch):
@@ -759,6 +775,91 @@ class TestSettingsWindowController:
         assert "Hide Delay" in behavior_rows
         assert "Unhide Delay" in behavior_rows
         assert "Open On" in behavior_rows
+
+    def test_appearance_and_behavior_rows_have_visible_info_icons(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        controller = settings_mod.SettingsWindowController(
+            parent=object(),
+            runtime=MagicMock(),
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=_config(),
+        )
+
+        controller.show()
+        stack = controller._window.child.children[1]
+        appearance_box = stack.pages[0][0]
+        behavior_box = stack.pages[1][0]
+
+        def rows_by_label(tab_box):
+            rows = {}
+            for section in tab_box.get_children():
+                if not isinstance(section, FakeBox):
+                    continue
+                children = section.get_children()
+                if len(children) < 2 or not isinstance(children[1], FakeBox):
+                    continue
+                for row in children[1].get_children():
+                    if not isinstance(row, FakeBox) or len(row.get_children()) < 2:
+                        continue
+                    title = row.get_children()[0]
+                    if isinstance(title, FakeLabel):
+                        rows[title.get_label()] = row
+            return rows
+
+        appearance_rows = rows_by_label(appearance_box)
+        behavior_rows = rows_by_label(behavior_box)
+        rows = {**appearance_rows, **behavior_rows}
+        existing_info_rows = {
+            "Extra Distance from Edge",
+            "Hide Mode",
+            "Monitor",
+            "Pressure Threshold",
+        }
+        expected_tooltip_rows = {
+            "Theme",
+            "Icon Size",
+            "Transparency",
+            "Zoom",
+            "Zoom Percent",
+            "Show Tooltips",
+            "Window Previews",
+            "Show Window Counts",
+            "Position",
+            "Follow Cursor",
+            "Current Workspace Only",
+            "Lock Positions",
+            "Anchor Applets to End",
+            "Anchor Files to End",
+            "Left Click",
+            "Middle Click",
+            "Window List Sort",
+            "Hide Delay",
+            "Unhide Delay",
+            "Pressure Reveal",
+            "Open On",
+        }
+
+        for label in expected_tooltip_rows:
+            row = rows[label]
+            title, control = row.get_children()[:2]
+            assert title.tooltip_text is None
+            assert isinstance(control, FakeBox)
+            control_children = control.get_children()
+            assert len(control_children) == 2
+            assert isinstance(control_children[1], FakeEventBox)
+            assert control_children[1]._docking_info_label.get_label()
+
+        for label in existing_info_rows:
+            row = rows[label]
+            title, control = row.get_children()[:2]
+            assert row.tooltip_text is None
+            assert title.tooltip_text is None
+            assert getattr(control, "tooltip_text", None) is None
 
     def test_monitor_selector_saves_connector_and_repositions(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)


### PR DESCRIPTION
## Summary
- add clear tooltip text to Appearance and Behavior settings entries that did not already have an info entry
- keep existing info-icon explanations unchanged for Hide Mode, Extra Distance from Edge, and Pressure Threshold
- add settings tests that verify tooltip coverage for eligible rows
- update the translation template for the new strings

## Tests
- pre-commit hook: 3705 passed, 1 skipped, 12 deselected
- ruff format/check passed
- ty completed with existing unrelated warnings
- i18n template/catalog checks passed
- package-data and translation packaging checks passed