### PR TITLE
Allow Ctrl right-click to open the dock menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cair
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Running](#running)
+- [First Use](#first-use)
 - [Configuration](#configuration)
 - [Managing Dock Items](#managing-dock-items)
 - [Applets](#applets)
@@ -257,6 +258,31 @@ DOCKING_BACKEND=wayland-layer-shell docking   # wlroots compositors
 DOCKING_BACKEND=reduced docking               # any Wayland (no WM integration)
 DOCKING_BACKEND=x11 docking                   # X11 (full support)
 ```
+
+## First Use
+
+Start by opening the dock menu: right-click the shelf background between icons.
+If the dock is full or the background is hard to hit, hold **Ctrl** while
+right-clicking anywhere on the shelf to show the same dock menu.
+
+The first things to explore are:
+
+- **Preferences**: open right-click -> **Preferences** to choose position,
+  monitor behavior, icon size, zoom, hiding, click actions, themes, tooltips,
+  previews, and update checks.
+- **Add Applet**: right-click the shelf background -> **Add Applet** to add
+  launchers, system status, media, productivity, and utility applets.
+- **Add Separator**: right-click the shelf background where the separator
+  should appear -> **Add Separator**.
+- **Pin and remove items**: right-click a running app -> **Keep in Dock**,
+  right-click a pinned item -> **Remove from Dock**, or drag an unlocked item
+  off the dock to remove it.
+- **Drag items in**: drop applications, `.desktop` files, files, folders, and
+  AppImages onto the dock to pin them.
+- **Folder stacks**: pin a folder and open it from the dock for quick access to
+  its contents.
+- **Diagnostics**: open right-click -> **Diagnostics** when checking backend
+  support or preparing a support report.
 
 ## Configuration
 

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -899,7 +899,12 @@ class DockWindow(Gtk.Window):
 
         if event.button == MOUSE_RIGHT:
             cursor_main = event.x if is_horizontal(pos=self.config.pos) else event.y
-            self._menu.show(event, cursor_main)
+            force_background = bool(event.state & Gdk.ModifierType.CONTROL_MASK)
+            self._menu.show(
+                event,
+                cursor_main,
+                force_background=force_background,
+            )
             return True
 
         if event.button in (MOUSE_LEFT, MOUSE_MIDDLE):

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -336,15 +336,23 @@ class MenuHandler:
         """Warm visible folder stacks so hover-open can render from cache."""
         self._folder_stack.schedule_visible_prewarm(items)
 
-    def show(self, event: Gdk.EventButton, cursor_main: float) -> None:
+    def show(
+        self,
+        event: Gdk.EventButton,
+        cursor_main: float,
+        *,
+        force_background: bool = False,
+    ) -> None:
         """Build and show the right-click context menu.
 
         Hit-tests the cursor to determine whether to show an item-specific
         menu (desktop actions, pin/unpin, close) or a dock background menu
-        (autohide, theme, position, applets, quit).
+        (autohide, theme, position, applets, quit). When *force_background*
+        is true, the background menu is shown even if the pointer is over an
+        item; this makes the global dock menu reachable from any shelf point.
         """
         frame = self._geometry_builder.build_frame(cursor_x=event.x, cursor_y=event.y)
-        item = frame.item_at_point(event.x, event.y)
+        item = None if force_background else frame.item_at_point(event.x, event.y)
         self._folder_stack.close()
 
         if item:

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -152,7 +152,33 @@ class TestButtonReleaseFlow:
         )
         # Then
         assert handled is True
-        stub._menu.show.assert_called_once_with(event, 12.0)
+        stub._menu.show.assert_called_once_with(
+            event,
+            12.0,
+            force_background=False,
+        )
+
+    def test_ctrl_right_click_opens_background_context_menu(self):
+        # Given
+        stub, _item = _make_stub()
+        event = SimpleNamespace(
+            x=12.0,
+            y=6.0,
+            button=dock_window_mod.MOUSE_RIGHT,
+            state=dock_window_mod.Gdk.ModifierType.CONTROL_MASK,
+        )
+
+        # When
+        handled = dock_window_mod.DockWindow._on_button_release(
+            stub, MagicMock(), event
+        )
+        # Then
+        assert handled is True
+        stub._menu.show.assert_called_once_with(
+            event,
+            12.0,
+            force_background=True,
+        )
 
     def test_left_click_on_applet_updates_tooltip_immediately(self, monkeypatch):
         # Given

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -1460,6 +1460,30 @@ class TestMenuCallbacks:
         assert built == [("item", item)]
         assert handler._runtime.menu_popup_opened.call_count == 1
 
+    def test_show_can_force_background_menu_over_item(self, handler, monkeypatch):
+        event = SimpleNamespace(x=20.0, y=9.0)
+        item = DockItem(desktop_id="firefox.desktop")
+        handler._geometry_builder = SimpleNamespace(
+            build_frame=lambda **_kwargs: _frame(item=item, insert_index=2)
+        )
+        built: list[tuple[str, object]] = []
+
+        monkeypatch.setattr(
+            handler,
+            "_build_item_menu",
+            lambda *, menu, item: built.append(("item", item)),
+        )
+        monkeypatch.setattr(
+            handler,
+            "_build_dock_menu",
+            lambda *, menu, insert_index: built.append(("dock", insert_index)),
+        )
+
+        handler.show(event=event, cursor_main=20.0, force_background=True)
+
+        assert built == [("dock", 2)]
+        assert handler._runtime.menu_popup_opened.call_count == 1
+
     def test_append_desktop_actions_triggers_launch_action(self, handler, monkeypatch):
         # Given
         menu = FakeMenu()


### PR DESCRIPTION
## Summary
- let Ctrl+right-click force the dock background menu from anywhere on the shelf
- keep normal right-click item menus unchanged
- add a README First Use section covering the dock menu, Preferences, applets, separators, pinning, folder stacks, and Diagnostics