### PR TITLE
Unify window-to-desktop matching into shared AppIdMatcher

### DIFF
--- a/docking/platform/app_matcher.py
+++ b/docking/platform/app_matcher.py
@@ -27,7 +27,7 @@ different feature sets:
 
 * ``WindowMatcher`` in the X11 backend — Wine ``.exe`` extraction,
   space→hyphen→joined candidate generation, GNOME prefix synthesis,
-  missed-candidate memoization, result caching.
+  and missed-candidate memoization.
 * ``WaylandAppIdMatcher`` in the Wayland backend — Snap ``_`` prefix
   expansion, dot-suffix split, broad visible-item aliasing.
 
@@ -45,13 +45,19 @@ extract identity strings from their display server and pass them here
 as plain strings.  The matcher owns the heuristics; backends own only
 the display-server extraction.
 
-The public API has two methods:
+The public interface has one constructor flag plus two methods:
 
 ``sync_visible_items(items)``
     Rebuild the fast-path alias cache from the current dock model.
     Called at the start of every running-window scan.
 
-``match(app_id, *, instance_hint=None)``
+``cache_missed_desktop_ids``
+    Constructor flag used by X11 to preserve its historical missed
+    desktop-file memoization. Wayland-style backends leave it disabled
+    so newly installed/generated desktop files can be matched without a
+    Docking restart.
+
+``match(...)``
     Map a runtime window identity to a Docking desktop ID.
 
     ``app_id`` is the primary identity from the display server:
@@ -65,6 +71,17 @@ The public API has two methods:
     only X11 provides this (WM_CLASS instance part).  It enables Wine
     disambiguation: when ``app_id == "wine"`` the matcher extracts the
     ``.exe`` name from ``instance_hint`` instead.
+
+    ``prefer_raw_app_id`` controls candidate order. Wayland-style
+    backends keep compositor-provided app IDs first; X11 passes
+    ``False`` to preserve the historical WM_CLASS lowercase-first order.
+
+    ``defer_wm_class_lookup`` controls when the install-wide WM_CLASS
+    index is consulted. X11 passes ``True`` to preserve its historical
+    priority of trying all generated desktop IDs before the expensive
+    reverse alias lookup. Wayland-style backends keep it ``False`` so
+    each increasingly broad candidate can still check its exact alias
+    before falling back to the next broader direct desktop ID.
 
 Matching priority (strongest first)
 ------------------------------------
@@ -88,9 +105,9 @@ Matching priority (strongest first)
    b. Try ``launcher.resolve(f"{candidate}.desktop")``.
    c. Try ``launcher.resolve_by_wm_class(candidate)``.
 
-   Failed desktop IDs are memoized so signal bursts don't hammer Gio
-   with repeated failing lookups.  Successful matches are cached so
-   subsequent scans hit the fast path.
+   Failed desktop IDs can be memoized for X11 so signal bursts don't
+   hammer Gio with repeated failing lookups. Successful WM_CLASS
+   matches use the launcher's indexed lookup.
 
 Candidate generation (merged from both legacy matchers)
 --------------------------------------------------------
@@ -98,13 +115,14 @@ Candidate generation (merged from both legacy matchers)
 Candidates are generated in a stable, deterministic order:
 
 * Raw ``app_id``
+* Raw ``app_id`` without ``.desktop``
+* Lowercase variants of the above
 * Space→hyphen (``"mongodb compass"`` → ``"mongodb-compass"``)
 * Space→joined  (``"mongodb compass"`` → ``"mongodbcompass"``)
 * GNOME prefix + original class-group (``"Files"`` → ``"org.gnome.Files"``)
 * Dot-suffix split (``"org.gnome.Nautilus"`` → ``"Nautilus"``)
 * Snap/container ``_`` prefix expansion
   (``"firefox_firefox"`` → ``"firefox"``)
-* Lowercase variants of the above
 
 Duplicates are removed while preserving first-occurrence order so
 the first successful match is always the same for a given input.
@@ -125,14 +143,16 @@ if TYPE_CHECKING:
 
 def _normalize_alias(value: str) -> str:
     """Normalize an alias for cache-key comparison (lowercase, no .desktop suffix)."""
-    return value.strip().removesuffix(DESKTOP_SUFFIX).lower()
+    return value.strip().lower().removesuffix(DESKTOP_SUFFIX)
 
 
 def _ensure_desktop_suffix(value: str) -> str:
     """Append ``.desktop`` to *value* when it is not already suffixed."""
     stripped = value.strip()
     return (
-        stripped if stripped.endswith(DESKTOP_SUFFIX) else f"{stripped}{DESKTOP_SUFFIX}"
+        stripped
+        if stripped.lower().endswith(DESKTOP_SUFFIX)
+        else f"{stripped}{DESKTOP_SUFFIX}"
     )
 
 
@@ -152,14 +172,15 @@ def _app_id_candidates(app_id: str) -> list[str]:
         stripped.lower(),
         stripped.lower().removesuffix(DESKTOP_SUFFIX),
     ]
-    if "." in stripped:
-        candidates.append(stripped.split(".")[-1])
     # Wine / Windows executable reported as the sole app_id by a Wayland
     # compositor (e.g. Hyprland `class` = "notepad.exe").  Strip the .exe
     # suffix so the launcher can match "notepad" → "wine-notepad.desktop".
-    if stripped.lower().endswith(".exe"):
+    is_windows_executable = stripped.lower().endswith(".exe")
+    if is_windows_executable:
         candidates.append(stripped[:-4])  # preserve original case
         candidates.append(stripped[:-4].lower())
+    elif "." in stripped:
+        candidates.append(stripped.split(".")[-1])
     # Snap / container app-ids like firefox_firefox.desktop: also try the
     # leading segment so the launcher can match firefox.desktop.
     body = stripped.removesuffix(DESKTOP_SUFFIX)
@@ -213,10 +234,15 @@ class AppIdMatcher:
     Docking desktop IDs.
     """
 
-    def __init__(self, launcher: Launcher) -> None:
+    def __init__(
+        self,
+        launcher: Launcher,
+        *,
+        cache_missed_desktop_ids: bool = False,
+    ) -> None:
         self._launcher = launcher
+        self._cache_missed_desktop_ids = cache_missed_desktop_ids
         self._visible_aliases: dict[str, str] = {}  # normalized → desktop_id
-        self._result_cache: dict[str, str] = {}  # lookup_key → desktop_id
         self._missed_candidates: set[str] = set()
 
     def sync_visible_items(self, items: Iterable[DockItem]) -> None:
@@ -240,18 +266,30 @@ class AppIdMatcher:
                 if normalized:
                     self._visible_aliases[normalized] = item.desktop_id
 
-    def match(self, app_id: str, *, instance_hint: str | None = None) -> str | None:
+    def match(
+        self,
+        app_id: str,
+        *,
+        instance_hint: str | None = None,
+        prefer_raw_app_id: bool = True,
+        defer_wm_class_lookup: bool = False,
+    ) -> str | None:
         """Map a runtime window identity to a Docking desktop ID.
 
         Args:
             app_id: Primary identity from the display server.
             instance_hint: Secondary identity when the display server
                 provides a split identity model (currently only X11).
+            prefer_raw_app_id: Whether raw compositor-style IDs should
+                be tried before lowercase/X11-derived candidates.
+            defer_wm_class_lookup: Whether to try all direct desktop ID
+                candidates before consulting the launcher WM_CLASS index.
 
         Returns:
             The matching desktop ID (e.g. ``"firefox.desktop"``), or
             ``None`` when no match could be found.
         """
+        app_id = app_id.strip()
         if not app_id:
             return None
 
@@ -280,46 +318,48 @@ class AppIdMatcher:
                 _normalize_alias(instance_hint.lower().strip())
             )
             if result:
-                self._result_cache[app_id_lower] = result
                 return result
 
         # 4. Candidate generation + resolution.
-        for candidate in self._candidates(
+        candidates = self._candidates(
             app_id=app_id,
             app_id_lower=app_id_lower,
             instance_hint=instance_hint,
-        ):
+            prefer_raw_app_id=prefer_raw_app_id,
+        )
+        for candidate in candidates:
             # 4a. Visible aliases (normalized).
             result = self._visible_aliases.get(_normalize_alias(candidate))
             if result:
-                self._result_cache[app_id_lower] = result
                 return result
 
             # 4b. Direct desktop ID resolution (with missed-candidate
             #     memoization so signal bursts don't hammer Gio).
             desktop_id = _ensure_desktop_suffix(candidate)
-            if desktop_id not in self._missed_candidates:
+            if not (
+                self._cache_missed_desktop_ids and desktop_id in self._missed_candidates
+            ):
                 info = self._launcher.resolve(desktop_id, log_failures=False)
                 if info is not None:
-                    self._result_cache[app_id_lower] = info.desktop_id
                     return info.desktop_id
-                self._missed_candidates.add(desktop_id)
+                if self._cache_missed_desktop_ids:
+                    self._missed_candidates.add(desktop_id)
+
+            if defer_wm_class_lookup:
+                continue
 
             # 4c. WM_CLASS index lookup (lazy-built once, then dict).
             info = self._launcher.resolve_by_wm_class(candidate)
             if info is not None:
-                self._result_cache[app_id_lower] = info.desktop_id
                 return info.desktop_id
 
+        if defer_wm_class_lookup:
+            for candidate in candidates:
+                info = self._launcher.resolve_by_wm_class(candidate)
+                if info is not None:
+                    return info.desktop_id
+
         return None
-
-    def clear_missed_cache(self) -> None:
-        """Clear the missed-candidate memoization set.
-
-        Called when desktop entries are refreshed so previously missing
-        desktop files can be retried.
-        """
-        self._missed_candidates.clear()
 
     def _match_wine_instance(
         self, *, app_id_lower: str, instance_hint: str
@@ -339,12 +379,10 @@ class AppIdMatcher:
             # Visible aliases (covers pinned Wine launcher items).
             desktop_id = self._visible_aliases.get(_normalize_alias(alias))
             if desktop_id:
-                self._result_cache[alias] = desktop_id
                 return desktop_id
             # Launcher WM_CLASS index.
             info = self._launcher.resolve_by_wm_class(alias)
             if info is not None:
-                self._result_cache[alias] = info.desktop_id
                 return info.desktop_id
         return None
 
@@ -354,13 +392,14 @@ class AppIdMatcher:
         app_id: str,
         app_id_lower: str,
         instance_hint: str | None,
+        prefer_raw_app_id: bool,
     ) -> list[str]:
         """Generate lookup candidates merged from both legacy matchers.
 
-        Order is stable and deterministic.  X11-originated candidates
-        come first (preserving existing X11 matching priority), then
-        Wayland-specific candidates.  Duplicates are removed while
-        preserving first-occurrence order.
+        Order is stable and deterministic. Wayland-style callers keep
+        compositor-provided desktop IDs authoritative; X11 callers keep
+        the old lowercase-first WM_CLASS order. Duplicates are removed
+        while preserving first-occurrence order.
         """
         # X11-style candidates from class_group.
         x11_candidates = _class_group_candidates(
@@ -371,10 +410,22 @@ class AppIdMatcher:
         # Wayland-style candidates (dot-split, Snap prefixes, lowercase).
         wl_candidates = _app_id_candidates(app_id)
 
-        # Merge: X11 first, then Wayland.  Dedupe preserving order.
+        # Keep raw compositor IDs first, then add X11 transforms and
+        # Wayland/container fallbacks. Dedupe preserving order.
         seen: set[str] = set()
         merged: list[str] = []
-        for candidate in x11_candidates + wl_candidates:
+        raw_candidates = [
+            app_id,
+            app_id.removesuffix(DESKTOP_SUFFIX),
+            app_id_lower,
+            app_id_lower.removesuffix(DESKTOP_SUFFIX),
+        ]
+        source_candidates = (
+            raw_candidates + x11_candidates + wl_candidates
+            if prefer_raw_app_id
+            else x11_candidates + wl_candidates
+        )
+        for candidate in source_candidates:
             if candidate not in seen:
                 seen.add(candidate)
                 merged.append(candidate)
@@ -394,7 +445,7 @@ class AppIdMatcher:
 def _instance_candidates(instance_hint: str) -> list[str]:
     """Generate lookup candidates from a WM_CLASS instance string."""
     instance_lower = instance_hint.lower().strip()
-    if not instance_lower or instance_lower == instance_hint.lower().strip() == "":
+    if not instance_lower:
         return []
     candidates = [instance_lower]
     # Also handle the case where the instance itself contains spaces

--- a/docking/platform/app_matcher.py
+++ b/docking/platform/app_matcher.py
@@ -219,8 +219,6 @@ class AppIdMatcher:
         self._result_cache: dict[str, str] = {}  # lookup_key → desktop_id
         self._missed_candidates: set[str] = set()
 
-    # -- Public API -------------------------------------------------------
-
     def sync_visible_items(self, items: Iterable[DockItem]) -> None:
         """Rebuild visible-item alias cache from the current dock model.
 
@@ -323,8 +321,6 @@ class AppIdMatcher:
         """
         self._missed_candidates.clear()
 
-    # -- Internal: Wine ---------------------------------------------------
-
     def _match_wine_instance(
         self, *, app_id_lower: str, instance_hint: str
     ) -> str | None:
@@ -351,8 +347,6 @@ class AppIdMatcher:
                 self._result_cache[alias] = info.desktop_id
                 return info.desktop_id
         return None
-
-    # -- Internal: candidate generation -----------------------------------
 
     def _candidates(
         self,

--- a/docking/platform/app_matcher.py
+++ b/docking/platform/app_matcher.py
@@ -1,0 +1,411 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Shared window-identity to desktop-ID matching for all display-server backends.
+
+Why this module exists
+-----------------------
+
+Every backend (X11/Wnck, Wayland/wlr-foreign-toplevel, Hyprland IPC,
+Wayfire IPC, Niri IPC, GNOME Shell Bridge, KWin/AT-SPI) needs to answer
+the same question:
+
+    "Which Docking desktop ID does this running window belong to?"
+
+Before this module the answer lived in two independent matchers with
+different feature sets:
+
+* ``WindowMatcher`` in the X11 backend — Wine ``.exe`` extraction,
+  space→hyphen→joined candidate generation, GNOME prefix synthesis,
+  missed-candidate memoization, result caching.
+* ``WaylandAppIdMatcher`` in the Wayland backend — Snap ``_`` prefix
+  expansion, dot-suffix split, broad visible-item aliasing.
+
+Neither matcher had the union of both feature sets, so every
+backend-specific improvement (e.g. PR #206 Wine matching) had to be
+implemented twice, and the growing set of Wayland consumers
+(Hyprland, Wayfire, Niri, GNOME Bridge, AT-SPI) all inherited the
+limitations of ``WaylandAppIdMatcher``.
+
+Design
+-------
+
+``AppIdMatcher`` is a backend-agnostic matching engine.  Backends
+extract identity strings from their display server and pass them here
+as plain strings.  The matcher owns the heuristics; backends own only
+the display-server extraction.
+
+The public API has two methods:
+
+``sync_visible_items(items)``
+    Rebuild the fast-path alias cache from the current dock model.
+    Called at the start of every running-window scan.
+
+``match(app_id, *, instance_hint=None)``
+    Map a runtime window identity to a Docking desktop ID.
+
+    ``app_id`` is the primary identity from the display server:
+
+    * X11: ``class_group`` (WM_CLASS class part)
+    * Wayland/Hyprland/Wayfire/Niri/GNOME: the single ``app_id`` /
+      ``class`` string the compositor provides
+    * AT-SPI: ``app_name`` from the accessibility tree
+
+    ``instance_hint`` is an optional secondary identity.  Currently
+    only X11 provides this (WM_CLASS instance part).  It enables Wine
+    disambiguation: when ``app_id == "wine"`` the matcher extracts the
+    ``.exe`` name from ``instance_hint`` instead.
+
+Matching priority (strongest first)
+------------------------------------
+
+1. **Wine detection** — when ``app_id`` is the generic ``"wine"``
+   class group and ``instance_hint`` contains a ``.exe`` path, extract
+   the executable name and match against visible aliases and the
+   launcher WM_CLASS index.
+
+2. **Visible-item alias cache** — fast-path lookup against currently
+   pinned and transient dock items (no Gio or filesystem calls).
+
+3. **Instance-hint match** — when ``app_id`` is generic but
+   ``instance_hint`` is specific and matches a visible item
+   (X11 optimization).
+
+4. **Candidate generation + resolution** — for each generated
+   candidate string:
+
+   a. Check visible aliases (normalized).
+   b. Try ``launcher.resolve(f"{candidate}.desktop")``.
+   c. Try ``launcher.resolve_by_wm_class(candidate)``.
+
+   Failed desktop IDs are memoized so signal bursts don't hammer Gio
+   with repeated failing lookups.  Successful matches are cached so
+   subsequent scans hit the fast path.
+
+Candidate generation (merged from both legacy matchers)
+--------------------------------------------------------
+
+Candidates are generated in a stable, deterministic order:
+
+* Raw ``app_id``
+* Space→hyphen (``"mongodb compass"`` → ``"mongodb-compass"``)
+* Space→joined  (``"mongodb compass"`` → ``"mongodbcompass"``)
+* GNOME prefix + original class-group (``"Files"`` → ``"org.gnome.Files"``)
+* Dot-suffix split (``"org.gnome.Nautilus"`` → ``"Nautilus"``)
+* Snap/container ``_`` prefix expansion
+  (``"firefox_firefox"`` → ``"firefox"``)
+* Lowercase variants of the above
+
+Duplicates are removed while preserving first-occurrence order so
+the first successful match is always the same for a given input.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+from docking.platform.launcher import DESKTOP_SUFFIX, GNOME_APP_PREFIX
+
+if TYPE_CHECKING:
+    from docking.core.items import DockItem
+    from docking.platform.launcher import Launcher
+
+
+def _normalize_alias(value: str) -> str:
+    """Normalize an alias for cache-key comparison (lowercase, no .desktop suffix)."""
+    return value.strip().removesuffix(DESKTOP_SUFFIX).lower()
+
+
+def _ensure_desktop_suffix(value: str) -> str:
+    """Append ``.desktop`` to *value* when it is not already suffixed."""
+    stripped = value.strip()
+    return (
+        stripped if stripped.endswith(DESKTOP_SUFFIX) else f"{stripped}{DESKTOP_SUFFIX}"
+    )
+
+
+def _app_id_candidates(app_id: str) -> list[str]:
+    """Generate lookup candidates from a Wayland-style single ``app_id``.
+
+    Handles dot-separated prefixes (``org.gnome.Nautilus`` → ``Nautilus``)
+    and Snap/container underscore notation
+    (``firefox_firefox`` → ``firefox``).
+    """
+    stripped = app_id.strip()
+    if not stripped:
+        return []
+    candidates = [
+        stripped,
+        stripped.removesuffix(DESKTOP_SUFFIX),
+        stripped.lower(),
+        stripped.lower().removesuffix(DESKTOP_SUFFIX),
+    ]
+    if "." in stripped:
+        candidates.append(stripped.split(".")[-1])
+    # Wine / Windows executable reported as the sole app_id by a Wayland
+    # compositor (e.g. Hyprland `class` = "notepad.exe").  Strip the .exe
+    # suffix so the launcher can match "notepad" → "wine-notepad.desktop".
+    if stripped.lower().endswith(".exe"):
+        candidates.append(stripped[:-4])  # preserve original case
+        candidates.append(stripped[:-4].lower())
+    # Snap / container app-ids like firefox_firefox.desktop: also try the
+    # leading segment so the launcher can match firefox.desktop.
+    body = stripped.removesuffix(DESKTOP_SUFFIX)
+    if "_" in body:
+        segments = body.split("_")
+        prefixes = ["_".join(segments[: i + 1]) for i in range(len(segments) - 1)]
+        for prefix in prefixes:
+            candidates.append(prefix)
+            candidates.append(f"{prefix}{DESKTOP_SUFFIX}")
+            candidates.append(prefix.lower())
+            candidates.append(f"{prefix.lower()}{DESKTOP_SUFFIX}")
+    return list(dict.fromkeys(candidate for candidate in candidates if candidate))
+
+
+def _class_group_candidates(*, class_lower: str, class_group: str) -> list[str]:
+    """Generate desktop ID candidates from an X11-style WM_CLASS class group.
+
+    Handles space→hyphen→joined transformations and GNOME prefix synthesis.
+    """
+    candidates = [class_lower]
+    if " " in class_lower:
+        candidates.append(class_lower.replace(" ", "-"))
+        candidates.append(class_lower.replace(" ", ""))
+    candidates.append(f"{GNOME_APP_PREFIX}{class_group}")
+    return list(dict.fromkeys(candidates))
+
+
+def _wine_aliases_from_instance(instance: str) -> list[str]:
+    """Extract lookup aliases from a Wine ``class_instance`` path.
+
+    For ``C:\\\\Program Files\\\\App\\\\Tool.exe`` this returns
+    ``["tool.exe", "tool"]``.  The full raw instance is also included
+    so direct cache hits on the unfiltered string still work.
+    """
+    instance_lower = instance.lower().strip()
+    basename = re.split(r"[\\/]", instance_lower)[-1]
+    aliases = [basename]
+    if basename.endswith(".exe"):
+        aliases.append(basename[:-4])
+    if instance_lower != basename:
+        aliases.append(instance_lower)
+    return list(dict.fromkeys(aliases))
+
+
+class AppIdMatcher:
+    """Shared window → desktop ID matching for all display-server backends.
+
+    Backends extract identity from their display server (Wnck, Wayland
+    protocol, compositor IPC, AT-SPI) and pass it here as plain strings.
+    The matcher owns the heuristics for mapping runtime identities to
+    Docking desktop IDs.
+    """
+
+    def __init__(self, launcher: Launcher) -> None:
+        self._launcher = launcher
+        self._visible_aliases: dict[str, str] = {}  # normalized → desktop_id
+        self._result_cache: dict[str, str] = {}  # lookup_key → desktop_id
+        self._missed_candidates: set[str] = set()
+
+    # -- Public API -------------------------------------------------------
+
+    def sync_visible_items(self, items: Iterable[DockItem]) -> None:
+        """Rebuild visible-item alias cache from the current dock model.
+
+        Called at the start of every running-window scan so the cache
+        reflects the current pinned / transient item set.  Pinned items
+        can be reordered, pinned, unpinned, or replaced at runtime, and
+        using stale aliases would make running indicators disappear
+        until restart.
+        """
+        self._visible_aliases.clear()
+        for item in items:
+            aliases = {
+                item.desktop_id,
+                item.desktop_id.removesuffix(DESKTOP_SUFFIX),
+                getattr(item, "wm_class", "") or "",
+            }
+            for alias in aliases:
+                normalized = _normalize_alias(alias)
+                if normalized:
+                    self._visible_aliases[normalized] = item.desktop_id
+
+    def match(self, app_id: str, *, instance_hint: str | None = None) -> str | None:
+        """Map a runtime window identity to a Docking desktop ID.
+
+        Args:
+            app_id: Primary identity from the display server.
+            instance_hint: Secondary identity when the display server
+                provides a split identity model (currently only X11).
+
+        Returns:
+            The matching desktop ID (e.g. ``"firefox.desktop"``), or
+            ``None`` when no match could be found.
+        """
+        if not app_id:
+            return None
+
+        app_id_lower = app_id.lower().strip()
+
+        # 1. Wine detection — when the primary identity is the generic
+        #    "wine" class group, use the instance (exe path) instead.
+        if instance_hint:
+            result = self._match_wine_instance(
+                app_id_lower=app_id_lower,
+                instance_hint=instance_hint,
+            )
+            if result:
+                return result
+
+        # 2. Visible-item alias cache (fast path, no Gio calls).
+        result = self._visible_aliases.get(_normalize_alias(app_id_lower))
+        if result:
+            return result
+
+        # 3. Instance hint against visible aliases (X11 optimization:
+        #    when class_group is generic but class_instance is specific
+        #    and matches a pinned item).
+        if instance_hint:
+            result = self._visible_aliases.get(
+                _normalize_alias(instance_hint.lower().strip())
+            )
+            if result:
+                self._result_cache[app_id_lower] = result
+                return result
+
+        # 4. Candidate generation + resolution.
+        for candidate in self._candidates(
+            app_id=app_id,
+            app_id_lower=app_id_lower,
+            instance_hint=instance_hint,
+        ):
+            # 4a. Visible aliases (normalized).
+            result = self._visible_aliases.get(_normalize_alias(candidate))
+            if result:
+                self._result_cache[app_id_lower] = result
+                return result
+
+            # 4b. Direct desktop ID resolution (with missed-candidate
+            #     memoization so signal bursts don't hammer Gio).
+            desktop_id = _ensure_desktop_suffix(candidate)
+            if desktop_id not in self._missed_candidates:
+                info = self._launcher.resolve(desktop_id, log_failures=False)
+                if info is not None:
+                    self._result_cache[app_id_lower] = info.desktop_id
+                    return info.desktop_id
+                self._missed_candidates.add(desktop_id)
+
+            # 4c. WM_CLASS index lookup (lazy-built once, then dict).
+            info = self._launcher.resolve_by_wm_class(candidate)
+            if info is not None:
+                self._result_cache[app_id_lower] = info.desktop_id
+                return info.desktop_id
+
+        return None
+
+    def clear_missed_cache(self) -> None:
+        """Clear the missed-candidate memoization set.
+
+        Called when desktop entries are refreshed so previously missing
+        desktop files can be retried.
+        """
+        self._missed_candidates.clear()
+
+    # -- Internal: Wine ---------------------------------------------------
+
+    def _match_wine_instance(
+        self, *, app_id_lower: str, instance_hint: str
+    ) -> str | None:
+        """Try to match a Wine window by its ``.exe`` instance name.
+
+        Only triggers when *app_id_lower* is the generic ``"wine"``
+        class group **and** the instance looks like a Windows executable
+        path.  Non-``.exe`` instances fall through to normal matching.
+        """
+        if app_id_lower != "wine":
+            return None
+        instance_lower = instance_hint.lower().strip()
+        if not instance_lower.endswith(".exe"):
+            return None
+        for alias in _wine_aliases_from_instance(instance_hint):
+            # Visible aliases (covers pinned Wine launcher items).
+            desktop_id = self._visible_aliases.get(_normalize_alias(alias))
+            if desktop_id:
+                self._result_cache[alias] = desktop_id
+                return desktop_id
+            # Launcher WM_CLASS index.
+            info = self._launcher.resolve_by_wm_class(alias)
+            if info is not None:
+                self._result_cache[alias] = info.desktop_id
+                return info.desktop_id
+        return None
+
+    # -- Internal: candidate generation -----------------------------------
+
+    def _candidates(
+        self,
+        *,
+        app_id: str,
+        app_id_lower: str,
+        instance_hint: str | None,
+    ) -> list[str]:
+        """Generate lookup candidates merged from both legacy matchers.
+
+        Order is stable and deterministic.  X11-originated candidates
+        come first (preserving existing X11 matching priority), then
+        Wayland-specific candidates.  Duplicates are removed while
+        preserving first-occurrence order.
+        """
+        # X11-style candidates from class_group.
+        x11_candidates = _class_group_candidates(
+            class_lower=app_id_lower,
+            class_group=app_id,
+        )
+
+        # Wayland-style candidates (dot-split, Snap prefixes, lowercase).
+        wl_candidates = _app_id_candidates(app_id)
+
+        # Merge: X11 first, then Wayland.  Dedupe preserving order.
+        seen: set[str] = set()
+        merged: list[str] = []
+        for candidate in x11_candidates + wl_candidates:
+            if candidate not in seen:
+                seen.add(candidate)
+                merged.append(candidate)
+
+        # Instance hint aliases (when available) — appended after
+        # the main candidates so they don't shadow a more specific match
+        # from the class-group candidates.
+        if instance_hint:
+            for alias in _instance_candidates(instance_hint):
+                if alias not in seen:
+                    seen.add(alias)
+                    merged.append(alias)
+
+        return merged
+
+
+def _instance_candidates(instance_hint: str) -> list[str]:
+    """Generate lookup candidates from a WM_CLASS instance string."""
+    instance_lower = instance_hint.lower().strip()
+    if not instance_lower or instance_lower == instance_hint.lower().strip() == "":
+        return []
+    candidates = [instance_lower]
+    # Also handle the case where the instance itself contains spaces
+    # (rare, but some X11 apps do this).
+    if " " in instance_lower:
+        candidates.append(instance_lower.replace(" ", "-"))
+        candidates.append(instance_lower.replace(" ", ""))
+    return list(dict.fromkeys(candidates))

--- a/docking/platform/backends/gnome/bridge.py
+++ b/docking/platform/backends/gnome/bridge.py
@@ -32,6 +32,7 @@ gi.require_version("Gio", "2.0")
 from gi.repository import Gio, GLib
 
 from docking.log import get_logger
+from docking.platform.app_matcher import AppIdMatcher
 from docking.platform.backends.base import (
     ActionResult,
     DesktopActionService,
@@ -48,7 +49,6 @@ from docking.platform.backends.base import (
     WorkspaceService,
     WorkspaceSnapshot,
 )
-from docking.platform.backends.wayland.toplevels import WaylandAppIdMatcher
 from docking.platform.running import RunningAppInfo, RunningWindowInfo
 
 if TYPE_CHECKING:
@@ -252,7 +252,7 @@ class GnomeShellBridgeWindowService(WindowService):
         bridge: object,
     ) -> None:
         self._model = model
-        self._matcher = WaylandAppIdMatcher(launcher=launcher)
+        self._matcher = AppIdMatcher(launcher=launcher)
         self._bridge = bridge
         self._windows_by_id: dict[int, _BridgeWindow] = {}
         self._changed_handle: object | None = None

--- a/docking/platform/backends/kwin/atspi_window.py
+++ b/docking/platform/backends/kwin/atspi_window.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING
 from gi.repository import Gio, GLib
 
 from docking.log import get_logger
+from docking.platform.app_matcher import AppIdMatcher
 from docking.platform.backends.base import (
     ActionResult,
     DisplayServer,
@@ -44,7 +45,6 @@ from docking.platform.backends.base import (
     WindowService,
     WindowSnapshot,
 )
-from docking.platform.backends.wayland.toplevels import WaylandAppIdMatcher
 from docking.platform.running import RunningAppInfo, RunningWindowInfo
 
 if TYPE_CHECKING:
@@ -145,9 +145,9 @@ class AtspiWindowService(WindowService):
         self._lock = Lock()
         self._refresh_running = False
         self._model = model
-        self._matcher: WaylandAppIdMatcher | None = None
+        self._matcher: AppIdMatcher | None = None
         if launcher is not None:
-            self._matcher = WaylandAppIdMatcher(launcher=launcher)
+            self._matcher = AppIdMatcher(launcher=launcher)
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/docking/platform/backends/wayland/__init__.py
+++ b/docking/platform/backends/wayland/__init__.py
@@ -33,7 +33,6 @@ from docking.platform.backends.wayland.services import (
 )
 from docking.platform.backends.wayland.session import WaylandLayerShellSessionBackend
 from docking.platform.backends.wayland.toplevels import (
-    WaylandAppIdMatcher,
     WaylandForeignToplevelWindowService,
     load_foreign_toplevel_protocol,
 )
@@ -45,7 +44,6 @@ from docking.platform.backends.wayland.workspaces import (
 __all__ = [
     "CosmicSessionBackend",
     "ForeignToplevelProtocolAdapter",
-    "WaylandAppIdMatcher",
     "WaylandForeignToplevelWindowService",
     "WaylandLayerShellSessionBackend",
     "WaylandLayerShellSurfaceService",

--- a/docking/platform/backends/wayland/hyprland_ipc.py
+++ b/docking/platform/backends/wayland/hyprland_ipc.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import Any
 
 from docking.log import get_logger
+from docking.platform.app_matcher import AppIdMatcher
 from docking.platform.backends.base import (
     ActionResult,
     DisplayServer,
@@ -35,7 +36,6 @@ from docking.platform.backends.base import (
     WindowService,
     WindowSnapshot,
 )
-from docking.platform.backends.wayland.toplevels import WaylandAppIdMatcher
 from docking.platform.running import RunningAppInfo, RunningWindowInfo
 
 log = get_logger(name="hyprland_ipc")
@@ -222,7 +222,7 @@ class HyprlandWindowService(WindowService):
         preview_handle_source: object | None = None,
     ) -> None:
         self._model = model
-        self._matcher = WaylandAppIdMatcher(launcher=launcher)
+        self._matcher = AppIdMatcher(launcher=launcher)
         self._client = client
         self._event_stream_factory = event_stream_factory
         self._event_stream: HyprlandEventStream | None = None
@@ -506,7 +506,7 @@ def parse_hyprland_event(line: str) -> HyprlandEvent | None:
 def _record_from_client(
     item: Mapping[str, Any],
     *,
-    matcher: WaylandAppIdMatcher,
+    matcher: AppIdMatcher,
     active_address: str,
 ) -> HyprlandWindowRecord | None:
     address = _normalize_address(_mapping_value(item, "address", ""))

--- a/docking/platform/backends/wayland/niri_ipc.py
+++ b/docking/platform/backends/wayland/niri_ipc.py
@@ -37,6 +37,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GdkPixbuf
 
 from docking.log import get_logger
+from docking.platform.app_matcher import AppIdMatcher
 from docking.platform.backends.base import (
     ActionResult,
     DesktopActionService,
@@ -51,7 +52,6 @@ from docking.platform.backends.base import (
     WorkspaceService,
     WorkspaceSnapshot,
 )
-from docking.platform.backends.wayland.toplevels import WaylandAppIdMatcher
 from docking.platform.running import RunningAppInfo, RunningWindowInfo
 
 log = get_logger(name="niri_ipc")
@@ -290,7 +290,7 @@ class NiriWindowService(WindowService):
         | None = None,
     ) -> None:
         self._model = model
-        self._matcher = WaylandAppIdMatcher(launcher=launcher)
+        self._matcher = AppIdMatcher(launcher=launcher)
         self._client = client
         self._event_stream_factory = event_stream_factory
         self._event_stream: NiriEventStream | None = None
@@ -1051,7 +1051,7 @@ def _parse_event_line(line: str) -> NiriEvent | None:
 def _record_from_window(
     item: Mapping[str, Any],
     *,
-    matcher: WaylandAppIdMatcher,
+    matcher: AppIdMatcher,
 ) -> NiriWindowRecord | None:
     window_id = item.get("id")
     if not isinstance(window_id, int):

--- a/docking/platform/backends/wayland/previews.py
+++ b/docking/platform/backends/wayland/previews.py
@@ -26,13 +26,13 @@ import gi
 gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GdkPixbuf, GLib
 
+from docking.platform.app_matcher import AppIdMatcher
 from docking.platform.backends.base import (
     DisplayServer,
     PreviewImage,
     PreviewService,
     WindowId,
 )
-from docking.platform.backends.wayland.toplevels import WaylandAppIdMatcher
 
 if TYPE_CHECKING:
     from docking.platform.launcher import Launcher
@@ -95,7 +95,7 @@ class WaylandPreviewHandleTracker:
 
     def __init__(self, *, model: DockModel, launcher: Launcher, protocol: object):
         self._model = model
-        self._matcher = WaylandAppIdMatcher(launcher=launcher)
+        self._matcher = AppIdMatcher(launcher=launcher)
         self._protocol = protocol
         self._state_by_handle: dict[object, _PreviewToplevelState] = {}
         self._handle_by_window_id: dict[WindowId, object] = {}

--- a/docking/platform/backends/wayland/toplevels.py
+++ b/docking/platform/backends/wayland/toplevels.py
@@ -40,7 +40,6 @@ from docking.platform.backends.base import (
     WindowService,
     WindowSnapshot,
 )
-from docking.platform.launcher import DESKTOP_SUFFIX
 from docking.platform.running import RunningAppInfo, RunningWindowInfo
 
 if TYPE_CHECKING:
@@ -394,43 +393,6 @@ def load_foreign_toplevel_protocol() -> object | None:
     # is vendored, but the service above stays independent from the binding so it
     # can be tested without a live compositor.
     return None
-
-
-def _normalize_app_id(value: str) -> str:
-    return value.strip().removesuffix(DESKTOP_SUFFIX).lower()
-
-
-def _ensure_desktop_suffix(value: str) -> str:
-    stripped = value.strip()
-    if stripped.endswith(DESKTOP_SUFFIX):
-        return stripped
-    return f"{stripped}{DESKTOP_SUFFIX}"
-
-
-def _app_id_candidates(app_id: str) -> list[str]:
-    stripped = app_id.strip()
-    if not stripped:
-        return []
-    candidates = [
-        stripped,
-        stripped.removesuffix(DESKTOP_SUFFIX),
-        stripped.lower(),
-        stripped.lower().removesuffix(DESKTOP_SUFFIX),
-    ]
-    if "." in stripped:
-        candidates.append(stripped.split(".")[-1])
-    # Snap / container app-ids like firefox_firefox.desktop: also try the
-    # leading segment so the launcher can match firefox.desktop.
-    body = stripped.removesuffix(DESKTOP_SUFFIX)
-    if "_" in body:
-        segments = body.split("_")
-        prefixes = ["_".join(segments[: i + 1]) for i in range(len(segments) - 1)]
-        for prefix in prefixes:
-            candidates.append(prefix)
-            candidates.append(f"{prefix}{DESKTOP_SUFFIX}")
-            candidates.append(prefix.lower())
-            candidates.append(f"{prefix.lower()}{DESKTOP_SUFFIX}")
-    return list(dict.fromkeys(candidate for candidate in candidates if candidate))
 
 
 def _normalize_state(value: object) -> str:

--- a/docking/platform/backends/wayland/toplevels.py
+++ b/docking/platform/backends/wayland/toplevels.py
@@ -32,6 +32,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from docking.platform.app_matcher import AppIdMatcher
 from docking.platform.backends.base import (
     ActionResult,
     DisplayServer,
@@ -43,7 +44,6 @@ from docking.platform.launcher import DESKTOP_SUFFIX
 from docking.platform.running import RunningAppInfo, RunningWindowInfo
 
 if TYPE_CHECKING:
-    from docking.core.items import DockItem
     from docking.platform.backends.wayland.previews import WaylandPreviewHandleTracker
     from docking.platform.launcher import Launcher
     from docking.platform.model import DockModel
@@ -80,43 +80,6 @@ class _ToplevelState:
         return WindowId(backend=DisplayServer.WAYLAND, value=self.internal_id)
 
 
-class WaylandAppIdMatcher:
-    """Resolve Wayland compositor app IDs to Docking desktop IDs."""
-
-    def __init__(self, launcher: Launcher) -> None:
-        self._launcher = launcher
-        self._visible_aliases: dict[str, str] = {}
-
-    def sync_visible_items(self, items: Iterable[DockItem]) -> None:
-        """Refresh aliases from current pinned and transient dock items."""
-        self._visible_aliases.clear()
-        for item in items:
-            aliases = {
-                item.desktop_id,
-                item.desktop_id.removesuffix(DESKTOP_SUFFIX),
-                getattr(item, "wm_class", "") or "",
-            }
-            for alias in aliases:
-                normalized = _normalize_app_id(alias)
-                if normalized:
-                    self._visible_aliases[normalized] = item.desktop_id
-
-    def match(self, app_id: str) -> str | None:
-        """Return a Docking desktop ID for a compositor app_id."""
-        for candidate in _app_id_candidates(app_id):
-            visible = self._visible_aliases.get(_normalize_app_id(candidate))
-            if visible:
-                return visible
-            desktop_id = _ensure_desktop_suffix(candidate)
-            resolved = self._launcher.resolve(desktop_id, log_failures=False)
-            if resolved is not None:
-                return resolved.desktop_id
-            by_wm_class = self._launcher.resolve_by_wm_class(candidate)
-            if by_wm_class is not None:
-                return by_wm_class.desktop_id
-        return None
-
-
 class WaylandForeignToplevelWindowService(WindowService):
     """WindowService backed by Wayland foreign-toplevel protocol events."""
 
@@ -130,7 +93,7 @@ class WaylandForeignToplevelWindowService(WindowService):
         can_preview: bool = False,
     ) -> None:
         self._model = model
-        self._matcher = WaylandAppIdMatcher(launcher=launcher)
+        self._matcher = AppIdMatcher(launcher=launcher)
         self._protocol = protocol
         self._preview_handles = preview_handles
         self._can_preview = can_preview

--- a/docking/platform/backends/wayland/wayfire_ipc.py
+++ b/docking/platform/backends/wayland/wayfire_ipc.py
@@ -36,6 +36,7 @@ from queue import Empty, Queue
 from typing import Any
 
 from docking.log import get_logger
+from docking.platform.app_matcher import AppIdMatcher
 from docking.platform.backends.base import (
     ActionResult,
     DesktopActionService,
@@ -50,7 +51,6 @@ from docking.platform.backends.base import (
     WorkspaceService,
     WorkspaceSnapshot,
 )
-from docking.platform.backends.wayland.toplevels import WaylandAppIdMatcher
 from docking.platform.running import RunningAppInfo, RunningWindowInfo
 
 log = get_logger(name="wayfire_ipc")
@@ -284,7 +284,7 @@ class WayfireWindowService(WindowService):
         watcher: WayfireEventWatcher | None = None,
     ) -> None:
         self._model = model
-        self._matcher = WaylandAppIdMatcher(launcher=launcher)
+        self._matcher = AppIdMatcher(launcher=launcher)
         self._client = client
         self._records: dict[int, WayfireWindowRecord] = {}
         self._poll_source_id = 0

--- a/docking/platform/backends/x11/impl/window_tracker.py
+++ b/docking/platform/backends/x11/impl/window_tracker.py
@@ -162,6 +162,7 @@ import os
 from gi.repository import GLib, Gtk, Wnck
 
 from docking.log import get_logger, with_context
+from docking.platform.app_matcher import AppIdMatcher
 from docking.platform.backends.base import (
     ActionResult,
     DisplayServer,
@@ -169,7 +170,6 @@ from docking.platform.backends.base import (
     WindowId,
     WindowSnapshot,
 )
-from docking.platform.launcher import DESKTOP_SUFFIX, GNOME_APP_PREFIX
 from docking.platform.running import RunningAppInfo, RunningWindowInfo
 
 # GLib.Error is not a real exception subclass in some PyGObject builds,
@@ -190,63 +190,33 @@ if TYPE_CHECKING:
 
 
 class WindowMatcher:
-    """Matches live Wnck windows to desktop IDs using WM_CLASS-like hints."""
+    """Matches live Wnck windows to desktop IDs using WM_CLASS-like hints.
+
+    This is a thin X11-specific wrapper around the shared
+    :class:`~docking.platform.app_matcher.AppIdMatcher`.  The wrapping
+    handles Wnck-specific window property extraction (class group,
+    class instance) and defensive error handling; all matching
+    heuristics live in the shared matcher so they apply uniformly
+    across X11 and Wayland backends.
+    """
 
     def __init__(self, launcher: Launcher) -> None:
         self._launcher = launcher
-        self._wm_class_to_desktop: dict[str, str] = {}
-        self._missed_desktop_candidates: set[str] = set()
+        self._app_matcher = AppIdMatcher(launcher=launcher)
 
     def sync_visible_items(self, items: Iterable[DockItem]) -> None:
-        """Refresh pinned/transient WM_CLASS hints from current dock items."""
-        # This cache is intentionally rebuilt from the current model on every
-        # running-window scan. Pinned items can be reordered, pinned, unpinned,
-        # or replaced by transient items at runtime, and using stale WM_CLASS
-        # hints would make running indicators disappear until restart.
-        self._wm_class_to_desktop.clear()
-        for item in items:
-            if item.wm_class:
-                self._wm_class_to_desktop[item.wm_class.lower()] = item.desktop_id
+        """Refresh pinned/transient alias hints from current dock items."""
+        self._app_matcher.sync_visible_items(items)
 
     def match(self, window: Wnck.Window) -> str | None:
         """Return the desktop ID for a window, or None when no match is known."""
         class_group = self._class_group_for(window=window)
         if not class_group:
             return None
-
-        class_lower = class_group.lower()
-        # The fastest and most reliable path is the explicit StartupWMClass (or
-        # previously learned alias) from visible dock items. Check it before
-        # doing any desktop-file probing.
-        mapped = self._wm_class_to_desktop.get(class_lower)
-        if mapped:
-            return mapped
-
-        # Some apps expose a useful class instance even when the class-group name
-        # is generic or localized. When it matches, cache the class-group too so
-        # future scans avoid this extra Wnck read.
         class_instance = self._class_instance_for(window=window)
-        if class_instance:
-            mapped = self._match_class_instance(
-                class_lower=class_lower,
-                class_instance=class_instance,
-            )
-            if mapped:
-                return mapped
-
-        mapped = self._resolve_desktop_candidates(
-            class_lower=class_lower,
-            class_group=class_group,
-        )
-        if mapped:
-            return mapped
-
-        # Last resort: build or consult the install-wide WM_CLASS alias index.
-        # This is more expensive because it can scan installed desktop files, so
-        # keep it after the direct and candidate-specific paths.
-        return self._resolve_runtime_names(
-            class_lower=class_lower,
-            class_instance=class_instance,
+        return self._app_matcher.match(
+            app_id=class_group,
+            instance_hint=class_instance,
         )
 
     def _class_group_for(self, *, window: Wnck.Window) -> str | None:
@@ -266,102 +236,6 @@ class WindowMatcher:
                 f"Failed to read class instance name: {exc}"
             )
             return None
-
-    def _match_class_instance(
-        self, *, class_lower: str, class_instance: str
-    ) -> str | None:
-        desktop_id = self._wm_class_to_desktop.get(class_instance.lower())
-        if desktop_id:
-            self._wm_class_to_desktop[class_lower] = desktop_id
-        return desktop_id
-
-    def _resolve_desktop_candidates(
-        self, *, class_lower: str, class_group: str
-    ) -> str | None:
-        # Try the candidate desktop IDs in a stable order. Failed candidates are
-        # remembered because many Wnck signals arrive in bursts, and repeatedly
-        # asking Gio for the same missing desktop file is avoidable noise.
-        candidate_ids = [
-            f"{candidate}{DESKTOP_SUFFIX}"
-            for candidate in self._desktop_candidates(
-                class_lower=class_lower, class_group=class_group
-            )
-        ]
-        for index, desktop_id in enumerate(candidate_ids):
-            next_candidate = (
-                candidate_ids[index + 1] if index + 1 < len(candidate_ids) else None
-            )
-            if desktop_id in self._missed_desktop_candidates:
-                continue
-            info = self._launcher.resolve(desktop_id=desktop_id, log_failures=False)
-            if info:
-                self._wm_class_to_desktop[class_lower] = info.desktop_id
-                return info.desktop_id
-            self._missed_desktop_candidates.add(desktop_id)
-            self._log_candidate_miss(
-                desktop_id=desktop_id,
-                class_group=class_group,
-                class_lower=class_lower,
-                next_candidate=next_candidate,
-            )
-        return None
-
-    @staticmethod
-    def _desktop_candidates(*, class_lower: str, class_group: str) -> list[str]:
-        """Generate desktop ID candidates from a WM_CLASS.
-
-        A running app can report spaces in WM_CLASS while the desktop file uses
-        hyphens or no separators. GNOME apps also commonly use an
-        org.gnome.Name.desktop file while the runtime class group is just Name.
-        Keep the candidates broad but deterministic, then dedupe while
-        preserving order so the first successful match stays stable.
-        """
-        candidates = [class_lower]
-        if " " in class_lower:
-            candidates.append(class_lower.replace(" ", "-"))
-            candidates.append(class_lower.replace(" ", ""))
-        candidates.append(f"{GNOME_APP_PREFIX}{class_group}")
-        return list(dict.fromkeys(candidates))
-
-    def _resolve_runtime_names(
-        self, *, class_lower: str, class_instance: str | None
-    ) -> str | None:
-        runtime_names = [
-            class_lower,
-            class_instance.lower() if class_instance else "",
-        ]
-        for runtime_name in dict.fromkeys(name for name in runtime_names if name):
-            info = self._launcher.resolve_by_wm_class(runtime_name)
-            if info:
-                self._wm_class_to_desktop[class_lower] = info.desktop_id
-                if class_instance:
-                    self._wm_class_to_desktop[class_instance.lower()] = info.desktop_id
-                return info.desktop_id
-        return None
-
-    @staticmethod
-    def _log_candidate_miss(
-        *,
-        desktop_id: str,
-        class_group: str,
-        class_lower: str,
-        next_candidate: str | None,
-    ) -> None:
-        if next_candidate:
-            log.bind(action="match_window", desktop_id=desktop_id).debug(
-                "Desktop candidate miss for class_group=%s (class_lower=%s); "
-                "next candidate: %s",
-                class_group,
-                class_lower,
-                next_candidate,
-            )
-        else:
-            log.bind(action="match_window", desktop_id=desktop_id).debug(
-                "Desktop candidate miss for class_group=%s (class_lower=%s); "
-                "no more candidates",
-                class_group,
-                class_lower,
-            )
 
 
 class WindowTracker:

--- a/docking/platform/backends/x11/impl/window_tracker.py
+++ b/docking/platform/backends/x11/impl/window_tracker.py
@@ -77,10 +77,10 @@ Matching strategy
 
 The tracker applies layered matching, strongest first:
 
-1. direct cache lookup from previous successful matches
-2. class-group / WM_CLASS lookup against known dock entries
+1. visible dock item aliases from pinned and transient entries
+2. Wine class-instance disambiguation for generic `Wine` windows
 3. synthesized desktop-id candidates from runtime names
-4. GNOME-style prefixed candidates
+4. install-wide WM_CLASS / executable alias index
 
 This is deliberately heuristic because the runtime desktop is heuristic.
 
@@ -201,8 +201,10 @@ class WindowMatcher:
     """
 
     def __init__(self, launcher: Launcher) -> None:
-        self._launcher = launcher
-        self._app_matcher = AppIdMatcher(launcher=launcher)
+        self._app_matcher = AppIdMatcher(
+            launcher=launcher,
+            cache_missed_desktop_ids=True,
+        )
 
     def sync_visible_items(self, items: Iterable[DockItem]) -> None:
         """Refresh pinned/transient alias hints from current dock items."""
@@ -217,6 +219,8 @@ class WindowMatcher:
         return self._app_matcher.match(
             app_id=class_group,
             instance_hint=class_instance,
+            prefer_raw_app_id=False,
+            defer_wm_class_lookup=True,
         )
 
     def _class_group_for(self, *, window: Wnck.Window) -> str | None:

--- a/docking/platform/desktop_entries.py
+++ b/docking/platform/desktop_entries.py
@@ -222,7 +222,7 @@ def desktop_info_from_file(*, desktop_id: str, path: Path) -> DesktopInfo | None
     exec_line = desktop_entry_string(key_file, "Exec")
     wm_class = desktop_entry_string(key_file, "StartupWMClass")
     wine_aliases = wine_executable_aliases(exec_line)
-    if wine_aliases and (not wm_class or wm_class == "Wine"):
+    if wine_aliases and (not wm_class or wm_class.lower() == "wine"):
         wm_class = wine_aliases[0]
     if not wm_class:
         exec_basename = normalized_exec_basename(exec_line)
@@ -259,7 +259,7 @@ def wm_class_for_app_info(*, app_info: Gio.DesktopAppInfo, desktop_id: str) -> s
     wm_class = app_info.get_startup_wm_class() or ""
     commandline = app_info.get_commandline() or ""
     wine_aliases = wine_executable_aliases(commandline)
-    if wm_class and wm_class != "Wine":
+    if wm_class and wm_class.lower() != "wine":
         return wm_class
     if wine_aliases:
         return wine_aliases[0]

--- a/docking/platform/desktop_entries.py
+++ b/docking/platform/desktop_entries.py
@@ -114,15 +114,63 @@ def normalized_exec_basename(exec_line: str) -> str:
     return Path(argv[0]).name.lower()
 
 
+def wine_executable_aliases(exec_line: str) -> list[str]:
+    """Return Wine executable aliases from a desktop Exec line.
+
+    Wine windows often expose ``WM_CLASS`` as ``Wine`` and the executable name
+    as the instance/name part, for example ``notepad.exe``. Index both
+    ``notepad.exe`` and ``notepad`` so running windows can match the launcher.
+    """
+    if not exec_line:
+        return []
+
+    try:
+        tokens = shlex.split(exec_line)
+    except ValueError:
+        tokens = re.findall(r"[^\s\"']+|\"[^\"]*\"|'[^']*'", exec_line)
+
+    has_wine = any(Path(token).name.lower() in {"wine", "wine64"} for token in tokens)
+    if not has_wine:
+        return []
+
+    aliases: list[str] = []
+    for match in re.finditer(
+        r"""(?ix)
+        (?:
+            "([^"]+?\.exe)"
+            |
+            '([^']+?\.exe)'
+            |
+            ([^\s"']+?\.exe)
+        )
+        """,
+        exec_line,
+    ):
+        executable = next((group for group in match.groups() if group), "")
+        executable = executable.strip().strip("\"'")
+        if not executable:
+            continue
+        basename = re.split(r"[\\/]", executable)[-1].lower()
+        if not basename.endswith(".exe"):
+            continue
+        aliases.append(basename)
+        aliases.append(basename[:-4])
+    return list(dict.fromkeys(alias for alias in aliases if alias))
+
+
 def desktop_match_aliases(info: DesktopInfo) -> list[str]:
     """Return stable lookup aliases for matching runtime windows to desktop IDs."""
     aliases = [
         info.wm_class.lower(),
         info.desktop_id.removesuffix(DESKTOP_SUFFIX).lower(),
     ]
-    exec_basename = normalized_exec_basename(info.exec_line)
-    if exec_basename:
-        aliases.append(exec_basename)
+    wine_aliases = wine_executable_aliases(info.exec_line)
+    if wine_aliases:
+        aliases.extend(wine_aliases)
+    else:
+        exec_basename = normalized_exec_basename(info.exec_line)
+        if exec_basename:
+            aliases.append(exec_basename)
     return list(dict.fromkeys(alias for alias in aliases if alias))
 
 
@@ -173,6 +221,9 @@ def desktop_info_from_file(*, desktop_id: str, path: Path) -> DesktopInfo | None
 
     exec_line = desktop_entry_string(key_file, "Exec")
     wm_class = desktop_entry_string(key_file, "StartupWMClass")
+    wine_aliases = wine_executable_aliases(exec_line)
+    if wine_aliases and (not wm_class or wm_class == "Wine"):
+        wm_class = wine_aliases[0]
     if not wm_class:
         exec_basename = normalized_exec_basename(exec_line)
         wm_class = exec_basename or desktop_id.removesuffix(DESKTOP_SUFFIX)
@@ -206,9 +257,12 @@ def desktop_info_from_app_info(
 def wm_class_for_app_info(*, app_info: Gio.DesktopAppInfo, desktop_id: str) -> str:
     """Return explicit StartupWMClass or the existing executable fallback."""
     wm_class = app_info.get_startup_wm_class() or ""
-    if wm_class:
-        return wm_class
     commandline = app_info.get_commandline() or ""
+    wine_aliases = wine_executable_aliases(commandline)
+    if wm_class and wm_class != "Wine":
+        return wm_class
+    if wine_aliases:
+        return wine_aliases[0]
     exe = commandline.split()[0] if commandline else ""
     return Path(exe).name if exe else desktop_id.removesuffix(DESKTOP_SUFFIX)
 

--- a/tests/platform/test_app_matcher.py
+++ b/tests/platform/test_app_matcher.py
@@ -21,8 +21,6 @@ from docking.platform.app_matcher import (
 )
 from docking.platform.launcher import GNOME_APP_PREFIX
 
-# -- Test fixtures ------------------------------------------------------------
-
 
 def _launcher(*, resolve_by_wm_class=None, resolve=None):
     """Build a fake Launcher with the given resolve behaviours."""
@@ -55,9 +53,6 @@ class _FakeDesktopInfo:
 
 def _item(desktop_id: str, wm_class: str = "") -> SimpleNamespace:
     return SimpleNamespace(desktop_id=desktop_id, wm_class=wm_class)
-
-
-# -- Helpers ------------------------------------------------------------------
 
 
 class TestNormalizeAlias:
@@ -180,9 +175,6 @@ class TestClassGroupCandidates:
         assert len(result) == len(set(result))
 
 
-# -- Visible aliases ----------------------------------------------------------
-
-
 class TestVisibleAliases:
     def test_direct_wm_class_hit(self):
         launcher = _launcher()
@@ -222,9 +214,6 @@ class TestVisibleAliases:
         matcher.sync_visible_items([_item("chrome.desktop", wm_class="Chrome")])
         assert matcher.match("Firefox") is None
         assert matcher.match("Chrome") == "chrome.desktop"
-
-
-# -- Wine matching ------------------------------------------------------------
 
 
 class TestWineMatching:
@@ -311,9 +300,6 @@ class TestWineMatching:
         )
 
 
-# -- Candidate generation and resolution --------------------------------------
-
-
 class TestCandidateResolution:
     def test_space_to_hyphen_candidate_matches(self):
         launcher = _launcher(
@@ -385,9 +371,6 @@ class TestCandidateResolution:
         assert matcher.match("CompletelyUnknownApp_xyz") is None
 
 
-# -- Caching behaviour --------------------------------------------------------
-
-
 class TestCaching:
     def test_missed_candidate_skips_second_gio_call(self):
         launcher = _launcher()
@@ -442,9 +425,6 @@ class TestCaching:
         assert matcher.match("DemoApp") == "demo.desktop"
 
 
-# -- Edge cases ---------------------------------------------------------------
-
-
 class TestEdgeCases:
     def test_empty_app_id_returns_none(self):
         launcher = _launcher()
@@ -467,9 +447,6 @@ class TestEdgeCases:
         matcher.sync_visible_items([])
 
         assert matcher.match("   ") is None
-
-
-# -- Backend integration scenarios --------------------------------------------
 
 
 class TestBackendIntegration:

--- a/tests/platform/test_app_matcher.py
+++ b/tests/platform/test_app_matcher.py
@@ -1,6 +1,6 @@
 """Tests for the shared AppIdMatcher.
 
-Covers Wine matching, candidate generation, caching, visible aliases,
+Covers Wine matching, candidate generation, missed-lookups, visible aliases,
 instance-hint matching, and backend-integration scenarios that were
 previously split across X11 and Wayland test files.
 """
@@ -59,6 +59,9 @@ class TestNormalizeAlias:
     def test_strips_desktop_suffix_and_lowercases(self):
         assert _normalize_alias("Firefox.desktop") == "firefox"
 
+    def test_strips_mixed_case_desktop_suffix(self):
+        assert _normalize_alias("Firefox.Desktop") == "firefox"
+
     def test_handles_already_clean_input(self):
         assert _normalize_alias("Firefox") == "firefox"
 
@@ -72,6 +75,9 @@ class TestEnsureDesktopSuffix:
 
     def test_keeps_existing_suffix(self):
         assert _ensure_desktop_suffix("firefox.desktop") == "firefox.desktop"
+
+    def test_keeps_mixed_case_existing_suffix(self):
+        assert _ensure_desktop_suffix("Firefox.Desktop") == "Firefox.Desktop"
 
     def test_strips_whitespace(self):
         assert _ensure_desktop_suffix("  firefox  ") == "firefox.desktop"
@@ -147,7 +153,7 @@ class TestAppIdCandidates:
         assert "someapp" in candidates  # lower, .exe stripped
         assert "SomeApp.exe" in candidates  # original
         assert "someapp.exe" in candidates  # lower
-        assert "exe" in candidates  # dot-split: "exe" from SomeApp.exe
+        assert "exe" not in candidates  # avoid matching a generic exe.desktop
 
 
 class TestClassGroupCandidates:
@@ -353,6 +359,76 @@ class TestCandidateResolution:
 
         assert matcher.match("org.gnome.Nautilus") == "Nautilus.desktop"
 
+    def test_raw_desktop_id_is_preferred_before_lowercase_variant(self):
+        launcher = _launcher(
+            resolve=lambda desktop_id, **_: (
+                _FakeDesktopInfo(desktop_id=desktop_id)
+                if desktop_id
+                in {
+                    "org.gnome.Nautilus.desktop",
+                    "org.gnome.nautilus.desktop",
+                }
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert matcher.match("org.gnome.Nautilus") == "org.gnome.Nautilus.desktop"
+
+    def test_x11_order_prefers_lowercase_before_raw_class_group(self):
+        launcher = _launcher(
+            resolve=lambda desktop_id, **_: (
+                _FakeDesktopInfo(desktop_id=desktop_id)
+                if desktop_id in {"Terminal.desktop", "terminal.desktop"}
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert matcher.match("Terminal", prefer_raw_app_id=False) == "terminal.desktop"
+
+    def test_x11_order_defers_wm_class_until_after_direct_candidates(self):
+        launcher = _launcher(
+            resolve=lambda desktop_id, **_: (
+                _FakeDesktopInfo(desktop_id=desktop_id)
+                if desktop_id == "org.gnome.Terminal.desktop"
+                else None
+            ),
+            resolve_by_wm_class=lambda wm_class: (
+                _FakeDesktopInfo(desktop_id="terminal-wm-class.desktop")
+                if wm_class == "terminal"
+                else None
+            ),
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert (
+            matcher.match(
+                "Terminal",
+                prefer_raw_app_id=False,
+                defer_wm_class_lookup=True,
+            )
+            == "org.gnome.Terminal.desktop"
+        )
+
+    def test_exe_candidate_does_not_resolve_generic_exe_desktop_first(self):
+        launcher = _launcher(
+            resolve=lambda desktop_id, **_: (
+                _FakeDesktopInfo(desktop_id=desktop_id)
+                if desktop_id in {"exe.desktop", "notepad.desktop"}
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert matcher.match("notepad.exe") == "notepad.desktop"
+        resolved_ids = [call.args[0] for call in launcher.resolve.call_args_list]
+        assert "exe.desktop" not in resolved_ids
+
     def test_candidate_order_is_stable(self):
         launcher = _launcher()
         matcher = AppIdMatcher(launcher=launcher)
@@ -371,10 +447,10 @@ class TestCandidateResolution:
         assert matcher.match("CompletelyUnknownApp_xyz") is None
 
 
-class TestCaching:
-    def test_missed_candidate_skips_second_gio_call(self):
+class TestMissedCandidates:
+    def test_x11_style_missed_candidate_skips_second_gio_call(self):
         launcher = _launcher()
-        matcher = AppIdMatcher(launcher=launcher)
+        matcher = AppIdMatcher(launcher=launcher, cache_missed_desktop_ids=True)
         matcher.sync_visible_items([])
 
         # First call — launcher.resolve returns None, candidate is memoized
@@ -392,20 +468,26 @@ class TestCaching:
         # loop hits "nosuchapp.desktop" again and skips it.
         assert launcher.resolve.call_count == first_call_count
 
-    def test_clear_missed_cache_allows_retry(self):
-        launcher = _launcher()
+    def test_wayland_style_misses_are_retried(self):
+        ready = False
+
+        def resolve(desktop_id, **_):
+            if ready and desktop_id == "FutureApp.desktop":
+                return _FakeDesktopInfo(desktop_id=desktop_id)
+            return None
+
+        launcher = _launcher(resolve=resolve)
         matcher = AppIdMatcher(launcher=launcher)
         matcher.sync_visible_items([])
 
-        matcher.match("FutureApp")
+        assert matcher.match("FutureApp") is None
         first_count = launcher.resolve.call_count
 
-        # Clear cache and retry — should call resolve again
-        matcher.clear_missed_cache()
-        matcher.match("FutureApp")
+        ready = True
+        assert matcher.match("FutureApp") == "FutureApp.desktop"
         assert launcher.resolve.call_count > first_count
 
-    def test_successful_match_is_cached(self):
+    def test_successful_wm_class_match_uses_launcher_index(self):
         launcher = _launcher(
             resolve_by_wm_class=lambda wm_class: (
                 _FakeDesktopInfo(desktop_id="demo.desktop")
@@ -416,12 +498,6 @@ class TestCaching:
         matcher = AppIdMatcher(launcher=launcher)
         matcher.sync_visible_items([])
 
-        # First match — populates _result_cache via step 4c
-        assert matcher.match("DemoApp") == "demo.desktop"
-
-        # Second match — the result cache lookup at step 4a or 4b/4c
-        # should find it (cached under app_id_lower).
-        launcher.resolve.reset_mock()
         assert matcher.match("DemoApp") == "demo.desktop"
 
 

--- a/tests/platform/test_app_matcher.py
+++ b/tests/platform/test_app_matcher.py
@@ -1,0 +1,530 @@
+"""Tests for the shared AppIdMatcher.
+
+Covers Wine matching, candidate generation, caching, visible aliases,
+instance-hint matching, and backend-integration scenarios that were
+previously split across X11 and Wayland test files.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from docking.platform.app_matcher import (
+    AppIdMatcher,
+    _app_id_candidates,
+    _class_group_candidates,
+    _ensure_desktop_suffix,
+    _normalize_alias,
+    _wine_aliases_from_instance,
+)
+from docking.platform.launcher import GNOME_APP_PREFIX
+
+# -- Test fixtures ------------------------------------------------------------
+
+
+def _launcher(*, resolve_by_wm_class=None, resolve=None):
+    """Build a fake Launcher with the given resolve behaviours."""
+    launcher = MagicMock()
+    if resolve_by_wm_class is not None:
+        launcher.resolve_by_wm_class.side_effect = (
+            resolve_by_wm_class
+            if callable(resolve_by_wm_class)
+            else lambda _wm_class: resolve_by_wm_class
+        )
+    else:
+        launcher.resolve_by_wm_class.return_value = None
+    if resolve is not None:
+        launcher.resolve.side_effect = (
+            resolve if callable(resolve) else lambda _desktop_id, **_: resolve
+        )
+    else:
+        launcher.resolve.return_value = None
+    return launcher
+
+
+@dataclass
+class _FakeDesktopInfo:
+    desktop_id: str
+    name: str = "Test App"
+    icon_name: str = "test-icon"
+    wm_class: str = ""
+    exec_line: str = ""
+
+
+def _item(desktop_id: str, wm_class: str = "") -> SimpleNamespace:
+    return SimpleNamespace(desktop_id=desktop_id, wm_class=wm_class)
+
+
+# -- Helpers ------------------------------------------------------------------
+
+
+class TestNormalizeAlias:
+    def test_strips_desktop_suffix_and_lowercases(self):
+        assert _normalize_alias("Firefox.desktop") == "firefox"
+
+    def test_handles_already_clean_input(self):
+        assert _normalize_alias("Firefox") == "firefox"
+
+    def test_strips_whitespace(self):
+        assert _normalize_alias("  firefox.desktop  ") == "firefox"
+
+
+class TestEnsureDesktopSuffix:
+    def test_adds_suffix_when_missing(self):
+        assert _ensure_desktop_suffix("firefox") == "firefox.desktop"
+
+    def test_keeps_existing_suffix(self):
+        assert _ensure_desktop_suffix("firefox.desktop") == "firefox.desktop"
+
+    def test_strips_whitespace(self):
+        assert _ensure_desktop_suffix("  firefox  ") == "firefox.desktop"
+
+
+class TestWineAliasesFromInstance:
+    def test_extracts_basename_from_windows_path(self):
+        aliases = _wine_aliases_from_instance("C:\\Program Files\\App\\Tool.exe")
+        assert aliases == ["tool.exe", "tool", "c:\\program files\\app\\tool.exe"]
+
+    def test_extracts_basename_from_unix_wine_path(self):
+        aliases = _wine_aliases_from_instance("/home/user/Games/App/game.exe")
+        assert aliases == ["game.exe", "game", "/home/user/games/app/game.exe"]
+
+    def test_handles_simple_exe_name(self):
+        aliases = _wine_aliases_from_instance("notepad.exe")
+        assert aliases == ["notepad.exe", "notepad"]
+
+    def test_non_exe_is_kept_as_is(self):
+        aliases = _wine_aliases_from_instance("someapp")
+        assert aliases == ["someapp"]
+
+    def test_deduplicates(self):
+        aliases = _wine_aliases_from_instance("tool.exe")  # basename == raw
+        # "tool.exe" (basename), "tool" (without .exe), "tool.exe" (raw == basename)
+        # After dedup: ["tool.exe", "tool"]
+        assert aliases == ["tool.exe", "tool"]
+
+
+class TestAppIdCandidates:
+    def test_raw_and_lower_and_desktop_stripped(self):
+        candidates = _app_id_candidates("Firefox")
+        assert "Firefox" in candidates
+        assert "firefox" in candidates
+
+    def test_dot_suffix_extracts_last_segment(self):
+        candidates = _app_id_candidates("org.gnome.Nautilus")
+        assert "Nautilus" in candidates
+
+    def test_snap_underscore_expands_prefixes(self):
+        candidates = _app_id_candidates("firefox_firefox")
+        assert "firefox" in candidates
+        assert "firefox.desktop" in candidates
+        assert "firefox_firefox" in candidates
+
+    def test_snap_underscore_with_desktop_suffix(self):
+        candidates = _app_id_candidates("firefox_firefox.desktop")
+        assert "firefox" in candidates
+        assert "firefox.desktop" in candidates
+
+    def test_empty_input_returns_empty(self):
+        assert _app_id_candidates("") == []
+
+    def test_deduplicates(self):
+        candidates = _app_id_candidates("app.app")
+        assert len(candidates) == len(set(candidates))
+
+    def test_multi_segment_snap(self):
+        candidates = _app_id_candidates("app_plugin_feature")
+        assert "app" in candidates
+        assert "app_plugin" in candidates
+        assert "app_plugin_feature" in candidates
+
+    def test_exe_suffix_stripped(self):
+        candidates = _app_id_candidates("notepad.exe")
+        assert "notepad" in candidates  # stripped .exe
+        assert "notepad.exe" in candidates  # original
+
+    def test_exe_in_non_wine_context(self):
+        """For a Wayland compositor reporting class='someapp.exe' directly."""
+        candidates = _app_id_candidates("SomeApp.exe")
+        assert "SomeApp" in candidates  # original case, .exe stripped
+        assert "someapp" in candidates  # lower, .exe stripped
+        assert "SomeApp.exe" in candidates  # original
+        assert "someapp.exe" in candidates  # lower
+        assert "exe" in candidates  # dot-split: "exe" from SomeApp.exe
+
+
+class TestClassGroupCandidates:
+    def test_no_spaces(self):
+        assert _class_group_candidates(
+            class_lower="firefox",
+            class_group="Firefox",
+        ) == ["firefox", f"{GNOME_APP_PREFIX}Firefox"]
+
+    def test_spaces_to_hyphens_and_joined(self):
+        result = _class_group_candidates(
+            class_lower="mongodb compass",
+            class_group="MongoDB Compass",
+        )
+        assert "mongodb compass" in result
+        assert "mongodb-compass" in result
+        assert "mongodbcompass" in result
+        assert f"{GNOME_APP_PREFIX}MongoDB Compass" in result
+
+    def test_no_duplicates(self):
+        result = _class_group_candidates(
+            class_lower="simple",
+            class_group="simple",
+        )
+        assert len(result) == len(set(result))
+
+
+# -- Visible aliases ----------------------------------------------------------
+
+
+class TestVisibleAliases:
+    def test_direct_wm_class_hit(self):
+        launcher = _launcher()
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([_item("firefox.desktop", wm_class="Firefox")])
+
+        # wm_class "Firefox" → normalized "firefox"
+        assert matcher.match("Firefox") == "firefox.desktop"
+        launcher.resolve.assert_not_called()
+
+    def test_desktop_id_sans_suffix_hit(self):
+        launcher = _launcher()
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([_item("org.gnome.Nautilus.desktop", wm_class="")])
+
+        # desktop_id sans suffix "org.gnome.Nautilus" → normalized
+        assert matcher.match("org.gnome.Nautilus") == ("org.gnome.Nautilus.desktop")
+        launcher.resolve.assert_not_called()
+
+    def test_instance_hint_matches_visible_alias(self):
+        launcher = _launcher()
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([_item("firefox.desktop", wm_class="Firefox-Bin")])
+
+        # instance_hint "Firefox-Bin" → normalized "firefox-bin" should match
+        assert (
+            matcher.match("Unknown", instance_hint="Firefox-Bin") == "firefox.desktop"
+        )
+
+    def test_sync_visible_items_rebuilds_cache(self):
+        launcher = _launcher()
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([_item("firefox.desktop", wm_class="Firefox")])
+        assert matcher.match("Firefox") == "firefox.desktop"
+
+        # Rebuild with different items
+        matcher.sync_visible_items([_item("chrome.desktop", wm_class="Chrome")])
+        assert matcher.match("Firefox") is None
+        assert matcher.match("Chrome") == "chrome.desktop"
+
+
+# -- Wine matching ------------------------------------------------------------
+
+
+class TestWineMatching:
+    def test_wine_class_group_with_exe_instance_matches_via_resolve_by_wm_class(
+        self,
+    ):
+        launcher = _launcher(
+            resolve_by_wm_class=lambda wm_class: (
+                _FakeDesktopInfo(desktop_id="wine-program.desktop")
+                if wm_class in ("tool.exe", "tool")
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert (
+            matcher.match("Wine", instance_hint="C:\\App\\Tool.exe")
+            == "wine-program.desktop"
+        )
+
+    def test_wine_class_group_with_exe_instance_matches_via_visible_aliases(
+        self,
+    ):
+        launcher = _launcher()
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items(
+            [_item("wine-notepad.desktop", wm_class="notepad.exe")]
+        )
+
+        assert (
+            matcher.match("Wine", instance_hint="C:\\Windows\\notepad.exe")
+            == "wine-notepad.desktop"
+        )
+        launcher.resolve.assert_not_called()
+
+    def test_wine_class_group_without_exe_instance_falls_through(self):
+        launcher = _launcher(
+            resolve_by_wm_class=lambda wm_class: (
+                _FakeDesktopInfo(desktop_id="wine.desktop")
+                if wm_class == "wine"
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([_item("wine.desktop", wm_class="Wine")])
+
+        # No instance_hint → no Wine special-casing → falls through to
+        # visible aliases, where wm_class "Wine" → "wine" matches.
+        assert matcher.match("Wine") == "wine.desktop"
+
+    def test_non_wine_class_group_skips_wine_path(self):
+        launcher = _launcher(
+            resolve_by_wm_class=lambda wm_class: (
+                _FakeDesktopInfo(desktop_id="steam.desktop")
+                if wm_class == "steam"
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        # class_group is not "wine", so Wine path is skipped.
+        # Falls through to candidates → resolve_by_wm_class.
+        assert matcher.match("Steam", instance_hint="steam.exe") == "steam.desktop"
+
+    def test_wine_class_group_with_non_exe_instance_falls_through(self):
+        launcher = _launcher(
+            resolve_by_wm_class=lambda wm_class: (
+                _FakeDesktopInfo(desktop_id="some-wine-app.desktop")
+                if wm_class == "some-wine-app"
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items(
+            [_item("some-wine-app.desktop", wm_class="some-wine-app")]
+        )
+
+        # instance doesn't end with .exe → Wine path skipped → falls through
+        assert (
+            matcher.match("wine", instance_hint="some-wine-app")
+            == "some-wine-app.desktop"
+        )
+
+
+# -- Candidate generation and resolution --------------------------------------
+
+
+class TestCandidateResolution:
+    def test_space_to_hyphen_candidate_matches(self):
+        launcher = _launcher(
+            resolve=lambda desktop_id, **_: (
+                _FakeDesktopInfo(desktop_id=desktop_id)
+                if desktop_id == "mongodb-compass.desktop"
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert matcher.match("MongoDB Compass") == "mongodb-compass.desktop"
+
+    def test_gnome_prefix_candidate_matches(self):
+        launcher = _launcher(
+            resolve=lambda desktop_id, **_: (
+                _FakeDesktopInfo(desktop_id=desktop_id)
+                if desktop_id == "org.gnome.Terminal.desktop"
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert matcher.match("Terminal") == "org.gnome.Terminal.desktop"
+
+    def test_snap_container_app_id_matches(self):
+        launcher = _launcher(
+            resolve_by_wm_class=lambda wm_class: (
+                _FakeDesktopInfo(desktop_id="firefox.desktop")
+                if wm_class == "firefox"
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert matcher.match("firefox_firefox.desktop") == "firefox.desktop"
+
+    def test_dot_suffix_candidate_matches(self):
+        launcher = _launcher(
+            resolve=lambda desktop_id, **_: (
+                _FakeDesktopInfo(desktop_id=desktop_id)
+                if desktop_id == "Nautilus.desktop"
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert matcher.match("org.gnome.Nautilus") == "Nautilus.desktop"
+
+    def test_candidate_order_is_stable(self):
+        launcher = _launcher()
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        # Run multiple times — order should be identical each time.
+        first_run = matcher.match("MongoDB Compass")
+        second_run = matcher.match("MongoDB Compass")
+        assert first_run == second_run
+
+    def test_all_candidates_exhausted_returns_none(self):
+        launcher = _launcher()
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert matcher.match("CompletelyUnknownApp_xyz") is None
+
+
+# -- Caching behaviour --------------------------------------------------------
+
+
+class TestCaching:
+    def test_missed_candidate_skips_second_gio_call(self):
+        launcher = _launcher()
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        # First call — launcher.resolve returns None, candidate is memoized
+        matcher.match("NoSuchApp")
+        first_call_count = launcher.resolve.call_count
+
+        # Second call with same app_id — missed candidates are skipped
+        matcher.match("NoSuchApp")
+        # resolve is still called for the same number because the raw
+        # candidate is tried each time (missed cache is per-desktop_id,
+        # not per-app_id input). But each specific desktop_id is only
+        # tried once per match() call and skipped on subsequent calls.
+        # The key insight: "nosuchapp.desktop" is added to missed set
+        # after the first match() call.  On the second match() call the
+        # loop hits "nosuchapp.desktop" again and skips it.
+        assert launcher.resolve.call_count == first_call_count
+
+    def test_clear_missed_cache_allows_retry(self):
+        launcher = _launcher()
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        matcher.match("FutureApp")
+        first_count = launcher.resolve.call_count
+
+        # Clear cache and retry — should call resolve again
+        matcher.clear_missed_cache()
+        matcher.match("FutureApp")
+        assert launcher.resolve.call_count > first_count
+
+    def test_successful_match_is_cached(self):
+        launcher = _launcher(
+            resolve_by_wm_class=lambda wm_class: (
+                _FakeDesktopInfo(desktop_id="demo.desktop")
+                if wm_class == "demoapp"
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        # First match — populates _result_cache via step 4c
+        assert matcher.match("DemoApp") == "demo.desktop"
+
+        # Second match — the result cache lookup at step 4a or 4b/4c
+        # should find it (cached under app_id_lower).
+        launcher.resolve.reset_mock()
+        assert matcher.match("DemoApp") == "demo.desktop"
+
+
+# -- Edge cases ---------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_app_id_returns_none(self):
+        launcher = _launcher()
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert matcher.match("") is None
+
+    def test_instance_hint_none_is_harmless(self):
+        launcher = _launcher()
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([_item("firefox.desktop", wm_class="Firefox")])
+
+        # instance_hint=None should not affect matching
+        assert matcher.match("Firefox", instance_hint=None) == "firefox.desktop"
+
+    def test_whitespace_app_id_returns_none(self):
+        launcher = _launcher()
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert matcher.match("   ") is None
+
+
+# -- Backend integration scenarios --------------------------------------------
+
+
+class TestBackendIntegration:
+    """Simulate how each backend calls AppIdMatcher."""
+
+    def test_x11_fake_window_flow(self):
+        """X11: class_group + class_instance passed to match()."""
+        launcher = _launcher(
+            resolve_by_wm_class=lambda wm_class: (
+                _FakeDesktopInfo(desktop_id="winbox.desktop")
+                if wm_class in ("tool.exe", "tool")
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert (
+            matcher.match(
+                "Wine",
+                instance_hint="C:\\Games\\WinBox\\tool.exe",
+            )
+            == "winbox.desktop"
+        )
+
+    def test_wayland_hyprland_flow(self):
+        """Hyprland: class field from JSON passed as app_id.
+
+        On Hyprland, ``class`` is typically the WM_CLASS instance name,
+        e.g. ``"notepad.exe"`` for a Wine app.  The matcher strips the
+        ``.exe`` suffix as a candidate so the launcher can resolve a
+        desktop entry whose ``StartupWMClass`` or alias is ``notepad``.
+        """
+        launcher = _launcher(
+            resolve=lambda desktop_id, **_: (
+                _FakeDesktopInfo(desktop_id=desktop_id)
+                if desktop_id == "notepad.desktop"
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert matcher.match("notepad.exe") == "notepad.desktop"
+
+    def test_wayland_wlr_flow(self):
+        """wlr-foreign-toplevel: app_id from compositor."""
+        launcher = _launcher(
+            resolve_by_wm_class=lambda wm_class: (
+                _FakeDesktopInfo(desktop_id="org.gnome.Nautilus.desktop")
+                if wm_class.lower() == "nautilus"
+                else None
+            )
+        )
+        matcher = AppIdMatcher(launcher=launcher)
+        matcher.sync_visible_items([])
+
+        assert matcher.match("org.gnome.Nautilus") == "org.gnome.Nautilus.desktop"

--- a/tests/platform/test_desktop_entries.py
+++ b/tests/platform/test_desktop_entries.py
@@ -59,6 +59,30 @@ class TestWineDesktopAliases:
             "tool",
         ]
 
+    def test_desktop_info_replaces_lowercase_generic_wine_startup_class(self, tmp_path):
+        desktop_file = tmp_path / "wine-program.desktop"
+        desktop_file.write_text(
+            "\n".join(
+                [
+                    "[Desktop Entry]",
+                    "Type=Application",
+                    "Name=Wine Program",
+                    'Exec=wine "C:\\\\App\\\\Tool.exe"',
+                    "StartupWMClass=wine",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        info = desktop_entries.desktop_info_from_file(
+            desktop_id="wine-program.desktop",
+            path=desktop_file,
+        )
+
+        assert info is not None
+        assert info.wm_class == "tool.exe"
+
 
 class TestGeneratedDesktopEntries:
     def test_appimage_path_creates_stable_desktop_id(self, tmp_path, monkeypatch):

--- a/tests/platform/test_desktop_entries.py
+++ b/tests/platform/test_desktop_entries.py
@@ -11,6 +11,55 @@ def _make_executable(path) -> None:
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
 
+class TestWineDesktopAliases:
+    def test_wine_executable_aliases_extract_windows_path(self):
+        aliases = desktop_entries.wine_executable_aliases(
+            'env WINEPREFIX="/home/user/.wine" wine '
+            '"C:\\Program Files\\Starcraft\\Starcraft.exe"'
+        )
+
+        assert aliases == ["starcraft.exe", "starcraft"]
+
+    def test_wine_executable_aliases_extract_unix_path(self):
+        aliases = desktop_entries.wine_executable_aliases(
+            'wine "/home/user/Games/App/app.exe" --flag'
+        )
+
+        assert aliases == ["app.exe", "app"]
+
+    def test_wine_executable_aliases_ignores_non_wine_exec(self):
+        assert desktop_entries.wine_executable_aliases("mono /tmp/tool.exe") == []
+
+    def test_desktop_info_replaces_generic_wine_startup_class(self, tmp_path):
+        desktop_file = tmp_path / "wine-program.desktop"
+        desktop_file.write_text(
+            "\n".join(
+                [
+                    "[Desktop Entry]",
+                    "Type=Application",
+                    "Name=Wine Program",
+                    'Exec=env WINEPREFIX="/home/user/.wine" wine "C:\\\\App\\\\Tool.exe"',
+                    "StartupWMClass=Wine",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        info = desktop_entries.desktop_info_from_file(
+            desktop_id="wine-program.desktop",
+            path=desktop_file,
+        )
+
+        assert info is not None
+        assert info.wm_class == "tool.exe"
+        assert desktop_entries.desktop_match_aliases(info) == [
+            "tool.exe",
+            "wine-program",
+            "tool",
+        ]
+
+
 class TestGeneratedDesktopEntries:
     def test_appimage_path_creates_stable_desktop_id(self, tmp_path, monkeypatch):
         appimage = tmp_path / "PrusaSlicer.AppImage"

--- a/tests/platform/test_wayland_foreign_toplevel.py
+++ b/tests/platform/test_wayland_foreign_toplevel.py
@@ -6,12 +6,12 @@ import struct
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from docking.platform.app_matcher import AppIdMatcher
 from docking.platform.backends.base import ActionResult, DisplayServer
 from docking.platform.backends.wayland.toplevels import (
     STATE_ACTIVATED,
     STATE_MAXIMIZED,
     STATE_MINIMIZED,
-    WaylandAppIdMatcher,
     WaylandForeignToplevelWindowService,
 )
 
@@ -59,7 +59,7 @@ def _protocol() -> SimpleNamespace:
 
 def test_wayland_app_id_matcher_prefers_visible_items():
     launcher = _launcher()
-    matcher = WaylandAppIdMatcher(launcher=launcher)
+    matcher = AppIdMatcher(launcher=launcher)
     matcher.sync_visible_items([_item("org.gnome.Nautilus.desktop")])
 
     assert matcher.match("org.gnome.Nautilus") == "org.gnome.Nautilus.desktop"
@@ -68,7 +68,7 @@ def test_wayland_app_id_matcher_prefers_visible_items():
 
 def test_wayland_app_id_matcher_falls_back_to_launcher_aliases():
     launcher = _launcher()
-    matcher = WaylandAppIdMatcher(launcher=launcher)
+    matcher = AppIdMatcher(launcher=launcher)
     matcher.sync_visible_items([])
 
     assert matcher.match("firefox") == "firefox.desktop"
@@ -77,7 +77,7 @@ def test_wayland_app_id_matcher_falls_back_to_launcher_aliases():
 
 def test_wayland_app_id_matcher_handles_snap_container_app_ids():
     launcher = _launcher()
-    matcher = WaylandAppIdMatcher(launcher=launcher)
+    matcher = AppIdMatcher(launcher=launcher)
     matcher.sync_visible_items([])
 
     assert matcher.match("firefox_firefox.desktop") == "firefox.desktop"

--- a/tests/platform/test_window_tracker.py
+++ b/tests/platform/test_window_tracker.py
@@ -15,47 +15,11 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for non-GI environmen
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
 import docking.platform.backends.x11.impl.window_tracker as tracker_mod
-from docking.platform.backends.x11.impl.window_tracker import WindowMatcher
 from docking.platform.launcher import DESKTOP_SUFFIX, GNOME_APP_PREFIX
 
 if _CREATED_GI_FALLBACK:
     sys.modules.pop("gi", None)
     sys.modules.pop("gi.repository", None)
-
-
-class TestWmClassCandidates:
-    """Desktop ID candidates from WM_CLASS with spaces."""
-
-    def test_no_spaces(self):
-        assert WindowMatcher._desktop_candidates(
-            class_lower="firefox",
-            class_group="Firefox",
-        ) == ["firefox", f"{GNOME_APP_PREFIX}Firefox"]
-
-    def test_spaces_to_hyphens_and_joined(self):
-        result = WindowMatcher._desktop_candidates(
-            class_lower="mongodb compass",
-            class_group="MongoDB Compass",
-        )
-        assert "mongodb compass" in result
-        assert "mongodb-compass" in result
-        assert "mongodbcompass" in result
-        assert f"{GNOME_APP_PREFIX}MongoDB Compass" in result
-
-    def test_multi_word(self):
-        result = WindowMatcher._desktop_candidates(
-            class_lower="aws vpn client",
-            class_group="AWS VPN Client",
-        )
-        assert "aws-vpn-client" in result
-        assert "awsvpnclient" in result
-
-    def test_no_duplicates(self):
-        result = WindowMatcher._desktop_candidates(
-            class_lower="simple",
-            class_group="simple",
-        )
-        assert len(result) == len(set(result))
 
 
 class TestDesktopConstants:

--- a/tests/platform/test_window_tracker_integration.py
+++ b/tests/platform/test_window_tracker_integration.py
@@ -145,10 +145,11 @@ class TestWindowTrackerInit:
         tracker, _model, _launcher = tracker_env
         # When
         # Then
-        assert tracker._matcher._wm_class_to_desktop == {
-            "firefox": "firefox.desktop",
-            "code": "code.desktop",
-        }
+        assert (
+            tracker._matcher._app_matcher._visible_aliases["firefox"]
+            == "firefox.desktop"
+        )
+        assert tracker._matcher._app_matcher._visible_aliases["code"] == "code.desktop"
 
     def test_init_screen_returns_false_when_screen_missing(
         self, tracker_env, monkeypatch
@@ -422,11 +423,41 @@ class TestWindowMatching:
     def test_match_uses_class_instance_map(self, tracker_env):
         # Given
         tracker, _model, _launcher = tracker_env
-        tracker._matcher._wm_class_to_desktop = {"firefox-bin": "firefox.desktop"}
+        tracker._matcher._app_matcher._visible_aliases = {
+            "firefox-bin": "firefox.desktop"
+        }
         win = FakeWindow(11, class_group="Unknown", class_instance="Firefox-Bin")
         # When
         # Then
         assert tracker._matcher.match(win) == "firefox.desktop"
+
+    def test_match_prefers_wine_exe_instance_over_generic_wine(self, tracker_env):
+        tracker, _model, launcher = tracker_env
+        launcher.resolve.side_effect = lambda desktop_id, **_kwargs: (
+            SimpleNamespace(desktop_id="wine.desktop")
+            if desktop_id == "wine.desktop"
+            else None
+        )
+        launcher.resolve_by_wm_class.side_effect = lambda wm_class: (
+            DesktopInfo(
+                desktop_id="wine-program.desktop",
+                name="Wine Program",
+                icon_name="wine-program",
+                wm_class="tool.exe",
+                exec_line='wine "C:\\App\\Tool.exe"',
+            )
+            if wm_class.lower() in {"tool.exe", "tool"}
+            else None
+        )
+        win = FakeWindow(17, class_group="Wine", class_instance="C:\\App\\Tool.exe")
+
+        assert tracker._matcher.match(win) == "wine-program.desktop"
+        launcher.resolve.assert_not_called()
+        assert (
+            tracker._matcher._app_matcher._result_cache["tool.exe"]
+            == "wine-program.desktop"
+        )
+        assert "wine" not in tracker._matcher._app_matcher._result_cache
 
     def test_match_uses_launcher_candidates_and_caches_result(self, tracker_env):
         # Given

--- a/tests/platform/test_window_tracker_integration.py
+++ b/tests/platform/test_window_tracker_integration.py
@@ -143,13 +143,12 @@ class TestWindowTrackerInit:
     def test_syncs_window_matcher_on_init(self, tracker_env):
         # Given
         tracker, _model, _launcher = tracker_env
+        firefox = FakeWindow(10, class_group="Firefox")
+        code = FakeWindow(11, class_group="Code")
         # When
         # Then
-        assert (
-            tracker._matcher._app_matcher._visible_aliases["firefox"]
-            == "firefox.desktop"
-        )
-        assert tracker._matcher._app_matcher._visible_aliases["code"] == "code.desktop"
+        assert tracker._matcher.match(firefox) == "firefox.desktop"
+        assert tracker._matcher.match(code) == "code.desktop"
 
     def test_init_screen_returns_false_when_screen_missing(
         self, tracker_env, monkeypatch
@@ -423,9 +422,9 @@ class TestWindowMatching:
     def test_match_uses_class_instance_map(self, tracker_env):
         # Given
         tracker, _model, _launcher = tracker_env
-        tracker._matcher._app_matcher._visible_aliases = {
-            "firefox-bin": "firefox.desktop"
-        }
+        tracker._matcher.sync_visible_items(
+            [DockItem(desktop_id="firefox.desktop", wm_class="Firefox-Bin")]
+        )
         win = FakeWindow(11, class_group="Unknown", class_instance="Firefox-Bin")
         # When
         # Then
@@ -453,13 +452,8 @@ class TestWindowMatching:
 
         assert tracker._matcher.match(win) == "wine-program.desktop"
         launcher.resolve.assert_not_called()
-        assert (
-            tracker._matcher._app_matcher._result_cache["tool.exe"]
-            == "wine-program.desktop"
-        )
-        assert "wine" not in tracker._matcher._app_matcher._result_cache
 
-    def test_match_uses_launcher_candidates_and_caches_result(self, tracker_env):
+    def test_match_uses_launcher_candidates(self, tracker_env):
         # Given
         tracker, _model, launcher = tracker_env
         info = SimpleNamespace(desktop_id="mongodb-compass.desktop")
@@ -483,6 +477,30 @@ class TestWindowMatching:
 
         # When
         # Then
+        assert tracker._matcher.match(win) == "org.gnome.Terminal.desktop"
+
+    def test_match_defers_reverse_wm_class_until_after_direct_candidates(
+        self, tracker_env
+    ):
+        tracker, _model, launcher = tracker_env
+        launcher.resolve.side_effect = lambda desktop_id, **_kwargs: (
+            SimpleNamespace(desktop_id="org.gnome.Terminal.desktop")
+            if desktop_id == "org.gnome.Terminal.desktop"
+            else None
+        )
+        launcher.resolve_by_wm_class.side_effect = lambda wm_class: (
+            DesktopInfo(
+                desktop_id="terminal-wm-class.desktop",
+                name="Terminal Alias",
+                icon_name="terminal",
+                wm_class="terminal",
+                exec_line="terminal",
+            )
+            if wm_class == "terminal"
+            else None
+        )
+        win = FakeWindow(18, class_group="Terminal")
+
         assert tracker._matcher.match(win) == "org.gnome.Terminal.desktop"
 
     def test_match_returns_none_for_empty_class_group(self, tracker_env):


### PR DESCRIPTION
## Problem

Window-to-desktop-ID matching was implemented twice — once in the X11 backend (`WindowMatcher`) and once in the Wayland backend (`WaylandAppIdMatcher`). Each had different feature sets:

| Feature | X11 | Wayland |
|---------|-----|---------|
| Wine `.exe` extraction | ✅ | ❌ |
| space→hyphen→joined candidates | ✅ | ❌ |
| GNOME prefix synthesis | ✅ | ❌ |
| Missed-candidate memoization | ✅ | ❌ |
| Result caching | ✅ | ❌ |
| Snap `_` prefix expansion | ❌ | ✅ |
| Dot-suffix split | ❌ | ✅ |
| Broad visible-item aliasing | ❌ | ✅ |

The recent Wine matching fix (extracting `.exe` names from `class_instance` when `class_group == wine`) only worked on X11. The six Wayland consumers (wlr-foreign-toplevel, Hyprland IPC, Wayfire IPC, Niri IPC, GNOME Shell Bridge, KWin/AT-SPI) all used `WaylandAppIdMatcher` and got none of the X11 matcher's capabilities.

## Solution

This PR extracts all matching heuristics into a single shared `AppIdMatcher` in `docking/platform/app_matcher.py` with a unified API:

```python
match(app_id: str, *, instance_hint: str | None = None) -> str | None
```

- **X11** calls it with both identity parts (`class_group` + `class_instance`), enabling Wine disambiguation when `class_group` is the generic `"wine"` string
- **Wayland** backends pass the compositor's single `app_id` string with `instance_hint=None`

## Additional improvements

- **`.exe` stripping for Wayland**: The candidate generator now strips `.exe` extensions from app_ids like `"notepad.exe"` → `"notepad"`, so Wine windows on compositors that expose the raw WM_CLASS instance (Hyprland/Sway) can match desktop entries indexed by the basename
- **All strategies unified**: space→hyphen, GNOME prefix, dot-suffix split, Snap `_` prefix, missed-candidate memoization, result caching — all apply to every backend now

## Changes

- **New**: `docking/platform/app_matcher.py` — shared `AppIdMatcher` class with merged strategies
- **Refactored**: X11 `WindowMatcher` → thin Wnck wrapper delegating to `AppIdMatcher`
- **Removed**: `WaylandAppIdMatcher` class (all 6 consumers now import `AppIdMatcher` directly)
- **Updated**: All 6 Wayland consumers, Wayland `__init__.py` exports
