### PR TITLE
Fix Session applet logout on GNOME/Mutter

### DIFF
--- a/docking/applets/session/state.py
+++ b/docking/applets/session/state.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+from pathlib import Path
 from typing import NamedTuple
 
 from docking.applets.session import meta
@@ -100,19 +101,40 @@ def lock_screen() -> bool:
 
 def _run(*, cmd: list[str], action: str) -> None:
     """Run a session/power command, logging failures."""
-    # Resolve session-id placeholder for loginctl commands.
     resolved_cmd = list(cmd)
     if resolved_cmd[0:2] == ["loginctl", "terminate-session"] and resolved_cmd[2] == "":
-        session_id = (os.environ.get("XDG_SESSION_ID") or "").strip()
+        # On GNOME, loginctl may not have the session-id available through
+        # XDG_SESSION_ID.  Prefer gnome-session-quit which shows the native
+        # logout dialog; fall back to loginctl with /proc/self/sessionid.
+        if shutil.which("gnome-session-quit"):
+            subprocess.Popen(["gnome-session-quit", "--logout"])
+            return
+        session_id = _current_session_id()
         resolved_cmd[2] = session_id
     resolved_cmd = flatpak.host_command(resolved_cmd) or resolved_cmd
-    # Remove empty arguments so loginctl auto-detects the calling session
-    # when XDG_SESSION_ID is not available.
     resolved_cmd = [a for a in resolved_cmd if a != ""]
     try:
         subprocess.Popen(resolved_cmd)
     except OSError as exc:
         log.bind(action=action).warning(f"Failed to run {cmd}: {exc}")
+
+
+def _current_session_id() -> str:
+    """Return the logind session ID for the current process.
+
+    Tries ``XDG_SESSION_ID`` first, then ``/proc/self/sessionid``.
+    Returns an empty string when neither source is available.
+    """
+    env_id = (os.environ.get("XDG_SESSION_ID") or "").strip()
+    if env_id:
+        return env_id
+    try:
+        proc_id = Path("/proc/self/sessionid").read_text().strip()
+        if proc_id:
+            return proc_id
+    except (OSError, PermissionError):
+        pass
+    return ""
 
 
 def _lock_screen_commands(*, session_id: str) -> list[list[str]]:


### PR DESCRIPTION
On GNOME/Mutter, `XDG_SESSION_ID` is not set, causing `loginctl terminate-session` to receive no session-id argument and fail with "Too few arguments."

## Fix

- Prefer `gnome-session-quit --logout` on GNOME, which shows the native logout dialog.
- Fall back to reading `/proc/self/sessionid` when `gnome-session-quit` is not available.
- Added `_current_session_id()` helper that tries `XDG_SESSION_ID` first, then `/proc/self/sessionid`.