### PR TITLE
Increase test coverage across core, platform, UI, IPC, and applet modules

### DIFF
--- a/tests/applets/test_base.py
+++ b/tests/applets/test_base.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import cairo
+import pytest
 
 import docking.applets.base as base_mod
 from docking.applets.base import (
@@ -237,3 +238,83 @@ class TestDrawIconLabel:
             fill_rgba=(0.9, 1.0, 0.9, 1.0),
             outline_rgba=(0.0, 0.0, 0.0, 0.75),
         )
+
+    def test_draw_icon_label_empty_text_is_noop(self):
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 48, 48)
+        cr = cairo.Context(surface)
+        # Should not raise
+        draw_icon_label(cr=cr, text="", size=48)
+
+    def test_fit_icon_label_falls_through_to_min_font_size(self):
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 48, 48)
+        cr = cairo.Context(surface)
+        _layout, logical, font_size = _fit_icon_label_layout(
+            cr=cr,
+            text="a" * 100,
+            max_width=10.0,
+            initial_font_size=24,
+            min_font_size=4,
+        )
+        assert font_size == 4  # Falls through to min font
+        assert logical.width > 0
+
+
+class TestAppletDefaultHooks:
+    def test_create_docking_icon_raises_not_implemented(self):
+        applet = _DeferredInitApplet()
+        with pytest.raises(NotImplementedError):
+            applet.create_docking_icon(48)
+
+    def test_system_icon_name_defaults_to_icon_name(self):
+        applet = _DeferredInitApplet()
+        assert applet.system_icon_name() == applet.icon_name
+
+    def test_icon_source_no_system_support_returns_docking(self):
+        applet = _DeferredInitApplet()
+        applet.supports_system_icon = False
+        assert applet.icon_source() == ICON_SOURCE_DOCKING
+
+    def test_set_icon_source_no_system_support_returns_early(self):
+        applet = _DeferredInitApplet()
+        applet.supports_system_icon = False
+        # Should not raise or save
+        applet.set_icon_source(ICON_SOURCE_SYSTEM)
+
+    def test_set_icon_source_same_value_returns_early(self, monkeypatch):
+        applet = _DeferredInitApplet()
+        applet.supports_system_icon = True
+        monkeypatch.setattr(
+            applet, "load_prefs", lambda: {ICON_SOURCE_PREF_KEY: ICON_SOURCE_DOCKING}
+        )
+        # Should not raise
+        applet.set_icon_source(ICON_SOURCE_DOCKING)
+
+    def test_set_popup_anchor(self):
+        applet = _DeferredInitApplet()
+        anchor = MagicMock()
+        applet.set_popup_anchor(anchor)
+        assert applet._popup_anchor is anchor
+
+    def test_accepts_drop_uris_defaults_false(self):
+        applet = _DeferredInitApplet()
+        assert applet.accepts_drop_uris() is False
+
+    def test_on_drop_uris_default_returns_false(self):
+        applet = _DeferredInitApplet()
+        assert applet.on_drop_uris(["file:///test.txt"]) is False
+
+    def test_set_services_default_is_noop(self):
+        applet = _DeferredInitApplet()
+        services = MagicMock()
+        # Should not raise
+        applet.set_services(services)
+
+    def test_on_scroll_default_is_noop(self):
+        applet = _DeferredInitApplet()
+        # Should not raise
+        applet.on_scroll(direction_up=True)
+
+    def test_refresh_tooltip_default_is_noop(self):
+        applet = _DeferredInitApplet()
+        # Should not raise
+        applet.refresh_tooltip()

--- a/tests/applets/test_caffeine.py
+++ b/tests/applets/test_caffeine.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 from docking.applets.caffeine.applet import CaffeineApplet
 from docking.applets.caffeine.inhibit import CompositeInhibitor
 from docking.applets.caffeine.state import (
@@ -276,3 +278,232 @@ class TestApplet:
         applet.on_clicked()
         labels = [item.get_label() for item in applet.get_menu_items()]
         assert "Active" in labels
+
+
+# -- Inhibitors ----------------------------------------------------------------
+
+
+class TestScreenSaverInhibitor:
+    def test_initial_state_inactive(self):
+        from docking.applets.caffeine.inhibit import ScreenSaverInhibitor
+
+        inh = ScreenSaverInhibitor()
+        assert inh.active is False
+
+    def test_acquire_releases_then_release_is_noop(self):
+        from docking.applets.caffeine.inhibit import ScreenSaverInhibitor
+
+        inh = ScreenSaverInhibitor()
+        # Release when never acquired is a no-op
+        inh.release()
+        assert inh.active is False
+
+    def test_release_after_manual_clear_is_noop(self):
+        from docking.applets.caffeine.inhibit import ScreenSaverInhibitor
+
+        inh = ScreenSaverInhibitor()
+        inh._cookie = 42  # Simulate acquired state
+        inh._conn = MagicMock()
+        inh._target = ("name", "/path", "iface")
+        # Clear cookie manually (simulating release)
+        inh._cookie = None
+        inh.release()
+        assert inh.active is False
+
+
+class TestSystemdSleepInhibitor:
+    def test_initial_state_inactive(self):
+        from docking.applets.caffeine.inhibit import SystemdSleepInhibitor
+
+        inh = SystemdSleepInhibitor()
+        assert inh.active is False
+
+    def test_release_when_never_acquired_is_noop(self):
+        from docking.applets.caffeine.inhibit import SystemdSleepInhibitor
+
+        inh = SystemdSleepInhibitor()
+        inh.release()
+        assert inh.active is False
+
+    def test_release_when_proc_already_finished_is_noop(self):
+        from docking.applets.caffeine.inhibit import SystemdSleepInhibitor
+
+        inh = SystemdSleepInhibitor()
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = 0  # Already finished
+        inh._proc = fake_proc
+        inh.release()
+        assert inh.active is False
+
+    def test_release_terminate_oserror_is_handled(self):
+        from docking.applets.caffeine.inhibit import SystemdSleepInhibitor
+
+        inh = SystemdSleepInhibitor()
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None  # Still running
+        fake_proc.terminate.side_effect = OSError("no process")
+        inh._proc = fake_proc
+        inh.release()
+        assert inh._proc is None  # proc cleared
+
+    def test_release_timeout_triggers_kill(self):
+        import subprocess
+
+        from docking.applets.caffeine.inhibit import SystemdSleepInhibitor
+
+        inh = SystemdSleepInhibitor()
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None  # Still running
+        fake_proc.wait.side_effect = subprocess.TimeoutExpired(cmd="test", timeout=2)
+        inh._proc = fake_proc
+        inh.release()
+        fake_proc.kill.assert_called_once()
+        assert inh._proc is None
+
+
+class TestCompositeInhibitorParts:
+    def test_default_constructor_creates_parts(self):
+        from docking.applets.caffeine.inhibit import CompositeInhibitor
+
+        comp = CompositeInhibitor()
+        assert len(comp._parts) == 2  # ScreenSaver + SystemdSleep
+
+    def test_active_property_when_none_active(self):
+        from docking.applets.caffeine.inhibit import CompositeInhibitor
+
+        comp = CompositeInhibitor(
+            parts=(FakePart(succeeds=False), FakePart(succeeds=False))
+        )
+        comp.acquire()
+        # Both parts failed, neither should be active
+        assert all(not p.active for p in comp._parts)
+
+    def test_active_property_when_one_active(self):
+        from docking.applets.caffeine.inhibit import CompositeInhibitor
+
+        comp = CompositeInhibitor(
+            parts=(FakePart(succeeds=False), FakePart(succeeds=True))
+        )
+        comp.acquire()
+        assert comp.active is True
+
+    def test_default_inhibitor_returns_composite(self):
+        from docking.applets.caffeine.inhibit import (
+            CompositeInhibitor,
+            default_inhibitor,
+        )
+
+        inh = default_inhibitor()
+        assert isinstance(inh, CompositeInhibitor)
+        assert len(inh._parts) == 2
+
+
+class TestScreenSaverInhibitorDBus:
+    def test_acquire_already_active_returns_true(self):
+        from docking.applets.caffeine.inhibit import ScreenSaverInhibitor
+
+        inh = ScreenSaverInhibitor()
+        inh._cookie = 42
+        inh._conn = MagicMock()
+        inh._target = ("name", "/path", "iface")
+        assert inh.acquire() is True
+
+    def test_acquire_no_session_bus_returns_false(self, monkeypatch):
+        from gi.repository import GLib
+
+        from docking.applets.caffeine.inhibit import ScreenSaverInhibitor
+
+        inh = ScreenSaverInhibitor()
+        monkeypatch.setattr(
+            "docking.applets.caffeine.inhibit.Gio.bus_get_sync",
+            lambda *a: (_ for _ in ()).throw(GLib.Error("no bus", 0, 0)),
+        )
+        assert inh.acquire() is False
+
+    def test_acquire_calls_dbus_and_succeeds(self, monkeypatch):
+        from docking.applets.caffeine.inhibit import ScreenSaverInhibitor
+
+        inh = ScreenSaverInhibitor()
+        fake_conn = MagicMock()
+        fake_conn.call_sync.return_value.unpack.return_value = (42,)
+        monkeypatch.setattr(
+            "docking.applets.caffeine.inhibit.Gio.bus_get_sync",
+            lambda *a: fake_conn,
+        )
+        assert inh.acquire() is True
+        assert inh._cookie == 42
+        assert inh._conn is fake_conn
+
+    def test_acquire_all_targets_fail_returns_false(self, monkeypatch):
+        from gi.repository import GLib
+
+        from docking.applets.caffeine.inhibit import ScreenSaverInhibitor
+
+        inh = ScreenSaverInhibitor()
+        fake_conn = MagicMock()
+        fake_conn.call_sync.side_effect = GLib.Error("fail", 0, 0)
+        monkeypatch.setattr(
+            "docking.applets.caffeine.inhibit.Gio.bus_get_sync",
+            lambda *a: fake_conn,
+        )
+        assert inh.acquire() is False
+
+    def test_release_calls_uninhibit(self, monkeypatch):
+        from docking.applets.caffeine.inhibit import ScreenSaverInhibitor
+
+        inh = ScreenSaverInhibitor()
+        fake_conn = MagicMock()
+        inh._cookie = 42
+        inh._conn = fake_conn
+        inh._target = (
+            "org.freedesktop.ScreenSaver",
+            "/ScreenSaver",
+            "org.freedesktop.ScreenSaver",
+        )
+        inh.release()
+        fake_conn.call_sync.assert_called_once()
+        assert inh._cookie is None
+
+    def test_release_uninhibit_glib_error_is_handled(self, monkeypatch):
+        from gi.repository import GLib
+
+        from docking.applets.caffeine.inhibit import ScreenSaverInhibitor
+
+        inh = ScreenSaverInhibitor()
+        fake_conn = MagicMock()
+        fake_conn.call_sync.side_effect = GLib.Error("uninhibit fail", 0, 0)
+        inh._cookie = 42
+        inh._conn = fake_conn
+        inh._target = (
+            "org.freedesktop.ScreenSaver",
+            "/ScreenSaver",
+            "org.freedesktop.ScreenSaver",
+        )
+        # Should not raise
+        inh.release()
+        assert inh._cookie is None
+
+
+class TestSystemdSleepInhibitorProc:
+    def test_acquire_already_active_returns_true(self):
+        from docking.applets.caffeine.inhibit import SystemdSleepInhibitor
+
+        inh = SystemdSleepInhibitor()
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None  # Still running
+        inh._proc = fake_proc
+        assert inh.acquire() is True
+
+    def test_acquire_oserror_returns_false(self, monkeypatch):
+        import subprocess
+
+        from docking.applets.caffeine.inhibit import SystemdSleepInhibitor
+
+        inh = SystemdSleepInhibitor()
+        monkeypatch.setattr(
+            subprocess,
+            "Popen",
+            lambda *a, **kw: (_ for _ in ()).throw(OSError("no systemd-inhibit")),
+        )
+        assert inh.acquire() is False
+        assert inh._proc is None

--- a/tests/applets/test_caffeine.py
+++ b/tests/applets/test_caffeine.py
@@ -416,7 +416,9 @@ class TestScreenSaverInhibitorDBus:
         inh = ScreenSaverInhibitor()
         monkeypatch.setattr(
             "docking.applets.caffeine.inhibit.Gio.bus_get_sync",
-            lambda *a: (_ for _ in ()).throw(GLib.Error("no bus", 0, 0)),
+            lambda *a: (_ for _ in ()).throw(
+                GLib.Error(message="no bus", domain="g-io-error-quark", code=0)
+            ),
         )
         assert inh.acquire() is False
 
@@ -441,7 +443,9 @@ class TestScreenSaverInhibitorDBus:
 
         inh = ScreenSaverInhibitor()
         fake_conn = MagicMock()
-        fake_conn.call_sync.side_effect = GLib.Error("fail", 0, 0)
+        fake_conn.call_sync.side_effect = GLib.Error(
+            message="fail", domain="g-io-error-quark", code=0
+        )
         monkeypatch.setattr(
             "docking.applets.caffeine.inhibit.Gio.bus_get_sync",
             lambda *a: fake_conn,
@@ -471,7 +475,9 @@ class TestScreenSaverInhibitorDBus:
 
         inh = ScreenSaverInhibitor()
         fake_conn = MagicMock()
-        fake_conn.call_sync.side_effect = GLib.Error("uninhibit fail", 0, 0)
+        fake_conn.call_sync.side_effect = GLib.Error(
+            message="uninhibit fail", domain="g-io-error-quark", code=0
+        )
         inh._cookie = 42
         inh._conn = fake_conn
         inh._target = (

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -680,7 +680,11 @@ class TestDefaultDesktopIdFor:
                 AppInfo=SimpleNamespace(
                     get_default_for_type=lambda _ct, _must_support_uris: (
                         _ for _ in ()
-                    ).throw(GLib.Error("No app for type", 0, 0))
+                    ).throw(
+                        GLib.Error(
+                            message="No app for type", domain="g-io-error-quark", code=0
+                        )
+                    )
                 )
             ),
         )

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -646,6 +646,277 @@ class TestConfigSave:
         assert len(fsynced) >= 2
 
 
+class TestNormalizeHideMode:
+    def test_normalize_hide_mode_returns_default_on_value_error(self, monkeypatch):
+
+        warnings: list[str] = []
+
+        class _Capture:
+            def warning(self, msg, *args):
+                warnings.append(msg % args)
+
+        monkeypatch.setattr(config_mod, "logger", _Capture())
+        result = config_mod._normalize_hide_mode("bogus_mode")
+        assert result == "none"
+        assert any("Invalid hide mode" in w for w in warnings)
+
+    def test_normalize_hide_mode_non_string_returns_default(self):
+        assert config_mod._normalize_hide_mode(42) == "none"
+        assert config_mod._normalize_hide_mode(None) == "none"
+        assert config_mod._normalize_hide_mode(["autohide"]) == "none"
+
+
+class TestDefaultDesktopIdFor:
+    def test_glib_error_returns_none(self, monkeypatch):
+        import gi
+
+        gi.require_version("Gio", "2.0")
+        from gi.repository import GLib
+
+        monkeypatch.setattr(
+            gi.repository,
+            "Gio",
+            SimpleNamespace(
+                AppInfo=SimpleNamespace(
+                    get_default_for_type=lambda _ct, _must_support_uris: (
+                        _ for _ in ()
+                    ).throw(GLib.Error("No app for type", 0, 0))
+                )
+            ),
+        )
+        result = config_mod._default_desktop_id_for("application/x-nope")
+        assert result is None
+
+    def test_app_info_none_returns_none(self, monkeypatch):
+        import gi
+
+        gi.require_version("Gio", "2.0")
+        monkeypatch.setattr(
+            gi.repository,
+            "Gio",
+            SimpleNamespace(
+                AppInfo=SimpleNamespace(
+                    get_default_for_type=lambda _ct, _must_support_uris: None
+                )
+            ),
+        )
+        result = config_mod._default_desktop_id_for("application/x-none")
+        assert result is None
+
+    def test_empty_desktop_id_returns_none(self, monkeypatch):
+        import gi
+
+        gi.require_version("Gio", "2.0")
+        monkeypatch.setattr(
+            gi.repository,
+            "Gio",
+            SimpleNamespace(
+                AppInfo=SimpleNamespace(
+                    get_default_for_type=lambda _ct, _must_support_uris: (
+                        SimpleNamespace(get_id=lambda: "")
+                    )
+                )
+            ),
+        )
+        result = config_mod._default_desktop_id_for("application/x-empty")
+        assert result is None
+
+
+class TestUriIsDir:
+    def test_non_file_uri_returns_false(self):
+        assert config_mod._uri_is_dir("http://example.com") is False
+        assert config_mod._uri_is_dir("") is False
+        assert config_mod._uri_is_dir("not-a-uri") is False
+
+    def test_invalid_uri_returns_false_logs_warning(self, monkeypatch):
+        import docking.core.config as config_mod
+
+        warnings: list[str] = []
+
+        class _Capture:
+            def warning(self, msg, *args):
+                warnings.append(msg % args)
+
+        monkeypatch.setattr(config_mod, "logger", _Capture())
+
+        def _raise_valueerror(_path):
+            raise ValueError("unsupported path encoding")
+
+        monkeypatch.setattr(config_mod.Path, "is_dir", _raise_valueerror)
+        # Any file:// URI triggers the code path; Path.is_dir raises
+        result = config_mod._uri_is_dir("file:///bad/path")
+        assert result is False
+        assert any("Invalid file URI" in w for w in warnings)
+
+
+class TestNormalizeBool:
+    def test_normalize_bool_non_matching_string_returns_default(self):
+        assert config_mod._normalize_bool("maybe", default=True) is True
+        assert config_mod._normalize_bool("maybe", default=False) is False
+
+    def test_normalize_bool_non_string_type_returns_default(self):
+        assert config_mod._normalize_bool([True], default=True) is True
+        assert config_mod._normalize_bool(None, default=False) is False
+
+
+class TestNormalizeInt:
+    def test_normalize_int_non_numeric_returns_default(self):
+        assert config_mod._normalize_int([1, 2, 3], default=10) == 10
+        assert config_mod._normalize_int(None, default=5) == 5
+
+    def test_normalize_int_bool_converts(self):
+        assert config_mod._normalize_int(True, default=10) == 1
+        assert config_mod._normalize_int(False, default=10) == 0
+
+    def test_normalize_int_clamps_to_range(self):
+        assert config_mod._normalize_int(50, default=10, minimum=0, maximum=30) == 30
+        assert config_mod._normalize_int(-5, default=10, minimum=0, maximum=30) == 0
+
+    def test_normalize_int_invalid_string_returns_default(self):
+        assert config_mod._normalize_int("abc", default=7) == 7
+
+
+class TestNormalizeFloat:
+    def test_normalize_float_bool_converts(self):
+        assert config_mod._normalize_float(True, default=1.0) == 1.0
+        assert config_mod._normalize_float(False, default=1.0) == 0.0
+
+    def test_normalize_float_non_numeric_returns_default(self):
+        assert config_mod._normalize_float([1.0], default=3.5) == 3.5
+        assert config_mod._normalize_float(None, default=2.0) == 2.0
+
+    def test_normalize_float_clamps_to_range(self):
+        assert (
+            config_mod._normalize_float(10.0, default=5.0, minimum=0.0, maximum=3.0)
+            == 3.0
+        )
+        assert (
+            config_mod._normalize_float(-1.0, default=5.0, minimum=0.0, maximum=3.0)
+            == 0.0
+        )
+
+    def test_normalize_float_invalid_string_returns_default(self):
+        assert config_mod._normalize_float("xyz", default=2.5) == 2.5
+
+
+class TestNormalizeOptionalText:
+    def test_normalize_optional_text_none_returns_none(self):
+        assert config_mod._normalize_optional_text(None) is None
+
+    def test_normalize_optional_text_empty_after_strip_returns_none(self):
+        assert config_mod._normalize_optional_text("   ") is None
+
+    def test_normalize_optional_text_returns_stripped(self):
+        assert config_mod._normalize_optional_text("  hello  ") == "hello"
+
+    def test_normalize_optional_text_converts_non_string(self):
+        assert config_mod._normalize_optional_text(42) == "42"
+
+
+class TestNormalizeRecentApps:
+    def test_normalize_recent_apps_non_list_returns_empty(self):
+        assert config_mod._normalize_recent_apps(None) == []
+        assert config_mod._normalize_recent_apps("not a list") == []
+        assert config_mod._normalize_recent_apps({}) == []
+
+    def test_normalize_recent_apps_drops_non_dict_entries(self):
+        raw = [
+            "string_entry",
+            {"desktop_id": "good.desktop", "last_closed": 1000},
+        ]
+        result = config_mod._normalize_recent_apps(raw)
+        assert result == [{"desktop_id": "good.desktop", "last_closed": 1000}]
+
+    def test_normalize_recent_apps_drops_entries_without_valid_desktop_id(self):
+        raw = [
+            {"desktop_id": "", "last_closed": 1000},
+            {"desktop_id": 123, "last_closed": 1000},
+            {"last_closed": 1000},
+            {"desktop_id": "ok.desktop", "last_closed": 500},
+        ]
+        result = config_mod._normalize_recent_apps(raw)
+        assert result == [{"desktop_id": "ok.desktop", "last_closed": 500}]
+
+    def test_normalize_recent_apps_drops_entries_without_valid_last_closed(self):
+        raw = [
+            {"desktop_id": "a.desktop", "last_closed": "string_time"},
+            {"desktop_id": "b.desktop"},
+            {"desktop_id": "c.desktop", "last_closed": 1.5},
+        ]
+        result = config_mod._normalize_recent_apps(raw)
+        assert result == [{"desktop_id": "c.desktop", "last_closed": 1}]
+
+
+class TestConfigSaveEdgeCases:
+    def test_save_cleanup_oserror_when_unlink_fails(self, tmp_path, monkeypatch):
+        path = tmp_path / "dock.json"
+        config = Config(icon_size=96)
+
+        def _patched_write_json_atomic_candidate(*, path, payload):
+            path.write_text("{}")
+            raise OSError("disk full")
+
+        monkeypatch.setattr(
+            config_mod,
+            "_write_json_atomic_candidate",
+            _patched_write_json_atomic_candidate,
+        )
+        # Also make unlink fail so the cleanup handler fires
+        monkeypatch.setattr(
+            config_mod.Path,
+            "unlink",
+            lambda _self, **kw: (_ for _ in ()).throw(OSError("unlink failed")),
+        )
+        unlink_errors: list[str] = []
+
+        class _Capture:
+            def warning(self, msg, *args):
+                unlink_errors.append(msg % args)
+
+        monkeypatch.setattr(config_mod, "logger", _Capture())
+
+        with pytest.raises(OSError):
+            config.save(path)
+
+        assert any(
+            "Failed to clean up temporary config file" in e for e in unlink_errors
+        )
+
+    def test_backup_cleanup_oserror_when_unlink_fails(self, tmp_path, monkeypatch):
+        source = tmp_path / "source.json"
+        backup = tmp_path / "backup.json"
+        source.write_text("{}", encoding="utf-8")
+        unlink_errors: list[str] = []
+
+        class _Capture:
+            def warning(self, msg, *args):
+                unlink_errors.append(msg % args)
+
+        monkeypatch.setattr(config_mod, "logger", _Capture())
+
+        # Make read_bytes raise so _write_backup_copy enters the except block
+        def _fail_read_bytes(_self):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(config_mod.Path, "read_bytes", _fail_read_bytes)
+        # Make unlink also fail so the cleanup handler fires
+        monkeypatch.setattr(
+            config_mod.Path,
+            "unlink",
+            lambda _self, **kw: (_ for _ in ()).throw(OSError("unlink failed")),
+        )
+
+        with pytest.raises(OSError):
+            config_mod._write_backup_copy(source=source, backup_path=backup)
+
+        assert any(
+            "Failed to clean up temporary backup file" in e for e in unlink_errors
+        )
+
+
+from types import SimpleNamespace
+
+
 class TestConfigHelpers:
     def test_pinned_entry_equality_and_raw_shapes(self, tmp_path):
         folder_uri = tmp_path.as_uri()

--- a/tests/core/test_theme.py
+++ b/tests/core/test_theme.py
@@ -1023,6 +1023,141 @@ class TestMigrationEdgeCases:
 
         assert json.loads(path.read_text()) == {"key": "value"}
 
+    def test_theme_path_set_empty_parts_returns_empty_tuple(self):
+        from docking.core.theme.migration import _theme_path_set
+
+        result = _theme_path_set({}, "", "value")
+        assert result == ()
+
+    def test_theme_path_set_replaces_non_dict_section(self, monkeypatch):
+        from docking.core.theme.migration import _theme_path_set
+
+        data = {"items": "string_not_dict"}
+        result = _theme_path_set(data, "items.glow.color", "#fff")
+        assert "not an object" in " ".join(result)
+
+    def test_create_migration_backup_cleanup_failure(self, tmp_path, monkeypatch):
+        from docking.core.theme import migration as m
+
+        path = tmp_path / "theme.json"
+        path.write_text("{}", encoding="utf-8")
+
+        # Make the backup write fail, then make unlink also fail
+        def _fail_unlink(_self, **kw):
+            raise OSError("unlink failed")
+
+        monkeypatch.setattr(m.Path, "unlink", _fail_unlink)
+        # Make open in write-binary mode fail
+        original_open = m.Path.open
+
+        def _failing_open(self, mode, **kw):
+            if mode == "wb":
+                raise OSError("write failed")
+            return original_open(self, mode, **kw)
+
+        monkeypatch.setattr(m.Path, "open", _failing_open)
+        monkeypatch.setattr(m.os, "fsync", lambda _fd: None)
+
+        with pytest.raises(OSError):
+            m._create_theme_migration_backup(path=path)
+
+    def test_write_theme_json_atomic_non_dict_payload(self, tmp_path):
+        from docking.core.theme.migration import _write_theme_json_atomic
+
+        path = tmp_path / "theme.json"
+        with pytest.raises(ValueError):
+            _write_theme_json_atomic(path=path, payload=[1, 2, 3])
+
+    def test_write_theme_json_atomic_cleanup_failure(self, tmp_path, monkeypatch):
+        from docking.core.theme import migration as m
+
+        path = tmp_path / "theme.json"
+        # Make replace fail so we enter except block, then make unlink also fail
+        monkeypatch.setattr(
+            m.Path,
+            "replace",
+            lambda _self, _other: (_ for _ in ()).throw(OSError("replace failed")),
+        )
+        monkeypatch.setattr(
+            m.Path,
+            "unlink",
+            lambda _self, **kw: (_ for _ in ()).throw(OSError("unlink cleanup failed")),
+        )
+        monkeypatch.setattr(m.os, "fsync", lambda _fd: None)
+
+        with pytest.raises(OSError):
+            m._write_theme_json_atomic(path=path, payload={"key": "value"})
+
+    def test_migrate_existing_user_theme_template_read_failure(
+        self, tmp_path, monkeypatch
+    ):
+        from docking.core.theme.theme import _migrate_existing_user_theme_template
+
+        path = tmp_path / "bad.json"
+        path.write_text("{}")
+        # Make open fail
+        monkeypatch.setattr(
+            __import__(
+                "docking.core.theme.theme",
+                fromlist=["_migrate_existing_user_theme_template"],
+            ).Path,
+            "open",
+            lambda _self, **kw: (_ for _ in ()).throw(OSError("read failed")),
+        )
+        # Should not raise
+        _migrate_existing_user_theme_template(path=path, directory=tmp_path)
+
+    def test_migrate_existing_user_theme_template_non_dict(self, tmp_path, caplog):
+        from docking.core.theme.theme import _migrate_existing_user_theme_template
+
+        path = tmp_path / "theme.json"
+        path.write_text("[]", encoding="utf-8")
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            _migrate_existing_user_theme_template(path=path, directory=tmp_path)
+        assert any("not a JSON object" in r.message for r in caplog.records)
+
+    def test_migrate_existing_user_theme_template_backfill_oserror(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        from docking.core.theme.theme import _migrate_existing_user_theme_template
+
+        path = tmp_path / "theme.json"
+        # Write just enough that migration succeeds but write_text fails on backfill
+        path.write_text(
+            json.dumps({"indicators": {"style": "dots", "fill": "flat"}}),
+            encoding="utf-8",
+        )
+        # Force write_text to fail
+        monkeypatch.setattr(
+            path.__class__,
+            "write_text",
+            lambda _self, _text, **kw: (_ for _ in ()).throw(OSError("write failed")),
+        )
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            _migrate_existing_user_theme_template(path=path, directory=tmp_path)
+
+    def test_invalid_indicator_style_logs_and_falls_back(self, tmp_path, caplog):
+        from docking.core.theme.theme import Theme
+
+        theme_data = {"indicators": {"style": "bogus", "fill": "flat"}}
+        theme_file = tmp_path / "bad-style.json"
+        theme_file.write_text(json.dumps(theme_data), encoding="utf-8")
+        import logging
+
+        with (
+            patch("docking.core.theme.theme._BUILTIN_THEMES_DIR", tmp_path),
+            caplog.at_level(logging.WARNING),
+        ):
+            t = Theme.load("bad-style", 48)
+        from docking.core.theme.theme import IndicatorStyle
+
+        assert t.indicator_style is IndicatorStyle.DOTS
+        assert any("indicator style" in r.message.lower() for r in caplog.records)
+
 
 class TestIndicatorFill:
     """Indicator fill (flat vs glow) theme field and JSON loading."""

--- a/tests/integration/test_recent_apps_flow.py
+++ b/tests/integration/test_recent_apps_flow.py
@@ -1,0 +1,174 @@
+"""Integration tests for the recent apps end-to-end flow.
+
+Exercises the model, config, launcher, and recent_docs modules together.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from docking.applets.services import AppletServices
+from docking.core.config import Config
+from docking.platform.model import DockModel
+from docking.platform.running import RunningAppInfo
+
+
+def _make_running(**kw) -> RunningAppInfo:
+    defaults = {"count": 1, "active": False, "urgent": False}
+    return RunningAppInfo(**(defaults | kw))
+
+
+def _make_launcher(*desktop_ids: str):
+    launcher = MagicMock()
+    infos = {}
+    for did in desktop_ids:
+        info = MagicMock()
+        info.desktop_id = did
+        info.name = did.removesuffix(".desktop")
+        info.icon_name = "test-icon"
+        info.wm_class = did.removesuffix(".desktop")
+        infos[did] = info
+
+    def resolve(desktop_id, **_kwargs):
+        return infos.get(desktop_id)
+
+    launcher.resolve.side_effect = resolve
+    launcher.load_icon.return_value = MagicMock()
+    return launcher
+
+
+class TestRecentAppsFullFlow:
+    """End-to-end: app launched, closed, appears in recent, pinned, etc."""
+
+    def test_launch_close_reappear_flow(self):
+        """App is launched, closed, shown as recent, then relaunched."""
+        config = Config()
+        config.show_recent_apps = True
+        config.recent_apps_max = 5
+        config.recent_apps_retention_days = 14
+        config.pinned = []
+        launcher = _make_launcher("firefox.desktop")
+        model = DockModel(config, launcher, AppletServices())
+
+        # App appears running
+        model.update_running({"firefox.desktop": _make_running()})
+        assert any(
+            i.desktop_id == "firefox.desktop" and i.is_running
+            for i in model.visible_items()
+        )
+
+        # App closes
+        model.update_running({})
+        items = model.visible_items()
+        recent = [i for i in items if i.is_recent]
+        assert any(i.desktop_id == "firefox.desktop" for i in recent)
+
+        # App relaunches
+        model.update_running({"firefox.desktop": _make_running()})
+        items = model.visible_items()
+        ff = next(i for i in items if i.desktop_id == "firefox.desktop")
+        assert ff.is_running
+        assert not ff.is_recent  # Not in recent section while running
+
+    def test_recent_app_pinning_promotes_to_persistent(self):
+        """Pinning a recent app makes it a pinned (persistent) item."""
+        config = Config()
+        config.show_recent_apps = True
+        config.recent_apps_max = 10
+        config.recent_apps_retention_days = 30
+        config.pinned = []
+        launcher = _make_launcher("gedit.desktop")
+        model = DockModel(config, launcher, AppletServices())
+
+        # Launch and close to get it in recent
+        model.update_running({"gedit.desktop": _make_running()})
+        model.update_running({})
+
+        recent_items = [i for i in model.visible_items() if i.is_recent]
+        assert len(recent_items) >= 1
+        assert any(i.desktop_id == "gedit.desktop" for i in recent_items)
+
+        # Pin it
+        model.pin_item("gedit.desktop")
+        pinned_ids = [i.desktop_id for i in model.visible_items() if i.is_pinned]
+        assert "gedit.desktop" in pinned_ids
+
+    def test_disabled_recent_apps_clears_on_rebuild(self):
+        """When recent apps is disabled, the section disappears."""
+        config = Config(
+            show_recent_apps=True,
+            recent_apps_max=5,
+            recent_apps_retention_days=14,
+            pinned=[],
+        )
+        # Set recent_apps via constructor won't work directly, use the
+        # model's mechanism
+        launcher = _make_launcher("old.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        # Start with recent apps enabled and an app in recent
+        model.update_running({"old.desktop": _make_running()})
+        model.update_running({})
+
+        items_before = model.visible_items()
+        assert any(i.is_recent for i in items_before)
+
+        config.show_recent_apps = False
+        model.rebuild_recent_apps()
+
+        items_after = model.visible_items()
+        assert not any(i.is_recent for i in items_after)
+
+    def test_unresolvable_recent_entry_is_skipped(self):
+        """A recent app entry for a nonexistent launcher is skipped gracefully."""
+        config = Config()
+        config.show_recent_apps = True
+        config.recent_apps_max = 10
+        config.recent_apps_retention_days = 30
+        config.pinned = []
+        config.recent_apps = [
+            {"desktop_id": "ghost.desktop", "last_closed": 999999},
+        ]
+        launcher = _make_launcher()  # No launchers
+        model = DockModel(config, launcher, AppletServices())
+
+        items = model.visible_items()
+        recent = [i for i in items if i.is_recent]
+        assert len(recent) == 0  # Unresolvable entry skipped
+
+    def test_find_by_desktop_id_in_recent_section(self):
+        """find_by_desktop_id works for items in the recent section."""
+        config = Config(
+            show_recent_apps=True,
+            recent_apps_max=10,
+            recent_apps_retention_days=30,
+            pinned=[],
+        )
+        launcher = _make_launcher("gedit.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        # Get gedit into recent by launching and closing it
+        model.update_running({"gedit.desktop": _make_running()})
+        model.update_running({})
+
+        item = model.find_by_desktop_id("gedit.desktop")
+        assert item is not None
+        assert item.is_recent
+
+    def test_config_save_includes_recent_apps(self, tmp_path):
+        """Saving config persists recent_apps list."""
+        config = Config()
+        config.show_recent_apps = True
+        config.recent_apps_max = 10
+        config.recent_apps_retention_days = 30
+        config.recent_apps = [
+            {"desktop_id": "app.desktop", "last_closed": 1000},
+        ]
+        path = tmp_path / "dock.json"
+        config.save(path)
+
+        import json
+
+        data = json.loads(path.read_text())
+        assert data.get("show_recent_apps") is True
+        assert data.get("recent_apps_max") == 10
+        assert data.get("recent_apps_retention_days") == 30
+        assert len(data.get("recent_apps", [])) == 1

--- a/tests/ipc/test_items_service.py
+++ b/tests/ipc/test_items_service.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -14,7 +16,7 @@ if str(ROOT) not in sys.path:
 from gi.repository import GLib
 
 from docking.core.position import Position
-from docking.ipc.introspection import ITEMS_INTERFACE, OBJECT_PATH
+from docking.ipc.introspection import ITEMS_INTERFACE, OBJECT_PATH, UNKNOWN_METHOD_ERROR
 from docking.ipc.items_service import DockItemsService
 from docking.ui.geometry import anchor_from_draw_rect
 
@@ -292,6 +294,295 @@ class TestDockItemsServiceSignals:
         assert connection.emitted == [
             (None, OBJECT_PATH, ITEMS_INTERFACE, "Changed", None)
         ]
+
+
+class TestDockItemsServiceEdgeCases:
+    def test_start_already_started_returns_early(self, monkeypatch):
+        model = _make_model()
+        window = _make_window()
+        connection = _FakeConnection()
+        monkeypatch.setattr(
+            "docking.ipc.items_service.Gio.bus_get_sync",
+            lambda *_args: connection,
+        )
+        monkeypatch.setattr(
+            "docking.ipc.items_service.Gio.bus_own_name_on_connection",
+            lambda *_args: 23,
+        )
+        monkeypatch.setattr(
+            "docking.ipc.items_service.GLib.timeout_add",
+            lambda *_args: 77,
+        )
+
+        service = DockItemsService(model=model, window=window)
+        service.start()
+        # Second start should be a no-op
+        service.start()
+        # Should still have only one registration
+        assert len(connection.register_calls) == 1
+
+    def test_start_bus_connection_failure_logs_warning(self, monkeypatch):
+        model = _make_model()
+        window = _make_window()
+        monkeypatch.setattr(
+            "docking.ipc.items_service.Gio.bus_get_sync",
+            lambda *_args: (_ for _ in ()).throw(RuntimeError("no bus")),
+        )
+        warnings: list[str] = []
+
+        class _Capture:
+            def warning(self, msg, *args):
+                warnings.append(msg % args)
+
+        monkeypatch.setattr("docking.ipc.items_service.log", _Capture())
+
+        service = DockItemsService(model=model, window=window)
+        service.start()
+
+        assert any("Could not connect to session bus" in w for w in warnings)
+
+    def test_start_registration_failure_unowns_and_logs(self, monkeypatch):
+        model = _make_model()
+        window = _make_window()
+        connection = _FakeConnection()
+        monkeypatch.setattr(
+            "docking.ipc.items_service.Gio.bus_get_sync",
+            lambda *_args: connection,
+        )
+        owner_id = 0
+
+        def _bus_own_name(*_args):
+            nonlocal owner_id
+            owner_id = 23
+            return owner_id
+
+        monkeypatch.setattr(
+            "docking.ipc.items_service.Gio.bus_own_name_on_connection",
+            _bus_own_name,
+        )
+        # Make register_object fail
+        connection.register_object = lambda *args, **kwargs: (_ for _ in ()).throw(
+            RuntimeError("registration failed")
+        )
+        unowned: list[int] = []
+
+        def _bus_unown_name(oid):
+            unowned.append(oid)
+
+        monkeypatch.setattr(
+            "docking.ipc.items_service.Gio.bus_unown_name",
+            _bus_unown_name,
+        )
+        warnings: list[str] = []
+
+        class _Capture:
+            def warning(self, msg, *args):
+                warnings.append(msg % args)
+
+        monkeypatch.setattr("docking.ipc.items_service.log", _Capture())
+
+        service = DockItemsService(model=model, window=window)
+        service.start()
+
+        assert unowned == [23]
+        assert any("Could not register D-Bus service" in w for w in warnings)
+
+    def test_attach_listener_already_subscribed_is_noop(self):
+        model = _make_model()
+        window = _make_window()
+        service = DockItemsService(model=model, window=window)
+        service._subscribed_to_model = True
+
+        service._attach_model_change_listener()
+
+        model.add_change_listener.assert_not_called()
+
+    def test_detach_listener_not_subscribed_is_noop(self):
+        model = _make_model()
+        window = _make_window()
+        service = DockItemsService(model=model, window=window)
+        service._subscribed_to_model = False
+
+        service._detach_model_change_listener()
+
+        model.remove_change_listener.assert_not_called()
+
+    def test_schedule_changed_signal_no_connection(self):
+        model = _make_model()
+        window = _make_window()
+        service = DockItemsService(model=model, window=window)
+        service._connection = None
+        service._registration_id = 1
+        service._changed_source_id = 0
+
+        # Should not raise
+        service._schedule_changed_signal()
+        assert service._changed_source_id == 0
+
+    def test_emit_changed_signal_no_connection(self):
+        model = _make_model()
+        window = _make_window()
+        service = DockItemsService(model=model, window=window)
+        service._connection = None
+        service._registration_id = 1
+        service._changed_source_id = 5
+
+        result = service._emit_changed_signal()
+
+        assert result is False
+
+    def test_emit_changed_signal_exception_logs_warning(self, monkeypatch):
+        model = _make_model()
+        window = _make_window()
+        connection = _FakeConnection()
+        connection.emit_signal = lambda *args: (_ for _ in ()).throw(
+            RuntimeError("emit failed")
+        )
+        service = DockItemsService(model=model, window=window)
+        service._connection = connection
+        service._registration_id = 1
+        warnings: list[str] = []
+
+        class _Capture:
+            def warning(self, msg, *args):
+                warnings.append(msg % args)
+
+        monkeypatch.setattr("docking.ipc.items_service.log", _Capture())
+
+        result = service._emit_changed_signal()
+
+        assert result is False
+        assert any("Failed to emit D-Bus Changed signal" in w for w in warnings)
+
+    def test_handle_method_call_unknown_interface(self):
+        service = DockItemsService(model=_make_model(), window=_make_window())
+        invocation = _FakeInvocation()
+
+        service._handle_method_call(
+            None,
+            "",
+            OBJECT_PATH,
+            "org.unknown.Interface",
+            "SomeMethod",
+            GLib.Variant("()", ()),
+            invocation,
+        )
+
+        assert invocation.error == (
+            UNKNOWN_METHOD_ERROR,
+            "Unknown interface: org.unknown.Interface",
+        )
+
+    def test_handle_method_call_dispatch_exception(self, monkeypatch):
+        service = DockItemsService(model=_make_model(), window=_make_window())
+        invocation = _FakeInvocation()
+        # Force an exception in dispatch
+        monkeypatch.setattr(
+            service,
+            "_dispatch_call",
+            lambda **kwargs: (_ for _ in ()).throw(ValueError("boom")),
+        )
+
+        service._handle_method_call(
+            None,
+            "",
+            OBJECT_PATH,
+            ITEMS_INTERFACE,
+            "SomeMethod",
+            GLib.Variant("()", ()),
+            invocation,
+        )
+
+        assert invocation.error == (
+            "org.docking.Docking.Error.Failed",
+            "boom",
+        )
+
+    def test_handle_method_call_returns_value_on_success(self):
+        service = DockItemsService(model=_make_model(), window=_make_window())
+        invocation = _FakeInvocation()
+
+        service._handle_method_call(
+            None,
+            "",
+            OBJECT_PATH,
+            ITEMS_INTERFACE,
+            "GetCount",
+            GLib.Variant("()", ()),
+            invocation,
+        )
+
+        assert invocation.error is None
+        assert invocation.value is not None
+
+    def test_dispatch_call_wrong_argument_count_raises_valueerror(self):
+        service = DockItemsService(model=_make_model(), window=_make_window())
+
+        # Pin expects (s) but we pass (ii)
+        with pytest.raises(ValueError, match="expects one string argument"):
+            service._dispatch_call(
+                method_name="Pin",
+                parameters=GLib.Variant("(ii)", (1, 2)),
+            )
+
+    def test_dispatch_call_non_string_argument_raises_valueerror(self):
+        service = DockItemsService(model=_make_model(), window=_make_window())
+
+        with pytest.raises(ValueError, match="expects one string argument"):
+            service._dispatch_call(
+                method_name="Pin",
+                parameters=GLib.Variant("(i)", (42,)),
+            )
+
+    def test_get_hover_anchor_none_returns_failure_tuple(self):
+        model = _make_model()
+        window = _make_window()
+        window.get_hover_anchor = MagicMock(return_value=None)
+        service = DockItemsService(model=model, window=window)
+
+        result = service._dispatch_call(
+            method_name="GetHoverAnchor",
+            parameters=GLib.Variant("(s)", ("missing.desktop",)),
+        )
+
+        assert result.unpack() == (False, -1, -1, "")
+
+    def test_pin_item_already_pinned_returns_false(self):
+        model = _make_model()
+        service = DockItemsService(model=model, window=_make_window())
+
+        result = service._dispatch_call(
+            method_name="Pin",
+            parameters=GLib.Variant("(s)", ("firefox.desktop",)),
+        )
+
+        assert result.unpack() == (False,)
+        model.pin_item.assert_not_called()
+
+    def test_unpin_transient_item_returns_false(self):
+        model = _make_model()
+        service = DockItemsService(model=model, window=_make_window())
+
+        result = service._dispatch_call(
+            method_name="Unpin",
+            parameters=GLib.Variant("(s)", ("missing.desktop",)),
+        )
+
+        assert result.unpack() == (False,)
+        model.unpin_item.assert_not_called()
+
+    def test_remove_is_alias_for_unpin(self):
+        model = _make_model()
+        service = DockItemsService(model=model, window=_make_window())
+
+        # Remove on pinned item succeeds (delegates to unpin)
+        result = service._dispatch_call(
+            method_name="Remove",
+            parameters=GLib.Variant("(s)", ("firefox.desktop",)),
+        )
+
+        assert result.unpack() == (True,)
+        model.unpin_item.assert_called_once_with("firefox.desktop")
 
 
 class TestHoverAnchorHelper:

--- a/tests/platform/test_model.py
+++ b/tests/platform/test_model.py
@@ -845,3 +845,153 @@ class TestDockItemAnimationFields:
         item.last_launched = 67890
         # Then
         assert item.last_clicked == 12345
+
+
+class TestRecentAppsIntegration:
+    """Integration tests for the recent apps section of DockModel."""
+
+    def test_recent_apps_disabled_no_section_appears(self):
+        config = _make_config(["a.desktop"], show_recent_apps=False)
+        launcher = _make_launcher("a.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        # No recent apps in visible items
+        items = model.visible_items()
+        assert all(not item.is_recent for item in items)
+
+    def test_recent_apps_enabled_empty_by_default(self):
+        config = _make_config(["a.desktop"], show_recent_apps=True)
+        launcher = _make_launcher("a.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        # Only pinned items, no recent section because no apps closed
+        items = model.visible_items()
+        assert all(not item.is_recent for item in items)
+
+    def test_app_closed_appears_in_recent(self):
+        config = _make_config(["a.desktop"], show_recent_apps=True)
+        launcher = _make_launcher("a.desktop", "b.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        # App b is running
+        model.update_running({"b.desktop": _running()})
+        items_before = model.visible_items()
+        b_before = next(i for i in items_before if i.desktop_id == "b.desktop")
+        assert b_before.is_running
+        assert not b_before.is_recent
+        # App b closes
+        model.update_running({})
+        items_after = model.visible_items()
+        # b.desktop should now be marked as recent
+        b_items = [
+            i for i in items_after if i.desktop_id == "b.desktop" and i.is_recent
+        ]
+        assert len(b_items) >= 1
+
+    def test_recent_app_not_duplicated_when_pinned(self):
+        config = _make_config(["firefox.desktop"], show_recent_apps=True)
+        launcher = _make_launcher("firefox.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        model.update_running({"firefox.desktop": _running()})
+        model.update_running({})
+        items = model.visible_items()
+        # Firefox is pinned, should not appear as recent
+        recent_ids = [i.desktop_id for i in items if i.is_recent]
+        assert "firefox.desktop" not in recent_ids
+
+    def test_pin_recent_item_moves_it_to_pinned(self):
+        config = _make_config(["a.desktop"], show_recent_apps=True)
+        launcher = _make_launcher("a.desktop", "b.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        model.update_running({"b.desktop": _running()})
+        model.update_running({})
+        # b.desktop should be in recent
+        items_before = model.visible_items()
+        recent_before = [i for i in items_before if i.is_recent]
+        assert any(i.desktop_id == "b.desktop" for i in recent_before)
+        # Pin it
+        model.pin_item("b.desktop")
+        # Should now be pinned
+        items = model.visible_items()
+        pinned_ids = [i.desktop_id for i in items if i.is_pinned]
+        assert "b.desktop" in pinned_ids
+
+    def test_recent_app_max_limit(self):
+        config = _make_config(["pinned.desktop"], show_recent_apps=True)
+        config.recent_apps_max = 2
+        launcher = _make_launcher(
+            "pinned.desktop", "a.desktop", "b.desktop", "c.desktop"
+        )
+        model = DockModel(config, launcher, AppletServices())
+        # Close three apps
+        for did in ["a.desktop", "b.desktop", "c.desktop"]:
+            model.update_running({did: _running()})
+        model.update_running({})
+        recent = [i for i in model.visible_items() if i.is_recent]
+        assert len(recent) <= 2
+
+    def test_recent_app_running_not_in_recent_section(self):
+        config = _make_config(["a.desktop"], show_recent_apps=True)
+        launcher = _make_launcher("a.desktop", "b.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        # b closes
+        model.update_running({"b.desktop": _running()})
+        model.update_running({})
+        # b should be recent
+        assert any(
+            i.desktop_id == "b.desktop" and i.is_recent for i in model.visible_items()
+        )
+        # b starts again
+        model.update_running({"b.desktop": _running()})
+        # b should now be transient (running but not pinned)
+        items = model.visible_items()
+        b_item = next(i for i in items if i.desktop_id == "b.desktop")
+        assert not b_item.is_recent
+        assert b_item.is_running
+
+    def test_rebuild_recent_apps_public_method(self):
+        config = _make_config(["a.desktop"], show_recent_apps=True)
+        config.recent_apps = [{"desktop_id": "b.desktop", "last_closed": 9999999999}]
+        launcher = _make_launcher("a.desktop", "b.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        # Clear via rebuild
+        config.show_recent_apps = False
+        model.rebuild_recent_apps()
+        assert all(not i.is_recent for i in model.visible_items())
+        # Re-enable
+        config.show_recent_apps = True
+        config.recent_apps = [{"desktop_id": "b.desktop", "last_closed": 9999999999}]
+        model.rebuild_recent_apps()
+        recent = [i for i in model.visible_items() if i.is_recent]
+        # b.desktop should be in recent (from config list)
+        assert any(i.desktop_id == "b.desktop" for i in recent)
+
+    def test_find_by_desktop_id_searches_recent(self):
+        config = _make_config(["a.desktop"], show_recent_apps=True)
+        config.recent_apps = [{"desktop_id": "b.desktop", "last_closed": 9999999999}]
+        launcher = _make_launcher("a.desktop", "b.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        # Find recent item
+        item = model.find_by_desktop_id("b.desktop")
+        assert item is not None
+        assert item.is_recent
+
+    def test_recent_app_retention_days_pruning(self):
+        import time
+
+        config = _make_config(["a.desktop"], show_recent_apps=True)
+        config.recent_apps_retention_days = 1
+        config.recent_apps_max = 10
+        launcher = _make_launcher("a.desktop", "old.desktop", "new.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        # Close an app with old timestamp
+        model.update_running({"old.desktop": _running()})
+        model.update_running({})
+        # Manually set the last_closed to be old
+        for item in model.visible_items():
+            if item.desktop_id == "old.desktop" and item.is_recent:
+                item.last_closed = time.time() - (2 * 86400)  # 2 days ago
+        # Now close a new app
+        model.update_running({"new.desktop": _running()})
+        model.update_running({})
+        recent = [i for i in model.visible_items() if i.is_recent]
+        # old.desktop should be pruned (older than 1 day), new.desktop should remain
+        recent_ids = [i.desktop_id for i in recent]
+        assert "new.desktop" in recent_ids

--- a/tests/platform/test_recent_docs.py
+++ b/tests/platform/test_recent_docs.py
@@ -1,0 +1,344 @@
+"""Tests for recent_docs module — document-to-app association."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from docking.platform.recent_docs import RecentDoc, recent_docs_for_app
+
+
+class _FakeRecentItem:
+    """Minimal fake for Gtk.RecentInfo."""
+
+    def __init__(
+        self,
+        uri: str,
+        name: str,
+        mime: str,
+        modified: int,
+        *,
+        is_local: bool = True,
+        exists: bool = True,
+        has_application: bool = True,
+    ):
+        self._uri = uri
+        self._name = name
+        self._mime = mime
+        self._modified = modified
+        self._is_local = is_local
+        self._exists = exists
+        self._has_application = has_application
+
+    def get_uri(self) -> str:
+        return self._uri
+
+    def get_short_name(self) -> str:
+        return self._name
+
+    def get_mime_type(self) -> str:
+        return self._mime
+
+    def get_modified(self) -> int:
+        return self._modified
+
+    def is_local(self) -> bool:
+        return self._is_local
+
+    def exists(self) -> bool:
+        return self._exists
+
+    def has_application(self, app_name: str) -> bool:
+        return self._has_application
+
+
+class TestRecentDocDataclass:
+    def test_recent_doc_fields(self):
+        doc = RecentDoc(
+            uri="file:///home/user/doc.txt",
+            name="doc.txt",
+            mime_type="text/plain",
+            modified=1000,
+        )
+        assert doc.uri == "file:///home/user/doc.txt"
+        assert doc.name == "doc.txt"
+        assert doc.mime_type == "text/plain"
+        assert doc.modified == 1000
+
+    def test_recent_doc_is_frozen(self):
+        doc = RecentDoc(
+            uri="file:///a",
+            name="a",
+            mime_type="text/plain",
+            modified=1,
+        )
+        from dataclasses import FrozenInstanceError
+
+        with pytest.raises(FrozenInstanceError):
+            doc.uri = "other"
+
+
+class TestRecentDocsForApp:
+    def test_empty_desktop_id_returns_empty(self):
+        result = recent_docs_for_app("", launcher=MagicMock(), limit=10)
+        assert result == []
+
+    def test_nonexistent_desktop_entry_returns_empty(self, monkeypatch):
+        import docking.platform.recent_docs as mod
+
+        monkeypatch.setattr(
+            mod.desktop_entries,
+            "resolve_app_info",
+            lambda desktop_id, **kw: None,
+        )
+        result = recent_docs_for_app("missing.desktop", launcher=MagicMock(), limit=10)
+        assert result == []
+
+    def test_empty_recent_store_returns_empty(self, monkeypatch):
+        import docking.platform.recent_docs as mod
+
+        monkeypatch.setattr(
+            mod.desktop_entries,
+            "resolve_app_info",
+            lambda desktop_id, **kw: SimpleNamespace(
+                app_info=SimpleNamespace(get_display_name=lambda: "Firefox")
+            ),
+        )
+        fake_manager = MagicMock()
+        fake_manager.get_items.return_value = []
+        monkeypatch.setattr(mod.Gtk.RecentManager, "get_default", lambda: fake_manager)
+
+        result = recent_docs_for_app("firefox.desktop", launcher=MagicMock(), limit=10)
+        assert result == []
+
+    def test_filters_non_local_files(self, monkeypatch):
+        import docking.platform.recent_docs as mod
+
+        monkeypatch.setattr(
+            mod.desktop_entries,
+            "resolve_app_info",
+            lambda desktop_id, **kw: SimpleNamespace(
+                app_info=SimpleNamespace(get_display_name=lambda: "Firefox")
+            ),
+        )
+        items = [
+            _FakeRecentItem(
+                "file:///remote/doc.txt",
+                "doc.txt",
+                "text/plain",
+                2000,
+                is_local=False,
+                exists=True,
+                has_application=True,
+            ),
+            _FakeRecentItem(
+                "file:///local/doc.txt",
+                "doc.txt",
+                "text/plain",
+                1000,
+                is_local=True,
+                exists=True,
+                has_application=True,
+            ),
+        ]
+        fake_manager = MagicMock()
+        fake_manager.get_items.return_value = items
+        monkeypatch.setattr(mod.Gtk.RecentManager, "get_default", lambda: fake_manager)
+
+        result = recent_docs_for_app("firefox.desktop", launcher=MagicMock(), limit=10)
+        assert len(result) == 1
+        assert result[0].uri == "file:///local/doc.txt"
+
+    def test_filters_nonexistent_files(self, monkeypatch):
+        import docking.platform.recent_docs as mod
+
+        monkeypatch.setattr(
+            mod.desktop_entries,
+            "resolve_app_info",
+            lambda desktop_id, **kw: SimpleNamespace(
+                app_info=SimpleNamespace(get_display_name=lambda: "Firefox")
+            ),
+        )
+        items = [
+            _FakeRecentItem(
+                "file:///deleted/doc.txt",
+                "doc.txt",
+                "text/plain",
+                1000,
+                is_local=True,
+                exists=False,
+                has_application=True,
+            ),
+            _FakeRecentItem(
+                "file:///alive/doc.txt",
+                "doc.txt",
+                "text/plain",
+                500,
+                is_local=True,
+                exists=True,
+                has_application=True,
+            ),
+        ]
+        fake_manager = MagicMock()
+        fake_manager.get_items.return_value = items
+        monkeypatch.setattr(mod.Gtk.RecentManager, "get_default", lambda: fake_manager)
+
+        result = recent_docs_for_app("firefox.desktop", launcher=MagicMock(), limit=10)
+        assert len(result) == 1
+        assert result[0].uri == "file:///alive/doc.txt"
+
+    def test_filters_wrong_application(self, monkeypatch):
+        import docking.platform.recent_docs as mod
+
+        monkeypatch.setattr(
+            mod.desktop_entries,
+            "resolve_app_info",
+            lambda desktop_id, **kw: SimpleNamespace(
+                app_info=SimpleNamespace(get_display_name=lambda: "Firefox")
+            ),
+        )
+        items = [
+            _FakeRecentItem(
+                "file:///chrome/doc.txt",
+                "doc.txt",
+                "text/plain",
+                1000,
+                is_local=True,
+                exists=True,
+                has_application=False,
+            ),
+            _FakeRecentItem(
+                "file:///firefox/doc.txt",
+                "doc.txt",
+                "text/plain",
+                500,
+                is_local=True,
+                exists=True,
+                has_application=True,
+            ),
+        ]
+        fake_manager = MagicMock()
+        fake_manager.get_items.return_value = items
+        monkeypatch.setattr(mod.Gtk.RecentManager, "get_default", lambda: fake_manager)
+
+        result = recent_docs_for_app("firefox.desktop", launcher=MagicMock(), limit=10)
+        assert len(result) == 1
+        assert result[0].uri == "file:///firefox/doc.txt"
+
+    def test_respects_limit(self, monkeypatch):
+        import docking.platform.recent_docs as mod
+
+        monkeypatch.setattr(
+            mod.desktop_entries,
+            "resolve_app_info",
+            lambda desktop_id, **kw: SimpleNamespace(
+                app_info=SimpleNamespace(get_display_name=lambda: "Firefox")
+            ),
+        )
+        items = [
+            _FakeRecentItem(
+                f"file:///doc{i}.txt",
+                f"doc{i}.txt",
+                "text/plain",
+                1000 - i,
+                is_local=True,
+                exists=True,
+                has_application=True,
+            )
+            for i in range(20)
+        ]
+        fake_manager = MagicMock()
+        fake_manager.get_items.return_value = items
+        monkeypatch.setattr(mod.Gtk.RecentManager, "get_default", lambda: fake_manager)
+
+        result = recent_docs_for_app("firefox.desktop", launcher=MagicMock(), limit=5)
+        assert len(result) == 5
+
+    def test_sorts_by_modified_descending(self, monkeypatch):
+        import docking.platform.recent_docs as mod
+
+        monkeypatch.setattr(
+            mod.desktop_entries,
+            "resolve_app_info",
+            lambda desktop_id, **kw: SimpleNamespace(
+                app_info=SimpleNamespace(get_display_name=lambda: "Firefox")
+            ),
+        )
+        items = [
+            _FakeRecentItem(
+                "file:///old.txt",
+                "old.txt",
+                "text/plain",
+                500,
+                is_local=True,
+                exists=True,
+                has_application=True,
+            ),
+            _FakeRecentItem(
+                "file:///new.txt",
+                "new.txt",
+                "text/plain",
+                2000,
+                is_local=True,
+                exists=True,
+                has_application=True,
+            ),
+            _FakeRecentItem(
+                "file:///mid.txt",
+                "mid.txt",
+                "text/plain",
+                1000,
+                is_local=True,
+                exists=True,
+                has_application=True,
+            ),
+        ]
+        fake_manager = MagicMock()
+        fake_manager.get_items.return_value = items
+        monkeypatch.setattr(mod.Gtk.RecentManager, "get_default", lambda: fake_manager)
+
+        result = recent_docs_for_app("firefox.desktop", launcher=MagicMock(), limit=10)
+        assert len(result) == 3
+        assert result[0].uri == "file:///new.txt"
+        assert result[1].uri == "file:///mid.txt"
+        assert result[2].uri == "file:///old.txt"
+
+    def test_filters_empty_mime_type(self, monkeypatch):
+        import docking.platform.recent_docs as mod
+
+        monkeypatch.setattr(
+            mod.desktop_entries,
+            "resolve_app_info",
+            lambda desktop_id, **kw: SimpleNamespace(
+                app_info=SimpleNamespace(get_display_name=lambda: "Firefox")
+            ),
+        )
+        items = [
+            _FakeRecentItem(
+                "file:///no-mime.txt",
+                "no-mime.txt",
+                "",
+                1000,
+                is_local=True,
+                exists=True,
+                has_application=True,
+            ),
+            _FakeRecentItem(
+                "file:///has-mime.txt",
+                "has-mime.txt",
+                "text/plain",
+                500,
+                is_local=True,
+                exists=True,
+                has_application=True,
+            ),
+        ]
+        fake_manager = MagicMock()
+        fake_manager.get_items.return_value = items
+        monkeypatch.setattr(mod.Gtk.RecentManager, "get_default", lambda: fake_manager)
+
+        result = recent_docs_for_app("firefox.desktop", launcher=MagicMock(), limit=10)
+        assert len(result) == 1
+        assert result[0].uri == "file:///has-mime.txt"

--- a/tests/ui/test_diagnostics_ui.py
+++ b/tests/ui/test_diagnostics_ui.py
@@ -1,0 +1,169 @@
+"""Tests for the diagnostics UI controller.
+
+Focuses on logic that can be tested without a full GTK display.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+# Ensure GTK mocking happens before the diagnostics module loads
+try:
+    import gi  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover
+    gi_mock = MagicMock()
+    gi_mock.require_version = MagicMock()
+    gi_mock.repository.GLib.markup_escape_text.side_effect = lambda text: text
+    sys.modules.setdefault("gi", gi_mock)
+    sys.modules.setdefault("gi.repository", gi_mock.repository)
+
+from docking.platform.diagnostics import DiagnosticCheck, DiagnosticFeature
+from docking.ui.diagnostics import DiagnosticsDialogController
+
+
+class TestDiagnosticsStaticMethods:
+    def test_status_symbol_ok(self):
+        assert DiagnosticsDialogController._status_symbol("ok") == "OK"
+
+    def test_status_symbol_error(self):
+        assert DiagnosticsDialogController._status_symbol("error") == "X"
+
+    def test_status_symbol_warning(self):
+        assert DiagnosticsDialogController._status_symbol("warning") == "!"
+
+    def test_status_symbol_unknown(self):
+        assert DiagnosticsDialogController._status_symbol("info") == "i"
+        assert DiagnosticsDialogController._status_symbol("") == "i"
+
+    def test_yes_no_true(self):
+        assert "Yes" in DiagnosticsDialogController._yes_no(True)
+
+    def test_yes_no_false(self):
+        assert "No" in DiagnosticsDialogController._yes_no(False)
+
+    def test_unknown_yes_no_with_value(self):
+        assert "Yes" in DiagnosticsDialogController._unknown_yes_no(True)
+        assert "No" in DiagnosticsDialogController._unknown_yes_no(False)
+
+    def test_unknown_yes_no_with_none(self):
+        assert "Unknown" in DiagnosticsDialogController._unknown_yes_no(None)
+
+
+class TestDiagnosticsControllerInit:
+    def test_init_sets_parent_and_backend(self):
+        parent = MagicMock()
+        backend = MagicMock()
+        controller = DiagnosticsDialogController(parent=parent, backend=backend)
+        assert controller._parent is parent
+        assert controller._backend is backend
+        assert controller._window is None
+        assert controller._snapshot is None
+
+
+class TestDiagnosticsOnDestroy:
+    def test_on_destroy_clears_window(self):
+        parent = MagicMock()
+        backend = MagicMock()
+        controller = DiagnosticsDialogController(parent=parent, backend=backend)
+        fake_window = MagicMock()
+        controller._window = fake_window
+        controller._on_destroy(fake_window)
+        assert controller._window is None
+
+    def test_on_destroy_different_window_ignored(self):
+        parent = MagicMock()
+        backend = MagicMock()
+        controller = DiagnosticsDialogController(parent=parent, backend=backend)
+        original = MagicMock()
+        controller._window = original
+        controller._on_destroy(MagicMock())
+        assert controller._window is original
+
+
+class TestDiagnosticsCurrentReport:
+    def test_current_report_uses_existing_snapshot(self, monkeypatch):
+        import docking.ui.diagnostics as mod
+
+        parent = MagicMock()
+        backend = MagicMock()
+        controller = DiagnosticsDialogController(parent=parent, backend=backend)
+        fake_snapshot = MagicMock()
+        controller._snapshot = fake_snapshot
+        monkeypatch.setattr(
+            mod, "format_diagnostics_report", lambda s: "formatted report"
+        )
+        report = controller._current_report()
+        assert report == "formatted report"
+
+    def test_current_report_collects_when_no_snapshot(self, monkeypatch):
+        import docking.ui.diagnostics as mod
+
+        parent = MagicMock()
+        parent.get_display.return_value = MagicMock()
+        backend = MagicMock()
+        controller = DiagnosticsDialogController(parent=parent, backend=backend)
+        fake_snapshot = MagicMock()
+        monkeypatch.setattr(mod, "collect_diagnostics", lambda **kw: fake_snapshot)
+        monkeypatch.setattr(mod, "format_diagnostics_report", lambda s: "report text")
+        report = controller._current_report()
+        assert controller._snapshot is fake_snapshot
+        assert report == "report text"
+
+
+class TestDiagnosticsFeatureRow:
+    def test_feature_row_available(self):
+        parent = MagicMock()
+        backend = MagicMock()
+        controller = DiagnosticsDialogController(parent=parent, backend=backend)
+        feature = DiagnosticFeature(
+            id="compositing",
+            label="Compositing",
+            detail="Compositor is active",
+            available=True,
+        )
+        row = controller._feature_row(feature)
+        assert row is not None
+
+    def test_feature_row_unavailable(self):
+        parent = MagicMock()
+        backend = MagicMock()
+        controller = DiagnosticsDialogController(parent=parent, backend=backend)
+        feature = DiagnosticFeature(
+            id="compositing",
+            label="Compositing",
+            detail="No compositor detected",
+            available=False,
+        )
+        row = controller._feature_row(feature)
+        assert row is not None
+
+
+class TestDiagnosticsCheckRow:
+    def test_check_row_with_fix_hint(self):
+        parent = MagicMock()
+        backend = MagicMock()
+        controller = DiagnosticsDialogController(parent=parent, backend=backend)
+        check = DiagnosticCheck(
+            id="theme",
+            label="Theme",
+            detail="Missing theme file",
+            status="warning",
+            fix_hint="Reinstall the theme",
+        )
+        row = controller._check_row(check)
+        assert row is not None
+
+    def test_check_row_without_fix_hint(self):
+        parent = MagicMock()
+        backend = MagicMock()
+        controller = DiagnosticsDialogController(parent=parent, backend=backend)
+        check = DiagnosticCheck(
+            id="deps",
+            label="Dependencies",
+            detail="All dependencies found",
+            status="ok",
+            fix_hint=None,
+        )
+        row = controller._check_row(check)
+        assert row is not None

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -1507,3 +1507,222 @@ class TestSettingsWindowController:
             isinstance(child, FakeGrid) for child in controller._applets_box.children
         )
         applets_mod.get_applet_catalog.cache_clear()
+
+
+class TestRecentSettingsBehavior:
+    """Tests for recent apps/docs settings controls."""
+
+    def test_show_recent_apps_changed_disabled_clears_and_redraws(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+
+        config = _config()
+        config.show_recent_apps = True
+        config.recent_apps = [{"desktop_id": "test.desktop", "last_closed": 1000}]
+        runtime = MagicMock()
+        controller = settings_mod.SettingsWindowController(
+            parent=MagicMock(),
+            runtime=runtime,
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=config,
+        )
+        controller.show()
+
+        # Disable recent apps
+        config.show_recent_apps = False
+        controller._after_show_recent_apps_changed(False)
+
+        assert config.recent_apps == []
+        config.save.assert_called()
+        runtime.queue_draw.assert_called()
+
+
+class TestBindingEdgeCases:
+    """Test edge cases in the binding/sync system."""
+
+    def test_sync_widgets_no_window_is_noop(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        controller = settings_mod.SettingsWindowController(
+            parent=MagicMock(),
+            runtime=MagicMock(),
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=_config(),
+        )
+        controller._window = None
+        # Should not raise
+        controller._sync_widgets()
+
+    def test_binding_changed_ignores_none_value(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        config = _config()
+        controller = settings_mod.SettingsWindowController(
+            parent=MagicMock(),
+            runtime=MagicMock(),
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=config,
+        )
+        original = config.icon_size
+        binding = MagicMock()
+        binding.config_attr = "icon_size"
+        binding.read_widget.return_value = None
+        binding.on_change = None
+
+        controller._on_binding_changed(binding)
+
+        assert config.icon_size == original
+
+    def test_binding_changed_value_unchanged_skips_save(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        config = _config()
+        config.save.reset_mock()
+        controller = settings_mod.SettingsWindowController(
+            parent=MagicMock(),
+            runtime=MagicMock(),
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=config,
+        )
+        binding = MagicMock()
+        binding.config_attr = "icon_size"
+        binding.read_widget.return_value = config.icon_size
+        binding.on_change = None
+
+        controller._on_binding_changed(binding)
+
+        config.save.assert_not_called()
+
+    def test_binding_changed_during_sync_is_noop(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        config = _config()
+        controller = settings_mod.SettingsWindowController(
+            parent=MagicMock(),
+            runtime=MagicMock(),
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=config,
+        )
+        controller._syncing_widgets = True
+        binding = MagicMock()
+
+        controller._on_binding_changed(binding)
+
+        binding.read_widget.assert_not_called()
+
+
+class TestSettingsRuntimeCallbacks:
+    def test_after_icon_size_changed_applies_theme_and_repositions(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        runtime = MagicMock()
+        config = _config()
+        controller = settings_mod.SettingsWindowController(
+            parent=MagicMock(),
+            runtime=runtime,
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=config,
+        )
+
+        controller._after_icon_size_changed(64)
+
+        runtime.reposition.assert_called()
+        runtime.queue_draw.assert_called()
+
+    def test_after_tooltips_changed_disabled_hides_tooltip(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        runtime = MagicMock()
+        config = _config()
+        controller = settings_mod.SettingsWindowController(
+            parent=MagicMock(),
+            runtime=runtime,
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=config,
+        )
+
+        controller._after_tooltips_changed(False)
+
+        runtime.hide_tooltip.assert_called_once()
+
+    def test_after_tooltips_changed_enabled_no_hide(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        runtime = MagicMock()
+        config = _config()
+        controller = settings_mod.SettingsWindowController(
+            parent=MagicMock(),
+            runtime=runtime,
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=config,
+        )
+
+        controller._after_tooltips_changed(True)
+
+        runtime.hide_tooltip.assert_not_called()
+
+    def test_update_hide_mode_description_without_combo(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        controller = settings_mod.SettingsWindowController(
+            parent=MagicMock(),
+            runtime=MagicMock(),
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=_config(),
+        )
+        controller._hide_mode_combo = None
+        # Should not raise
+        controller._update_hide_mode_description()
+
+    def test_update_updates_status_without_label(self, monkeypatch):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(settings_mod, "Gdk", FakeGdk)
+        monkeypatch.setattr(
+            settings_mod, "load_catalog_icon", lambda applet_id, size: None
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        controller = settings_mod.SettingsWindowController(
+            parent=MagicMock(),
+            runtime=MagicMock(),
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=_config(),
+        )
+        controller._update_status_label = None
+        # Should not raise
+        controller._update_updates_status()

--- a/tests/ui/test_tooltip.py
+++ b/tests/ui/test_tooltip.py
@@ -338,6 +338,239 @@ class TestTooltipGapBehavior:
         tooltip._tooltip_window.hide.assert_not_called()
 
 
+class TestParseTimestamp:
+    def test_parse_timestamp_none_returns_none(self):
+        assert tooltip_mod.parse_timestamp(None) is None
+
+    def test_parse_timestamp_datetime_naive_gets_utc(self):
+        import datetime as dt
+
+        naive = dt.datetime(2025, 6, 15, 10, 30, 0)
+        result = tooltip_mod.parse_timestamp(naive)
+        assert result.tzinfo is not None
+        assert result.tzinfo == dt.timezone.utc
+
+    def test_parse_timestamp_datetime_aware_preserves_tz(self):
+        import datetime as dt
+
+        aware = dt.datetime(2025, 6, 15, 10, 30, 0, tzinfo=dt.timezone.utc)
+        result = tooltip_mod.parse_timestamp(aware)
+        assert result == aware
+
+    def test_parse_timestamp_empty_string_returns_none(self):
+        assert tooltip_mod.parse_timestamp("") is None
+        assert tooltip_mod.parse_timestamp("   ") is None
+
+    def test_parse_timestamp_valid_iso_string(self):
+        import datetime as dt
+
+        result = tooltip_mod.parse_timestamp("2025-06-15T10:30:00+00:00")
+        assert result == dt.datetime(2025, 6, 15, 10, 30, 0, tzinfo=dt.timezone.utc)
+
+    def test_parse_timestamp_z_suffix(self):
+        import datetime as dt
+
+        result = tooltip_mod.parse_timestamp("2025-06-15T10:30:00Z")
+        assert result == dt.datetime(2025, 6, 15, 10, 30, 0, tzinfo=dt.timezone.utc)
+
+    def test_parse_timestamp_invalid_string_returns_none(self):
+        assert tooltip_mod.parse_timestamp("not-a-date") is None
+
+
+class TestFormatRelativeInterval:
+    def test_format_seconds(self):
+        from docking.ui.tooltip import _format_relative_interval
+
+        assert "1 second" in _format_relative_interval(1)
+        assert "5 seconds" in _format_relative_interval(5)
+
+    def test_format_minutes(self):
+        from docking.ui.tooltip import _format_relative_interval
+
+        assert "1 minute" in _format_relative_interval(60)
+        assert "3 minutes" in _format_relative_interval(180)
+
+    def test_format_hours(self):
+        from docking.ui.tooltip import _format_relative_interval
+
+        assert "1 hour" in _format_relative_interval(3600)
+        assert "2 hours" in _format_relative_interval(7200)
+
+    def test_format_days(self):
+        from docking.ui.tooltip import _format_relative_interval
+
+        assert "1 day" in _format_relative_interval(86400)
+        assert "5 days" in _format_relative_interval(432000)
+
+    def test_negative_seconds_clamped_to_zero(self):
+        from docking.ui.tooltip import _format_relative_interval
+
+        assert "0 seconds" in _format_relative_interval(-100)
+
+
+class TestRelativeTimeLabel:
+    def test_relative_time_label_none_timestamp_returns_empty(self):
+        from docking.ui.tooltip import relative_time_label
+
+        assert relative_time_label(None) == ""
+
+    def test_relative_time_label_parsed_none_returns_empty(self, monkeypatch):
+        from docking.ui.tooltip import relative_time_label
+
+        monkeypatch.setattr(tooltip_mod, "parse_timestamp", lambda ts: None)
+        assert relative_time_label("2025-06-15T10:30:00Z") == ""
+
+    def test_relative_time_label_just_now(self):
+        import datetime as dt
+
+        from docking.ui.tooltip import relative_time_label
+
+        now = dt.datetime(2025, 6, 15, 10, 30, 0, tzinfo=dt.timezone.utc)
+        assert relative_time_label(now, now=now) == "just now"
+
+    def test_relative_time_label_naive_now_gets_utc(self):
+        import datetime as dt
+
+        from docking.ui.tooltip import relative_time_label
+
+        timestamp = dt.datetime(2025, 6, 15, 10, 29, 0, tzinfo=dt.timezone.utc)
+        naive_now = dt.datetime(2025, 6, 15, 10, 30, 0)
+        result = relative_time_label(timestamp, now=naive_now)
+        assert "1 minute" in result
+        assert "ago" in result
+
+    def test_relative_time_label_seconds_ago(self):
+        import datetime as dt
+
+        from docking.ui.tooltip import relative_time_label
+
+        now = dt.datetime(2025, 6, 15, 10, 30, 0, tzinfo=dt.timezone.utc)
+        thirty_sec_ago = dt.datetime(2025, 6, 15, 10, 29, 30, tzinfo=dt.timezone.utc)
+        result = relative_time_label(thirty_sec_ago, now=now)
+        assert "30 seconds" in result
+        assert "ago" in result
+
+
+class TestSetTheme:
+    def test_set_theme_updates_theme_reference(self):
+        tooltip = _make_tooltip()
+        new_theme = SimpleNamespace(launch_bounce_height=0.7)
+        tooltip.set_theme(new_theme)
+        assert tooltip._theme is new_theme
+
+
+class TestRecentItemTooltip:
+    def test_recent_item_display_text_includes_relative_time(self, monkeypatch):
+        import time
+
+        window = MagicMock()
+        window.get_size.return_value = (300, 80)
+        window.get_position.return_value = (10, 10)
+        config = SimpleNamespace(
+            pos=Position.BOTTOM,
+            icon_size=48,
+            tooltips_enabled=True,
+        )
+        model = MagicMock()
+        model.visible_items = MagicMock(return_value=[])
+        theme = SimpleNamespace(horizontal_padding=8, item_padding=8, bottom_padding=4)
+        tooltip = TooltipManager(window, config, model, theme)
+        show_tooltip = MagicMock()
+        tooltip._show_tooltip = show_tooltip  # type: ignore[method-assign]
+
+        # recent item with a plausible timestamp (5 min ago)
+        item = MagicMock()
+        item.name = "Firefox"
+        item.is_recent = True
+        item.last_closed = time.time() - 300
+        item.tooltip_builder = None
+
+        monkeypatch.setattr(
+            tooltip_mod.GLib, "idle_add", lambda callback: callback() or 1
+        )
+
+        frame = _frame_for_item(item, anchor_x=40.0, anchor_y=10.0)
+        tooltip.update(item=item, geometry=frame)
+
+        show_tooltip.assert_called_once()
+        kwargs = show_tooltip.call_args.kwargs
+        assert "Firefox" in kwargs["text"]
+        # Should contain a relative time line — check for "ago" and a time unit
+        assert "\n" in kwargs["text"]
+        assert "ago" in kwargs["text"]
+
+    def test_recent_item_without_last_closed_no_suffix(self, monkeypatch):
+        window = MagicMock()
+        window.get_size.return_value = (300, 80)
+        window.get_position.return_value = (10, 10)
+        config = SimpleNamespace(
+            pos=Position.BOTTOM,
+            icon_size=48,
+            tooltips_enabled=True,
+        )
+        model = MagicMock()
+        model.visible_items = MagicMock(return_value=[])
+        theme = SimpleNamespace(horizontal_padding=8, item_padding=8, bottom_padding=4)
+        tooltip = TooltipManager(window, config, model, theme)
+        show_tooltip = MagicMock()
+        tooltip._show_tooltip = show_tooltip  # type: ignore[method-assign]
+
+        item = MagicMock()
+        item.name = "Firefox"
+        item.is_recent = True
+        item.last_closed = 0  # no timestamp
+        item.tooltip_builder = None
+
+        monkeypatch.setattr(
+            tooltip_mod.GLib, "idle_add", lambda callback: callback() or 1
+        )
+
+        frame = _frame_for_item(item, anchor_x=40.0, anchor_y=10.0)
+        tooltip.update(item=item, geometry=frame)
+
+        show_tooltip.assert_called_once()
+        kwargs = show_tooltip.call_args.kwargs
+        assert kwargs["text"] == "Firefox"
+        assert "\n" not in kwargs["text"]
+
+
+class TestShowTooltipTypeError:
+    def test_show_tooltip_swallows_typeerror_from_transient_for(self, monkeypatch):
+        class _BrokenTransientWindow(_FakeTooltipWindow):
+            def set_transient_for(self, _window):
+                raise TypeError("set_transient_for not supported")
+
+            def set_attached_to(self, _window):
+                raise TypeError("set_attached_to not supported")
+
+        class _BrokenGtk:
+            Window = _BrokenTransientWindow
+            Label = _FakeTooltipLabel
+            WindowType = SimpleNamespace(POPUP=1)
+            StateFlags = SimpleNamespace(NORMAL=1)
+
+        monkeypatch.setattr(tooltip_mod, "Gtk", _BrokenGtk)
+        monkeypatch.setattr(tooltip_mod, "Gdk", _FakeGdk)
+
+        tooltip = TooltipManager(
+            MagicMock(),
+            SimpleNamespace(icon_size=48),
+            MagicMock(),
+            SimpleNamespace(launch_bounce_height=0.0),
+        )
+
+        # Should not raise
+        tooltip._show_tooltip(
+            text="Firefox",
+            pos=Position.BOTTOM,
+            anchor_x=2.0,
+            anchor_y=4.0,
+            widget=None,
+            content_changed=True,
+        )
+        assert tooltip._tooltip_window is not None
+
+
 class TestTooltipContentCoalescing:
     def test_rapid_hover_changes_only_show_last_item(self, monkeypatch):
         tooltip = _make_tooltip()

--- a/tests/ui/test_update_popup.py
+++ b/tests/ui/test_update_popup.py
@@ -1,0 +1,191 @@
+"""Tests for the update popup controller."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from docking.core.updates import ReleaseInfo, UpdateState
+from docking.ui.update_popup import (
+    REMIND_LATER_HOURS,
+    UPDATE_CHECK_DELAY_S,
+    UPDATE_POPUP_GAP_PX,
+    UpdateCheckController,
+)
+
+
+class TestUpdateCheckConstants:
+    def test_constants_are_reasonable(self):
+        assert UPDATE_CHECK_DELAY_S > 0
+        assert UPDATE_POPUP_GAP_PX > 0
+        assert REMIND_LATER_HOURS > 0
+
+
+class TestUpdateCheckControllerInit:
+    def test_init_sets_window_and_config(self):
+        window = MagicMock()
+        config = MagicMock()
+        controller = UpdateCheckController(window=window, config=config)
+        assert controller._window is window
+        assert controller._config is config
+        assert controller._popup is None
+        assert controller._latest_release is None
+        assert controller._start_source_id == 0
+
+
+class TestUpdateCheckControllerStart:
+    def test_start_already_scheduled_returns(self):
+        window = MagicMock()
+        config = MagicMock()
+        config.update_check_enabled = True
+        controller = UpdateCheckController(window=window, config=config)
+        controller._start_source_id = 42
+        controller.start()
+        assert controller._start_source_id == 42
+
+    def test_start_disabled_returns(self):
+        window = MagicMock()
+        config = MagicMock()
+        config.update_check_enabled = False
+        controller = UpdateCheckController(window=window, config=config)
+        controller.start()
+        assert controller._start_source_id == 0
+
+    def test_start_schedules_timeout(self, monkeypatch):
+        import docking.ui.update_popup as mod
+
+        window = MagicMock()
+        config = MagicMock()
+        config.update_check_enabled = True
+        config.update_check_interval_hours = 24
+        controller = UpdateCheckController(window=window, config=config)
+
+        monkeypatch.setattr(
+            mod, "load_state", lambda: SimpleNamespace(last_checked_at=None)
+        )
+        monkeypatch.setattr(mod, "should_check_for_updates", lambda **kw: True)
+        monkeypatch.setattr(mod.GLib, "timeout_add_seconds", lambda delay, cb, *a: 99)
+
+        controller.start()
+
+        assert controller._start_source_id == 99
+
+
+class TestUpdateCheckHideAndDismiss:
+    def test_hide_popup_hides_window(self):
+        window = MagicMock()
+        config = MagicMock()
+        controller = UpdateCheckController(window=window, config=config)
+        fake_popup = MagicMock()
+        controller._popup = fake_popup
+
+        controller._hide_popup()
+
+        fake_popup.hide.assert_called_once()
+
+    def test_hide_popup_no_popup_no_error(self):
+        window = MagicMock()
+        config = MagicMock()
+        controller = UpdateCheckController(window=window, config=config)
+        controller._popup = None
+        controller._hide_popup()  # Should not raise
+
+    def test_open_url_calls_gio_launch(self, monkeypatch):
+        import docking.ui.update_popup as mod
+
+        window = MagicMock()
+        config = MagicMock()
+        controller = UpdateCheckController(window=window, config=config)
+        monkeypatch.setattr(mod.Gio.AppInfo, "launch_default_for_uri", MagicMock())
+
+        controller._open_url("https://example.com")
+
+        mod.Gio.AppInfo.launch_default_for_uri.assert_called_once_with(
+            "https://example.com", None
+        )
+
+    def test_on_view_release_hides_and_opens_url(self, monkeypatch):
+        import docking.ui.update_popup as mod
+
+        window = MagicMock()
+        config = MagicMock()
+        controller = UpdateCheckController(window=window, config=config)
+        controller._latest_release = ReleaseInfo(
+            version="3.0.0",
+            name="v3.0.0",
+            url="https://example.com/release",
+        )
+        fake_popup = MagicMock()
+        controller._popup = fake_popup
+        monkeypatch.setattr(mod.Gio.AppInfo, "launch_default_for_uri", MagicMock())
+
+        controller._on_view_release(MagicMock())
+
+        fake_popup.hide.assert_called_once()
+
+    def test_on_later_saves_reminder_and_hides(self, monkeypatch):
+        import docking.ui.update_popup as mod
+
+        window = MagicMock()
+        config = MagicMock()
+        controller = UpdateCheckController(window=window, config=config)
+        controller._latest_release = ReleaseInfo(
+            version="3.0.0",
+            name="v3.0.0",
+            url="https://example.com/release",
+        )
+        fake_popup = MagicMock()
+        controller._popup = fake_popup
+        monkeypatch.setattr(mod, "save_state", MagicMock())
+        monkeypatch.setattr(mod, "load_state", lambda: UpdateState())
+        monkeypatch.setattr(mod, "utc_now_iso", lambda _dt=None: "2025-01-01T00:00:00Z")
+
+        controller._on_later(MagicMock())
+
+        fake_popup.hide.assert_called_once()
+        mod.save_state.assert_called_once()
+
+    def test_on_ignore_saves_and_hides(self, monkeypatch):
+        import docking.ui.update_popup as mod
+
+        window = MagicMock()
+        config = MagicMock()
+        controller = UpdateCheckController(window=window, config=config)
+        controller._latest_release = ReleaseInfo(
+            version="3.0.0",
+            name="v3.0.0",
+            url="https://example.com/release",
+        )
+        fake_popup = MagicMock()
+        controller._popup = fake_popup
+        monkeypatch.setattr(mod, "save_state", MagicMock())
+        monkeypatch.setattr(mod, "load_state", lambda: UpdateState())
+
+        controller._on_ignore(MagicMock())
+
+        fake_popup.hide.assert_called_once()
+        mod.save_state.assert_called_once()
+
+    def test_on_check_finished_no_release_no_popup(self, monkeypatch):
+        import docking.ui.update_popup as mod
+
+        window = MagicMock()
+        config = MagicMock()
+        controller = UpdateCheckController(window=window, config=config)
+        save_called = []
+
+        def _save(s):
+            save_called.append(s)
+
+        monkeypatch.setattr(mod, "save_state", _save)
+        monkeypatch.setattr(mod, "load_state", lambda: UpdateState())
+        monkeypatch.setattr(
+            mod,
+            "decide_update_popup",
+            lambda **kw: SimpleNamespace(should_show=False, release=None),
+        )
+
+        result = controller._on_check_finished(None, "")
+
+        assert result is False
+        assert len(save_called) == 1  # State is always saved


### PR DESCRIPTION
## Summary

Increases project test coverage from 89% to 90% (3,711 to 3,884 tests, 269 previously uncovered lines now covered).

## Module improvements

| Module | Before | After |
|---|---|---|
| config.py | 94% | 100% |
| tooltip.py | 94% | 100% |
| items_service.py | 81% | 100% |
| theme/theme.py | 95% | 100% |
| theme/migration.py | 91% | 99% |
| recent_docs.py | 0% | 100% |
| caffeine/inhibit.py | 39% | 99% |
| settings.py | 93% | 96% |
| base.py | 86% | 92% |
| diagnostics.py | 18% | 49% |
| update_popup.py | 25% | 46% |

## What was covered

- **config.py**: Normalization edge cases, GLib.Error paths, recent apps validation, cleanup failure handlers
- **tooltip.py**: Timestamp parsing (ISO/Z-suffix/invalid), relative time labels, recent item tooltip formatting, TypeError handling for transient-for
- **items_service.py**: D-Bus start/stop edge cases, bus registration failures, signal debouncing, argument validation, pin/unpin state checks
- **theme modules**: Migration edge cases (path set/pop, backup cleanup failures, atomic write error recovery), indicator style fallback
- **recent_docs.py**: Full test suite for document-to-app association (filtering by local/exists/has_application, sorting by modification time, limit enforcement)
- **settings.py**: Recent apps/docs toggle behavior, binding edge cases (sync guards, None values, duplicate values), runtime callbacks
- **diagnostics.py**: Static methods (status symbols, yes/no helpers), controller init/destroy, current report collection, feature/check row building
- **update_popup.py**: Controller lifecycle (start scheduling, hide/dismiss actions), remind later, ignore version, URL opening
- **caffeine/inhibit.py**: ScreenSaverInhibitor DBus acquire/release (all targets fail, GLib.Error handling), SystemdSleepInhibitor subprocess handling (OSError, timeout, kill), CompositeInhibitor edge cases
- **base.py**: Default hook no-ops, icon source guards, popup anchor, drop URI defaults, font fitting fallthrough
- **model**: 9 integration tests for recent apps flow (launch-close-recent-pin lifecycle)

## Files changed

- Modified 8 existing test files
- Added 4 new test files (recent_docs, diagnostics_ui, update_popup, integration/recent_apps_flow)
- +2,490 lines of test code