### PR TITLE
Fix trash opening fallback commands

### DIFF
--- a/docking/applets/trash/backend.py
+++ b/docking/applets/trash/backend.py
@@ -93,14 +93,68 @@ def _kde_kiorc_file() -> Path:
     return xdg_config_home() / "kiorc"
 
 
-def _open_trash_uri(uri: str) -> None:
+def _open_trash_uri(
+    uri: str, *, fallback_commands: tuple[tuple[str, ...], ...] = ()
+) -> None:
     if is_flatpak() and _open_host_trash_uri(uri=uri):
         return
 
     try:
         Gio.AppInfo.launch_default_for_uri(uri, None)
+        return
     except GLib.Error as exc:
-        log.bind(action="open_trash").warning("Failed to open trash: %s", exc)
+        gio_error = exc
+
+    if _open_trash_with_commands(uri=uri, commands=fallback_commands):
+        return
+
+    log.bind(action="open_trash").warning("Failed to open trash: %s", gio_error)
+
+
+def _open_trash_with_commands(
+    *, uri: str, commands: tuple[tuple[str, ...], ...]
+) -> bool:
+    for command in (*commands, ("gio", "open", uri), ("xdg-open", uri)):
+        resolved = _available_open_command(command)
+        if resolved is None:
+            continue
+        try:
+            subprocess.Popen(resolved)
+            return True
+        except OSError as exc:
+            log.bind(action="open_trash").debug(
+                "Failed to open trash with %s: %s",
+                resolved[0],
+                exc,
+            )
+
+    files_dir = _visible_trash_files_directory()
+    if not files_dir.exists():
+        return False
+    resolved = _available_open_command(("xdg-open", str(files_dir)))
+    if resolved is None:
+        return False
+    try:
+        subprocess.Popen(resolved)
+        return True
+    except OSError as exc:
+        log.bind(action="open_trash").debug(
+            "Failed to open trash files directory with %s: %s",
+            resolved[0],
+            exc,
+        )
+        return False
+
+
+def _available_open_command(command: tuple[str, ...]) -> tuple[str, ...] | None:
+    if is_flatpak():
+        host_command = flatpak.host_command(list(command))
+        if flatpak.host_command_available(command[0]) and host_command is not None:
+            return tuple(host_command)
+        return None
+    if shutil.which(command[0]):
+        return command
+    return None
 
 
 def _open_host_trash_uri(*, uri: str) -> bool:
@@ -157,6 +211,7 @@ class GioTrashBackend:
         ("org.gnome.Nautilus", "/org/gnome/Nautilus"),
     )
     confirmation_schema: tuple[str, str] | None = None
+    open_commands: tuple[tuple[str, ...], ...] = ()
 
     def count_items(self) -> int:
         if is_flatpak():
@@ -192,7 +247,7 @@ class GioTrashBackend:
         return Gio.File.new_for_uri(self.uri)
 
     def open(self) -> None:
-        _open_trash_uri(self.uri)
+        _open_trash_uri(self.uri, fallback_commands=self.open_commands)
 
     def empty(self, confirm: Callable[[], bool]) -> None:
         _ = confirm
@@ -296,6 +351,7 @@ class GnomeTrashBackend(GioTrashBackend):
 
     name = "gnome"
     dbus_targets = (("org.gnome.Nautilus", "/org/gnome/Nautilus"),)
+    open_commands = (("nautilus", "trash:///"),)
 
 
 class MateTrashBackend(GioTrashBackend):
@@ -303,6 +359,7 @@ class MateTrashBackend(GioTrashBackend):
 
     name = "mate"
     dbus_targets = (("org.mate.Caja", "/org/mate/Caja"),)
+    open_commands = (("caja", "trash:///"),)
     confirmation_schema = (
         "org.mate.caja.preferences",
         "/org/mate/caja/preferences/",
@@ -313,6 +370,7 @@ class CinnamonTrashBackend(GioTrashBackend):
     """Trash backend for Cinnamon/Nemo sessions."""
 
     name = "cinnamon"
+    open_commands = (("nemo", "trash:///"),)
     confirmation_schema = (
         "org.nemo.preferences",
         "/org/nemo/preferences/",

--- a/tests/applets/test_trash.py
+++ b/tests/applets/test_trash.py
@@ -44,9 +44,12 @@ class TestHelperFunctions:
     def test_open_trash_uri_handles_glib_error(self):
         from gi.repository import GLib
 
-        with patch(
-            "docking.applets.trash.backend.Gio.AppInfo.launch_default_for_uri",
-            side_effect=GLib.Error("no handler"),
+        with (
+            patch(
+                "docking.applets.trash.backend.Gio.AppInfo.launch_default_for_uri",
+                side_effect=GLib.Error("no handler"),
+            ),
+            patch("docking.applets.trash.backend.shutil.which", return_value=False),
         ):
             _open_trash_uri("trash:///")
 
@@ -265,6 +268,63 @@ class TestGioTrashBackend:
             ]
         )
         launch.assert_called_once_with("trash:///", None)
+
+    def test_mate_open_falls_back_to_caja_when_gio_rejects_trash_uri(self):
+        from gi.repository import GLib
+
+        with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=False),
+            patch(
+                "docking.applets.trash.backend.Gio.AppInfo.launch_default_for_uri",
+                side_effect=GLib.Error("operation not supported"),
+            ) as launch,
+            patch(
+                "docking.applets.trash.backend.shutil.which",
+                side_effect=lambda command: (
+                    f"/usr/bin/{command}" if command == "caja" else None
+                ),
+            ),
+            patch("docking.applets.trash.backend.subprocess.Popen") as popen,
+        ):
+            MateTrashBackend().open()
+
+        launch.assert_called_once_with("trash:///", None)
+        popen.assert_called_once_with(("caja", "trash:///"))
+
+    def test_open_falls_back_to_visible_trash_files_directory_when_uri_handlers_fail(
+        self, tmp_path
+    ):
+        from gi.repository import GLib
+
+        files_dir = tmp_path / "Trash" / "files"
+        files_dir.mkdir(parents=True)
+        with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=False),
+            patch(
+                "docking.applets.trash.backend._visible_trash_files_directory",
+                return_value=files_dir,
+            ),
+            patch(
+                "docking.applets.trash.backend.Gio.AppInfo.launch_default_for_uri",
+                side_effect=GLib.Error("operation not supported"),
+            ),
+            patch(
+                "docking.applets.trash.backend.shutil.which",
+                side_effect=lambda command: (
+                    f"/usr/bin/{command}" if command == "xdg-open" else None
+                ),
+            ),
+            patch(
+                "docking.applets.trash.backend.subprocess.Popen",
+                side_effect=[OSError("unsupported"), MagicMock()],
+            ) as popen,
+        ):
+            GioTrashBackend().open()
+
+        assert [args[0] for args, _kwargs in popen.call_args_list] == [
+            ("xdg-open", "trash:///"),
+            ("xdg-open", str(files_dir)),
+        ]
 
     def test_empty_trash_uses_dbus_first(self):
         bus = MagicMock()


### PR DESCRIPTION
## Summary
- keep Gio trash opening as the first path, but fall back to desktop file manager commands when Gio rejects trash:/// on older environments
- add MATE/Caja, GNOME/Nautilus, and Cinnamon/Nemo opener fallbacks
- fall back to opening the visible Trash files directory when URI handlers fail