### PR TITLE
Add custom dock item icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A lightweight, feature-rich dock for Linux written in Python with GTK 3 and Cair
 - 58 built-in applets for launching apps and commands, monitoring system state, controlling media, managing notes, files, folders, screenshots, power, networking, weather, and more.
 - Folder stacks and pinned files/folders, so directories and documents can live directly in the dock alongside applications.
 - Flexible dock layout with multi-position, multi-monitor, auto-hide, separators, and scalable sizing.
-- Deep customization through 13 built-in themes, transparency, icon sizing, menu behavior, and tooltip controls.
+- Deep customization through 13 built-in themes, transparency, icon sizing, per-item custom icons, menu behavior, and tooltip controls.
 - Broad release packaging: AppImage, Debian package, RPM, Flatpak, Snap, Arch package, and Nix output.
 - Desktop integration details such as Unity LauncherEntry badge/progress support, X11 background blur region export, and 74 locale catalogs plus English fallback.
 - Extensible Python applet system for adding custom dock-resident tools without changing the core runtime.
@@ -279,6 +279,9 @@ The first things to explore are:
   off the dock to remove it.
 - **Drag items in**: drop applications, `.desktop` files, files, folders, and
   AppImages onto the dock to pin them.
+- **Customize icons**: right-click a pinned app, file, or folder -> **Icon** ->
+  **Choose From File...** to use an image from disk, or reset it back to the
+  automatically detected icon.
 - **Folder stacks**: pin a folder and open it from the dock for quick access to
   its contents.
 - **Diagnostics**: open right-click -> **Diagnostics** when checking backend

--- a/docking/applets/applications/applet.py
+++ b/docking/applets/applications/applet.py
@@ -28,6 +28,7 @@ from docking.applets.applications import meta
 from docking.applets.applications.render import create_icon, make_menu_item_with_icon
 from docking.applets.applications.state import CATEGORY_ICONS, _build_app_categories
 from docking.applets.base import Applet
+from docking.core.icons import IconSource
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -48,7 +49,7 @@ class ApplicationsApplet(Applet):
     id = meta.id
     name = _("Applications")
     icon_name = "view-app-grid"
-    supports_system_icon = True
+    icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
         super().__init__(icon_size=icon_size, config=config)

--- a/docking/applets/base.py
+++ b/docking/applets/base.py
@@ -80,6 +80,7 @@ from gi.repository import GdkPixbuf, GLib, Gtk, Pango, PangoCairo
 
 from docking.applets.identity import applet_desktop_id
 from docking.applets.popup import PopupAnchor
+from docking.core.icons import ICON_SOURCE_PREF_KEY, IconSource, icon_source_from_value
 from docking.core.items import APPLET_KIND, DockItem
 from docking.log import get_logger
 
@@ -123,10 +124,9 @@ _BUNDLED_FALLBACK_ICON_PREFIXES = (
 
 CATALOG_ICON_DIR = "icons/applets"
 
-ICON_SOURCE_PREF_KEY = "icon_source"
-ICON_SOURCE_DOCKING = "docking"
-ICON_SOURCE_SYSTEM = "system"
-ICON_SOURCE_VALUES = frozenset({ICON_SOURCE_DOCKING, ICON_SOURCE_SYSTEM})
+ICON_SOURCE_DOCKING = IconSource.DOCKING.value
+ICON_SOURCE_SYSTEM = IconSource.SYSTEM.value
+ICON_SOURCE_VALUES = frozenset(source.value for source in IconSource)
 
 
 def _icon_name_candidates(name: str) -> tuple[str, ...]:
@@ -338,7 +338,7 @@ class Applet(ABC):
     id: str
     name: str
     icon_name: str
-    supports_system_icon = False
+    icon_source_options: tuple[IconSource, ...] = (IconSource.DOCKING,)
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
         self._config = config
@@ -396,28 +396,47 @@ class Applet(ABC):
         """Theme icon name used when the applet is set to System Icon."""
         return self.icon_name
 
+    def _declared_icon_source_options(self) -> tuple[IconSource, ...]:
+        declared = getattr(
+            type(self),
+            "icon_source_options",
+            Applet.icon_source_options,
+        )
+        if declared is not Applet.icon_source_options:
+            options: list[IconSource] = []
+            for source in declared:
+                parsed = icon_source_from_value(source)
+                if parsed is not None and parsed not in options:
+                    options.append(parsed)
+            return tuple(options) or (IconSource.DOCKING,)
+        return Applet.icon_source_options
+
+    def supports_icon_source(self, source: IconSource | str) -> bool:
+        """Whether this applet exposes the requested icon source."""
+        parsed = icon_source_from_value(source)
+        return parsed is not None and parsed in self._declared_icon_source_options()
+
     def icon_source(self) -> str:
         """Return the selected icon source, defaulting to the Docking icon."""
-        if not self.supports_system_icon:
-            return ICON_SOURCE_DOCKING
-        source = self.load_prefs().get(ICON_SOURCE_PREF_KEY)
-        if source == ICON_SOURCE_SYSTEM:
-            return ICON_SOURCE_SYSTEM
-        return ICON_SOURCE_DOCKING
+        source = icon_source_from_value(self.load_prefs().get(ICON_SOURCE_PREF_KEY))
+        if source is not None and self.supports_icon_source(source):
+            return source.value
+        return IconSource.DOCKING.value
 
     def uses_system_icon(self) -> bool:
         """Whether this applet currently requests a theme icon."""
-        return self.icon_source() == ICON_SOURCE_SYSTEM
+        return self.icon_source() == IconSource.SYSTEM.value
 
-    def set_icon_source(self, source: str) -> None:
+    def set_icon_source(self, source: IconSource | str) -> None:
         """Persist and present the selected icon source."""
-        if not self.supports_system_icon or source not in ICON_SOURCE_VALUES:
+        parsed = icon_source_from_value(source)
+        if parsed is None or not self.supports_icon_source(parsed):
             return
-        if source == self.icon_source():
+        if parsed.value == self.icon_source():
             return
 
         prefs = self.load_prefs()
-        prefs[ICON_SOURCE_PREF_KEY] = source
+        prefs[ICON_SOURCE_PREF_KEY] = parsed.value
         self.save_prefs(prefs)
         self.present()
 

--- a/docking/applets/calculator/applet.py
+++ b/docking/applets/calculator/applet.py
@@ -53,6 +53,7 @@ from docking.applets.calculator import meta
 from docking.applets.calculator.render import create_icon
 from docking.applets.calculator.state import evaluate, prefs_payload
 from docking.applets.popup import create_popup_window, show_wrapped_popup
+from docking.core.icons import IconSource
 from docking.i18n import _
 
 if TYPE_CHECKING:
@@ -76,7 +77,7 @@ class CalculatorApplet(Applet):
     id = meta.id
     name = _("Calculator")
     icon_name = "accessories-calculator"
-    supports_system_icon = True
+    icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
         self._popup: Gtk.Window | None = None

--- a/docking/applets/desktop/applet.py
+++ b/docking/applets/desktop/applet.py
@@ -25,6 +25,7 @@ from gi.repository import GdkPixbuf
 from docking.applets.base import Applet
 from docking.applets.desktop import meta
 from docking.applets.desktop.render import create_icon
+from docking.core.icons import IconSource
 from docking.i18n import _
 
 if TYPE_CHECKING:
@@ -39,7 +40,7 @@ class DesktopApplet(Applet):
     id = meta.id
     name = _("Desktop")
     icon_name = "user-desktop"
-    supports_system_icon = True
+    icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
         self._desktop_actions: DesktopActionService | None = None

--- a/docking/applets/runcommand/applet.py
+++ b/docking/applets/runcommand/applet.py
@@ -41,6 +41,7 @@ from docking.applets.runcommand.state import (
     prefs_payload,
     updated_history,
 )
+from docking.core.icons import IconSource
 from docking.i18n import _
 
 if TYPE_CHECKING:
@@ -61,7 +62,7 @@ class RunCommandApplet(Applet):
     id = meta.id
     name = _("Run Application")
     icon_name = "system-run"
-    supports_system_icon = True
+    icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
         prefs = config.applet_prefs.get(meta.id, {}) if config else {}

--- a/docking/applets/screenshot/applet.py
+++ b/docking/applets/screenshot/applet.py
@@ -28,6 +28,7 @@ from gi.repository import Gdk, GdkPixbuf, Gtk
 from docking.applets.base import Applet
 from docking.applets.menu import menu_sections
 from docking.applets.screenshot import meta
+from docking.core.icons import IconSource
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -52,7 +53,7 @@ class ScreenshotApplet(Applet):
     id = meta.id
     name = _("Screenshot")
     icon_name = "applets-screenshooter"
-    supports_system_icon = True
+    icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
         self._tool = _detect_tool()

--- a/docking/applets/session/applet.py
+++ b/docking/applets/session/applet.py
@@ -25,6 +25,7 @@ from gi.repository import Gtk
 from docking.applets.base import Applet
 from docking.applets.menu import menu_sections
 from docking.applets.session import meta
+from docking.core.icons import IconSource
 from docking.i18n import _
 
 from .render import create_session_icon
@@ -40,7 +41,7 @@ class SessionApplet(Applet):
     id = meta.id
     name = _("Session")
     icon_name = "system-log-out"
-    supports_system_icon = True
+    icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
         super().__init__(icon_size, config)

--- a/docking/applets/trash/applet.py
+++ b/docking/applets/trash/applet.py
@@ -29,6 +29,7 @@ from gi.repository import GdkPixbuf, Gio, GLib, Gtk
 from docking.applets.base import Applet
 from docking.applets.menu import menu_sections
 from docking.applets.trash import meta
+from docking.core.icons import IconSource
 from docking.i18n import _
 from docking.log import get_logger, with_context
 from docking.platform.environment import detect_desktop
@@ -48,7 +49,7 @@ class TrashApplet(Applet):
     id = meta.id
     name = _("Trash")
     icon_name = "user-trash"
-    supports_system_icon = True
+    icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
         self._desktop = detect_desktop()

--- a/docking/applets/usbwatch/applet.py
+++ b/docking/applets/usbwatch/applet.py
@@ -34,6 +34,7 @@ from docking.applets.usbwatch.state import (
     mounted_usb_devices,
     usbwatch_tooltip,
 )
+from docking.core.icons import IconSource
 from docking.i18n import _
 from docking.log import get_logger, with_context
 
@@ -49,7 +50,7 @@ class UsbWatchApplet(Applet):
     id = meta.id
     name = _("USB Watch")
     icon_name = "drive-removable-media-usb"
-    supports_system_icon = True
+    icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
         self._monitor = Gio.VolumeMonitor.get()

--- a/docking/core/icons.py
+++ b/docking/core/icons.py
@@ -1,0 +1,37 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Shared icon preference values."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class IconSource(str, Enum):
+    """Supported user-selectable icon sources."""
+
+    DOCKING = "docking"
+    SYSTEM = "system"
+    CUSTOM = "custom"
+
+
+ICON_SOURCE_PREF_KEY = "icon_source"
+CUSTOM_ICON_PATH_KEY = "custom_icon_path"
+
+
+def icon_source_from_value(value: object) -> IconSource | None:
+    """Parse a persisted icon source value."""
+    if isinstance(value, IconSource):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        return IconSource(value)
+    except ValueError:
+        return None

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-06-18 18:52+0200\n"
+"POT-Creation-Date: 2026-06-23 22:57+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -111,10 +111,11 @@ msgstr ""
 
 #: docking/applets/alarm/applet.py:163 docking/applets/clock/applet.py:218
 #: docking/applets/lastfm/applet.py:380 docking/applets/quicknote/applet.py:86
-#: docking/applets/runcommand/applet.py:121
-#: docking/applets/runcommand/applet.py:339
-#: docking/applets/sunrise/applet.py:188 docking/applets/trash/applet.py:127
+#: docking/applets/runcommand/applet.py:122
+#: docking/applets/runcommand/applet.py:340
+#: docking/applets/sunrise/applet.py:188 docking/applets/trash/applet.py:177
 #: docking/applets/weather/applet.py:271 docking/ui/diagnostics.py:342
+#: docking/ui/menu.py:484
 msgid "Cancel"
 msgstr ""
 
@@ -351,11 +352,11 @@ msgstr ""
 msgid "(c) {who}"
 msgstr ""
 
-#: docking/applets/applications/applet.py:49
+#: docking/applets/applications/applet.py:50
 msgid "Applications"
 msgstr ""
 
-#: docking/applets/applications/applet.py:90
+#: docking/applets/applications/applet.py:91
 msgid "Search applications..."
 msgstr ""
 
@@ -725,8 +726,8 @@ msgstr ""
 msgid "Active - {time} left"
 msgstr ""
 
-#: docking/applets/calculator/applet.py:77
-#: docking/applets/calculator/applet.py:95
+#: docking/applets/calculator/applet.py:78
+#: docking/applets/calculator/applet.py:96
 msgid "Calculator"
 msgstr ""
 
@@ -1194,7 +1195,7 @@ msgstr ""
 msgid "Week total at desk: {d}"
 msgstr ""
 
-#: docking/applets/desktop/applet.py:40
+#: docking/applets/desktop/applet.py:41
 #: docking/applets/workspaces/applet.py:101 docking/ui/diagnostics.py:147
 msgid "Desktop"
 msgstr ""
@@ -1233,7 +1234,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: docking/applets/docker/applet.py:146 docking/applets/session/state.py:43
+#: docking/applets/docker/applet.py:146 docking/applets/session/state.py:44
 msgid "Restart"
 msgstr ""
 
@@ -1976,56 +1977,57 @@ msgstr ""
 msgid "Clear Recent Files"
 msgstr ""
 
-#: docking/applets/runcommand/applet.py:62
-#: docking/applets/runcommand/applet.py:87
-#: docking/applets/runcommand/applet.py:117
-#: docking/applets/runcommand/applet.py:261
+#: docking/applets/runcommand/applet.py:63
+#: docking/applets/runcommand/applet.py:88
+#: docking/applets/runcommand/applet.py:118
+#: docking/applets/runcommand/applet.py:262
 msgid "Run Application"
 msgstr ""
 
-#: docking/applets/runcommand/applet.py:120
+#: docking/applets/runcommand/applet.py:121
 msgid "Help"
 msgstr ""
 
-#: docking/applets/runcommand/applet.py:122
+#: docking/applets/runcommand/applet.py:123
 msgid "Run"
 msgstr ""
 
-#: docking/applets/runcommand/applet.py:167
+#: docking/applets/runcommand/applet.py:168
 msgid "Run in terminal"
 msgstr ""
 
-#: docking/applets/runcommand/applet.py:169
+#: docking/applets/runcommand/applet.py:170
 msgid "Run with file..."
 msgstr ""
 
-#: docking/applets/runcommand/applet.py:174
+#: docking/applets/runcommand/applet.py:175
 msgid "Show list of known applications"
 msgstr ""
 
-#: docking/applets/runcommand/applet.py:180
-#: docking/applets/runcommand/applet.py:285
+#: docking/applets/runcommand/applet.py:181
+#: docking/applets/runcommand/applet.py:286
 msgid "Select an application to view its description."
 msgstr ""
 
-#: docking/applets/runcommand/applet.py:264
+#: docking/applets/runcommand/applet.py:265
 msgid "Type a command or select an application to launch it."
 msgstr ""
 
-#: docking/applets/runcommand/applet.py:335
+#: docking/applets/runcommand/applet.py:336
 msgid "Run with file"
 msgstr ""
 
-#: docking/applets/runcommand/applet.py:340
-#: docking/applets/systemtray/applet.py:254 docking/ui/menu.py:464
+#: docking/applets/runcommand/applet.py:341
+#: docking/applets/systemtray/applet.py:254 docking/ui/menu.py:486
+#: docking/ui/menu.py:571
 msgid "Open"
 msgstr ""
 
-#: docking/applets/screenshot/applet.py:53
+#: docking/applets/screenshot/applet.py:54
 msgid "Screenshot"
 msgstr ""
 
-#: docking/applets/screenshot/applet.py:90
+#: docking/applets/screenshot/applet.py:91
 #, python-brace-format
 msgid "Full Screen in {delay}s"
 msgstr ""
@@ -2058,23 +2060,23 @@ msgstr ""
 msgid "Invert Color"
 msgstr ""
 
-#: docking/applets/session/applet.py:41 docking/ui/diagnostics.py:148
+#: docking/applets/session/applet.py:42 docking/ui/diagnostics.py:148
 msgid "Session"
 msgstr ""
 
-#: docking/applets/session/applet.py:69 docking/applets/session/state.py:42
+#: docking/applets/session/applet.py:70 docking/applets/session/state.py:43
 msgid "Suspend"
 msgstr ""
 
-#: docking/applets/session/state.py:38
+#: docking/applets/session/state.py:39
 msgid "Lock Screen"
 msgstr ""
 
-#: docking/applets/session/state.py:41
+#: docking/applets/session/state.py:42
 msgid "Log Out"
 msgstr ""
 
-#: docking/applets/session/state.py:44
+#: docking/applets/session/state.py:45
 msgid "Shut Down"
 msgstr ""
 
@@ -2575,23 +2577,23 @@ msgstr ""
 msgid "{year} - {title}"
 msgstr ""
 
-#: docking/applets/trash/applet.py:49
+#: docking/applets/trash/applet.py:50
 msgid "Trash"
 msgstr ""
 
-#: docking/applets/trash/applet.py:78
+#: docking/applets/trash/applet.py:113
 msgid "Open Trash"
 msgstr ""
 
-#: docking/applets/trash/applet.py:81 docking/applets/trash/applet.py:128
+#: docking/applets/trash/applet.py:116 docking/applets/trash/applet.py:178
 msgid "Empty Trash"
 msgstr ""
 
-#: docking/applets/trash/applet.py:122
+#: docking/applets/trash/applet.py:172
 msgid "Empty all items from Trash?"
 msgstr ""
 
-#: docking/applets/trash/applet.py:125
+#: docking/applets/trash/applet.py:175
 msgid "All items in the Trash will be permanently deleted."
 msgstr ""
 
@@ -2687,16 +2689,16 @@ msgstr ""
 msgid "Copied!"
 msgstr ""
 
-#: docking/applets/usbwatch/applet.py:50 docking/applets/usbwatch/state.py:93
+#: docking/applets/usbwatch/applet.py:51 docking/applets/usbwatch/state.py:93
 #: docking/applets/usbwatch/state.py:100
 msgid "USB Watch"
 msgstr ""
 
-#: docking/applets/usbwatch/applet.py:74 docking/applets/usbwatch/state.py:94
+#: docking/applets/usbwatch/applet.py:75 docking/applets/usbwatch/state.py:94
 msgid "No mounted USB devices"
 msgstr ""
 
-#: docking/applets/usbwatch/applet.py:83
+#: docking/applets/usbwatch/applet.py:84
 #, python-brace-format
 msgid "Safely Remove {name}"
 msgstr ""
@@ -2780,7 +2782,7 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: docking/ui/diagnostics.py:71 docking/ui/menu.py:623
+#: docking/ui/diagnostics.py:71 docking/ui/menu.py:738
 msgid "Diagnostics"
 msgstr ""
 
@@ -2812,7 +2814,7 @@ msgstr ""
 msgid "Save Report..."
 msgstr ""
 
-#: docking/ui/diagnostics.py:122 docking/ui/menu.py:507
+#: docking/ui/diagnostics.py:122 docking/ui/menu.py:619
 msgid "Close"
 msgstr ""
 
@@ -2951,76 +2953,100 @@ msgstr ""
 msgid "%d More in Folder"
 msgstr ""
 
-#: docking/ui/menu.py:405
-msgid "Icon"
-msgstr ""
-
-#: docking/ui/menu.py:407
+#: docking/ui/menu.py:431
 msgid "Docking Icon"
 msgstr ""
 
-#: docking/ui/menu.py:408
+#: docking/ui/menu.py:432
 msgid "System Icon"
 msgstr ""
 
-#: docking/ui/menu.py:451 docking/ui/menu.py:471 docking/ui/menu.py:491
-#: docking/ui/menu.py:539
+#: docking/ui/menu.py:440 docking/ui/menu.py:449
+msgid "Icon"
+msgstr ""
+
+#: docking/ui/menu.py:452
+msgid "Default Icon"
+msgstr ""
+
+#: docking/ui/menu.py:456
+msgid "Choose From File..."
+msgstr ""
+
+#: docking/ui/menu.py:460
+msgid "Reset Custom Icon"
+msgstr ""
+
+#: docking/ui/menu.py:479
+msgid "Choose Icon"
+msgstr ""
+
+#: docking/ui/menu.py:502
+msgid "Images"
+msgstr ""
+
+#: docking/ui/menu.py:515
+msgid "Could not use selected icon"
+msgstr ""
+
+#: docking/ui/menu.py:558 docking/ui/menu.py:580 docking/ui/menu.py:603
+#: docking/ui/menu.py:654
 msgid "Remove from Dock"
 msgstr ""
 
-#: docking/ui/menu.py:498
+#: docking/ui/menu.py:610
 msgid "Keep in Dock"
 msgstr ""
 
-#: docking/ui/menu.py:507
+#: docking/ui/menu.py:619
 msgid "Close All"
 msgstr ""
 
-#: docking/ui/menu.py:524
+#: docking/ui/menu.py:636
 msgid "Sort By"
 msgstr ""
 
-#: docking/ui/menu.py:532
+#: docking/ui/menu.py:644
 msgid "Show Hidden Files"
 msgstr ""
 
-#: docking/ui/menu.py:569
+#: docking/ui/menu.py:684
 msgid "Add Applet"
 msgstr ""
 
-#: docking/ui/menu.py:607
+#: docking/ui/menu.py:722
 msgid "No Applets Available"
 msgstr ""
 
-#: docking/ui/menu.py:614
+#: docking/ui/menu.py:729
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:628 docking/ui/settings.py:204
+#: docking/ui/menu.py:743 docking/ui/settings.py:204
 msgid "Preferences"
 msgstr ""
 
-#: docking/ui/menu.py:633
+#: docking/ui/menu.py:748
 msgid "About"
 msgstr ""
 
-#: docking/ui/menu.py:638
+#: docking/ui/menu.py:753
 msgid "Get Support"
 msgstr ""
 
-#: docking/ui/menu.py:645
+#: docking/ui/menu.py:760
 msgid "Quit"
 msgstr ""
 
-#: docking/ui/menu.py:711
+#: docking/ui/menu.py:826
 msgid "Clear Recent Documents"
 msgstr ""
 
-#: docking/ui/menu.py:720 docking/ui/settings.py:673
+#: docking/ui/menu.py:836 docking/ui/settings.py:673
 msgid "Recent Documents"
 msgstr ""
 
-#: docking/ui/menu.py:739
+#: docking/ui/menu.py:855
 msgid "Window"
 msgstr ""
 

--- a/docking/platform/icon_overrides.py
+++ b/docking/platform/icon_overrides.py
@@ -1,0 +1,72 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+"""Preference helpers for per-item custom dock icons."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from docking.core.icons import (
+    CUSTOM_ICON_PATH_KEY,
+    ICON_SOURCE_PREF_KEY,
+    IconSource,
+    icon_source_from_value,
+)
+
+if TYPE_CHECKING:
+    from docking.core.config import Config
+    from docking.core.items import DockItem
+
+
+def item_icon_key(item: DockItem) -> str:
+    """Return the stable preference key for an item's icon override."""
+    return item.prefs_key or item.target or item.desktop_id
+
+
+def item_icon_prefs(config: Config, item: DockItem) -> dict[str, Any]:
+    """Return a mutable copy of an item's icon preference map."""
+    key = item_icon_key(item=item)
+    stored = config.item_prefs.get(key, {})
+    return dict(stored) if isinstance(stored, dict) else {}
+
+
+def custom_icon_path(config: Config, item: DockItem) -> Path | None:
+    """Return a configured custom icon path for an item, if active."""
+    prefs = item_icon_prefs(config=config, item=item)
+    if icon_source_from_value(prefs.get(ICON_SOURCE_PREF_KEY)) is not IconSource.CUSTOM:
+        return None
+    raw_path = prefs.get(CUSTOM_ICON_PATH_KEY)
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    path = Path(raw_path).expanduser()
+    if not path.is_absolute():
+        return None
+    return path
+
+
+def set_custom_icon(config: Config, item: DockItem, path: Path) -> None:
+    """Persist a custom icon path for an item."""
+    key = item_icon_key(item=item)
+    prefs = item_icon_prefs(config=config, item=item)
+    prefs[ICON_SOURCE_PREF_KEY] = IconSource.CUSTOM.value
+    prefs[CUSTOM_ICON_PATH_KEY] = str(path)
+    config.item_prefs[key] = prefs
+
+
+def reset_custom_icon(config: Config, item: DockItem) -> None:
+    """Clear a custom icon path for an item, preserving unrelated preferences."""
+    key = item_icon_key(item=item)
+    prefs = item_icon_prefs(config=config, item=item)
+    prefs.pop(ICON_SOURCE_PREF_KEY, None)
+    prefs.pop(CUSTOM_ICON_PATH_KEY, None)
+    if prefs:
+        config.item_prefs[key] = prefs
+    else:
+        config.item_prefs.pop(key, None)

--- a/docking/platform/launcher.py
+++ b/docking/platform/launcher.py
@@ -189,6 +189,11 @@ class FileTargetInfo(NamedTuple):
     is_dir: bool
 
 
+def fallback_file_icon_name(*, is_dir: bool) -> str:
+    """Return the theme icon name for file targets without richer metadata."""
+    return "folder" if is_dir else "text-x-generic"
+
+
 def _host_icon_file_candidates(icon_name: str) -> list[Path]:
     icon_path = Path(icon_name)
     if not icon_path.is_absolute():
@@ -350,6 +355,19 @@ class Launcher:
         self._icon_cache[key] = pixbuf
         return pixbuf
 
+    def load_icon_file(self, path: Path, size: int) -> GdkPixbuf.Pixbuf | None:
+        """Load an absolute image path as an icon without a generic fallback."""
+        if not path.is_absolute() or not path.is_file():
+            return None
+        try:
+            return self._load_cached_file_icon(path=path, size=size)
+        except (OSError, GLib.Error) as exc:
+            log.bind(action="load_icon_file", path=str(path), size=size).debug(
+                "Failed to load custom icon file: %s",
+                exc,
+            )
+            return None
+
     def load_desktop_icon(
         self, info: desktop_entries.DesktopInfo, size: int
     ) -> GdkPixbuf.Pixbuf | None:
@@ -418,11 +436,8 @@ class Launcher:
             return None
 
         icon = info.get_icon()
-        icon_name = (
-            "folder"
-            if info.get_file_type() == Gio.FileType.DIRECTORY
-            else "text-x-generic"
-        )
+        is_dir = info.get_file_type() == Gio.FileType.DIRECTORY
+        icon_name = fallback_file_icon_name(is_dir=is_dir)
         return FileTargetInfo(
             target=uri,
             name=info.get_display_name()
@@ -434,9 +449,9 @@ class Launcher:
                 gicon=icon,
                 content_type=info.get_content_type() or "",
                 size=size,
-                is_dir=info.get_file_type() == Gio.FileType.DIRECTORY,
+                is_dir=is_dir,
             ),
-            is_dir=info.get_file_type() == Gio.FileType.DIRECTORY,
+            is_dir=is_dir,
         )
 
     def resolve_file_icon(
@@ -463,7 +478,7 @@ class Launcher:
                             exc,
                         )
 
-        icon_name = "folder" if is_dir else "text-x-generic"
+        icon_name = fallback_file_icon_name(is_dir=is_dir)
         return self.load_gicon(gicon=gicon, size=size) or self.load_icon(
             icon_name=icon_name,
             size=size,

--- a/docking/platform/model.py
+++ b/docking/platform/model.py
@@ -144,6 +144,7 @@ from __future__ import annotations
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import gi
@@ -167,6 +168,8 @@ from docking.core.items import (
 )
 from docking.core.math import clamp
 from docking.log import get_logger, with_context
+from docking.platform import icon_overrides
+from docking.platform.launcher import fallback_file_icon_name
 from docking.platform.running import RunningAppInfo
 
 gi.require_version("Gtk", "3.0")
@@ -305,6 +308,7 @@ class DockModel:
                 ),
                 icon=icon,
             )
+            self._apply_icon_override(item=item)
             self._recent_apps.append(item)
             if isinstance(last_closed, (int, float)):
                 self._recent_closed_at[desktop_id] = int(last_closed)
@@ -354,6 +358,7 @@ class DockModel:
             last_closed=time.time(),
             icon=icon,
         )
+        self._apply_icon_override(item=item)
         self._recent_apps.insert(0, item)
         self._recent_closed_at[desktop_id] = int(time.time())
         self._persist_recent_apps()
@@ -427,7 +432,7 @@ class DockModel:
             if info is None:
                 return None
             icon = self._launcher.load_desktop_icon(info=info, size=icon_size)
-            return DockItem(
+            item = DockItem(
                 desktop_id=entry.id,
                 kind=APP_KIND,
                 target=entry.target,
@@ -437,11 +442,23 @@ class DockModel:
                 is_pinned=True,
                 icon=icon,
             )
+            return self._apply_icon_override(item=item)
 
         info = self._launcher.resolve_file(target=entry.target, size=icon_size)
         if info is None:
-            return None
-        return DockItem(
+            icon_name = fallback_file_icon_name(is_dir=entry.kind == FOLDER_KIND)
+            item = DockItem(
+                desktop_id=entry.id,
+                kind=entry.kind,
+                target=entry.target,
+                name=entry.target,
+                icon_name=icon_name,
+                is_pinned=True,
+                icon=self._launcher.load_icon(icon_name=icon_name, size=icon_size),
+                prefs_key=entry.target,
+            )
+            return self._apply_icon_override(item=item)
+        item = DockItem(
             desktop_id=entry.id,
             kind=entry.kind,
             target=entry.target,
@@ -451,6 +468,7 @@ class DockModel:
             icon=info.icon,
             prefs_key=entry.target,
         )
+        return self._apply_icon_override(item=item)
 
     def _make_app_item(
         self, *, desktop_id: str, is_pinned: bool, running_info: RunningAppInfo | None
@@ -481,6 +499,59 @@ class DockModel:
         )
         item.window_urgent = running_info.urgent if running_info is not None else False
         self._recompute_urgent(item=item)
+        return self._apply_icon_override(item=item)
+
+    def _default_icon_for_item(self, item: DockItem) -> None:
+        """Reload an item's default icon fields without replacing the item."""
+        icon_size = self._config.scaled_icon_size
+        if item.kind == APP_KIND:
+            resolved = self._launcher.resolve(
+                desktop_id=item.target or item.desktop_id,
+                log_failures=False,
+            )
+            if resolved is None:
+                item.icon_name = item.icon_name or "application-x-executable"
+                item.icon = self._launcher.load_icon(
+                    icon_name=item.icon_name,
+                    size=icon_size,
+                )
+                return
+            item.name = resolved.name
+            item.icon_name = resolved.icon_name
+            item.wm_class = resolved.wm_class
+            item.icon = self._launcher.load_desktop_icon(info=resolved, size=icon_size)
+            return
+
+        if item.kind in {FILE_KIND, FOLDER_KIND}:
+            info = self._launcher.resolve_file(target=item.target, size=icon_size)
+            if info is None:
+                item.icon_name = fallback_file_icon_name(
+                    is_dir=item.kind == FOLDER_KIND,
+                )
+                item.icon = self._launcher.load_icon(
+                    icon_name=item.icon_name,
+                    size=icon_size,
+                )
+                return
+            item.target = info.target
+            item.name = info.name
+            item.icon_name = info.icon_name
+            item.icon = info.icon
+
+    def _apply_icon_override(self, item: DockItem) -> DockItem:
+        """Apply a persisted custom icon to a normal dock item when available."""
+        if item.kind not in {APP_KIND, FILE_KIND, FOLDER_KIND}:
+            return item
+        path = icon_overrides.custom_icon_path(config=self._config, item=item)
+        if path is None:
+            return item
+        icon = self._launcher.load_icon_file(
+            path=path,
+            size=self._config.scaled_icon_size,
+        )
+        if icon is not None:
+            item.icon = icon
+            item.icon_name = path.name
         return item
 
     @staticmethod
@@ -780,6 +851,58 @@ class DockModel:
                 return item
         return None
 
+    def matching_icon_items(self, item: DockItem) -> list[DockItem]:
+        """Return visible model-owned items sharing an icon preference key."""
+        key = icon_overrides.item_icon_key(item=item)
+        return [
+            candidate
+            for candidate in self.pinned_items + self._recent_apps + self._transient
+            if candidate.kind in {APP_KIND, FILE_KIND, FOLDER_KIND}
+            and icon_overrides.item_icon_key(item=candidate) == key
+        ]
+
+    def set_custom_icon(self, item: DockItem, path: Path) -> bool:
+        """Persist a custom icon for a pinned normal item and refresh matches."""
+        if not self._can_edit_custom_icon(item=item):
+            return False
+        selected = path.expanduser()
+        if (
+            not selected.is_absolute()
+            or not selected.is_file()
+            or self._launcher.load_icon_file(
+                path=selected,
+                size=self._config.scaled_icon_size,
+            )
+            is None
+        ):
+            return False
+        icon_overrides.set_custom_icon(config=self._config, item=item, path=selected)
+        self._config.save()
+        self.refresh_item_icons(item=item)
+        return True
+
+    def reset_custom_icon(self, item: DockItem) -> None:
+        """Remove a custom icon override for a pinned normal item."""
+        if not self._can_edit_custom_icon(item=item):
+            return
+        icon_overrides.reset_custom_icon(config=self._config, item=item)
+        self._config.save()
+        self.refresh_item_icons(item=item)
+
+    def refresh_item_icons(self, item: DockItem) -> None:
+        """Refresh icon fields for all model items sharing the same preference key."""
+        refreshed = False
+        for candidate in self.matching_icon_items(item=item):
+            self._default_icon_for_item(item=candidate)
+            self._apply_icon_override(item=candidate)
+            refreshed = True
+        if refreshed:
+            self.notify()
+
+    @staticmethod
+    def _can_edit_custom_icon(item: DockItem) -> bool:
+        return item.is_pinned and item.kind in {APP_KIND, FILE_KIND, FOLDER_KIND}
+
     def update_running(self, running: dict[str, RunningAppInfo]) -> None:
         """Update running state from WindowTracker data.
 
@@ -1012,6 +1135,20 @@ class DockModel:
             self.pinned_items.append(item)
             self._persist_pinned_changes()
             self.notify()
+
+    def insert_pinned_item(self, item: DockItem, index: int) -> bool:
+        """Insert a resolved pinned item, applying final model-owned persistence."""
+        if item.kind not in {APP_KIND, FILE_KIND, FOLDER_KIND}:
+            return False
+        if self.find_by_desktop_id(item.desktop_id) is not None:
+            return False
+        item.is_pinned = True
+        self._apply_icon_override(item=item)
+        insert_at = max(0, min(index, len(self.pinned_items)))
+        self.pinned_items.insert(insert_at, item)
+        self._persist_pinned_changes()
+        self.notify()
+        return True
 
     def unpin_item(self, desktop_id: str) -> None:
         """Unpin an item. If running, becomes transient. If recently used, becomes

--- a/docking/ui/dnd.py
+++ b/docking/ui/dnd.py
@@ -159,7 +159,6 @@ from typing import TYPE_CHECKING
 
 import gi
 
-from docking.core.config import PinnedEntry
 from docking.core.items import APP_KIND, APPLET_KIND, FILE_KIND, FOLDER_KIND, DockItem
 from docking.core.position import Position, is_horizontal
 from docking.log import get_logger
@@ -496,15 +495,7 @@ class DnDHandler:
         added = False
         for uri in uris:
             item = self._item_from_uri(uri=uri)
-            if item and not self._model.find_by_desktop_id(item.desktop_id):
-                insert_at = min(insert_at, len(self._model.pinned_items))
-                self._model.pinned_items.insert(insert_at, item)
-                self._config.pinned.insert(
-                    insert_at,
-                    PinnedEntry(kind=item.kind, target=item.target),
-                )
-                self._model.sync_pinned_to_config()
-                self._config.save()
+            if item and self._model.insert_pinned_item(item=item, index=insert_at):
                 # External insertion should snap to the new final layout.
                 # Slide offsets are useful for internal reorder, but for a
                 # completed drop they make the dock look like it is slowly
@@ -512,7 +503,6 @@ class DnDHandler:
                 # committed the drop.
                 self._renderer.slide_offsets.clear()
                 self._renderer.prev_positions.clear()
-                self._model.notify()
                 insert_at += 1
                 added = True
 

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -151,6 +151,7 @@ from __future__ import annotations
 
 import datetime as dt
 from collections.abc import Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import gi
@@ -178,9 +179,11 @@ from docking.applets.identity import (
 from docking.applets.identity import is_applet_desktop_id as is_applet
 from docking.applets.separator import meta as _separator_meta
 from docking.core.config import WindowListSort
+from docking.core.icons import IconSource, icon_source_from_value
 from docking.core.items import FILE_KIND, FOLDER_KIND
 from docking.i18n import _
 from docking.log import get_logger
+from docking.platform import icon_overrides
 from docking.platform.backends.base import DisplayServer
 from docking.platform.recent_docs import recent_docs_for_app
 from docking.ui.about import AboutDialogController
@@ -408,18 +411,112 @@ class MenuHandler:
         self._cleanup_folder_menu_tree(menu)
         self._runtime.menu_popup_closed()
 
+    @staticmethod
+    def _applet_icon_source_options(applet: Applet) -> tuple[IconSource, ...]:
+        declared = getattr(applet, "icon_source_options", None)
+        if isinstance(declared, tuple | list):
+            options = tuple(
+                source
+                for source in (icon_source_from_value(value) for value in declared)
+                if source is not None
+            )
+            if options:
+                return tuple(dict.fromkeys(options))
+        return (IconSource.DOCKING,)
+
     def _build_applet_icon_source_menu(self, applet: Applet) -> Gtk.MenuItem:
+        labels = {
+            ICON_SOURCE_DOCKING: _("Docking Icon"),
+            ICON_SOURCE_SYSTEM: _("System Icon"),
+        }
+        items = tuple(
+            (labels[source.value], source.value)
+            for source in self._applet_icon_source_options(applet=applet)
+            if source.value in labels
+        )
         return _build_radio_submenu(
             label=_("Icon"),
-            items=(
-                (_("Docking Icon"), ICON_SOURCE_DOCKING),
-                (_("System Icon"), ICON_SOURCE_SYSTEM),
-            ),
+            items=items,
             current=applet.icon_source(),
             on_changed=lambda widget, source: self._on_applet_icon_source_changed(
                 widget, applet, source
             ),
         )
+
+    def _build_icon_menu(self, item: DockItem) -> Gtk.MenuItem:
+        menu_item = Gtk.MenuItem(label=_("Icon"))
+        submenu = Gtk.Menu()
+
+        default_item = Gtk.MenuItem(label=_("Default Icon"))
+        default_item.connect("activate", lambda _: self._model.reset_custom_icon(item))
+        submenu.append(default_item)
+
+        choose_item = Gtk.MenuItem(label=_("Choose From File..."))
+        choose_item.connect("activate", lambda _: self._on_choose_custom_icon(item))
+        submenu.append(choose_item)
+
+        reset_item = Gtk.MenuItem(label=_("Reset Custom Icon"))
+        reset_item.set_sensitive(
+            icon_overrides.custom_icon_path(config=self._config, item=item) is not None
+        )
+        reset_item.connect("activate", lambda _: self._model.reset_custom_icon(item))
+        submenu.append(reset_item)
+
+        menu_item.set_submenu(submenu)
+        return menu_item
+
+    def _on_choose_custom_icon(self, item: DockItem) -> None:
+        path = self._choose_icon_file()
+        if path is None:
+            return
+        if not self._model.set_custom_icon(item=item, path=path):
+            self._show_icon_error(path=path)
+
+    def _choose_icon_file(self) -> Path | None:
+        dialog = Gtk.FileChooserDialog(
+            title=_("Choose Icon"),
+            transient_for=self._dock_window,
+            action=Gtk.FileChooserAction.OPEN,
+        )
+        dialog.add_buttons(
+            _("Cancel"),
+            Gtk.ResponseType.CANCEL,
+            _("Open"),
+            Gtk.ResponseType.OK,
+        )
+        self._add_icon_file_filters(dialog=dialog)
+        try:
+            response = dialog.run()
+            if response != Gtk.ResponseType.OK:
+                return None
+            filename = dialog.get_filename()
+            return Path(filename).expanduser() if filename else None
+        finally:
+            dialog.destroy()
+
+    @staticmethod
+    def _add_icon_file_filters(dialog: Gtk.FileChooserDialog) -> None:
+        image_filter = Gtk.FileFilter()
+        image_filter.set_name(_("Images"))
+        for mime_type in ("image/png", "image/svg+xml", "image/x-xpixmap"):
+            image_filter.add_mime_type(mime_type)
+        for pattern in ("*.png", "*.svg", "*.xpm"):
+            image_filter.add_pattern(pattern)
+        dialog.add_filter(image_filter)
+
+    def _show_icon_error(self, *, path: Path) -> None:
+        dialog = Gtk.MessageDialog(
+            transient_for=self._dock_window,
+            flags=Gtk.DialogFlags.MODAL,
+            message_type=Gtk.MessageType.ERROR,
+            buttons=Gtk.ButtonsType.CLOSE,
+            text=_("Could not use selected icon"),
+        )
+        dialog.format_secondary_text(str(path))
+        try:
+            dialog.run()
+        finally:
+            dialog.destroy()
 
     def _on_applet_icon_source_changed(
         self,
@@ -446,7 +543,7 @@ class MenuHandler:
             has_icon_source = False
             if applet:
                 applet_items = applet.get_menu_items()
-                has_icon_source = applet.supports_system_icon is True
+                has_icon_source = len(self._applet_icon_source_options(applet)) > 1
                 for mi in applet_items:
                     menu.append(mi)
                 if applet_items and has_icon_source:
@@ -474,6 +571,8 @@ class MenuHandler:
                 "activate", lambda _: launcher_mod.open_target(item.target)
             )
             menu.append(open_item)
+            if item.is_pinned:
+                menu.append(self._build_icon_menu(item))
             if not locked:
                 menu.append(Gtk.SeparatorMenuItem())
                 remove = Gtk.MenuItem(label=_("Remove from Dock"))
@@ -492,6 +591,9 @@ class MenuHandler:
 
         # Open windows - click to activate
         self._append_open_windows(menu=menu, desktop_id=item.desktop_id)
+
+        if item.is_pinned:
+            menu.append(self._build_icon_menu(item))
 
         # Pin/Unpin (hidden when icons are locked)
         if not locked:
@@ -541,6 +643,9 @@ class MenuHandler:
         hidden.set_active(bool(prefs["show_hidden"]))
         hidden.connect("toggled", self._on_folder_hidden_toggled, item)
         menu.append(hidden)
+
+        if item.is_pinned:
+            menu.append(self._build_icon_menu(item))
 
         if not self._config.lock_icons:
             menu.append(Gtk.SeparatorMenuItem())

--- a/tests/applets/test_base.py
+++ b/tests/applets/test_base.py
@@ -17,6 +17,7 @@ from docking.applets.base import (
     _icon_label_outline_width,
     draw_icon_label,
 )
+from docking.core.icons import IconSource
 
 
 class _DeferredInitApplet(Applet):
@@ -71,7 +72,7 @@ class _SystemIconApplet(Applet):
     id = "session"
     name = "System Icon"
     icon_name = "system-log-out"
-    supports_system_icon = True
+    icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
     def __init__(self, config=None) -> None:
         self.docking_icon = object()
@@ -271,18 +272,15 @@ class TestAppletDefaultHooks:
 
     def test_icon_source_no_system_support_returns_docking(self):
         applet = _DeferredInitApplet()
-        applet.supports_system_icon = False
         assert applet.icon_source() == ICON_SOURCE_DOCKING
 
     def test_set_icon_source_no_system_support_returns_early(self):
         applet = _DeferredInitApplet()
-        applet.supports_system_icon = False
         # Should not raise or save
         applet.set_icon_source(ICON_SOURCE_SYSTEM)
 
     def test_set_icon_source_same_value_returns_early(self, monkeypatch):
-        applet = _DeferredInitApplet()
-        applet.supports_system_icon = True
+        applet = _SystemIconApplet()
         monkeypatch.setattr(
             applet, "load_prefs", lambda: {ICON_SOURCE_PREF_KEY: ICON_SOURCE_DOCKING}
         )

--- a/tests/bdd_support/harness.py
+++ b/tests/bdd_support/harness.py
@@ -11,6 +11,7 @@ import docking.ui.dnd as dnd_mod
 import docking.ui.dock_window as dock_window_mod
 import docking.ui.hover as hover_mod
 import docking.ui.preview as preview_mod
+from docking.core.config import PinnedEntry
 from docking.core.items import FOLDER_KIND, DockItem
 from docking.core.position import Position
 from docking.ui.autohide import AutoHideController, HideState
@@ -397,10 +398,22 @@ class DockHarness:
         self._drag_handler.drop_insert_index = target_index
         self._drag_handler._model.pinned_items = []
         self._drag_handler._model.find_by_desktop_id.return_value = None
-        self._drag_handler._model.sync_pinned_to_config = MagicMock()
         self._drag_handler._model.notify = MagicMock()
         self._drag_handler._config.pinned = []
         self._drag_handler._config.save = MagicMock()
+
+        def insert_pinned_item(*, item: DockItem, index: int) -> bool:
+            item.is_pinned = True
+            self._drag_handler._model.pinned_items.insert(index, item)
+            self._drag_handler._config.pinned.insert(
+                index,
+                PinnedEntry(kind=item.kind, target=item.target),
+            )
+            self._drag_handler._config.save()
+            self._drag_handler._model.notify()
+            return True
+
+        self._drag_handler._model.insert_pinned_item.side_effect = insert_pinned_item
         self._drag_handler._launcher.resolve.return_value = SimpleNamespace(
             name="Firefox",
             icon_name="firefox",

--- a/tests/platform/test_icon_overrides.py
+++ b/tests/platform/test_icon_overrides.py
@@ -1,0 +1,69 @@
+"""Tests for custom icon preference helpers."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from docking.core.icons import CUSTOM_ICON_PATH_KEY, ICON_SOURCE_PREF_KEY, IconSource
+from docking.core.items import DockItem
+from docking.platform import icon_overrides
+
+
+def test_set_custom_icon_persists_item_preference_path():
+    config = SimpleNamespace(item_prefs={})
+    item = DockItem(desktop_id="firefox.desktop", target="firefox.desktop")
+    path = Path("/home/user/icons/firefox.png")
+
+    icon_overrides.set_custom_icon(config=config, item=item, path=path)
+
+    assert config.item_prefs["firefox.desktop"] == {
+        ICON_SOURCE_PREF_KEY: IconSource.CUSTOM.value,
+        CUSTOM_ICON_PATH_KEY: str(path),
+    }
+
+
+def test_custom_icon_path_requires_custom_source_and_absolute_path():
+    item = DockItem(desktop_id="firefox.desktop", target="firefox.desktop")
+    config = SimpleNamespace(
+        item_prefs={
+            "firefox.desktop": {
+                ICON_SOURCE_PREF_KEY: IconSource.SYSTEM.value,
+                CUSTOM_ICON_PATH_KEY: "/home/user/icons/firefox.png",
+            }
+        }
+    )
+
+    assert icon_overrides.custom_icon_path(config=config, item=item) is None
+
+    config.item_prefs["firefox.desktop"][ICON_SOURCE_PREF_KEY] = IconSource.CUSTOM.value
+    config.item_prefs["firefox.desktop"][CUSTOM_ICON_PATH_KEY] = "relative.png"
+
+    assert icon_overrides.custom_icon_path(config=config, item=item) is None
+
+    config.item_prefs["firefox.desktop"][CUSTOM_ICON_PATH_KEY] = (
+        "/home/user/icons/firefox.png"
+    )
+
+    assert icon_overrides.custom_icon_path(config=config, item=item) == Path(
+        "/home/user/icons/firefox.png"
+    )
+
+
+def test_reset_custom_icon_preserves_unrelated_preferences():
+    config = SimpleNamespace(
+        item_prefs={
+            "file:///tmp/docs": {
+                ICON_SOURCE_PREF_KEY: IconSource.CUSTOM.value,
+                CUSTOM_ICON_PATH_KEY: "/home/user/docs.png",
+                "show_hidden": True,
+            }
+        }
+    )
+    item = DockItem(
+        desktop_id="file:///tmp/docs",
+        target="file:///tmp/docs",
+        prefs_key="file:///tmp/docs",
+    )
+
+    icon_overrides.reset_custom_icon(config=config, item=item)
+
+    assert config.item_prefs["file:///tmp/docs"] == {"show_hidden": True}

--- a/tests/platform/test_launcher.py
+++ b/tests/platform/test_launcher.py
@@ -132,6 +132,37 @@ class TestIconCache:
         assert ("application-x-executable", 48) in launcher._icon_cache
         assert ("application-x-executable", 96) in launcher._icon_cache
 
+    def test_load_icon_file_loads_absolute_file_without_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        launcher = Launcher()
+        icon_path = tmp_path / "icon.png"
+        icon_path.write_bytes(b"fake")
+        pixbuf = object()
+        pixbuf_cls = MagicMock()
+        pixbuf_cls.new_from_file_at_scale.return_value = pixbuf
+        monkeypatch.setattr(
+            launcher_mod.GdkPixbuf,
+            "Pixbuf",
+            pixbuf_cls,
+            raising=False,
+        )
+
+        out = launcher.load_icon_file(icon_path, 48)
+
+        assert out is pixbuf
+        pixbuf_cls.new_from_file_at_scale.assert_called_once_with(
+            str(icon_path),
+            48,
+            48,
+            True,
+        )
+
+    def test_load_icon_file_returns_none_for_missing_file(self):
+        launcher = Launcher()
+
+        assert launcher.load_icon_file(Path("/missing/icon.png"), 48) is None
+
     def test_default_directory_app_name_returns_display_name(self):
         launcher = Launcher()
         app_info = MagicMock()

--- a/tests/platform/test_model.py
+++ b/tests/platform/test_model.py
@@ -1,6 +1,7 @@
 """Tests for the dock data model."""
 
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
 try:
@@ -13,6 +14,7 @@ except ModuleNotFoundError:  # pragma: no cover
 
 from docking.applets.services import AppletServices
 from docking.core.config import PinnedEntry
+from docking.core.icons import CUSTOM_ICON_PATH_KEY, ICON_SOURCE_PREF_KEY, IconSource
 from docking.core.items import APP_KIND, FILE_KIND, FOLDER_KIND
 from docking.platform.model import DockItem, DockModel, LauncherEntryState
 from docking.platform.running import RunningAppInfo
@@ -35,6 +37,8 @@ def _make_launcher(*desktop_ids: str):
 
     launcher.resolve.side_effect = resolve
     launcher.load_icon.return_value = MagicMock()  # fake pixbuf
+    launcher.load_desktop_icon.return_value = MagicMock()
+    launcher.load_icon_file.return_value = None
     return launcher
 
 
@@ -195,6 +199,118 @@ class TestPinUnpin:
         while model.tick_animations():
             pass
         assert len(model.visible_items()) == 1
+        config.save.assert_called_once()
+
+
+class TestCustomIcons:
+    def test_pinned_app_applies_custom_icon_on_load(self):
+        config = _make_config(["a.desktop"])
+        config.item_prefs = {
+            "a.desktop": {
+                ICON_SOURCE_PREF_KEY: IconSource.CUSTOM.value,
+                CUSTOM_ICON_PATH_KEY: "/home/user/a.png",
+            }
+        }
+        launcher = _make_launcher("a.desktop")
+        custom_icon = object()
+        launcher.load_icon_file.return_value = custom_icon
+
+        model = DockModel(config, launcher, AppletServices())
+
+        item = model.visible_items()[0]
+        assert item.icon is custom_icon
+        assert item.icon_name == "a.png"
+        launcher.load_icon_file.assert_called_once_with(
+            path=Path("/home/user/a.png"),
+            size=48,
+        )
+
+    def test_set_custom_icon_persists_and_refreshes_matching_items(self, tmp_path):
+        config = _make_config(["a.desktop"], show_recent_apps=True)
+        launcher = _make_launcher("a.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        pinned = model.visible_items()[0]
+        recent = DockItem(
+            desktop_id="a.desktop",
+            kind=APP_KIND,
+            target="a.desktop",
+            is_recent=True,
+            icon=object(),
+        )
+        model._recent_apps.append(recent)
+        custom_path = tmp_path / "custom.png"
+        custom_path.write_bytes(b"not actually decoded in this unit test")
+        custom_icon = object()
+        launcher.load_icon_file.return_value = custom_icon
+        callback = MagicMock()
+        model.add_change_listener(callback)
+
+        assert model.set_custom_icon(pinned, custom_path)
+
+        assert config.item_prefs["a.desktop"] == {
+            ICON_SOURCE_PREF_KEY: IconSource.CUSTOM.value,
+            CUSTOM_ICON_PATH_KEY: str(custom_path),
+        }
+        assert pinned.icon is custom_icon
+        assert recent.icon is custom_icon
+        config.save.assert_called_once()
+        callback.assert_called_once()
+
+    def test_refresh_item_icons_preserves_runtime_state(self, tmp_path):
+        config = _make_config(["a.desktop"])
+        launcher = _make_launcher("a.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        item = model.visible_items()[0]
+        item.is_running = True
+        item.instance_count = 2
+        item.badge_count = 7
+        item.progress_visible = True
+        item.window_urgent = True
+        item.insert_factor = 0.5
+        config.item_prefs = {
+            "a.desktop": {
+                ICON_SOURCE_PREF_KEY: IconSource.CUSTOM.value,
+                CUSTOM_ICON_PATH_KEY: str(tmp_path / "custom.png"),
+            }
+        }
+        custom_icon = object()
+        launcher.load_icon_file.return_value = custom_icon
+
+        model.refresh_item_icons(item)
+
+        assert item.icon is custom_icon
+        assert item.is_running is True
+        assert item.instance_count == 2
+        assert item.badge_count == 7
+        assert item.progress_visible is True
+        assert item.window_urgent is True
+        assert item.insert_factor == 0.5
+
+    def test_insert_pinned_item_applies_override_and_persists(self):
+        config = _make_config([])
+        config.item_prefs = {
+            "tool.desktop": {
+                ICON_SOURCE_PREF_KEY: IconSource.CUSTOM.value,
+                CUSTOM_ICON_PATH_KEY: "/home/user/tool.png",
+            }
+        }
+        launcher = _make_launcher("tool.desktop")
+        custom_icon = object()
+        launcher.load_icon_file.return_value = custom_icon
+        model = DockModel(config, launcher, AppletServices())
+        item = DockItem(
+            desktop_id="tool.desktop",
+            kind=APP_KIND,
+            target="tool.desktop",
+            is_pinned=True,
+            icon=object(),
+        )
+
+        assert model.insert_pinned_item(item=item, index=0)
+
+        assert model.pinned_items == [item]
+        assert item.icon is custom_icon
+        assert config.pinned == [PinnedEntry(kind=APP_KIND, target="tool.desktop")]
         config.save.assert_called_once()
 
 

--- a/tests/ui/test_dnd_integration.py
+++ b/tests/ui/test_dnd_integration.py
@@ -16,6 +16,7 @@ except ModuleNotFoundError:  # pragma: no cover
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
 import docking.ui.dnd as dnd_mod
+from docking.core.config import PinnedEntry
 from docking.core.items import APP_KIND, APPLET_KIND, FILE_KIND, FOLDER_KIND
 from docking.core.position import Position
 from docking.platform.model import DockItem
@@ -44,6 +45,7 @@ def _make_handler(monkeypatch, lock_icons: bool = False):
     default_frame = _frame()
 
     model = MagicMock()
+    model.find_by_desktop_id.return_value = None
     config = SimpleNamespace(
         lock_icons=lock_icons,
         pos=Position.BOTTOM,
@@ -53,6 +55,18 @@ def _make_handler(monkeypatch, lock_icons: bool = False):
         pinned=[],
         save=MagicMock(),
     )
+
+    def insert_pinned_item(*, item: DockItem, index: int) -> bool:
+        if model.find_by_desktop_id(item.desktop_id) is not None:
+            return False
+        item.is_pinned = True
+        model.pinned_items.insert(index, item)
+        config.pinned.insert(index, PinnedEntry(kind=item.kind, target=item.target))
+        config.save()
+        model.notify()
+        return True
+
+    model.insert_pinned_item.side_effect = insert_pinned_item
     renderer = SimpleNamespace(slide_offsets={}, prev_positions={})
     theme = SimpleNamespace(item_padding=8, horizontal_padding=10)
     launcher = MagicMock()
@@ -383,7 +397,7 @@ class TestDropAndReceive:
         assert [entry.target for entry in handler._config.pinned] == ["firefox.desktop"]
         assert len(handler._model.pinned_items) == 1
         handler._config.save.assert_called_once()
-        handler._model.sync_pinned_to_config.assert_called_once()
+        handler._model.insert_pinned_item.assert_called_once()
         assert handler._renderer.slide_offsets == {}
         assert handler._renderer.prev_positions == {}
         handler._model.notify.assert_called_once()
@@ -698,7 +712,7 @@ class TestDropAndReceive:
             generated.desktop_id
         ]
         handler._config.save.assert_called_once()
-        handler._model.sync_pinned_to_config.assert_called_once()
+        handler._model.insert_pinned_item.assert_called_once()
         handler._model.notify.assert_called_once()
         finish.assert_called_once_with(ANY, True, False, 77)
 

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -807,12 +807,79 @@ class TestItemMenus:
         next(mi for mi in menu.children if mi.get_label() == "Close All").activate()
         handler._tracker.close_all.assert_called_once_with("firefox.desktop")
 
+    def test_pinned_app_item_menu_includes_icon_submenu(self, handler):
+        menu = FakeMenu()
+        item = DockItem(desktop_id="firefox.desktop", is_pinned=True)
+
+        handler._build_item_menu(menu=menu, item=item)
+
+        icon_menu = next(mi for mi in menu.children if mi.get_label() == "Icon")
+        assert [mi.get_label() for mi in icon_menu.get_submenu().get_children()] == [
+            "Default Icon",
+            "Choose From File...",
+            "Reset Custom Icon",
+        ]
+
+    def test_unpinned_app_item_menu_does_not_expose_icon_editing(self, handler):
+        menu = FakeMenu()
+        item = DockItem(desktop_id="firefox.desktop", is_pinned=False)
+
+        handler._build_item_menu(menu=menu, item=item)
+
+        assert "Icon" not in _labels(menu)
+
+    def test_locked_icons_still_allow_pinned_icon_submenu(self, handler):
+        handler._config.lock_icons = True
+        menu = FakeMenu()
+        item = DockItem(desktop_id="firefox.desktop", is_pinned=True)
+
+        handler._build_item_menu(menu=menu, item=item)
+
+        labels = _labels(menu)
+        assert "Icon" in labels
+        assert "Remove from Dock" not in labels
+
+    def test_choose_custom_icon_calls_model_api(self, handler, monkeypatch, tmp_path):
+        menu = FakeMenu()
+        item = DockItem(desktop_id="firefox.desktop", is_pinned=True)
+        selected = tmp_path / "icon.png"
+        monkeypatch.setattr(handler, "_choose_icon_file", lambda: selected)
+
+        handler._build_item_menu(menu=menu, item=item)
+        icon_menu = next(mi for mi in menu.children if mi.get_label() == "Icon")
+        choose = next(
+            mi
+            for mi in icon_menu.get_submenu().get_children()
+            if mi.get_label() == "Choose From File..."
+        )
+        choose.activate()
+
+        handler._model.set_custom_icon.assert_called_once_with(item=item, path=selected)
+
+    def test_reset_custom_icon_calls_model_api(self, handler):
+        menu = FakeMenu()
+        item = DockItem(desktop_id="firefox.desktop", is_pinned=True)
+
+        handler._build_item_menu(menu=menu, item=item)
+        icon_menu = next(mi for mi in menu.children if mi.get_label() == "Icon")
+        reset = next(
+            mi
+            for mi in icon_menu.get_submenu().get_children()
+            if mi.get_label() == "Reset Custom Icon"
+        )
+        reset.activate()
+
+        handler._model.reset_custom_icon.assert_called_once_with(item)
+
     def test_applet_item_menu_includes_icon_source_when_supported(self, handler):
         # Given
         menu = FakeMenu()
         applet_item = DockItem(desktop_id="applet://session")
         applet = SimpleNamespace(
-            supports_system_icon=True,
+            icon_source_options=(
+                menu_mod.IconSource.DOCKING,
+                menu_mod.IconSource.SYSTEM,
+            ),
             get_menu_items=MagicMock(return_value=[FakeMenuItem(label="Lock Screen")]),
             icon_source=MagicMock(return_value=menu_mod.ICON_SOURCE_DOCKING),
             set_icon_source=MagicMock(),

--- a/tests/ui/test_pointer_scenarios.py
+++ b/tests/ui/test_pointer_scenarios.py
@@ -26,6 +26,7 @@ import docking.ui.dnd as dnd_mod
 import docking.ui.dock_window as dock_window_mod
 import docking.ui.menu as menu_mod
 import docking.ui.placement as placement_mod
+from docking.core.config import PinnedEntry
 from docking.core.position import Position
 from docking.platform.model import DockItem
 from docking.ui.autohide import AutoHideController, HideState
@@ -97,6 +98,19 @@ class _ScenarioHarness:
         self.model.visible_items.return_value = self.items
         self.model.pinned_items = []
         self.model.find_by_desktop_id.return_value = None
+
+        def insert_pinned_item(*, item: DockItem, index: int) -> bool:
+            item.is_pinned = True
+            self.model.pinned_items.insert(index, item)
+            self.config.pinned.insert(
+                index,
+                PinnedEntry(kind=item.kind, target=item.target),
+            )
+            self.config.save()
+            self.model.notify()
+            return True
+
+        self.model.insert_pinned_item.side_effect = insert_pinned_item
         self.cursor_x = -1.0
         self.cursor_y = -1.0
         self.screen_pointer = (0, 0)

--- a/tools/generate_applet_catalog_icons.py
+++ b/tools/generate_applet_catalog_icons.py
@@ -98,8 +98,8 @@ from docking.applets.pomodoro.state import PomodoroState
 from docking.applets.powerprofiles.render import create_power_profiles_icon
 from docking.applets.quicknote.render import render_icon as render_quicknote
 from docking.applets.quote.render import draw_bulb_icon
-from docking.applets.runcommand.render import create_icon as render_runcommand
 from docking.applets.recentfiles.render import render_icon as render_recentfiles
+from docking.applets.runcommand.render import create_icon as render_runcommand
 from docking.applets.screenshot.applet import _draw_screenshot_icon
 from docking.applets.session.render import create_session_icon
 from docking.applets.speedtest.render import render_icon as render_speedtest

--- a/website/index.html
+++ b/website/index.html
@@ -339,7 +339,7 @@
           <article class="reveal rounded-[2rem] border border-white/12 bg-gradient-to-br from-skyline/12 to-skyline/6 p-6 shadow-soft backdrop-blur-2xl">
             <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-skyline/16 text-blue-100"><svg viewBox="0 0 24 24" class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 15c2-4 5-6 8-6s6 2 8 6"></path><path d="M4 9c2 4 5 6 8 6s6-2 8-6"></path></svg></div>
             <h3 class="mt-5 text-xl font-semibold text-white">Fully customizable themes</h3>
-            <p class="mt-3 text-sm leading-7 text-slate-300">Adjust the dock to your desktop instead of adapting your desktop to the dock.</p>
+            <p class="mt-3 text-sm leading-7 text-slate-300">Adjust themes, sizing, behavior, and pinned item icons so the dock fits the desktop you already use.</p>
           </article>
           <article class="reveal rounded-[2rem] border border-white/12 bg-gradient-to-br from-accent/12 to-ember/6 p-6 shadow-soft backdrop-blur-2xl">
             <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-accent/14 text-rose-100"><svg viewBox="0 0 24 24" class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="5" width="8" height="14" rx="2"></rect><rect x="13" y="8" width="8" height="8" rx="2"></rect></svg></div>


### PR DESCRIPTION
## Summary
- Add per-item custom icon preferences for pinned apps, files, folders, and generated launchers
- Move icon-source values into a shared core enum and migrate applet Docking/System icon options
- Route external drag-and-drop insertion through the model so icon overrides and persistence stay centralized
- Document the custom icon workflow in the README and website