### PR TITLE
Add per-app Recent Documents submenu (jumplists)

### DIFF
--- a/docking/core/config.py
+++ b/docking/core/config.py
@@ -288,6 +288,8 @@ DEFAULT_SHOW_RECENT_APPS = True
 DEFAULT_RECENT_APPS_MAX = 5
 DEFAULT_RECENT_APPS_RETENTION_DAYS = 14
 MIN_RECENT_APPS_RETENTION_DAYS = 1
+DEFAULT_SHOW_RECENT_DOCS_IN_MENU = True
+DEFAULT_RECENT_DOCS_MAX = 10
 MAX_RECENT_APPS_RETENTION_DAYS = 90
 
 logger = get_logger("config")
@@ -827,6 +829,10 @@ class Config:
     recent_apps_retention_days: int = DEFAULT_RECENT_APPS_RETENTION_DAYS
     # Persisted recent-app history: [{"desktop_id": "...", "last_closed": epoch}, ...]
     recent_apps: list[dict[str, object]] = field(default_factory=list)
+    # Whether to show a "Recent Documents" submenu when right-clicking apps
+    show_recent_docs_in_menu: bool = DEFAULT_SHOW_RECENT_DOCS_IN_MENU
+    # Per-app cap for recent document entries in the submenu
+    recent_docs_max: int = DEFAULT_RECENT_DOCS_MAX
 
     @property
     def pos(self) -> Position:
@@ -983,6 +989,16 @@ class Config:
             maximum=MAX_RECENT_APPS_RETENTION_DAYS,
         )
         self.recent_apps = _normalize_recent_apps(self.recent_apps)
+        self.show_recent_docs_in_menu = _normalize_bool(
+            self.show_recent_docs_in_menu,
+            default=DEFAULT_SHOW_RECENT_DOCS_IN_MENU,
+        )
+        self.recent_docs_max = _normalize_int(
+            self.recent_docs_max,
+            default=DEFAULT_RECENT_DOCS_MAX,
+            minimum=1,
+            maximum=25,
+        )
 
     @classmethod
     def load(cls, path: Path | str | None = None) -> Config:

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-06-17 21:25+0200\n"
+"POT-Creation-Date: 2026-06-18 18:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2017,7 +2017,7 @@ msgid "Run with file"
 msgstr ""
 
 #: docking/applets/runcommand/applet.py:340
-#: docking/applets/systemtray/applet.py:254 docking/ui/menu.py:462
+#: docking/applets/systemtray/applet.py:254 docking/ui/menu.py:464
 msgid "Open"
 msgstr ""
 
@@ -2780,7 +2780,7 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: docking/ui/diagnostics.py:71 docking/ui/menu.py:617
+#: docking/ui/diagnostics.py:71 docking/ui/menu.py:623
 msgid "Diagnostics"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Save Report..."
 msgstr ""
 
-#: docking/ui/diagnostics.py:122 docking/ui/menu.py:501
+#: docking/ui/diagnostics.py:122 docking/ui/menu.py:507
 msgid "Close"
 msgstr ""
 
@@ -2951,68 +2951,76 @@ msgstr ""
 msgid "%d More in Folder"
 msgstr ""
 
-#: docking/ui/menu.py:403
+#: docking/ui/menu.py:405
 msgid "Icon"
 msgstr ""
 
-#: docking/ui/menu.py:405
+#: docking/ui/menu.py:407
 msgid "Docking Icon"
 msgstr ""
 
-#: docking/ui/menu.py:406
+#: docking/ui/menu.py:408
 msgid "System Icon"
 msgstr ""
 
-#: docking/ui/menu.py:449 docking/ui/menu.py:469 docking/ui/menu.py:485
-#: docking/ui/menu.py:533
+#: docking/ui/menu.py:451 docking/ui/menu.py:471 docking/ui/menu.py:491
+#: docking/ui/menu.py:539
 msgid "Remove from Dock"
 msgstr ""
 
-#: docking/ui/menu.py:492
+#: docking/ui/menu.py:498
 msgid "Keep in Dock"
 msgstr ""
 
-#: docking/ui/menu.py:501
+#: docking/ui/menu.py:507
 msgid "Close All"
 msgstr ""
 
-#: docking/ui/menu.py:518
+#: docking/ui/menu.py:524
 msgid "Sort By"
 msgstr ""
 
-#: docking/ui/menu.py:526
+#: docking/ui/menu.py:532
 msgid "Show Hidden Files"
 msgstr ""
 
-#: docking/ui/menu.py:563
+#: docking/ui/menu.py:569
 msgid "Add Applet"
 msgstr ""
 
-#: docking/ui/menu.py:601
+#: docking/ui/menu.py:607
 msgid "No Applets Available"
 msgstr ""
 
-#: docking/ui/menu.py:608
+#: docking/ui/menu.py:614
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:622 docking/ui/settings.py:202
+#: docking/ui/menu.py:628 docking/ui/settings.py:202
 msgid "Preferences"
 msgstr ""
 
-#: docking/ui/menu.py:627
+#: docking/ui/menu.py:633
 msgid "About"
 msgstr ""
 
-#: docking/ui/menu.py:632
+#: docking/ui/menu.py:638
 msgid "Get Support"
 msgstr ""
 
-#: docking/ui/menu.py:639
+#: docking/ui/menu.py:645
 msgid "Quit"
 msgstr ""
 
-#: docking/ui/menu.py:677
+#: docking/ui/menu.py:711
+msgid "Clear Recent Documents"
+msgstr ""
+
+#: docking/ui/menu.py:720
+msgid "Recent Documents"
+msgstr ""
+
+#: docking/ui/menu.py:739
 msgid "Window"
 msgstr ""
 

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-06-18 18:46+0200\n"
+"POT-Creation-Date: 2026-06-18 18:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -379,7 +379,7 @@ msgstr ""
 msgid "Power Settings"
 msgstr ""
 
-#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:573
+#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:579
 msgid "Mouse"
 msgstr ""
 
@@ -1349,7 +1349,7 @@ msgid "{verb} every {interval}"
 msgstr ""
 
 #: docking/applets/freshness.py:43 docking/applets/freshness.py:50
-#: docking/ui/settings.py:229
+#: docking/ui/settings.py:231
 msgid "Updates"
 msgstr ""
 
@@ -2996,7 +2996,7 @@ msgstr ""
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:628 docking/ui/settings.py:202
+#: docking/ui/menu.py:628 docking/ui/settings.py:204
 msgid "Preferences"
 msgstr ""
 
@@ -3016,7 +3016,7 @@ msgstr ""
 msgid "Clear Recent Documents"
 msgstr ""
 
-#: docking/ui/menu.py:720
+#: docking/ui/menu.py:720 docking/ui/settings.py:673
 msgid "Recent Documents"
 msgstr ""
 
@@ -3034,413 +3034,429 @@ msgstr ""
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-#: docking/ui/settings.py:226
+#: docking/ui/settings.py:228
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:227 docking/ui/settings.py:600
+#: docking/ui/settings.py:229 docking/ui/settings.py:606
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:228
+#: docking/ui/settings.py:230
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:252
+#: docking/ui/settings.py:254
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:253
+#: docking/ui/settings.py:255
 msgid "Always on Top"
 msgstr ""
 
-#: docking/ui/settings.py:254
+#: docking/ui/settings.py:256
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:255
+#: docking/ui/settings.py:257
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:258
 msgid "Dodge Active"
 msgstr ""
 
-#: docking/ui/settings.py:257
+#: docking/ui/settings.py:259
 msgid "Dodge Windows"
 msgstr ""
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:260
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:269
+#: docking/ui/settings.py:271
 msgid "Toggle Focus"
 msgstr ""
 
-#: docking/ui/settings.py:270
+#: docking/ui/settings.py:272
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:271
+#: docking/ui/settings.py:273
 msgid "Most Recent Window"
 msgstr ""
 
-#: docking/ui/settings.py:278
+#: docking/ui/settings.py:280
 msgid "New Window"
 msgstr ""
 
-#: docking/ui/settings.py:279
+#: docking/ui/settings.py:281
 msgid "Minimize Windows"
 msgstr ""
 
-#: docking/ui/settings.py:280
+#: docking/ui/settings.py:282
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:289
 msgid "Click"
 msgstr ""
 
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:290
 msgid "Hover"
 msgstr ""
 
-#: docking/ui/settings.py:295
+#: docking/ui/settings.py:297
 msgid "Default"
 msgstr ""
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:298
 msgid "Alphabetical"
 msgstr ""
 
-#: docking/ui/settings.py:313
+#: docking/ui/settings.py:315
 msgid "Daily"
 msgstr ""
 
-#: docking/ui/settings.py:314
+#: docking/ui/settings.py:316
 msgid "Weekly"
 msgstr ""
 
-#: docking/ui/settings.py:335
+#: docking/ui/settings.py:337
 msgid ""
 "When Follow Cursor is enabled, the dock follows the pointer across monitors. "
 "The selected monitor is kept as the fallback."
 msgstr ""
 
-#: docking/ui/settings.py:381
+#: docking/ui/settings.py:383
 msgid "Added on top of the theme's own distance from the edge."
 msgstr ""
 
-#: docking/ui/settings.py:421
+#: docking/ui/settings.py:423
 msgid ""
 "Pixels of cursor pressure against the edge required to reveal a hidden dock. "
 "Higher values mean the dock will not reveal as easily."
 msgstr ""
 
-#: docking/ui/settings.py:439
+#: docking/ui/settings.py:445
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:441
+#: docking/ui/settings.py:447
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:441
+#: docking/ui/settings.py:447
 msgid "Choose the dock color palette."
 msgstr ""
 
-#: docking/ui/settings.py:443
+#: docking/ui/settings.py:449
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:445
+#: docking/ui/settings.py:451
 msgid "Set the base size of dock icons before zoom is applied."
 msgstr ""
 
-#: docking/ui/settings.py:448
+#: docking/ui/settings.py:454
 msgid "Transparency"
 msgstr ""
 
-#: docking/ui/settings.py:450
+#: docking/ui/settings.py:456
 msgid "Adjust how transparent the dock background is."
 msgstr ""
 
-#: docking/ui/settings.py:453
+#: docking/ui/settings.py:459
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:455
+#: docking/ui/settings.py:461
 msgid "Enlarge icons when the pointer hovers over the dock."
 msgstr ""
 
-#: docking/ui/settings.py:458
+#: docking/ui/settings.py:464
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:460
+#: docking/ui/settings.py:466
 msgid "Set how much hovered icons grow when zoom is enabled."
 msgstr ""
 
-#: docking/ui/settings.py:463
+#: docking/ui/settings.py:469
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:465
+#: docking/ui/settings.py:471
 msgid "Show item names and details when hovering over dock items."
 msgstr ""
 
-#: docking/ui/settings.py:468
+#: docking/ui/settings.py:474
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:470
+#: docking/ui/settings.py:476
 msgid "Show window thumbnails when hovering over running apps."
 msgstr ""
 
-#: docking/ui/settings.py:473
+#: docking/ui/settings.py:479
 msgid "Show Window Counts"
 msgstr ""
 
-#: docking/ui/settings.py:476
+#: docking/ui/settings.py:482
 msgid "Show a number on running app indicators when multiple windows are open."
 msgstr ""
 
-#: docking/ui/settings.py:484
+#: docking/ui/settings.py:490
 msgid "Placement"
 msgstr ""
 
-#: docking/ui/settings.py:487
+#: docking/ui/settings.py:493
 msgid "Position"
 msgstr ""
 
-#: docking/ui/settings.py:489
+#: docking/ui/settings.py:495
 msgid "Choose which screen edge the dock uses."
 msgstr ""
 
-#: docking/ui/settings.py:491
+#: docking/ui/settings.py:497
 msgid "Extra Distance from Edge"
 msgstr ""
 
-#: docking/ui/settings.py:493
+#: docking/ui/settings.py:499
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:496
+#: docking/ui/settings.py:502
 msgid "Show running windows only from the active workspace when supported."
 msgstr ""
 
-#: docking/ui/settings.py:504 docking/ui/settings.py:514
+#: docking/ui/settings.py:510 docking/ui/settings.py:520
 msgid "Monitor"
 msgstr ""
 
-#: docking/ui/settings.py:507
+#: docking/ui/settings.py:513
 msgid "Follow Cursor"
 msgstr ""
 
-#: docking/ui/settings.py:510
+#: docking/ui/settings.py:516
 msgid "Move the dock to the monitor where the pointer is currently located."
 msgstr ""
 
-#: docking/ui/settings.py:519
+#: docking/ui/settings.py:525
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:522
+#: docking/ui/settings.py:528
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:525
+#: docking/ui/settings.py:531
 msgid "Prevent dock items from being reordered or removed by drag and drop."
 msgstr ""
 
-#: docking/ui/settings.py:530
+#: docking/ui/settings.py:536
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:532
+#: docking/ui/settings.py:538
 msgid "Keep applets grouped at the end of the dock."
 msgstr ""
 
-#: docking/ui/settings.py:535
+#: docking/ui/settings.py:541
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:537
+#: docking/ui/settings.py:543
 msgid "Keep pinned files and folders grouped at the end of the dock."
 msgstr ""
 
-#: docking/ui/settings.py:576
+#: docking/ui/settings.py:582
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:579
+#: docking/ui/settings.py:585
 msgid ""
 "Choose what happens when clicking a running app with the left mouse button."
 msgstr ""
 
-#: docking/ui/settings.py:584
+#: docking/ui/settings.py:590
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:587
+#: docking/ui/settings.py:593
 msgid "Choose what happens when clicking an app with the middle mouse button."
 msgstr ""
 
-#: docking/ui/settings.py:592
+#: docking/ui/settings.py:598
 msgid "Window List Sort"
 msgstr ""
 
-#: docking/ui/settings.py:594
+#: docking/ui/settings.py:600
 msgid "Choose how open windows are ordered in app context menus."
 msgstr ""
 
-#: docking/ui/settings.py:602
+#: docking/ui/settings.py:608
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:604
+#: docking/ui/settings.py:610
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:607
+#: docking/ui/settings.py:613
 msgid "Set how long the dock waits before hiding after the pointer leaves."
 msgstr ""
 
-#: docking/ui/settings.py:612
+#: docking/ui/settings.py:618
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:615
+#: docking/ui/settings.py:621
 msgid "Set how long the dock waits before showing after the pointer returns."
 msgstr ""
 
-#: docking/ui/settings.py:620
+#: docking/ui/settings.py:626
 msgid "Pressure Reveal"
 msgstr ""
 
-#: docking/ui/settings.py:623
+#: docking/ui/settings.py:629
 msgid ""
 "Require the pointer to push against the screen edge before revealing a "
 "hidden dock."
 msgstr ""
 
-#: docking/ui/settings.py:627
+#: docking/ui/settings.py:633
 msgid "Pressure Threshold"
 msgstr ""
 
-#: docking/ui/settings.py:632
+#: docking/ui/settings.py:638
 msgid "Folder Stacks"
 msgstr ""
 
-#: docking/ui/settings.py:635
+#: docking/ui/settings.py:641
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:637
+#: docking/ui/settings.py:643
 msgid "Choose whether folder stacks open on click or while hovering."
 msgstr ""
 
-#: docking/ui/settings.py:643
+#: docking/ui/settings.py:649
 msgid "Recent Apps"
 msgstr ""
 
-#: docking/ui/settings.py:646
+#: docking/ui/settings.py:652
 msgid "Show Recently Used Apps"
 msgstr ""
 
-#: docking/ui/settings.py:649
+#: docking/ui/settings.py:655
 msgid "Show recently closed apps between pinned launchers and running apps."
 msgstr ""
 
-#: docking/ui/settings.py:654
+#: docking/ui/settings.py:660
 msgid "Number of Recent Apps"
 msgstr ""
 
-#: docking/ui/settings.py:656
+#: docking/ui/settings.py:662
 msgid "Maximum recently used app icons to display."
 msgstr ""
 
-#: docking/ui/settings.py:659
+#: docking/ui/settings.py:665
 msgid "Keep Recent Apps For"
 msgstr ""
 
-#: docking/ui/settings.py:661
+#: docking/ui/settings.py:667
 msgid "Remove recent apps after this many days of inactivity."
 msgstr ""
 
-#: docking/ui/settings.py:736
+#: docking/ui/settings.py:676
+msgid "Show Recent Documents"
+msgstr ""
+
+#: docking/ui/settings.py:679
+msgid "Show a \"Recent Documents\" submenu when right-clicking an app icon."
+msgstr ""
+
+#: docking/ui/settings.py:684
+msgid "Max Documents Per App"
+msgstr ""
+
+#: docking/ui/settings.py:686
+msgid "Maximum recent document entries shown per app."
+msgstr ""
+
+#: docking/ui/settings.py:761
 msgid "Check Now"
 msgstr ""
 
-#: docking/ui/settings.py:738
+#: docking/ui/settings.py:763
 msgid "View Releases"
 msgstr ""
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:775
 msgid "Update Checks"
 msgstr ""
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:777
 msgid "Check Automatically"
 msgstr ""
 
-#: docking/ui/settings.py:753
+#: docking/ui/settings.py:778
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:779
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:755
+#: docking/ui/settings.py:780
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:1116
+#: docking/ui/settings.py:1150
 msgid "Primary Display"
 msgstr ""
 
-#: docking/ui/settings.py:1257
+#: docking/ui/settings.py:1291
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:1261
+#: docking/ui/settings.py:1295
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:1263
+#: docking/ui/settings.py:1297
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:1344
+#: docking/ui/settings.py:1378
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1346
+#: docking/ui/settings.py:1380
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1349
+#: docking/ui/settings.py:1383
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:1351
+#: docking/ui/settings.py:1385
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1353
+#: docking/ui/settings.py:1387
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1355
+#: docking/ui/settings.py:1389
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1358
+#: docking/ui/settings.py:1392
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/platform/recent_docs.py
+++ b/docking/platform/recent_docs.py
@@ -1,0 +1,142 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Recent-document-to-app association for per-app jumplist menus.
+
+Reads the freedesktop.org recent-files store (via Gtk.RecentManager) and
+associates each file with dock apps using a three-tier matching strategy
+prioritised by precision:
+
+1. ``has_application()`` with the app's display name — the file was
+   *actually* opened with this app.  Most precise, zero false positives.
+2. MIME-type match against the app's ``get_supported_types()`` — the app
+   *could* open this file.  Capped at 5 items to limit noise.
+3. System default-handler check — this app is the registered default for
+   the file type.  Rarely hit, catches edge cases.
+
+Tier 1 results are shown exclusively when they exist; Tiers 2 and 3 are
+only used when Tier 1 is empty.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gio, Gtk
+
+from docking.log import get_logger
+
+if TYPE_CHECKING:
+    from docking.platform.launcher import Launcher
+
+log = get_logger(name="recent_docs")
+
+# Tier-2 MIME fallback cap to prevent noisy results when every image app
+# registers for image/png and similar broad types.
+_MIME_FALLBACK_CAP = 5
+
+
+@dataclass(frozen=True)
+class RecentDoc:
+    """One recent document associated with a dock app."""
+
+    uri: str
+    name: str  # short filename for display
+    mime_type: str
+    modified: int  # Unix timestamp
+
+
+def recent_docs_for_app(
+    desktop_id: str,
+    launcher: Launcher,
+    limit: int = 10,
+) -> list[RecentDoc]:
+    """Return recent documents associated with *desktop_id*, most-recent first.
+
+    Args:
+        desktop_id: The app's desktop-file ID (e.g. ``firefox.desktop``).
+        launcher: Resolver for desktop metadata and display names.
+        limit: Maximum number of documents to return (per-app cap).
+    """
+    if not desktop_id:
+        return []
+
+    try:
+        app_info = Gio.DesktopAppInfo.new(desktop_id)
+    except TypeError:
+        return []
+    if app_info is None:
+        return []
+
+    display_name = app_info.get_display_name()
+    supported = app_info.get_supported_types()
+
+    rm = Gtk.RecentManager.get_default()
+    all_items = rm.get_items()
+    if not all_items:
+        return []
+
+    # get_items() order is undefined — sort by modification time descending.
+    sorted_items = sorted(all_items, key=lambda i: i.get_modified(), reverse=True)
+
+    # ── Tier 1: files actually opened with this app ──
+    tier1: list[RecentDoc] = []
+    # ── Tier 2: files this app *could* open (MIME match) ──
+    tier2: list[RecentDoc] = []
+    # ── Tier 3: system default handler ──
+    tier3: list[RecentDoc] = []
+
+    for item in sorted_items:
+        if not item.is_local():
+            continue
+        if not item.exists():
+            continue
+        mime = item.get_mime_type()
+        if not mime:
+            continue
+
+        # Tier 1: has_application — the ground truth
+        if item.has_application(display_name):
+            tier1.append(_doc_from_item(item, mime))
+            if len(tier1) >= limit:
+                return tier1
+            continue
+
+        # Tier 2: MIME-type — noisy, only when Tier 1 is empty
+        if supported and mime in supported and len(tier2) < _MIME_FALLBACK_CAP:
+            tier2.append(_doc_from_item(item, mime))
+            continue
+
+        # Tier 3: default handler — edge cases
+        if not supported:
+            default = Gio.AppInfo.get_default_for_type(mime, False)
+            if default and default.get_id() == desktop_id:
+                tier3.append(_doc_from_item(item, mime))
+
+    # Tier 1 results are shown exclusively — no MIME noise mixed in.
+    if tier1:
+        return tier1
+    return (tier2 + tier3)[:limit]
+
+
+def _doc_from_item(item, mime: str) -> RecentDoc:
+    return RecentDoc(
+        uri=item.get_uri(),
+        name=item.get_short_name(),
+        mime_type=mime,
+        modified=item.get_modified(),
+    )

--- a/docking/platform/recent_docs.py
+++ b/docking/platform/recent_docs.py
@@ -14,18 +14,13 @@
 """Recent-document-to-app association for per-app jumplist menus.
 
 Reads the freedesktop.org recent-files store (via Gtk.RecentManager) and
-associates each file with dock apps using a three-tier matching strategy
-prioritised by precision:
+associates each file with dock apps using ``has_application()`` — the only
+reliable signal for "this app actually opened this file".
 
-1. ``has_application()`` with the app's display name — the file was
-   *actually* opened with this app.  Most precise, zero false positives.
-2. MIME-type match against the app's ``get_supported_types()`` — the app
-   *could* open this file.  Capped at 5 items to limit noise.
-3. System default-handler check — this app is the registered default for
-   the file type.  Rarely hit, catches edge cases.
-
-Tier 1 results are shown exclusively when they exist; Tiers 2 and 3 are
-only used when Tier 1 is empty.
+MIME-type matching (``get_supported_types()``) was tested and rejected:
+every image-handling app registers for ``image/png``, so Firefox, Chrome,
+GIMP, and EOM would all show the same PNGs regardless of which app the
+user actually used.  ``has_application()`` records the ground truth.
 """
 
 from __future__ import annotations
@@ -45,10 +40,6 @@ if TYPE_CHECKING:
 
 log = get_logger(name="recent_docs")
 
-# Tier-2 MIME fallback cap to prevent noisy results when every image app
-# registers for image/png and similar broad types.
-_MIME_FALLBACK_CAP = 5
-
 
 @dataclass(frozen=True)
 class RecentDoc:
@@ -67,6 +58,10 @@ def recent_docs_for_app(
 ) -> list[RecentDoc]:
     """Return recent documents associated with *desktop_id*, most-recent first.
 
+    Only returns files where ``has_application()`` confirms the app actually
+    opened them.  No MIME-type fallback — that produces identical noise across
+    all apps sharing the same broad type registrations.
+
     Args:
         desktop_id: The app's desktop-file ID (e.g. ``firefox.desktop``).
         launcher: Resolver for desktop metadata and display names.
@@ -83,7 +78,6 @@ def recent_docs_for_app(
         return []
 
     display_name = app_info.get_display_name()
-    supported = app_info.get_supported_types()
 
     rm = Gtk.RecentManager.get_default()
     all_items = rm.get_items()
@@ -93,13 +87,7 @@ def recent_docs_for_app(
     # get_items() order is undefined — sort by modification time descending.
     sorted_items = sorted(all_items, key=lambda i: i.get_modified(), reverse=True)
 
-    # ── Tier 1: files actually opened with this app ──
-    tier1: list[RecentDoc] = []
-    # ── Tier 2: files this app *could* open (MIME match) ──
-    tier2: list[RecentDoc] = []
-    # ── Tier 3: system default handler ──
-    tier3: list[RecentDoc] = []
-
+    docs: list[RecentDoc] = []
     for item in sorted_items:
         if not item.is_local():
             continue
@@ -108,29 +96,14 @@ def recent_docs_for_app(
         mime = item.get_mime_type()
         if not mime:
             continue
-
-        # Tier 1: has_application — the ground truth
-        if item.has_application(display_name):
-            tier1.append(_doc_from_item(item, mime))
-            if len(tier1) >= limit:
-                return tier1
+        if not item.has_application(display_name):
             continue
 
-        # Tier 2: MIME-type — noisy, only when Tier 1 is empty
-        if supported and mime in supported and len(tier2) < _MIME_FALLBACK_CAP:
-            tier2.append(_doc_from_item(item, mime))
-            continue
+        docs.append(_doc_from_item(item, mime))
+        if len(docs) >= limit:
+            break
 
-        # Tier 3: default handler — edge cases
-        if not supported:
-            default = Gio.AppInfo.get_default_for_type(mime, False)
-            if default and default.get_id() == desktop_id:
-                tier3.append(_doc_from_item(item, mime))
-
-    # Tier 1 results are shown exclusively — no MIME noise mixed in.
-    if tier1:
-        return tier1
-    return (tier2 + tier3)[:limit]
+    return docs
 
 
 def _doc_from_item(item, mime: str) -> RecentDoc:

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -709,9 +709,10 @@ class MenuHandler:
 
         submenu.append(Gtk.SeparatorMenuItem())
         clear = Gtk.MenuItem(label=_("Clear Recent Documents"))
+        recents = Gtk.RecentManager.get_default()
         clear.connect(
             "activate",
-            lambda _, rm=Gtk.RecentManager.get_default(), uris=[d.uri for d in docs]: (
+            lambda _, rm=recents, uris=[d.uri for d in docs]: (
                 [rm.remove_item(u) for u in uris]
             ),
         )

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -149,6 +149,7 @@ concerns in practice.
 
 from __future__ import annotations
 
+import datetime as dt
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -181,6 +182,7 @@ from docking.core.items import FILE_KIND, FOLDER_KIND
 from docking.i18n import _
 from docking.log import get_logger
 from docking.platform.backends.base import DisplayServer
+from docking.platform.recent_docs import recent_docs_for_app
 from docking.ui.about import AboutDialogController
 from docking.ui.diagnostics import DiagnosticsDialogController
 from docking.ui.folder.stack import FolderStackController
@@ -476,6 +478,10 @@ class MenuHandler:
         # Desktop actions (e.g. "New Window", "New Incognito Window")
         self._append_desktop_actions(menu=menu, desktop_id=item.desktop_id)
 
+        # Recent Documents (per-app jumplist)
+        if self._config.show_recent_docs_in_menu:
+            self._append_recent_docs(menu=menu, desktop_id=item.desktop_id)
+
         # Open windows - click to activate
         self._append_open_windows(menu=menu, desktop_id=item.desktop_id)
 
@@ -658,6 +664,62 @@ class MenuHandler:
                 ),
             )
             menu.append(mi)
+        menu.append(Gtk.SeparatorMenuItem())
+
+    def _append_recent_docs(self, menu: Gtk.Menu, desktop_id: str) -> None:
+        """Append a "Recent Documents" submenu for apps with recent file history."""
+        if not self._launcher:
+            return
+        docs = recent_docs_for_app(
+            desktop_id=desktop_id,
+            launcher=self._launcher,
+            limit=self._config.recent_docs_max,
+        )
+        if not docs:
+            return
+
+        submenu = Gtk.Menu()
+        for doc in docs:
+            row = Gtk.MenuItem()
+            box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+            try:
+                recent_item = Gtk.RecentManager.get_default().lookup_item(doc.uri)
+                if recent_item is not None:
+                    gicon = recent_item.get_gicon()
+                    if gicon is not None:
+                        icon = Gtk.Image.new_from_gicon(gicon, Gtk.IconSize.MENU)
+                        box.pack_start(icon, False, False, 0)
+            except Exception:
+                pass
+            name = Gtk.Label(label=doc.name, xalign=0)
+            name.set_ellipsize(Pango.EllipsizeMode.END)
+            name.set_max_width_chars(30)
+            box.pack_start(name, True, True, 0)
+            closed_dt = dt.datetime.fromtimestamp(doc.modified, tz=dt.timezone.utc)
+            from docking.ui.tooltip import relative_time_label
+
+            rel = relative_time_label(closed_dt)
+            ts = Gtk.Label(label=rel, xalign=1)
+            ts.set_sensitive(False)
+            box.pack_start(ts, False, False, 0)
+            row.add(box)
+            uri = doc.uri
+            row.connect("activate", lambda _, u=uri: launcher_mod.open_target(u))
+            submenu.append(row)
+
+        submenu.append(Gtk.SeparatorMenuItem())
+        clear = Gtk.MenuItem(label=_("Clear Recent Documents"))
+        clear.connect(
+            "activate",
+            lambda _, rm=Gtk.RecentManager.get_default(), uris=[d.uri for d in docs]: (
+                [rm.remove_item(u) for u in uris]
+            ),
+        )
+        submenu.append(clear)
+
+        item = Gtk.MenuItem(label=_("Recent Documents"))
+        item.set_submenu(submenu)
+        menu.append(item)
         menu.append(Gtk.SeparatorMenuItem())
 
     def _append_open_windows(self, menu: Gtk.Menu, desktop_id: str) -> None:

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -676,7 +676,7 @@ class SettingsWindowController:
                     _("Show Recent Documents"),
                     self._recent_docs_switch,
                     _(
-                        "Show a \"Recent Documents\" submenu when "
+                        'Show a "Recent Documents" submenu when '
                         "right-clicking an app icon."
                     ),
                 ),

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -184,6 +184,8 @@ class SettingsWindowController:
         self._recent_apps_switch: Any = None
         self._recent_apps_max_spin: Any = None
         self._recent_apps_retention_combo: Any = None
+        self._recent_docs_switch: Any = None
+        self._recent_docs_max_spin: Any = None
         self._applets_box: Any = None
         self._applet_checks: dict[str, Gtk.CheckButton] = {}
         self._bindings: list[_ScalarBinding] = []
@@ -431,6 +433,10 @@ class SettingsWindowController:
         self._recent_apps_retention_combo = Gtk.ComboBoxText()
         for days in (3, 7, 14, 30):
             self._recent_apps_retention_combo.append(str(days), str(days))
+        self._recent_docs_switch = self._new_switch()
+        self._recent_docs_max_spin = self._new_numeric_spin_button(
+            minimum=1, maximum=25, step=1
+        )
 
         self._register_bindings()
 
@@ -659,6 +665,25 @@ class SettingsWindowController:
                     _("Keep Recent Apps For"),
                     self._recent_apps_retention_combo,
                     _("Remove recent apps after this many days of inactivity."),
+                ),
+            ],
+        )
+        self._append_section(
+            outer=outer,
+            title=_("Recent Documents"),
+            rows=[
+                (
+                    _("Show Recent Documents"),
+                    self._recent_docs_switch,
+                    _(
+                        "Show a \"Recent Documents\" submenu when "
+                        "right-clicking an app icon."
+                    ),
+                ),
+                (
+                    _("Max Documents Per App"),
+                    self._recent_docs_max_spin,
+                    _("Maximum recent document entries shown per app."),
                 ),
             ],
         )
@@ -1016,6 +1041,15 @@ class SettingsWindowController:
                 ),
                 signal="changed",
                 on_change=lambda _value: self._runtime.queue_draw(),
+            ),
+            # Recent Documents
+            self._register_switch_binding(
+                config_attr="show_recent_docs_in_menu",
+                widget=self._recent_docs_switch,
+            ),
+            self._register_int_binding(
+                config_attr="recent_docs_max",
+                widget=self._recent_docs_max_spin,
             ),
         ]
 
@@ -1399,6 +1433,9 @@ class SettingsWindowController:
             self._recent_apps_max_spin.set_sensitive(recent_sensitive)
         if self._recent_apps_retention_combo is not None:
             self._recent_apps_retention_combo.set_sensitive(recent_sensitive)
+        docs_sensitive = bool(self._config.show_recent_docs_in_menu)
+        if self._recent_docs_max_spin is not None:
+            self._recent_docs_max_spin.set_sensitive(docs_sensitive)
 
     def _on_applet_toggled(
         self,

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -747,6 +747,13 @@ def handler(monkeypatch):
         item_prefs={},
         window_list_sort="default",
         save=MagicMock(),
+        show_recent_docs_in_menu=False,
+        recent_docs_max=10,
+        show_recent_apps=False,
+        recent_apps_max=5,
+        recent_apps_retention_days=14,
+        recent_apps=[],
+        recent_apps_opacity=0.85,
     )
     tracker = MagicMock()
     tracker.list_windows.return_value = []

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -631,6 +631,8 @@ def _config():
         recent_apps_max=5,
         recent_apps_retention_days=14,
         recent_apps=[],
+        show_recent_docs_in_menu=True,
+        recent_docs_max=10,
         save=MagicMock(),
     )
 
@@ -692,6 +694,7 @@ class TestSettingsWindowController:
             "<b>Behavior</b>",
             "<b>Folder Stacks</b>",
             "<b>Recent Apps</b>",
+            "<b>Recent Documents</b>",
         ]
         updates_box = stack.pages[3][0]
         updates_labels = [


### PR DESCRIPTION
Right-clicking an app icon now shows a "Recent Documents" submenu listing files recently opened with that application, ordered by recency. Mirrors Windows 7+ jumplists.

**How it works:**
- Reads the freedesktop.org recent-files store via `Gtk.RecentManager`
- Uses `has_application()` exclusively — only shows files the app *actually* opened. MIME-type matching was tested and rejected because every image-handling app registers for `image/png`, producing identical noise across Firefox, Chrome, GIMP, and EOM.
- Each document row shows: MIME type icon, filename, relative timestamp
- "Clear Recent Documents" removes all entries for that app

**Config fields (Behavior tab):**
- `show_recent_docs_in_menu` (toggle, default on)
- `recent_docs_max` (1–25, default 10)

**New module:** `docking/platform/recent_docs.py`

Works identically on X11 and Wayland (pure filesystem API).