### PR TITLE
Add drag-and-drop support to Trash applet

### DIFF
--- a/docking/applets/trash/applet.py
+++ b/docking/applets/trash/applet.py
@@ -73,6 +73,40 @@ class TrashApplet(Applet):
         """Open trash folder in the default file manager."""
         self._backend.open()
 
+    def accepts_drop_uris(self) -> bool:
+        """Allow local files/folders to be dropped onto the Trash icon."""
+        return True
+
+    def on_drop_uris(self, uris: list[str]) -> bool:
+        """Move dropped local files/folders to Trash."""
+        moved = False
+        failed = False
+        for uri in uris:
+            file = self._file_from_drop_uri(uri)
+            if file is None:
+                failed = True
+                continue
+            try:
+                if file.trash(None):
+                    moved = True
+                else:
+                    failed = True
+            except GLib.Error as exc:
+                failed = True
+                log.bind(action="drop_to_trash").warning(
+                    "Failed to move dropped item to trash: %s",
+                    exc,
+                )
+
+        if moved:
+            self._item_count = self._backend.count_items()
+            self.present()
+        elif failed:
+            log.bind(action="drop_to_trash").debug(
+                "Drop did not contain a local trashable file"
+            )
+        return moved
+
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         """Return 'Open Trash' and 'Empty Trash' menu items."""
         open_item = Gtk.MenuItem(label=_("Open Trash"))
@@ -113,6 +147,21 @@ class TrashApplet(Applet):
     def _empty_trash(self) -> None:
         """Empty trash through the selected backend."""
         self._backend.empty(self._confirm_empty_trash)
+
+    @staticmethod
+    def _file_from_drop_uri(uri: str) -> Gio.File | None:
+        text = uri.strip()
+        if not text:
+            return None
+        if text.startswith("file://"):
+            file = Gio.File.new_for_uri(text)
+        elif text.startswith("/"):
+            file = Gio.File.new_for_path(text)
+        else:
+            return None
+        if file.get_path() is None:
+            return None
+        return file
 
     def _confirm_empty_trash(self) -> bool:
         dialog = Gtk.MessageDialog(

--- a/tests/applets/test_trash.py
+++ b/tests/applets/test_trash.py
@@ -123,6 +123,78 @@ class TestTrashBackendSelection:
         )
 
 
+class TestTrashAppletDrops:
+    def test_accepts_drop_uris(self):
+        applet = TrashApplet.__new__(TrashApplet)
+
+        assert applet.accepts_drop_uris() is True
+
+    def test_file_from_drop_uri_accepts_file_uri(self, tmp_path):
+        path = tmp_path / "notes.txt"
+        path.write_text("notes")
+
+        file = TrashApplet._file_from_drop_uri(path.as_uri())
+
+        assert file is not None
+        assert file.get_path() == str(path)
+
+    def test_file_from_drop_uri_accepts_absolute_path(self, tmp_path):
+        path = tmp_path / "notes.txt"
+        path.write_text("notes")
+
+        file = TrashApplet._file_from_drop_uri(str(path))
+
+        assert file is not None
+        assert file.get_path() == str(path)
+
+    def test_file_from_drop_uri_rejects_non_local_uri(self):
+        assert TrashApplet._file_from_drop_uri("https://example.test/file.txt") is None
+        assert TrashApplet._file_from_drop_uri("trash:///") is None
+
+    def test_on_drop_uris_trashes_local_files_and_refreshes_count(self):
+        file = MagicMock()
+        file.trash.return_value = True
+        backend = MagicMock()
+        backend.count_items.return_value = 3
+        applet = TrashApplet.__new__(TrashApplet)
+        applet._backend = backend
+        applet._item_count = 0
+        applet.present = MagicMock()
+
+        with patch.object(TrashApplet, "_file_from_drop_uri", return_value=file):
+            assert applet.on_drop_uris(["file:///tmp/notes.txt"]) is True
+
+        file.trash.assert_called_once_with(None)
+        assert applet._item_count == 3
+        applet.present.assert_called_once()
+
+    def test_on_drop_uris_returns_false_when_gio_refuses_trash(self):
+        file = MagicMock()
+        file.trash.return_value = False
+        applet = TrashApplet.__new__(TrashApplet)
+        applet._backend = MagicMock()
+        applet._item_count = 0
+        applet.present = MagicMock()
+
+        with patch.object(TrashApplet, "_file_from_drop_uri", return_value=file):
+            assert applet.on_drop_uris(["file:///tmp/notes.txt"]) is False
+
+        applet._backend.count_items.assert_not_called()
+        applet.present.assert_not_called()
+
+    def test_on_drop_uris_returns_false_when_nothing_was_trashed(self):
+        applet = TrashApplet.__new__(TrashApplet)
+        applet._backend = MagicMock()
+        applet._item_count = 0
+        applet.present = MagicMock()
+
+        with patch.object(TrashApplet, "_file_from_drop_uri", return_value=None):
+            assert applet.on_drop_uris(["https://example.test/file.txt"]) is False
+
+        applet._backend.count_items.assert_not_called()
+        applet.present.assert_not_called()
+
+
 class TestGioTrashBackend:
     def test_counts_items(self):
         # Given an enumerator yielding 3 items


### PR DESCRIPTION
## Summary
- make the Trash applet accept local file/folder URI drops
- move dropped local items to trash through Gio.File.trash
- refresh the Trash icon count after successful drops