### PR TITLE
Refactor shared desktop entry handling

### DIFF
--- a/docking/applets/apps.py
+++ b/docking/applets/apps.py
@@ -21,9 +21,9 @@ from typing import NamedTuple
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gio, GLib
+from gi.repository import Gio
 
-from docking.platform.launcher import Launcher
+from docking.platform import desktop_entries
 from docking.platform.launcher import launch as launch_desktop_id
 
 
@@ -66,101 +66,16 @@ class ApplicationEntry(NamedTuple):
 
 def all_desktop_app_infos() -> list[ApplicationEntry]:
     """Return launchable desktop applications visible to applet UIs."""
-    apps: list[ApplicationEntry] = []
-    seen: set[str] = set()
-
-    for app_info in Gio.AppInfo.get_all():
-        if isinstance(app_info, Gio.DesktopAppInfo):
-            if app_info.get_is_hidden() or app_info.get_nodisplay():
-                continue
-            app_id = app_info.get_id()
-            if app_id:
-                seen.add(app_id)
-            apps.append(
-                ApplicationEntry(
-                    desktop_id=app_id or "",
-                    name=app_info.get_display_name() or app_id or "Unknown",
-                    categories=app_info.get_categories() or "",
-                    icon_name=app_info.get_icon().to_string()
-                    if app_info.get_icon()
-                    else "",
-                    app_info=app_info,
-                )
-            )
-
-    for desktop_dir in Launcher._get_desktop_dirs():
-        for path in desktop_dir.rglob("*.desktop"):
-            if not path.is_file():
-                continue
-            desktop_id = path.relative_to(desktop_dir).as_posix()
-            if desktop_id in seen:
-                continue
-            try:
-                app_info = Gio.DesktopAppInfo.new_from_filename(str(path))
-            except (TypeError, GLib.Error):
-                app_info = None
-            if app_info is None:
-                entry = _entry_from_desktop_file(desktop_id=desktop_id, path=path)
-            else:
-                if app_info.get_is_hidden() or app_info.get_nodisplay():
-                    continue
-                entry = ApplicationEntry(
-                    desktop_id=desktop_id,
-                    name=app_info.get_display_name() or desktop_id,
-                    categories=app_info.get_categories() or "",
-                    icon_name=app_info.get_icon().to_string()
-                    if app_info.get_icon()
-                    else "",
-                    app_info=app_info,
-                )
-            if entry is None:
-                continue
-            seen.add(desktop_id)
-            apps.append(entry)
-
-    return apps
-
-
-def _entry_from_desktop_file(*, desktop_id: str, path: Path) -> ApplicationEntry | None:
-    key_file = GLib.KeyFile()
-    try:
-        key_file.load_from_file(str(path), GLib.KeyFileFlags.NONE)
-    except GLib.Error:
-        return None
-    if _desktop_string(key_file=key_file, key="Type") != "Application":
-        return None
-    if _desktop_bool(key_file=key_file, key="Hidden") or _desktop_bool(
-        key_file=key_file,
-        key="NoDisplay",
-    ):
-        return None
-    return ApplicationEntry(
-        desktop_id=desktop_id,
-        name=_desktop_locale_string(key_file=key_file, key="Name") or desktop_id,
-        categories=_desktop_string(key_file=key_file, key="Categories"),
-        icon_name=_desktop_string(key_file=key_file, key="Icon"),
-    )
-
-
-def _desktop_string(*, key_file: GLib.KeyFile, key: str) -> str:
-    try:
-        return key_file.get_string("Desktop Entry", key).strip()
-    except GLib.Error:
-        return ""
-
-
-def _desktop_locale_string(*, key_file: GLib.KeyFile, key: str) -> str:
-    try:
-        return key_file.get_locale_string("Desktop Entry", key, None).strip()
-    except GLib.Error:
-        return _desktop_string(key_file=key_file, key=key)
-
-
-def _desktop_bool(*, key_file: GLib.KeyFile, key: str) -> bool:
-    try:
-        return bool(key_file.get_boolean("Desktop Entry", key))
-    except GLib.Error:
-        return False
+    return [
+        ApplicationEntry(
+            desktop_id=entry.desktop_id,
+            name=entry.name,
+            categories=entry.categories,
+            icon_name=entry.icon_name,
+            app_info=entry.app_info,
+        )
+        for entry in desktop_entries.all_desktop_app_listings()
+    ]
 
 
 __all__ = ["ApplicationEntry", "all_desktop_app_infos"]

--- a/docking/platform/desktop_entries.py
+++ b/docking/platform/desktop_entries.py
@@ -1,0 +1,454 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Shared XDG desktop-entry discovery and parsing helpers."""
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+from typing import NamedTuple
+from urllib.parse import unquote, urlparse
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gio, GLib
+
+from docking.log import get_logger, with_context
+from docking.platform.environment import is_flatpak, xdg_data_home
+
+DESKTOP_SUFFIX = ".desktop"
+FALLBACK_ICON = "application-x-executable"
+DEFAULT_XDG_DATA_DIRS = "/usr/local/share:/usr/share"
+SNAP_XDG_DATA_DIR = "/var/lib/snapd/desktop"
+HOST_XDG_DATA_DIRS = (
+    SNAP_XDG_DATA_DIR,
+    "/run/host/share",
+    "/run/host/usr/local/share",
+    "/run/host/usr/share",
+    "/run/host/var/lib/flatpak/exports/share",
+)
+HOST_FILESYSTEM_ROOT = Path("/run/host")
+
+log = with_context(get_logger(name="desktop_entries"))
+
+
+class DesktopInfo(NamedTuple):
+    """Resolved information from a .desktop file."""
+
+    desktop_id: str
+    name: str
+    icon_name: str
+    wm_class: str
+    exec_line: str
+
+
+class DesktopAction(NamedTuple):
+    """A .desktop Actions entry, for example ``new-window``."""
+
+    action_id: str
+    display_name: str
+
+
+class DesktopAppListing(NamedTuple):
+    """One launchable application visible to menu/applet UIs."""
+
+    desktop_id: str
+    name: str
+    categories: str
+    icon_name: str
+    app_info: Gio.DesktopAppInfo | None = None
+
+
+class ResolvedAppInfo(NamedTuple):
+    app_info: Gio.DesktopAppInfo
+    desktop_file: Path | None
+
+
+class ResolvedDesktopLaunch(NamedTuple):
+    exec_line: str
+    desktop_file: Path | None
+
+
+def normalized_exec_basename(exec_line: str) -> str:
+    """Return the lowercase executable basename from a desktop Exec line."""
+    if not exec_line:
+        return ""
+    try:
+        argv = shlex.split(exec_line)
+    except ValueError:
+        return ""
+    if not argv:
+        return ""
+    return Path(argv[0]).name.lower()
+
+
+def desktop_match_aliases(info: DesktopInfo) -> list[str]:
+    """Return stable lookup aliases for matching runtime windows to desktop IDs."""
+    aliases = [
+        info.wm_class.lower(),
+        info.desktop_id.removesuffix(DESKTOP_SUFFIX).lower(),
+    ]
+    exec_basename = normalized_exec_basename(info.exec_line)
+    if exec_basename:
+        aliases.append(exec_basename)
+    return list(dict.fromkeys(alias for alias in aliases if alias))
+
+
+def desktop_entry_string(key_file: GLib.KeyFile, key: str) -> str:
+    try:
+        return key_file.get_string("Desktop Entry", key).strip()
+    except GLib.Error:
+        return ""
+
+
+def desktop_entry_locale_string(key_file: GLib.KeyFile, key: str) -> str:
+    try:
+        return key_file.get_locale_string("Desktop Entry", key, None).strip()
+    except GLib.Error:
+        return desktop_entry_string(key_file, key)
+
+
+def desktop_entry_bool(key_file: GLib.KeyFile, key: str) -> bool:
+    try:
+        return bool(key_file.get_boolean("Desktop Entry", key))
+    except GLib.Error:
+        return False
+
+
+def load_desktop_key_file(path: Path) -> GLib.KeyFile | None:
+    key_file = GLib.KeyFile()
+    try:
+        key_file.load_from_file(str(path), GLib.KeyFileFlags.NONE)
+        return key_file
+    except GLib.Error as exc:
+        log.bind(action="parse_desktop_file").debug(
+            "Failed to parse desktop file %s: %s",
+            path,
+            exc,
+        )
+        return None
+
+
+def desktop_info_from_file(*, desktop_id: str, path: Path) -> DesktopInfo | None:
+    key_file = load_desktop_key_file(path)
+    if key_file is None:
+        return None
+
+    if desktop_entry_string(key_file, "Type") != "Application":
+        return None
+    if desktop_entry_bool(key_file, "Hidden"):
+        return None
+
+    exec_line = desktop_entry_string(key_file, "Exec")
+    wm_class = desktop_entry_string(key_file, "StartupWMClass")
+    if not wm_class:
+        exec_basename = normalized_exec_basename(exec_line)
+        wm_class = exec_basename or desktop_id.removesuffix(DESKTOP_SUFFIX)
+
+    return DesktopInfo(
+        desktop_id=desktop_id,
+        name=desktop_entry_locale_string(key_file, "Name") or desktop_id,
+        icon_name=desktop_entry_string(key_file, "Icon") or FALLBACK_ICON,
+        wm_class=wm_class,
+        exec_line=exec_line,
+    )
+
+
+def desktop_info_from_app_info(
+    *, desktop_id: str, app_info: Gio.DesktopAppInfo
+) -> DesktopInfo:
+    """Build dock metadata from resolved Gio desktop app info."""
+    icon = app_info.get_icon()
+    icon_name = icon.to_string() if icon else FALLBACK_ICON
+    wm_class = wm_class_for_app_info(app_info=app_info, desktop_id=desktop_id)
+
+    return DesktopInfo(
+        desktop_id=desktop_id,
+        name=app_info.get_display_name() or desktop_id,
+        icon_name=icon_name,
+        wm_class=wm_class,
+        exec_line=app_info.get_commandline() or "",
+    )
+
+
+def wm_class_for_app_info(*, app_info: Gio.DesktopAppInfo, desktop_id: str) -> str:
+    """Return explicit StartupWMClass or the existing executable fallback."""
+    wm_class = app_info.get_startup_wm_class() or ""
+    if wm_class:
+        return wm_class
+    commandline = app_info.get_commandline() or ""
+    exe = commandline.split()[0] if commandline else ""
+    return Path(exe).name if exe else desktop_id.removesuffix(DESKTOP_SUFFIX)
+
+
+def desktop_dirs() -> list[Path]:
+    """Get application .desktop file directories from XDG_DATA_DIRS."""
+    xdg = os.environ.get("XDG_DATA_DIRS", DEFAULT_XDG_DATA_DIRS)
+    dirs = []
+    for d in xdg.split(":"):
+        p = Path(d) / "applications"
+        if p.is_dir():
+            dirs.append(p)
+    for d in HOST_XDG_DATA_DIRS:
+        p = Path(d) / "applications"
+        if p.is_dir() and p not in dirs:
+            dirs.append(p)
+    user_apps = xdg_data_home() / "applications"
+    if user_apps.is_dir():
+        dirs.insert(0, user_apps)
+    if is_flatpak():
+        host_user_apps = Path.home() / ".local" / "share" / "applications"
+        if host_user_apps.is_dir() and host_user_apps not in dirs:
+            dirs.insert(0, host_user_apps)
+    return dirs
+
+
+def is_host_desktop_file(path: Path | None) -> bool:
+    if path is None:
+        return False
+    try:
+        path.relative_to(HOST_FILESYSTEM_ROOT)
+        return True
+    except ValueError:
+        pass
+
+    if not is_flatpak():
+        return False
+    try:
+        path.relative_to(Path.home() / ".local" / "share" / "applications")
+        return True
+    except ValueError:
+        pass
+
+    try:
+        path.relative_to(Path(SNAP_XDG_DATA_DIR) / "applications")
+        return True
+    except ValueError:
+        return False
+
+
+def find_desktop_file(
+    desktop_id: str,
+    *,
+    desktop_dirs_override: list[Path] | None = None,
+) -> Path | None:
+    for desktop_dir in desktop_dirs_override or desktop_dirs():
+        path = desktop_dir / desktop_id
+        if path.exists():
+            return path
+    return None
+
+
+def resolve_app_info(
+    desktop_id: str,
+    *,
+    action: str,
+    desktop_dirs_override: list[Path] | None = None,
+    log_failures: bool = True,
+) -> ResolvedAppInfo | None:
+    resolve_errors: list[str] = []
+    try:
+        app_info = Gio.DesktopAppInfo.new(desktop_id)
+    except (TypeError, GLib.Error) as exc:
+        resolve_errors.append(f"desktop app info: {exc}")
+        app_info = None
+    if app_info is not None:
+        return ResolvedAppInfo(
+            app_info=app_info,
+            desktop_file=find_desktop_file(
+                desktop_id,
+                desktop_dirs_override=desktop_dirs_override,
+            ),
+        )
+
+    path = find_desktop_file(
+        desktop_id,
+        desktop_dirs_override=desktop_dirs_override,
+    )
+    if path is not None:
+        try:
+            app_info = Gio.DesktopAppInfo.new_from_filename(str(path))
+        except (TypeError, GLib.Error) as exc:
+            resolve_errors.append(f"{path}: {exc}")
+            app_info = None
+        if app_info is not None:
+            return ResolvedAppInfo(app_info=app_info, desktop_file=path)
+
+    if log_failures and resolve_errors:
+        log.bind(desktop_id=desktop_id, action=action).warning(
+            "Failed to resolve desktop app info: %s",
+            "; ".join(resolve_errors),
+        )
+    return None
+
+
+def resolve_desktop_launch(
+    desktop_id: str,
+    *,
+    action: str,
+    desktop_dirs_override: list[Path] | None = None,
+) -> ResolvedDesktopLaunch | None:
+    resolved = resolve_app_info(
+        desktop_id,
+        action=action,
+        desktop_dirs_override=desktop_dirs_override,
+        log_failures=False,
+    )
+    if resolved is not None:
+        return ResolvedDesktopLaunch(
+            exec_line=resolved.app_info.get_commandline() or "",
+            desktop_file=resolved.desktop_file,
+        )
+
+    path = find_desktop_file(
+        desktop_id,
+        desktop_dirs_override=desktop_dirs_override,
+    )
+    if path is None:
+        return None
+    info = desktop_info_from_file(desktop_id=desktop_id, path=path)
+    if info is None:
+        return None
+    return ResolvedDesktopLaunch(exec_line=info.exec_line, desktop_file=path)
+
+
+def desktop_file_actions(path: Path) -> list[DesktopAction]:
+    key_file = load_desktop_key_file(path)
+    if key_file is None:
+        return []
+    try:
+        action_ids = key_file.get_string_list("Desktop Entry", "Actions")
+    except GLib.Error:
+        return []
+
+    result: list[DesktopAction] = []
+    for action_id in action_ids:
+        group = f"Desktop Action {action_id}"
+        try:
+            name = key_file.get_locale_string(group, "Name", None).strip()
+        except GLib.Error:
+            name = ""
+        if name:
+            result.append(DesktopAction(action_id, name))
+    return result
+
+
+def desktop_file_action_exec(path: Path, action_id: str) -> str:
+    key_file = load_desktop_key_file(path)
+    if key_file is None:
+        return ""
+    try:
+        return key_file.get_string(f"Desktop Action {action_id}", "Exec").strip()
+    except GLib.Error:
+        return ""
+
+
+def desktop_listing_from_file(
+    *, desktop_id: str, path: Path
+) -> DesktopAppListing | None:
+    key_file = load_desktop_key_file(path)
+    if key_file is None:
+        return None
+    if desktop_entry_string(key_file, "Type") != "Application":
+        return None
+    if desktop_entry_bool(key_file, "Hidden") or desktop_entry_bool(
+        key_file,
+        "NoDisplay",
+    ):
+        return None
+    return DesktopAppListing(
+        desktop_id=desktop_id,
+        name=desktop_entry_locale_string(key_file, "Name") or desktop_id,
+        categories=desktop_entry_string(key_file, "Categories"),
+        icon_name=desktop_entry_string(key_file, "Icon"),
+    )
+
+
+def desktop_listing_from_app_info(
+    *, desktop_id: str, app_info: Gio.DesktopAppInfo
+) -> DesktopAppListing:
+    icon = app_info.get_icon()
+    return DesktopAppListing(
+        desktop_id=desktop_id,
+        name=app_info.get_display_name() or desktop_id or "Unknown",
+        categories=app_info.get_categories() or "",
+        icon_name=icon.to_string() if icon else "",
+        app_info=app_info,
+    )
+
+
+def all_desktop_app_listings() -> list[DesktopAppListing]:
+    """Return launchable desktop applications visible to applet UIs."""
+    apps: list[DesktopAppListing] = []
+    seen: set[str] = set()
+
+    for app_info in Gio.AppInfo.get_all():
+        if not isinstance(app_info, Gio.DesktopAppInfo):
+            continue
+        if app_info.get_is_hidden() or app_info.get_nodisplay():
+            continue
+        app_id = app_info.get_id()
+        if app_id:
+            seen.add(app_id)
+        apps.append(
+            desktop_listing_from_app_info(
+                desktop_id=app_id or "",
+                app_info=app_info,
+            )
+        )
+
+    for desktop_dir in desktop_dirs():
+        for path in desktop_dir.rglob(f"*{DESKTOP_SUFFIX}"):
+            if not path.is_file():
+                continue
+            desktop_id = path.relative_to(desktop_dir).as_posix()
+            if desktop_id in seen:
+                continue
+            try:
+                app_info = Gio.DesktopAppInfo.new_from_filename(str(path))
+            except (TypeError, GLib.Error):
+                app_info = None
+            if app_info is None:
+                entry = desktop_listing_from_file(desktop_id=desktop_id, path=path)
+            else:
+                if app_info.get_is_hidden() or app_info.get_nodisplay():
+                    continue
+                entry = desktop_listing_from_app_info(
+                    desktop_id=desktop_id,
+                    app_info=app_info,
+                )
+            if entry is None:
+                continue
+            seen.add(desktop_id)
+            apps.append(entry)
+
+    return apps
+
+
+def desktop_id_from_uri_or_path(target: str) -> str | None:
+    """Return a desktop ID from a local .desktop path or file URI."""
+    if not target:
+        return None
+    parsed = urlparse(target)
+    if parsed.scheme == "file":
+        path = Path(unquote(parsed.path))
+    elif parsed.scheme == "":
+        path = Path(target).expanduser()
+    else:
+        return None
+    if path.suffix != DESKTOP_SUFFIX:
+        return None
+    return path.name

--- a/docking/platform/launcher.py
+++ b/docking/platform/launcher.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 
-"""Desktop-entry resolution, icon loading, file-target metadata, and launching.
+"""Icon loading, file-target metadata, and desktop launch execution.
 
 Why this module exists
 
@@ -31,16 +31,18 @@ Two major jobs
 
 This module has two distinct responsibilities:
 
-1. Resolve targets into metadata
-   - desktop entry -> DesktopInfo
+1. Resolve runtime target metadata
+   - desktop entry metadata from ``platform.desktop_entries``
    - file/folder target -> FileTargetInfo
 
 2. Execute launch/open actions
    - start applications from desktop files
    - open files/folders with the desktop environment
 
-The rest of the dock should not need to know how XDG directories, Gio, icon
-themes, or command placeholders work.
+The rest of the dock should not need to know how Gio, icon themes, file
+metadata, or command placeholders work. XDG desktop-entry parsing and discovery
+live in ``docking.platform.desktop_entries`` so applets, DnD, recent documents,
+and launcher execution share the same behavior.
 
 Desktop entry resolution
 
@@ -57,7 +59,7 @@ The dock needs to expand them into:
 - startup WM_CLASS
 - exec line
 
-That is the purpose of `DesktopInfo`.
+That is the purpose of ``desktop_entries.DesktopInfo``.
 
 Resolution flow:
 
@@ -154,7 +156,8 @@ from gi.repository import GdkPixbuf, Gio, GLib, Gtk
 
 from docking.core.config import MiddleClickAction
 from docking.log import get_logger, with_context
-from docking.platform.environment import flatpak, is_flatpak, xdg_data_home
+from docking.platform import desktop_entries
+from docking.platform.environment import flatpak, is_flatpak
 
 DESKTOP_SUFFIX = ".desktop"
 FALLBACK_ICON = "application-x-executable"
@@ -176,16 +179,6 @@ ICON_FILE_EXTENSIONS = (".png", ".svg", ".xpm")
 log = with_context(get_logger(name="launcher"))
 
 
-class DesktopInfo(NamedTuple):
-    """Resolved information from a .desktop file."""
-
-    desktop_id: str
-    name: str
-    icon_name: str
-    wm_class: str
-    exec_line: str
-
-
 class FileTargetInfo(NamedTuple):
     """Resolved file/folder metadata for dock entries."""
 
@@ -194,101 +187,6 @@ class FileTargetInfo(NamedTuple):
     icon_name: str
     icon: GdkPixbuf.Pixbuf | None
     is_dir: bool
-
-
-class _ResolvedAppInfo(NamedTuple):
-    app_info: Gio.DesktopAppInfo
-    desktop_file: Path | None
-
-
-class _ResolvedDesktopLaunch(NamedTuple):
-    exec_line: str
-    desktop_file: Path | None
-
-
-def _normalized_exec_basename(exec_line: str) -> str:
-    """Return the lowercase executable basename from a desktop Exec line."""
-    if not exec_line:
-        return ""
-    try:
-        argv = shlex.split(exec_line)
-    except ValueError:
-        return ""
-    if not argv:
-        return ""
-    return Path(argv[0]).name.lower()
-
-
-def _desktop_match_aliases(info: DesktopInfo) -> list[str]:
-    """Return stable lookup aliases for matching runtime windows to desktop IDs."""
-    aliases = [
-        info.wm_class.lower(),
-        info.desktop_id.removesuffix(DESKTOP_SUFFIX).lower(),
-    ]
-    exec_basename = _normalized_exec_basename(info.exec_line)
-    if exec_basename:
-        aliases.append(exec_basename)
-    return list(dict.fromkeys(alias for alias in aliases if alias))
-
-
-def _desktop_entry_string(key_file: GLib.KeyFile, key: str) -> str:
-    try:
-        return key_file.get_string("Desktop Entry", key).strip()
-    except GLib.Error:
-        return ""
-
-
-def _desktop_entry_locale_string(key_file: GLib.KeyFile, key: str) -> str:
-    try:
-        return key_file.get_locale_string("Desktop Entry", key, None).strip()
-    except GLib.Error:
-        return _desktop_entry_string(key_file, key)
-
-
-def _desktop_entry_bool(key_file: GLib.KeyFile, key: str) -> bool:
-    try:
-        return bool(key_file.get_boolean("Desktop Entry", key))
-    except GLib.Error:
-        return False
-
-
-def _load_desktop_key_file(path: Path) -> GLib.KeyFile | None:
-    key_file = GLib.KeyFile()
-    try:
-        key_file.load_from_file(str(path), GLib.KeyFileFlags.NONE)
-        return key_file
-    except GLib.Error as exc:
-        log.bind(action="parse_desktop_file").debug(
-            "Failed to parse desktop file %s: %s",
-            path,
-            exc,
-        )
-        return None
-
-
-def _desktop_info_from_file(*, desktop_id: str, path: Path) -> DesktopInfo | None:
-    key_file = _load_desktop_key_file(path)
-    if key_file is None:
-        return None
-
-    if _desktop_entry_string(key_file, "Type") != "Application":
-        return None
-    if _desktop_entry_bool(key_file, "Hidden"):
-        return None
-
-    exec_line = _desktop_entry_string(key_file, "Exec")
-    wm_class = _desktop_entry_string(key_file, "StartupWMClass")
-    if not wm_class:
-        exec_basename = _normalized_exec_basename(exec_line)
-        wm_class = exec_basename or desktop_id.removesuffix(DESKTOP_SUFFIX)
-
-    return DesktopInfo(
-        desktop_id=desktop_id,
-        name=_desktop_entry_locale_string(key_file, "Name") or desktop_id,
-        icon_name=_desktop_entry_string(key_file, "Icon") or FALLBACK_ICON,
-        wm_class=wm_class,
-        exec_line=exec_line,
-    )
 
 
 def _host_icon_file_candidates(icon_name: str) -> list[Path]:
@@ -332,159 +230,20 @@ def _theme_icon_candidates(icon_name: str) -> list[str]:
     return list(dict.fromkeys(candidate for candidate in candidates if candidate))
 
 
-def _get_desktop_dirs() -> list[Path]:
-    """Get application .desktop file directories from XDG_DATA_DIRS."""
-    xdg = os.environ.get("XDG_DATA_DIRS", DEFAULT_XDG_DATA_DIRS)
-    dirs = []
-    for d in xdg.split(":"):
-        p = Path(d) / "applications"
-        if p.is_dir():
-            dirs.append(p)
-    for d in HOST_XDG_DATA_DIRS:
-        p = Path(d) / "applications"
-        if p.is_dir() and p not in dirs:
-            dirs.append(p)
-    user_apps = xdg_data_home() / "applications"
-    if user_apps.is_dir():
-        dirs.insert(0, user_apps)
-    if is_flatpak():
-        host_user_apps = Path.home() / ".local" / "share" / "applications"
-        if host_user_apps.is_dir() and host_user_apps not in dirs:
-            dirs.insert(0, host_user_apps)
-    return dirs
-
-
-def _is_host_desktop_file(path: Path | None) -> bool:
-    if path is None:
-        return False
-    try:
-        path.relative_to(HOST_FILESYSTEM_ROOT)
-        return True
-    except ValueError:
-        pass
-
-    if not is_flatpak():
-        return False
-    try:
-        path.relative_to(Path.home() / ".local" / "share" / "applications")
-        return True
-    except ValueError:
-        pass
-
-    try:
-        path.relative_to(Path(SNAP_XDG_DATA_DIR) / "applications")
-        return True
-    except ValueError:
-        return False
-
-
-def _find_desktop_file(desktop_id: str) -> Path | None:
-    for desktop_dir in _get_desktop_dirs():
-        path = desktop_dir / desktop_id
-        if path.exists():
-            return path
-    return None
-
-
-def _resolve_app_info(
-    desktop_id: str,
-    *,
-    action: str,
-    log_failures: bool = True,
-) -> _ResolvedAppInfo | None:
-    resolve_errors: list[str] = []
-    try:
-        app_info = Gio.DesktopAppInfo.new(desktop_id)
-    except (TypeError, GLib.Error) as exc:
-        resolve_errors.append(f"desktop app info: {exc}")
-        app_info = None
-    if app_info is not None:
-        return _ResolvedAppInfo(
-            app_info=app_info,
-            desktop_file=_find_desktop_file(desktop_id),
-        )
-
-    path = _find_desktop_file(desktop_id)
-    if path is not None:
-        try:
-            app_info = Gio.DesktopAppInfo.new_from_filename(str(path))
-        except (TypeError, GLib.Error) as exc:
-            resolve_errors.append(f"{path}: {exc}")
-        if app_info is not None:
-            return _ResolvedAppInfo(app_info=app_info, desktop_file=path)
-
-    if log_failures and resolve_errors:
-        log.bind(desktop_id=desktop_id, action=action).warning(
-            "Failed to resolve desktop app info: %s",
-            "; ".join(resolve_errors),
-        )
-    return None
-
-
-def _resolve_desktop_launch(
-    desktop_id: str, *, action: str
-) -> _ResolvedDesktopLaunch | None:
-    resolved = _resolve_app_info(desktop_id, action=action, log_failures=False)
-    if resolved is not None:
-        return _ResolvedDesktopLaunch(
-            exec_line=resolved.app_info.get_commandline() or "",
-            desktop_file=resolved.desktop_file,
-        )
-
-    path = _find_desktop_file(desktop_id)
-    if path is None:
-        return None
-    info = _desktop_info_from_file(desktop_id=desktop_id, path=path)
-    if info is None:
-        return None
-    return _ResolvedDesktopLaunch(exec_line=info.exec_line, desktop_file=path)
-
-
-def _desktop_file_actions(path: Path) -> list[DesktopAction]:
-    key_file = _load_desktop_key_file(path)
-    if key_file is None:
-        return []
-    try:
-        action_ids = key_file.get_string_list("Desktop Entry", "Actions")
-    except GLib.Error:
-        return []
-
-    result: list[DesktopAction] = []
-    for action_id in action_ids:
-        group = f"Desktop Action {action_id}"
-        try:
-            name = key_file.get_locale_string(group, "Name", None).strip()
-        except GLib.Error:
-            name = ""
-        if name:
-            result.append(DesktopAction(action_id, name))
-    return result
-
-
-def _desktop_file_action_exec(path: Path, action_id: str) -> str:
-    key_file = _load_desktop_key_file(path)
-    if key_file is None:
-        return ""
-    try:
-        return key_file.get_string(f"Desktop Action {action_id}", "Exec").strip()
-    except GLib.Error:
-        return ""
-
-
 class Launcher:
     """Resolves .desktop files via XDG_DATA_DIRS and loads icons."""
 
     def __init__(self) -> None:
-        self._desktop_dirs = _get_desktop_dirs()
+        self._desktop_dirs = desktop_entries.desktop_dirs()
         self._icon_cache: dict[tuple[str, int], GdkPixbuf.Pixbuf | None] = {}
         self._file_icon_cache: dict[
             tuple[str, int, int, int], GdkPixbuf.Pixbuf | None
         ] = {}
-        self._wm_class_index: dict[str, DesktopInfo] | None = None
+        self._wm_class_index: dict[str, desktop_entries.DesktopInfo] | None = None
 
     def resolve(
         self, desktop_id: str, *, log_failures: bool = True
-    ) -> DesktopInfo | None:
+    ) -> desktop_entries.DesktopInfo | None:
         """Resolve a desktop ID (e.g. 'firefox.desktop') to full info."""
         resolve_errors: list[str] = []
         app_info = self._desktop_app_info_for_id(
@@ -494,7 +253,7 @@ class Launcher:
         if app_info is None:
             info = self._resolve_desktop_file(desktop_id=desktop_id)
         else:
-            info = self._desktop_info_from_app_info(
+            info = desktop_entries.desktop_info_from_app_info(
                 desktop_id=desktop_id,
                 app_info=app_info,
             )
@@ -543,57 +302,29 @@ class Launcher:
                 resolve_errors.append(f"{path}: {exc}")
         return None
 
-    @staticmethod
-    def _wm_class_for_app_info(*, app_info: Gio.DesktopAppInfo, desktop_id: str) -> str:
-        """Return explicit StartupWMClass or the existing executable fallback."""
-        wm_class = app_info.get_startup_wm_class() or ""
-        if wm_class:
-            return wm_class
-        # Preserve the existing fallback policy: use the first token of the
-        # command line as a best-effort executable basename. This is less robust
-        # than full shell parsing, but changing it would be a behavior change for
-        # desktop files with unusual Exec fields.
-        commandline = app_info.get_commandline() or ""
-        exe = commandline.split()[0] if commandline else ""
-        return Path(exe).name if exe else desktop_id.removesuffix(DESKTOP_SUFFIX)
-
-    def _desktop_info_from_app_info(
-        self, *, desktop_id: str, app_info: Gio.DesktopAppInfo
-    ) -> DesktopInfo:
-        """Build dock metadata from resolved Gio desktop app info."""
-        icon = app_info.get_icon()
-        icon_name = icon.to_string() if icon else FALLBACK_ICON
-        wm_class = self._wm_class_for_app_info(
-            app_info=app_info,
-            desktop_id=desktop_id,
-        )
-
-        return DesktopInfo(
-            desktop_id=desktop_id,
-            name=app_info.get_display_name() or desktop_id,
-            icon_name=icon_name,
-            wm_class=wm_class,
-            exec_line=app_info.get_commandline() or "",
-        )
-
-    def _resolve_desktop_file(self, *, desktop_id: str) -> DesktopInfo | None:
+    def _resolve_desktop_file(
+        self, *, desktop_id: str
+    ) -> desktop_entries.DesktopInfo | None:
         for desktop_dir in self._desktop_dirs:
             path = desktop_dir / desktop_id
             if path.is_file():
-                return _desktop_info_from_file(desktop_id=desktop_id, path=path)
+                return desktop_entries.desktop_info_from_file(
+                    desktop_id=desktop_id,
+                    path=path,
+                )
         return None
 
-    def _cache_resolved_aliases(self, *, info: DesktopInfo) -> None:
+    def _cache_resolved_aliases(self, *, info: desktop_entries.DesktopInfo) -> None:
         if self._wm_class_index is None:
             return
         # The install-wide index is lazy. Resolving one desktop file before
         # the index exists should not force a full scan, but once the index
         # has been built this keeps later direct resolves visible to
         # resolve_by_wm_class.
-        for alias in _desktop_match_aliases(info):
+        for alias in desktop_entries.desktop_match_aliases(info):
             self._wm_class_index.setdefault(alias, info)
 
-    def resolve_by_wm_class(self, wm_class: str) -> DesktopInfo | None:
+    def resolve_by_wm_class(self, wm_class: str) -> desktop_entries.DesktopInfo | None:
         """Resolve an installed desktop file by runtime WM_CLASS or executable alias."""
         lookup = wm_class.lower().strip()
         if not lookup:
@@ -615,14 +346,17 @@ class Launcher:
         return pixbuf
 
     def load_desktop_icon(
-        self, info: DesktopInfo, size: int
+        self, info: desktop_entries.DesktopInfo, size: int
     ) -> GdkPixbuf.Pixbuf | None:
         """Load an application icon with desktop-entry fallbacks."""
         key = (f"desktop:{info.desktop_id}:{info.icon_name}:{info.exec_line}", size)
         if key in self._icon_cache:
             return self._icon_cache[key]
 
-        candidates = [info.icon_name, _normalized_exec_basename(info.exec_line)]
+        candidates = [
+            info.icon_name,
+            desktop_entries.normalized_exec_basename(info.exec_line),
+        ]
         for icon_name in dict.fromkeys(
             candidate for candidate in candidates if candidate
         ):
@@ -767,7 +501,7 @@ class Launcher:
 
     def _build_wm_class_index(self) -> None:
         """Index installed desktop entries by WM_CLASS-like runtime aliases."""
-        index: dict[str, DesktopInfo] = {}
+        index: dict[str, desktop_entries.DesktopInfo] = {}
         seen_desktop_ids: set[str] = set()
         for desktop_dir in self._desktop_dirs:
             for path in desktop_dir.rglob(f"*{DESKTOP_SUFFIX}"):
@@ -780,7 +514,7 @@ class Launcher:
                 info = self.resolve(desktop_id=desktop_id, log_failures=False)
                 if info is None:
                     continue
-                for alias in _desktop_match_aliases(info):
+                for alias in desktop_entries.desktop_match_aliases(info):
                     index.setdefault(alias, info)
         self._wm_class_index = index
 
@@ -866,49 +600,38 @@ class Launcher:
             )
             return None
 
-    @staticmethod
-    def _get_desktop_dirs() -> list[Path]:
-        return _get_desktop_dirs()
 
-
-class DesktopAction(NamedTuple):
-    """A .desktop Actions entry (e.g. "New Window")."""
-
-    action_id: str
-    display_name: str
-
-
-def get_actions(desktop_id: str) -> list[DesktopAction]:
+def get_actions(desktop_id: str) -> list[desktop_entries.DesktopAction]:
     """Return .desktop Actions entries (e.g. "New Window", "New Incognito Window")."""
-    resolved = _resolve_app_info(
+    resolved = desktop_entries.resolve_app_info(
         desktop_id,
         action="get_actions",
         log_failures=False,
     )
     if resolved is None:
-        path = _find_desktop_file(desktop_id)
-        return _desktop_file_actions(path) if path is not None else []
+        path = desktop_entries.find_desktop_file(desktop_id)
+        return desktop_entries.desktop_file_actions(path) if path is not None else []
     app_info = resolved.app_info
     result = []
     for action_id in app_info.list_actions():
         name = app_info.get_action_name(action_id)
         if name:
-            result.append(DesktopAction(action_id, name))
+            result.append(desktop_entries.DesktopAction(action_id, name))
     return result
 
 
 def launch_action(desktop_id: str, action_id: str) -> None:
     """Launch a named desktop action (from the .desktop [Desktop Action ...] group)."""
-    resolved = _resolve_app_info(
+    resolved = desktop_entries.resolve_app_info(
         desktop_id,
         action="launch_action",
         log_failures=False,
     )
     if resolved is None:
-        path = _find_desktop_file(desktop_id)
+        path = desktop_entries.find_desktop_file(desktop_id)
         if path is None:
             return
-        exec_line = _desktop_file_action_exec(path, action_id)
+        exec_line = desktop_entries.desktop_file_action_exec(path, action_id)
         _launch_exec_line(
             desktop_id=desktop_id,
             exec_line=exec_line,
@@ -916,11 +639,11 @@ def launch_action(desktop_id: str, action_id: str) -> None:
             action="launch_action",
         )
         return
-    if _is_host_desktop_file(resolved.desktop_file):
+    if desktop_entries.is_host_desktop_file(resolved.desktop_file):
         # Gio action launching would execute inside the sandbox. For host
         # desktop files, read the action Exec ourselves and delegate to host.
         exec_line = (
-            _desktop_file_action_exec(resolved.desktop_file, action_id)
+            desktop_entries.desktop_file_action_exec(resolved.desktop_file, action_id)
             if resolved.desktop_file is not None
             else ""
         )
@@ -945,7 +668,7 @@ def launch_action(desktop_id: str, action_id: str) -> None:
 
 def launch_new_window(desktop_id: str) -> None:
     """Open a new application window when the desktop entry exposes that action."""
-    resolved = _resolve_app_info(
+    resolved = desktop_entries.resolve_app_info(
         desktop_id,
         action="launch_new_window",
         log_failures=False,
@@ -955,11 +678,11 @@ def launch_new_window(desktop_id: str) -> None:
         return
     try:
         if MiddleClickAction.NEW_WINDOW.value in resolved.app_info.list_actions():
-            if _is_host_desktop_file(resolved.desktop_file):
+            if desktop_entries.is_host_desktop_file(resolved.desktop_file):
                 # Same rule as launch_action(): host desktop actions must not
                 # be launched through sandbox Gio.
                 exec_line = (
-                    _desktop_file_action_exec(
+                    desktop_entries.desktop_file_action_exec(
                         resolved.desktop_file,
                         MiddleClickAction.NEW_WINDOW.value,
                     )
@@ -991,7 +714,7 @@ def launch(desktop_id: str) -> None:
     session and process group. This prevents the child from receiving
     SIGHUP/SIGINT when the dock exits or the terminal sends Ctrl+C.
     """
-    resolved = _resolve_desktop_launch(desktop_id, action="launch")
+    resolved = desktop_entries.resolve_desktop_launch(desktop_id, action="launch")
     if resolved is None:
         return
     _launch_exec_line(
@@ -1023,7 +746,7 @@ def _launch_exec_line(
         return
     if not argv:
         return
-    if _is_host_desktop_file(desktop_file):
+    if desktop_entries.is_host_desktop_file(desktop_file):
         # Host launchers may reference binaries and environment only available
         # outside the sandbox, so never execute their Exec line directly.
         host_argv = flatpak.host_command(argv)

--- a/docking/platform/recent_docs.py
+++ b/docking/platform/recent_docs.py
@@ -31,9 +31,10 @@ from typing import TYPE_CHECKING
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gio, Gtk
+from gi.repository import Gtk
 
 from docking.log import get_logger
+from docking.platform import desktop_entries
 
 if TYPE_CHECKING:
     from docking.platform.launcher import Launcher
@@ -70,14 +71,15 @@ def recent_docs_for_app(
     if not desktop_id:
         return []
 
-    try:
-        app_info = Gio.DesktopAppInfo.new(desktop_id)
-    except TypeError:
-        return []
-    if app_info is None:
+    resolved = desktop_entries.resolve_app_info(
+        desktop_id,
+        action="recent_docs_for_app",
+        log_failures=False,
+    )
+    if resolved is None:
         return []
 
-    display_name = app_info.get_display_name()
+    display_name = resolved.app_info.get_display_name()
 
     rm = Gtk.RecentManager.get_default()
     all_items = rm.get_items()

--- a/docking/ui/dnd.py
+++ b/docking/ui/dnd.py
@@ -152,17 +152,15 @@ instead of assuming the ordinary event path will do it.
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import unquote, urlparse
 
 import gi
 
-import docking.platform.launcher as launcher_mod
 from docking.core.config import PinnedEntry
 from docking.core.items import APP_KIND, APPLET_KIND, FILE_KIND, FOLDER_KIND, DockItem
 from docking.core.position import Position, is_horizontal
 from docking.log import get_logger
+from docking.platform import desktop_entries
 from docking.ui.display import get_pointer_position, window_screen_position
 from docking.ui.geometry import DockGeometryBuilder
 from docking.ui.poof import show_poof
@@ -713,7 +711,7 @@ class DnDHandler:
 
     def _item_from_uri(self, uri: str) -> DockItem | None:
         """Build a pinned DockItem from an external URI drop."""
-        desktop_id = self._uri_to_desktop_id(uri)
+        desktop_id = desktop_entries.desktop_id_from_uri_or_path(uri)
         icon_size = self._config.scaled_icon_size
         log.debug("_item_from_uri: uri=%s desktop_id=%s", uri, desktop_id)
         if desktop_id:
@@ -752,17 +750,6 @@ class DnDHandler:
             icon=info.icon,
             prefs_key=info.target,
         )
-
-    @staticmethod
-    def _uri_to_desktop_id(uri: str) -> str | None:
-        """Extract a .desktop ID from a file URI or path."""
-        normalized = launcher_mod.normalize_file_target(uri)
-        if normalized is None:
-            return None
-        path = Path(unquote(urlparse(normalized).path))
-        if not path.name.endswith(".desktop"):
-            return None
-        return path.name
 
     def _begin_drag_autohide(self) -> None:
         if self._window.autohide.enabled:

--- a/tests/applets/test_applications.py
+++ b/tests/applets/test_applications.py
@@ -23,11 +23,11 @@ class TestBuildAppCategories:
 
         with (
             patch(
-                "docking.applets.apps.Gio.AppInfo.get_all",
+                "docking.platform.desktop_entries.Gio.AppInfo.get_all",
                 return_value=[mock_app],
             ),
             patch(
-                "docking.applets.apps.Launcher._get_desktop_dirs",
+                "docking.platform.desktop_entries.desktop_dirs",
                 return_value=[],
             ),
         ):
@@ -51,11 +51,11 @@ class TestBuildAppCategories:
             encoding="utf-8",
         )
         monkeypatch.setattr(
-            "docking.applets.apps.Gio.AppInfo.get_all",
+            "docking.platform.desktop_entries.Gio.AppInfo.get_all",
             list,
         )
         monkeypatch.setattr(
-            "docking.applets.apps.Launcher._get_desktop_dirs",
+            "docking.platform.desktop_entries.desktop_dirs",
             lambda: [host_apps],
         )
 
@@ -80,11 +80,11 @@ class TestBuildAppCategories:
                 encoding="utf-8",
             )
         monkeypatch.setattr(
-            "docking.applets.apps.Gio.AppInfo.get_all",
+            "docking.platform.desktop_entries.Gio.AppInfo.get_all",
             list,
         )
         monkeypatch.setattr(
-            "docking.applets.apps.Launcher._get_desktop_dirs",
+            "docking.platform.desktop_entries.desktop_dirs",
             lambda: [first_apps, second_apps],
         )
 

--- a/tests/platform/test_launcher.py
+++ b/tests/platform/test_launcher.py
@@ -17,9 +17,10 @@ except Exception:
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
 from docking.core.config import MiddleClickAction
+from docking.platform import desktop_entries as desktop_entries_mod
 from docking.platform import launcher as launcher_mod
+from docking.platform.desktop_entries import DesktopInfo
 from docking.platform.launcher import (
-    DesktopInfo,
     Launcher,
     get_actions,
     launch,
@@ -64,7 +65,11 @@ class TestGetDesktopDirs:
         host_share = tmp_path / "run" / "host" / "usr" / "share"
         host_apps = host_share / "applications"
         host_apps.mkdir(parents=True)
-        monkeypatch.setattr(launcher_mod, "HOST_XDG_DATA_DIRS", (str(host_share),))
+        monkeypatch.setattr(
+            desktop_entries_mod,
+            "HOST_XDG_DATA_DIRS",
+            (str(host_share),),
+        )
 
         # When
         with patch.dict(os.environ, {"XDG_DATA_DIRS": "/nonexistent/path"}):
@@ -77,7 +82,11 @@ class TestGetDesktopDirs:
         snap_desktop = tmp_path / "var" / "lib" / "snapd" / "desktop"
         snap_apps = snap_desktop / "applications"
         snap_apps.mkdir(parents=True)
-        monkeypatch.setattr(launcher_mod, "HOST_XDG_DATA_DIRS", (str(snap_desktop),))
+        monkeypatch.setattr(
+            desktop_entries_mod,
+            "HOST_XDG_DATA_DIRS",
+            (str(snap_desktop),),
+        )
 
         with patch.dict(os.environ, {"XDG_DATA_DIRS": "/nonexistent/path"}):
             launcher = Launcher()
@@ -88,7 +97,7 @@ class TestGetDesktopDirs:
         home = tmp_path / "home"
         host_user_apps = home / ".local" / "share" / "applications"
         host_user_apps.mkdir(parents=True)
-        monkeypatch.setattr(launcher_mod, "is_flatpak", lambda: True)
+        monkeypatch.setattr(desktop_entries_mod, "is_flatpak", lambda: True)
 
         with patch.dict(
             os.environ,
@@ -356,9 +365,9 @@ class TestDesktopActions:
         mock_app = MagicMock()
         mock_app.list_actions.return_value = ["new-window"]
         monkeypatch.setattr(
-            launcher_mod, "HOST_FILESYSTEM_ROOT", tmp_path / "run" / "host"
+            desktop_entries_mod, "HOST_FILESYSTEM_ROOT", tmp_path / "run" / "host"
         )
-        monkeypatch.setattr(launcher_mod, "_get_desktop_dirs", lambda: [host_apps])
+        monkeypatch.setattr(desktop_entries_mod, "desktop_dirs", lambda: [host_apps])
         monkeypatch.setattr(
             launcher_mod.flatpak,
             "spawn_path",
@@ -405,7 +414,7 @@ class TestDesktopActions:
         mock_app = MagicMock()
         mock_app.list_actions.return_value = ["extract-here"]
         mock_app.get_action_name.return_value = "Extract Here"
-        monkeypatch.setattr(launcher_mod, "_get_desktop_dirs", lambda: [host_apps])
+        monkeypatch.setattr(desktop_entries_mod, "desktop_dirs", lambda: [host_apps])
         monkeypatch.setattr(
             launcher_mod.Gio.DesktopAppInfo,
             "new",
@@ -445,7 +454,7 @@ class TestDesktopActions:
             )
         )
 
-        monkeypatch.setattr(launcher_mod, "_get_desktop_dirs", lambda: [host_apps])
+        monkeypatch.setattr(desktop_entries_mod, "desktop_dirs", lambda: [host_apps])
         monkeypatch.setattr(launcher_mod.Gio.DesktopAppInfo, "new", lambda _id: None)
         monkeypatch.setattr(
             launcher_mod.Gio.DesktopAppInfo,
@@ -1065,14 +1074,14 @@ class TestLaunch:
         mock_app = MagicMock()
         mock_app.get_commandline.return_value = "file-roller %U"
         monkeypatch.setattr(
-            launcher_mod, "HOST_FILESYSTEM_ROOT", tmp_path / "run" / "host"
+            desktop_entries_mod, "HOST_FILESYSTEM_ROOT", tmp_path / "run" / "host"
         )
         monkeypatch.setattr(
             launcher_mod.flatpak,
             "spawn_path",
             lambda **_: "/usr/bin/flatpak-spawn",
         )
-        monkeypatch.setattr(launcher_mod, "_get_desktop_dirs", lambda: [host_apps])
+        monkeypatch.setattr(desktop_entries_mod, "desktop_dirs", lambda: [host_apps])
         monkeypatch.setattr(
             launcher_mod.Gio.DesktopAppInfo,
             "new",
@@ -1117,7 +1126,7 @@ class TestLaunch:
 
         mock_app = MagicMock()
         mock_app.get_commandline.return_value = "user-app %U"
-        monkeypatch.setattr(launcher_mod, "is_flatpak", lambda: True)
+        monkeypatch.setattr(desktop_entries_mod, "is_flatpak", lambda: True)
         monkeypatch.setattr(
             launcher_mod.flatpak,
             "spawn_path",
@@ -1176,14 +1185,14 @@ class TestLaunch:
         )
 
         monkeypatch.setattr(
-            launcher_mod, "HOST_FILESYSTEM_ROOT", tmp_path / "run" / "host"
+            desktop_entries_mod, "HOST_FILESYSTEM_ROOT", tmp_path / "run" / "host"
         )
         monkeypatch.setattr(
             launcher_mod.flatpak,
             "spawn_path",
             lambda **_: "/usr/bin/flatpak-spawn",
         )
-        monkeypatch.setattr(launcher_mod, "_get_desktop_dirs", lambda: [host_apps])
+        monkeypatch.setattr(desktop_entries_mod, "desktop_dirs", lambda: [host_apps])
         monkeypatch.setattr(launcher_mod.Gio.DesktopAppInfo, "new", lambda _id: None)
         monkeypatch.setattr(
             launcher_mod.Gio.DesktopAppInfo,
@@ -1223,7 +1232,7 @@ class TestLaunch:
             "new",
             MagicMock(side_effect=TypeError("constructor returned NULL")),
         )
-        monkeypatch.setattr(launcher_mod, "_get_desktop_dirs", list)
+        monkeypatch.setattr(desktop_entries_mod, "desktop_dirs", list)
 
         launch(desktop_id="missing.desktop")
 

--- a/tests/platform/test_window_tracker_integration.py
+++ b/tests/platform/test_window_tracker_integration.py
@@ -18,7 +18,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for non-GI environmen
 
 import docking.platform.backends.x11.impl.window_tracker as window_tracker_mod
 from docking.platform.backends.base import ActionResult, DisplayServer, WindowId
-from docking.platform.launcher import DesktopInfo
+from docking.platform.desktop_entries import DesktopInfo
 from docking.platform.model import DockItem
 
 

--- a/tests/ui/test_dnd.py
+++ b/tests/ui/test_dnd.py
@@ -11,7 +11,8 @@ except ModuleNotFoundError:  # pragma: no cover
     sys.modules.setdefault("gi", gi_mock)
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
-from docking.ui.dnd import DRAG_ICON_SCALE, DnDHandler
+from docking.platform.desktop_entries import desktop_id_from_uri_or_path
+from docking.ui.dnd import DRAG_ICON_SCALE
 
 
 class TestConstants:
@@ -78,13 +79,13 @@ class TestAppletUriRejection:
         # Given
         uri = "applet://clock"
         # When / Then
-        assert DnDHandler._uri_to_desktop_id(uri) is None
+        assert desktop_id_from_uri_or_path(uri) is None
 
     def test_applet_uri_systemmonitor(self):
-        assert DnDHandler._uri_to_desktop_id("applet://systemmonitor") is None
+        assert desktop_id_from_uri_or_path("applet://systemmonitor") is None
 
     def test_applet_uri_trash(self):
-        assert DnDHandler._uri_to_desktop_id("applet://trash") is None
+        assert desktop_id_from_uri_or_path("applet://trash") is None
 
 
 class TestUriToDesktopId:
@@ -92,42 +93,42 @@ class TestUriToDesktopId:
         # Given
         uri = "file:///usr/share/applications/firefox.desktop"
         # When / Then
-        assert DnDHandler._uri_to_desktop_id(uri) == "firefox.desktop"
+        assert desktop_id_from_uri_or_path(uri) == "firefox.desktop"
 
     def test_file_uri_with_spaces(self):
         # Given
         uri = "file:///usr/share/applications/my%20app.desktop"
         # When / Then
-        assert DnDHandler._uri_to_desktop_id(uri) == "my app.desktop"
+        assert desktop_id_from_uri_or_path(uri) == "my app.desktop"
 
     def test_file_uri_snap(self):
         # Given
         uri = "file:///var/lib/snapd/desktop/applications/firefox_firefox.desktop"
         # When / Then
-        assert DnDHandler._uri_to_desktop_id(uri) == "firefox_firefox.desktop"
+        assert desktop_id_from_uri_or_path(uri) == "firefox_firefox.desktop"
 
     def test_plain_path(self):
         # Given
         uri = "firefox.desktop"
         # When / Then
-        assert DnDHandler._uri_to_desktop_id(uri) == "firefox.desktop"
+        assert desktop_id_from_uri_or_path(uri) == "firefox.desktop"
 
     def test_non_desktop_file_returns_none(self):
         # Given
         uri = "file:///home/user/document.pdf"
         # When / Then
-        assert DnDHandler._uri_to_desktop_id(uri) is None
+        assert desktop_id_from_uri_or_path(uri) is None
 
     def test_http_uri_returns_none(self):
         # Given
         uri = "https://example.com/app.desktop"
         # When / Then
-        assert DnDHandler._uri_to_desktop_id(uri) is None
+        assert desktop_id_from_uri_or_path(uri) is None
 
     def test_empty_string_returns_none(self):
         # Given / When / Then
-        assert DnDHandler._uri_to_desktop_id("") is None
+        assert desktop_id_from_uri_or_path("") is None
 
     def test_non_desktop_plain_path(self):
         # Given / When / Then
-        assert DnDHandler._uri_to_desktop_id("readme.txt") is None
+        assert desktop_id_from_uri_or_path("readme.txt") is None


### PR DESCRIPTION
## Summary
- add docking.platform.desktop_entries as the shared owner for XDG desktop-entry parsing, discovery, action lookup, and desktop URI/path extraction
- update launcher, applications applet, DnD, and recent-doc lookup to use the shared module
- remove duplicated desktop parsing from launcher/app applet helpers and update tests to target the new ownership

## Verification
- pre-commit hook passed: ruff format, ruff check, ty, i18n checks, package-data checks
- pytest: 3711 passed, 1 skipped, 12 deselected