### PR TITLE
Add drag-to-pin for executable launchers

### DIFF
--- a/docking/platform/desktop_entries.py
+++ b/docking/platform/desktop_entries.py
@@ -15,8 +15,14 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
+import re
 import shlex
+import subprocess
+import tempfile
+from contextlib import suppress
+from dataclasses import dataclass
 from pathlib import Path
 from typing import NamedTuple
 from urllib.parse import unquote, urlparse
@@ -41,6 +47,9 @@ HOST_XDG_DATA_DIRS = (
     "/run/host/var/lib/flatpak/exports/share",
 )
 HOST_FILESYSTEM_ROOT = Path("/run/host")
+GENERATED_DESKTOP_PREFIX = "docking-generated-"
+GENERATED_SOURCE_KEY = "X-Docking-Source-Path"
+GENERATED_MARKER_KEY = "X-Docking-Generated"
 
 log = with_context(get_logger(name="desktop_entries"))
 
@@ -80,6 +89,16 @@ class ResolvedAppInfo(NamedTuple):
 class ResolvedDesktopLaunch(NamedTuple):
     exec_line: str
     desktop_file: Path | None
+
+
+@dataclass(frozen=True)
+class GeneratedDesktopEntry:
+    """A user-local desktop file generated for a dropped executable."""
+
+    desktop_id: str
+    path: Path
+    name: str
+    icon_name: str
 
 
 def normalized_exec_basename(exec_line: str) -> str:
@@ -214,6 +233,11 @@ def desktop_dirs() -> list[Path]:
         if host_user_apps.is_dir() and host_user_apps not in dirs:
             dirs.insert(0, host_user_apps)
     return dirs
+
+
+def user_applications_dir() -> Path:
+    """Return the user-local applications directory for desktop entries."""
+    return xdg_data_home() / "applications"
 
 
 def is_host_desktop_file(path: Path | None) -> bool:
@@ -452,3 +476,206 @@ def desktop_id_from_uri_or_path(target: str) -> str | None:
     if path.suffix != DESKTOP_SUFFIX:
         return None
     return path.name
+
+
+def local_path_from_uri_or_path(target: str) -> Path | None:
+    """Return a local filesystem path from a file URI or plain local path."""
+    if not target:
+        return None
+    parsed = urlparse(target)
+    if parsed.scheme == "file":
+        return Path(unquote(parsed.path))
+    if parsed.scheme == "":
+        return Path(target).expanduser()
+    return None
+
+
+def appimage_path_needing_executable_permission(target: str | Path) -> Path | None:
+    """Return a local AppImage path when it exists but lacks executable permission."""
+    if isinstance(target, Path):
+        path = target.expanduser()
+    else:
+        path = local_path_from_uri_or_path(target)
+        if path is None:
+            return None
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError:
+        return None
+    if not resolved.is_file():
+        return None
+    if not resolved.name.lower().endswith(".appimage"):
+        return None
+    if os.access(resolved, os.X_OK):
+        return None
+    return resolved
+
+
+def make_user_executable(path: Path) -> bool:
+    """Add the user executable bit to a file, preserving existing permissions."""
+    try:
+        path.chmod(path.stat().st_mode | 0o100)
+    except OSError as exc:
+        log.bind(action="make_user_executable", path=str(path)).warning(
+            "Failed to make file executable: %s",
+            exc,
+        )
+        return False
+    return True
+
+
+def create_desktop_entry_for_executable(
+    target: str | Path,
+) -> GeneratedDesktopEntry | None:
+    """Create or update a generated desktop entry for a launchable local file."""
+    path = _local_executable_path(target)
+    if path is None:
+        return None
+
+    name = _display_name_from_path(path)
+    desktop_id = generated_desktop_id_for_path(path)
+    desktop_file = user_applications_dir() / desktop_id
+    icon_name = _icon_name_for_generated_entry(path)
+    content = _generated_desktop_entry_content(
+        name=name,
+        exec_path=path,
+        icon_name=icon_name,
+    )
+
+    try:
+        _write_desktop_file_atomically(path=desktop_file, content=content)
+    except OSError as exc:
+        log.bind(
+            action="write_generated_desktop_entry", path=str(desktop_file)
+        ).warning(
+            "Failed to write generated desktop entry: %s",
+            exc,
+        )
+        return None
+
+    _refresh_desktop_database(desktop_file.parent)
+    return GeneratedDesktopEntry(
+        desktop_id=desktop_id,
+        path=desktop_file,
+        name=name,
+        icon_name=icon_name,
+    )
+
+
+def generated_desktop_id_for_path(path: Path) -> str:
+    """Return the stable generated desktop ID for a source executable path."""
+    resolved = path.expanduser().resolve()
+    slug = _slugify_desktop_name(_display_name_from_path(resolved))
+    digest = hashlib.sha256(str(resolved).encode("utf-8")).hexdigest()[:12]
+    return f"{GENERATED_DESKTOP_PREFIX}{slug}-{digest}{DESKTOP_SUFFIX}"
+
+
+def _local_executable_path(target: str | Path) -> Path | None:
+    if isinstance(target, Path):
+        path = target.expanduser()
+    else:
+        path = local_path_from_uri_or_path(target)
+        if path is None:
+            return None
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        log.bind(action="resolve_executable_drop", target=str(target)).debug(
+            "Dropped executable path is not resolvable: %s",
+            exc,
+        )
+        return None
+    if not resolved.is_file():
+        return None
+    if not os.access(resolved, os.X_OK):
+        if resolved.name.lower().endswith(".appimage"):
+            log.bind(path=str(resolved)).info(
+                "Dropped AppImage is not executable; refusing to generate launcher"
+            )
+        return None
+    return resolved
+
+
+def _display_name_from_path(path: Path) -> str:
+    stem = path.name
+    if stem.lower().endswith(".appimage"):
+        stem = stem[: -len(".AppImage")]
+    elif path.suffix:
+        stem = path.stem
+    text = re.sub(r"[_-]+", " ", stem).strip()
+    text = re.sub(r"\s+", " ", text)
+    return text or path.name
+
+
+def _slugify_desktop_name(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return slug or "launcher"
+
+
+def _icon_name_for_generated_entry(path: Path) -> str:
+    if path.name.lower().endswith(".appimage"):
+        return "application-x-appimage"
+    return FALLBACK_ICON
+
+
+def _generated_desktop_entry_content(
+    *,
+    name: str,
+    exec_path: Path,
+    icon_name: str,
+) -> str:
+    return "\n".join(
+        [
+            "[Desktop Entry]",
+            "Type=Application",
+            f"Name={_escape_desktop_value(name)}",
+            f"Exec={_quote_exec_arg(str(exec_path))}",
+            "Terminal=false",
+            "Categories=Utility;",
+            f"Icon={_escape_desktop_value(icon_name)}",
+            f"{GENERATED_MARKER_KEY}=true",
+            f"{GENERATED_SOURCE_KEY}={_escape_desktop_value(str(exec_path))}",
+            "",
+        ]
+    )
+
+
+def _escape_desktop_value(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("\n", "\\n")
+
+
+def _quote_exec_arg(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("`", "\\`")
+    escaped = escaped.replace("$", "\\$")
+    return f'"{escaped}"'
+
+
+def _write_desktop_file_atomically(*, path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+        text=True,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        tmp_path.chmod(0o644)
+        tmp_path.replace(path)
+    except Exception:
+        with suppress(OSError):
+            tmp_path.unlink()
+        raise
+
+
+def _refresh_desktop_database(applications_dir: Path) -> None:
+    with suppress(OSError):
+        subprocess.Popen(
+            ["update-desktop-database", str(applications_dir)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )

--- a/docking/platform/launcher.py
+++ b/docking/platform/launcher.py
@@ -335,6 +335,11 @@ class Launcher:
             return None
         return self._wm_class_index.get(lookup)
 
+    def refresh_desktop_entries(self) -> None:
+        """Reload desktop-entry search paths and invalidate runtime alias cache."""
+        self._desktop_dirs = desktop_entries.desktop_dirs()
+        self._wm_class_index = None
+
     def load_icon(self, icon_name: str, size: int) -> GdkPixbuf.Pixbuf | None:
         """Load an icon by name at the given size, with caching."""
         key = (icon_name, size)

--- a/docking/ui/dnd.py
+++ b/docking/ui/dnd.py
@@ -35,7 +35,8 @@ This module intentionally keeps both major drag paths together:
    Move an existing dock item to a new index.
 
 2. External drop
-   Drop a `.desktop` URI onto the dock to pin a launcher.
+   Drop a `.desktop` URI, executable, AppImage, file, or folder onto the dock
+   to pin the matching launcher or target.
 
 Those are not split into separate classes because they share:
 
@@ -103,8 +104,9 @@ External drops use a different visual model:
     drag-drop / drag-data-received
       |
       +--> parse URI list
-      +--> resolve launcher metadata
-      +--> pin launcher at insert index
+      +--> resolve launcher/file metadata
+      +--> create generated desktop entries for executable drops when needed
+      +--> pin target at insert index
       +--> clear insertion gap
       +--> keep dock open if pointer is still on dock
 
@@ -152,6 +154,7 @@ instead of assuming the ordinary event path will do it.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import gi
@@ -737,6 +740,37 @@ class DnDHandler:
                 icon=icon,
             )
 
+        if not self._prepare_appimage_for_generation(uri):
+            return None
+
+        generated = desktop_entries.create_desktop_entry_for_executable(uri)
+        if generated is not None:
+            self._launcher.refresh_desktop_entries()
+            resolved = self._launcher.resolve(generated.desktop_id)
+            if resolved is None:
+                log.debug(
+                    "_item_from_uri: generated desktop entry did not resolve: %s",
+                    generated.desktop_id,
+                )
+                return None
+            icon = self._launcher.load_desktop_icon(resolved, icon_size)
+            log.debug(
+                "_item_from_uri: generated desktop_id=%s icon_name=%s icon_loaded=%s",
+                generated.desktop_id,
+                resolved.icon_name,
+                icon is not None,
+            )
+            return DockItem(
+                desktop_id=generated.desktop_id,
+                kind=APP_KIND,
+                target=generated.desktop_id,
+                name=resolved.name,
+                icon_name=resolved.icon_name,
+                wm_class=resolved.wm_class,
+                is_pinned=True,
+                icon=icon,
+            )
+
         info = self._launcher.resolve_file(target=uri, size=icon_size)
         if info is None:
             return None
@@ -750,6 +784,34 @@ class DnDHandler:
             icon=info.icon,
             prefs_key=info.target,
         )
+
+    def _prepare_appimage_for_generation(self, uri: str) -> bool:
+        appimage = desktop_entries.appimage_path_needing_executable_permission(uri)
+        if appimage is None:
+            return True
+        if not self._confirm_make_appimage_executable(appimage):
+            return False
+        return desktop_entries.make_user_executable(appimage)
+
+    def _confirm_make_appimage_executable(self, path: Path) -> bool:
+        dialog = Gtk.MessageDialog(
+            transient_for=self._window,
+            flags=Gtk.DialogFlags.MODAL,
+            message_type=Gtk.MessageType.WARNING,
+            buttons=Gtk.ButtonsType.CANCEL,
+            text="Make AppImage executable and pin it?",
+        )
+        dialog.format_secondary_text(
+            f"{path.name} is an AppImage, but it is not executable yet. "
+            "Docking can mark it executable so it can be pinned and launched."
+        )
+        dialog.add_button("Make Executable and Pin", Gtk.ResponseType.OK)
+        dialog.set_default_response(Gtk.ResponseType.CANCEL)
+        try:
+            response = dialog.run()
+        finally:
+            dialog.destroy()
+        return response == Gtk.ResponseType.OK
 
     def _begin_drag_autohide(self) -> None:
         if self._window.autohide.enabled:

--- a/tests/platform/test_desktop_entries.py
+++ b/tests/platform/test_desktop_entries.py
@@ -1,0 +1,137 @@
+"""Tests for shared desktop-entry helpers."""
+
+from __future__ import annotations
+
+import stat
+
+from docking.platform import desktop_entries
+
+
+def _make_executable(path) -> None:
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class TestGeneratedDesktopEntries:
+    def test_appimage_path_creates_stable_desktop_id(self, tmp_path, monkeypatch):
+        appimage = tmp_path / "PrusaSlicer.AppImage"
+        appimage.write_text("#!/bin/sh\n", encoding="utf-8")
+        _make_executable(appimage)
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+        monkeypatch.setattr(
+            desktop_entries, "_refresh_desktop_database", lambda _d: None
+        )
+
+        first = desktop_entries.create_desktop_entry_for_executable(appimage)
+        second = desktop_entries.create_desktop_entry_for_executable(appimage.as_uri())
+
+        assert first is not None
+        assert second is not None
+        assert first.desktop_id == second.desktop_id
+        assert first.desktop_id.startswith("docking-generated-prusaslicer-")
+        assert first.desktop_id.endswith(".desktop")
+
+    def test_generated_file_contains_marker_and_source_path(
+        self, tmp_path, monkeypatch
+    ):
+        binary = tmp_path / "my tool"
+        binary.write_text("#!/bin/sh\n", encoding="utf-8")
+        _make_executable(binary)
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+        monkeypatch.setattr(
+            desktop_entries, "_refresh_desktop_database", lambda _d: None
+        )
+
+        generated = desktop_entries.create_desktop_entry_for_executable(binary)
+
+        assert generated is not None
+        text = generated.path.read_text(encoding="utf-8")
+        assert "Type=Application\n" in text
+        assert "Name=my tool\n" in text
+        assert f'Exec="{binary.resolve()}"\n' in text
+        assert "X-Docking-Generated=true\n" in text
+        assert f"X-Docking-Source-Path={binary.resolve()}\n" in text
+
+        info = desktop_entries.desktop_info_from_file(
+            desktop_id=generated.desktop_id,
+            path=generated.path,
+        )
+        assert info is not None
+        assert info.name == "my tool"
+        assert info.icon_name == "application-x-executable"
+        assert info.exec_line == f'"{binary.resolve()}"'
+
+    def test_repeated_generation_is_idempotent(self, tmp_path, monkeypatch):
+        binary = tmp_path / "tool"
+        binary.write_text("#!/bin/sh\n", encoding="utf-8")
+        _make_executable(binary)
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+        monkeypatch.setattr(
+            desktop_entries, "_refresh_desktop_database", lambda _d: None
+        )
+
+        first = desktop_entries.create_desktop_entry_for_executable(binary)
+        second = desktop_entries.create_desktop_entry_for_executable(binary)
+
+        assert first is not None
+        assert second is not None
+        assert first.path == second.path
+        assert first.path.read_text(encoding="utf-8") == second.path.read_text(
+            encoding="utf-8"
+        )
+
+    def test_non_executable_regular_file_is_rejected(self, tmp_path, monkeypatch):
+        file_path = tmp_path / "notes.txt"
+        file_path.write_text("hello", encoding="utf-8")
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+
+        generated = desktop_entries.create_desktop_entry_for_executable(file_path)
+
+        assert generated is None
+        assert not (tmp_path / "data" / "applications").exists()
+
+    def test_non_executable_appimage_can_be_detected_and_marked_executable(
+        self, tmp_path
+    ):
+        appimage = tmp_path / "GIMP.AppImage"
+        appimage.write_text("#!/bin/sh\n", encoding="utf-8")
+        appimage.chmod(0o644)
+
+        detected = desktop_entries.appimage_path_needing_executable_permission(
+            appimage.as_uri()
+        )
+
+        assert detected == appimage.resolve()
+        assert desktop_entries.make_user_executable(detected)
+        assert detected.stat().st_mode & stat.S_IXUSR
+        assert (
+            desktop_entries.appimage_path_needing_executable_permission(
+                appimage.as_uri()
+            )
+            is None
+        )
+
+    def test_directories_and_non_local_uris_are_rejected(self, tmp_path):
+        assert desktop_entries.create_desktop_entry_for_executable(tmp_path) is None
+        assert (
+            desktop_entries.create_desktop_entry_for_executable(
+                "https://example.com/tool.AppImage"
+            )
+            is None
+        )
+
+    def test_exec_path_escapes_quotes_and_backslashes(self, tmp_path, monkeypatch):
+        binary = tmp_path / 'my "tool" \\ runner'
+        binary.write_text("#!/bin/sh\n", encoding="utf-8")
+        _make_executable(binary)
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+        monkeypatch.setattr(
+            desktop_entries, "_refresh_desktop_database", lambda _d: None
+        )
+
+        generated = desktop_entries.create_desktop_entry_for_executable(binary)
+
+        assert generated is not None
+        text = generated.path.read_text(encoding="utf-8")
+        assert 'Exec="' in text
+        assert '\\"tool\\"' in text
+        assert "\\\\ runner" in text

--- a/tests/ui/test_dnd_integration.py
+++ b/tests/ui/test_dnd_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import stat
 import sys
 from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock
@@ -89,6 +90,29 @@ def _make_handler(monkeypatch, lock_icons: bool = False):
         launcher,
         geometry_builder=SimpleNamespace(build_frame=lambda **_kwargs: default_frame),
     )
+
+
+class _FakeResponseDialog:
+    def __init__(self, response: int) -> None:
+        self.response = response
+        self.destroyed = False
+        self.secondary_text = ""
+        self.buttons: list[tuple[str, int]] = []
+
+    def format_secondary_text(self, text: str) -> None:
+        self.secondary_text = text
+
+    def add_button(self, label: str, response: int) -> None:
+        self.buttons.append((label, response))
+
+    def set_default_response(self, _response: int) -> None:
+        pass
+
+    def run(self) -> int:
+        return self.response
+
+    def destroy(self) -> None:
+        self.destroyed = True
 
 
 class TestSetupAndToggle:
@@ -534,6 +558,194 @@ class TestDropAndReceive:
         assert item is not None
         assert item.kind == FILE_KIND
         assert item.target == file_uri
+
+    def test_item_from_uri_builds_generated_launcher_for_executable(
+        self, monkeypatch, tmp_path
+    ):
+        handler = _make_handler(monkeypatch)
+        binary = tmp_path / "tool"
+        generated = dnd_mod.desktop_entries.GeneratedDesktopEntry(
+            desktop_id="docking-generated-tool-123.desktop",
+            path=tmp_path / "docking-generated-tool-123.desktop",
+            name="tool",
+            icon_name="application-x-executable",
+        )
+        resolved = SimpleNamespace(
+            name="tool",
+            icon_name="application-x-executable",
+            wm_class="tool",
+        )
+        monkeypatch.setattr(
+            dnd_mod.desktop_entries,
+            "create_desktop_entry_for_executable",
+            MagicMock(return_value=generated),
+        )
+        handler._launcher.resolve.return_value = resolved
+        icon = object()
+        handler._launcher.load_desktop_icon.return_value = icon
+
+        item = handler._item_from_uri(binary.as_uri())
+
+        assert item is not None
+        assert item.kind == APP_KIND
+        assert item.desktop_id == generated.desktop_id
+        assert item.target == generated.desktop_id
+        assert item.name == "tool"
+        assert item.icon is icon
+        handler._launcher.refresh_desktop_entries.assert_called_once_with()
+        handler._launcher.resolve.assert_called_once_with(generated.desktop_id)
+
+    def test_item_from_uri_confirms_chmod_for_non_executable_appimage(
+        self, monkeypatch, tmp_path
+    ):
+        handler = _make_handler(monkeypatch)
+        appimage = tmp_path / "GIMP-3.2.4-x86_64.AppImage"
+        appimage.write_text("#!/bin/sh\n", encoding="utf-8")
+        appimage.chmod(0o644)
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+        monkeypatch.setattr(
+            dnd_mod.desktop_entries, "_refresh_desktop_database", lambda _d: None
+        )
+        dialog = _FakeResponseDialog(dnd_mod.Gtk.ResponseType.OK)
+        monkeypatch.setattr(
+            dnd_mod.Gtk,
+            "MessageDialog",
+            lambda **_kwargs: dialog,
+        )
+        handler._launcher.resolve.return_value = SimpleNamespace(
+            name="GIMP 3.2.4 x86 64",
+            icon_name="application-x-appimage",
+            wm_class="GIMP-3.2.4-x86_64",
+        )
+
+        item = handler._item_from_uri(appimage.as_uri())
+
+        assert item is not None
+        assert item.kind == APP_KIND
+        assert item.desktop_id.startswith("docking-generated-gimp-3-2-4-x86-64-")
+        assert appimage.stat().st_mode & stat.S_IXUSR
+        assert dialog.destroyed
+        handler._launcher.refresh_desktop_entries.assert_called_once_with()
+
+    def test_item_from_uri_cancelled_appimage_permission_does_not_pin_file(
+        self, monkeypatch, tmp_path
+    ):
+        handler = _make_handler(monkeypatch)
+        appimage = tmp_path / "GIMP.AppImage"
+        appimage.write_text("#!/bin/sh\n", encoding="utf-8")
+        appimage.chmod(0o644)
+        dialog = _FakeResponseDialog(dnd_mod.Gtk.ResponseType.CANCEL)
+        monkeypatch.setattr(
+            dnd_mod.Gtk,
+            "MessageDialog",
+            lambda **_kwargs: dialog,
+        )
+
+        item = handler._item_from_uri(appimage.as_uri())
+
+        assert item is None
+        assert not (appimage.stat().st_mode & stat.S_IXUSR)
+        handler._launcher.resolve_file.assert_not_called()
+        handler._launcher.refresh_desktop_entries.assert_not_called()
+
+    def test_drag_data_received_pins_generated_launcher_for_executable(
+        self, monkeypatch, tmp_path
+    ):
+        handler = _make_handler(monkeypatch)
+        handler._drag_from = -1
+        handler._drop_committed = True
+        handler.drop_insert_index = 0
+        handler._model.pinned_items = []
+        handler._model.find_by_desktop_id.return_value = None
+        generated = dnd_mod.desktop_entries.GeneratedDesktopEntry(
+            desktop_id="docking-generated-tool-123.desktop",
+            path=tmp_path / "docking-generated-tool-123.desktop",
+            name="tool",
+            icon_name="application-x-executable",
+        )
+        resolved = SimpleNamespace(
+            name="tool",
+            icon_name="application-x-executable",
+            wm_class="tool",
+        )
+        monkeypatch.setattr(
+            dnd_mod.desktop_entries,
+            "create_desktop_entry_for_executable",
+            MagicMock(return_value=generated),
+        )
+        handler._launcher.resolve.return_value = resolved
+        selection = MagicMock()
+        selection.get_uris.return_value = [(tmp_path / "tool").as_uri()]
+        finish = MagicMock()
+        monkeypatch.setattr(dnd_mod.Gtk, "drag_finish", finish)
+
+        handler._on_drag_data_received(
+            handler._drawing_area,
+            MagicMock(),
+            0,
+            0,
+            selection,
+            1,
+            77,
+        )
+
+        assert [entry.kind for entry in handler._config.pinned] == [APP_KIND]
+        assert [entry.target for entry in handler._config.pinned] == [
+            generated.desktop_id
+        ]
+        assert [item.kind for item in handler._model.pinned_items] == [APP_KIND]
+        assert [item.desktop_id for item in handler._model.pinned_items] == [
+            generated.desktop_id
+        ]
+        handler._config.save.assert_called_once()
+        handler._model.sync_pinned_to_config.assert_called_once()
+        handler._model.notify.assert_called_once()
+        finish.assert_called_once_with(ANY, True, False, 77)
+
+    def test_drag_data_received_does_not_duplicate_generated_launcher(
+        self, monkeypatch, tmp_path
+    ):
+        handler = _make_handler(monkeypatch)
+        handler._drag_from = -1
+        handler._drop_committed = True
+        handler.drop_insert_index = 0
+        handler._model.pinned_items = []
+        generated = dnd_mod.desktop_entries.GeneratedDesktopEntry(
+            desktop_id="docking-generated-tool-123.desktop",
+            path=tmp_path / "docking-generated-tool-123.desktop",
+            name="tool",
+            icon_name="application-x-executable",
+        )
+        resolved = SimpleNamespace(
+            name="tool",
+            icon_name="application-x-executable",
+            wm_class="tool",
+        )
+        monkeypatch.setattr(
+            dnd_mod.desktop_entries,
+            "create_desktop_entry_for_executable",
+            MagicMock(return_value=generated),
+        )
+        handler._launcher.resolve.return_value = resolved
+        handler._model.find_by_desktop_id.return_value = DockItem(generated.desktop_id)
+        selection = MagicMock()
+        selection.get_uris.return_value = [(tmp_path / "tool").as_uri()]
+        finish = MagicMock()
+        monkeypatch.setattr(dnd_mod.Gtk, "drag_finish", finish)
+
+        handler._on_drag_data_received(
+            handler._drawing_area,
+            MagicMock(),
+            0,
+            0,
+            selection,
+            1,
+            77,
+        )
+
+        assert handler._config.pinned == []
+        assert handler._model.pinned_items == []
+        finish.assert_called_once_with(ANY, False, False, 77)
 
 
 class TestDragLeaveEnd:


### PR DESCRIPTION
## Summary
- generate stable user-local .desktop files for dropped executable files and AppImages
- prompt before marking non-executable AppImages executable, then pin the generated launcher as an app
- refresh launcher desktop-entry paths after generation and cover generated launcher DnD flows with tests

## Verification
- pre-commit hook passed: ruff format, ruff check, ty, i18n checks, package-data checks
- pytest: 3723 passed, 1 skipped, 12 deselected