### PR TITLE
Revert direct push of CI supply-chain cooldown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,5 @@
 name: CI
 
-# ── Supply-chain cooldown ─────────────────────────────────────────────
-# Every pip install step exports PIP_UPLOADED_PRIOR_TO set to 7 days ago
-# (pip >= 26.1).  This prevents freshly-published packages from being
-# resolved, mitigating supply-chain attacks where a compromised release
-# is pushed to PyPI.  Dependabot is also configured with a weekly schedule
-# (.github/dependabot.yml) so new versions age at least 0–7 days before a PR
-# is opened.
-# ──────────────────────────────────────────────────────────────────────
-
 on:
   push:
     branches: [master]
@@ -98,7 +89,6 @@ jobs:
           python3 -m venv .venv
           . .venv/bin/activate
           python -m pip install --upgrade pip
-          export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python -m pip install -e ".[dev]"
 
       - name: Verify POT is up to date
@@ -163,7 +153,6 @@ jobs:
           python3 -m venv --system-site-packages .venv
           . .venv/bin/activate
           python -m pip install --upgrade pip
-          export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python -m pip install -e ".[dev]"
 
       - name: Screenshot regression tests
@@ -246,7 +235,6 @@ jobs:
           python3 -m venv --system-site-packages .venv
           . .venv/bin/activate
           python -m pip install --upgrade pip
-          export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python -m pip install -e ".[dev]"
 
       - name: Install project without GI bindings
@@ -255,7 +243,6 @@ jobs:
           python -m venv .venv
           . .venv/bin/activate
           python -m pip install --upgrade pip setuptools wheel
-          export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python -m pip install pycairo
           python -m pip install -e ".[dev]"
 
@@ -341,7 +328,6 @@ jobs:
         if: matrix.python != '3.14'
         run: |
           python -m pip install --upgrade pip
-          export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python -m pip install pycairo "PyGObject==3.42.2"
           python -m pip install -e ".[dev]"
 
@@ -349,7 +335,6 @@ jobs:
         if: matrix.python == '3.14'
         run: |
           python -m pip install --upgrade pip
-          export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python -m pip install pycairo
           python -m pip install -e ".[dev]"
 
@@ -406,7 +391,6 @@ jobs:
           python3 -m venv --system-site-packages .venv
           . .venv/bin/activate
           python -m pip install --upgrade pip
-          export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python -m pip install -e ".[dev]"
 
       - name: Full tests
@@ -441,7 +425,6 @@ jobs:
           python3 -m venv --system-site-packages .venv
           . .venv/bin/activate
           python -m pip install --upgrade pip
-          export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python -m pip install -e ".[dev]"
 
       - name: Smoke tests
@@ -505,7 +488,6 @@ jobs:
           "$PYTHON" -m venv .venv
           . .venv/bin/activate
           python -m pip install --upgrade pip setuptools wheel
-          export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python -m pip install pycairo PyGObject
           python -m pip install -e ".[dev]"
 
@@ -866,7 +848,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y python3-apt python3-pip libfuse2 libgdk-pixbuf2.0-bin libglib2.0-bin libgtk-3-bin squashfs-tools gettext
           python3 -m pip install --upgrade pip
-          export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python3 -m pip install appimage-builder
 
       - name: Compile translations
@@ -895,7 +876,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y python3-apt python3-pip libfuse2 libgdk-pixbuf2.0-bin libglib2.0-bin libgtk-3-bin squashfs-tools gettext
           python3 -m pip install --upgrade pip
-          export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python3 -m pip install appimage-builder
 
       - name: Compile translations


### PR DESCRIPTION
Reverts commit de7990c5 which was pushed directly to master by mistake. The cooldown changes will be re-submitted via a proper PR.