### PR TITLE
Add startup tips popup

### DIFF
--- a/docking/app.py
+++ b/docking/app.py
@@ -90,7 +90,6 @@ from docking.platform.launcher import Launcher
 from docking.platform.model import DockModel
 from docking.platform.unity import UnityLauncherListener
 from docking.ui.factory import build_dock_window
-from docking.ui.new_year import NewYearGreetingController
 from docking.ui.renderer import DockRenderer
 
 if TYPE_CHECKING:
@@ -140,7 +139,6 @@ def main() -> None:
     )
     window = ui.window
     items_service = DockItemsService(model=model, window=window)
-    new_year = NewYearGreetingController(window=window)
 
     # Graceful shutdown on SIGINT/SIGTERM
     GLib.unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGINT, _quit)
@@ -149,14 +147,12 @@ def main() -> None:
     try:
         unity.start()
         window.show_all()
-        new_year.start()
         ui.start()
         GLib.idle_add(_start_runtime, items_service, model, backend)
         Gtk.main()
     finally:
         items_service.stop()
         ui.stop()
-        new_year.stop()
         unity.stop()
         model.stop_applets()
         backend.stop()

--- a/docking/core/config.py
+++ b/docking/core/config.py
@@ -269,6 +269,7 @@ DEFAULT_TOOLTIPS_ENABLED = True
 DEFAULT_ACTIVE_DISPLAY = False
 DEFAULT_UPDATE_CHECK_ENABLED = True
 DEFAULT_UPDATE_CHECK_INTERVAL_HOURS = 24
+DEFAULT_STARTUP_TIPS_ENABLED = True
 DEFAULT_THEME = "default"
 DEFAULT_TRANSPARENCY = 1.0
 MIN_ICON_SIZE = 32
@@ -791,6 +792,8 @@ class Config:
     update_check_enabled: bool = DEFAULT_UPDATE_CHECK_ENABLED
     # Minimum hours between automatic update checks
     update_check_interval_hours: int = DEFAULT_UPDATE_CHECK_INTERVAL_HOURS
+    # Whether Docking shows one usage tip on startup
+    startup_tips_enabled: bool = DEFAULT_STARTUP_TIPS_ENABLED
     # Left-click behavior for running apps
     left_click_action: str = DEFAULT_LEFT_CLICK_ACTION
     # Middle-click behavior for app items
@@ -934,6 +937,10 @@ class Config:
             self.update_check_interval_hours,
             default=DEFAULT_UPDATE_CHECK_INTERVAL_HOURS,
             minimum=1,
+        )
+        self.startup_tips_enabled = _normalize_bool(
+            self.startup_tips_enabled,
+            default=DEFAULT_STARTUP_TIPS_ENABLED,
         )
         self.left_click_action = _normalize_left_click_action(
             self.left_click_action,

--- a/docking/core/tips.py
+++ b/docking/core/tips.py
@@ -57,7 +57,9 @@ STARTUP_TIPS: tuple[StartupTip, ...] = (
         _("Open the dock menu from anywhere"),
         _(
             "Hold Ctrl and right-click anywhere on the shelf to open the dock "
-            "menu with Preferences, Applets, Diagnostics, and Quit."
+            "menu. This is the quickest path to Preferences, Applets, "
+            "Diagnostics, and Quit when there is no empty space near the "
+            "icons."
         ),
     ),
     StartupTip(
@@ -65,7 +67,8 @@ STARTUP_TIPS: tuple[StartupTip, ...] = (
         _("Start with Preferences"),
         _(
             "Use Preferences to adjust position, monitor behavior, icon size, "
-            "zoom, hiding, themes, previews, tooltips, and click actions."
+            "zoom, hiding, themes, previews, tooltips, and click actions. It "
+            "is the best first stop when the dock does not feel quite right."
         ),
     ),
     StartupTip(
@@ -73,25 +76,35 @@ STARTUP_TIPS: tuple[StartupTip, ...] = (
         _("Add applets from the dock menu"),
         _(
             "Right-click the shelf background and choose Add Applet to add "
-            "launchers, system status, media, productivity, and utility tools."
+            "launchers, system status, media controls, productivity helpers, "
+            "and small utility tools directly to the dock."
         ),
     ),
     StartupTip(
         "use-separators",
         _("Use separators for organization"),
-        _("Right-click where a divider should go and choose Add Separator."),
+        _(
+            "Right-click where a divider should go and choose Add Separator. "
+            "Separators make it easier to keep pinned apps, folders, and "
+            "applets in clear groups."
+        ),
     ),
     StartupTip(
         "pin-running-apps",
         _("Pin running apps"),
-        _("Right-click a running app and choose Keep in Dock."),
+        _(
+            "Right-click a running app and choose Keep in Dock. The launcher "
+            "will stay available after the app closes, so you can start it "
+            "again with one click."
+        ),
     ),
     StartupTip(
         "remove-pinned-items",
         _("Remove pinned items quickly"),
         _(
             "Right-click a pinned item and choose Remove from Dock, or drag "
-            "unlocked items off the dock."
+            "unlocked items off the dock. Removing a launcher does not "
+            "uninstall the application or delete your files."
         ),
     ),
     StartupTip(
@@ -99,20 +112,26 @@ STARTUP_TIPS: tuple[StartupTip, ...] = (
         _("Drop items onto the dock"),
         _(
             "Drag applications, .desktop files, files, folders, and AppImages "
-            "onto Docking to pin them."
+            "onto Docking to pin them. Dropped folders become folder stacks, "
+            "and dropped AppImages can get their own launcher."
         ),
     ),
     StartupTip(
         "open-files-with-apps",
         _("Open files with dock apps"),
-        _("Drag a file onto an application icon to open it with that app."),
+        _(
+            "Drag a file onto an application icon to open it with that app. "
+            "This is useful when the file manager would otherwise choose the "
+            "wrong default application."
+        ),
     ),
     StartupTip(
         "folder-stacks",
         _("Use folder stacks"),
         _(
             "Pin a folder and click it from the dock to browse its contents "
-            "without opening a file manager first."
+            "without opening a file manager first. It works well for common "
+            "places like Downloads, Projects, and screenshots."
         ),
     ),
     StartupTip(
@@ -120,7 +139,8 @@ STARTUP_TIPS: tuple[StartupTip, ...] = (
         _("Tune folder stack behavior"),
         _(
             "Right-click a pinned folder to sort contents, show hidden files, "
-            "or customize its icon."
+            "or customize its icon. These options let each stack behave like "
+            "the folder it represents."
         ),
     ),
     StartupTip(
@@ -128,59 +148,80 @@ STARTUP_TIPS: tuple[StartupTip, ...] = (
         _("Customize pinned icons"),
         _(
             "Right-click a pinned app, file, or folder and use Icon -> Choose "
-            "From File."
+            "From File. Custom icons are stored in Docking's config, so the "
+            "original desktop file or file on disk is left untouched."
         ),
     ),
     StartupTip(
         "applications-search",
         _("Use the Applications applet search"),
-        _("Add the Applications applet, open it, and type to filter installed apps."),
+        _(
+            "Add the Applications applet, open it, and type to filter "
+            "installed apps. It gives you a compact launcher menu without "
+            "leaving the dock."
+        ),
     ),
     StartupTip(
         "run-application",
         _("Use Run Application like Alt+F2"),
         _(
             "Add Run Application to launch commands, apps, and terminal "
-            "commands from the dock."
+            "commands from the dock. As you type, matching applications are "
+            "shown so you can launch by name or run a standalone command."
         ),
     ),
     StartupTip(
         "window-previews",
         _("Use window previews"),
-        _("Hover running apps to inspect open windows before switching."),
+        _(
+            "Hover running apps to inspect open windows before switching. "
+            "Previews help when one application has several windows open."
+        ),
     ),
     StartupTip(
         "click-behavior",
         _("Choose your click behavior"),
         _(
             "Preferences -> Behavior lets left click toggle, cycle, or focus "
-            "the most recent window."
+            "the most recent window. Pick the behavior that matches how you "
+            "switch between running applications."
         ),
     ),
     StartupTip(
         "ctrl-click-new-window",
         _("Ctrl-click opens a new window"),
-        _("Hold Ctrl while clicking an app icon to launch another window."),
+        _(
+            "Hold Ctrl while clicking an app icon to launch another window. "
+            "This works even when the app is already running and a normal "
+            "click would focus it."
+        ),
     ),
     StartupTip(
         "app-context-menus",
         _("Use app right-click menus"),
         _(
             "Right-click apps for desktop actions, open windows, recent "
-            "documents, pinning, and close actions."
+            "documents, pinning, and close actions. Many apps expose useful "
+            "shortcuts there, such as opening a private window or composing a "
+            "new message."
         ),
     ),
     StartupTip(
         "recent-files",
         _("Use Recent Files"),
-        _("Add the Recent Files applet to jump back into recently used documents."),
+        _(
+            "Add the Recent Files applet to jump back into documents you used "
+            "recently. It is a faster path when you remember the file, not the "
+            "folder."
+        ),
     ),
     StartupTip(
         "system-tray",
         _("Use System Tray when needed"),
         _(
             "Add System Tray for tray/status apps and use its menu to manage "
-            "tray ownership when supported."
+            "tray ownership when supported. This helps with legacy apps that "
+            "still rely on a classic notification area."
         ),
     ),
     StartupTip(
@@ -188,7 +229,9 @@ STARTUP_TIPS: tuple[StartupTip, ...] = (
         _("Use Diagnostics for support"),
         _(
             "Open Diagnostics before filing an issue to copy backend, session, "
-            "and feature details."
+            "and feature details. Including that report makes it much easier "
+            "to understand compositor, monitor, and environment-specific "
+            "problems."
         ),
     ),
 )

--- a/docking/core/tips.py
+++ b/docking/core/tips.py
@@ -1,0 +1,285 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Startup usage tips and persistent tip rotation state."""
+
+from __future__ import annotations
+
+import json
+import random
+import tempfile
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from docking.core.paths import ensure_parent_dir
+from docking.i18n import _
+from docking.log import get_logger
+from docking.platform.environment import docking_state_dir
+
+logger = get_logger("tips")
+
+DEFAULT_STATE_DIR = docking_state_dir()
+DEFAULT_STATE_FILE = DEFAULT_STATE_DIR / "tips.json"
+FIRST_TIP_ID = "dock-menu-ctrl-right-click"
+
+
+@dataclass(frozen=True, slots=True)
+class StartupTip:
+    """One translatable startup tip."""
+
+    id: str
+    title: str
+    body: str
+
+
+@dataclass(frozen=True, slots=True)
+class StartupTipsState:
+    """Persistent tip rotation state."""
+
+    shown_tip_ids: tuple[str, ...] = ()
+
+
+STARTUP_TIPS: tuple[StartupTip, ...] = (
+    StartupTip(
+        FIRST_TIP_ID,
+        _("Open the dock menu from anywhere"),
+        _(
+            "Hold Ctrl and right-click anywhere on the shelf to open the dock "
+            "menu with Preferences, Applets, Diagnostics, and Quit."
+        ),
+    ),
+    StartupTip(
+        "start-with-preferences",
+        _("Start with Preferences"),
+        _(
+            "Use Preferences to adjust position, monitor behavior, icon size, "
+            "zoom, hiding, themes, previews, tooltips, and click actions."
+        ),
+    ),
+    StartupTip(
+        "add-applets",
+        _("Add applets from the dock menu"),
+        _(
+            "Right-click the shelf background and choose Add Applet to add "
+            "launchers, system status, media, productivity, and utility tools."
+        ),
+    ),
+    StartupTip(
+        "use-separators",
+        _("Use separators for organization"),
+        _("Right-click where a divider should go and choose Add Separator."),
+    ),
+    StartupTip(
+        "pin-running-apps",
+        _("Pin running apps"),
+        _("Right-click a running app and choose Keep in Dock."),
+    ),
+    StartupTip(
+        "remove-pinned-items",
+        _("Remove pinned items quickly"),
+        _(
+            "Right-click a pinned item and choose Remove from Dock, or drag "
+            "unlocked items off the dock."
+        ),
+    ),
+    StartupTip(
+        "drop-items",
+        _("Drop items onto the dock"),
+        _(
+            "Drag applications, .desktop files, files, folders, and AppImages "
+            "onto Docking to pin them."
+        ),
+    ),
+    StartupTip(
+        "open-files-with-apps",
+        _("Open files with dock apps"),
+        _("Drag a file onto an application icon to open it with that app."),
+    ),
+    StartupTip(
+        "folder-stacks",
+        _("Use folder stacks"),
+        _(
+            "Pin a folder and click it from the dock to browse its contents "
+            "without opening a file manager first."
+        ),
+    ),
+    StartupTip(
+        "folder-stack-options",
+        _("Tune folder stack behavior"),
+        _(
+            "Right-click a pinned folder to sort contents, show hidden files, "
+            "or customize its icon."
+        ),
+    ),
+    StartupTip(
+        "custom-icons",
+        _("Customize pinned icons"),
+        _(
+            "Right-click a pinned app, file, or folder and use Icon -> Choose "
+            "From File."
+        ),
+    ),
+    StartupTip(
+        "applications-search",
+        _("Use the Applications applet search"),
+        _("Add the Applications applet, open it, and type to filter installed apps."),
+    ),
+    StartupTip(
+        "run-application",
+        _("Use Run Application like Alt+F2"),
+        _(
+            "Add Run Application to launch commands, apps, and terminal "
+            "commands from the dock."
+        ),
+    ),
+    StartupTip(
+        "window-previews",
+        _("Use window previews"),
+        _("Hover running apps to inspect open windows before switching."),
+    ),
+    StartupTip(
+        "click-behavior",
+        _("Choose your click behavior"),
+        _(
+            "Preferences -> Behavior lets left click toggle, cycle, or focus "
+            "the most recent window."
+        ),
+    ),
+    StartupTip(
+        "ctrl-click-new-window",
+        _("Ctrl-click opens a new window"),
+        _("Hold Ctrl while clicking an app icon to launch another window."),
+    ),
+    StartupTip(
+        "app-context-menus",
+        _("Use app right-click menus"),
+        _(
+            "Right-click apps for desktop actions, open windows, recent "
+            "documents, pinning, and close actions."
+        ),
+    ),
+    StartupTip(
+        "recent-files",
+        _("Use Recent Files"),
+        _("Add the Recent Files applet to jump back into recently used documents."),
+    ),
+    StartupTip(
+        "system-tray",
+        _("Use System Tray when needed"),
+        _(
+            "Add System Tray for tray/status apps and use its menu to manage "
+            "tray ownership when supported."
+        ),
+    ),
+    StartupTip(
+        "diagnostics",
+        _("Use Diagnostics for support"),
+        _(
+            "Open Diagnostics before filing an issue to copy backend, session, "
+            "and feature details."
+        ),
+    ),
+)
+
+
+def load_state(path: Path | str | None = None) -> StartupTipsState:
+    """Load startup tip state, falling back to defaults on invalid data."""
+    state_path = Path(path) if path is not None else DEFAULT_STATE_FILE
+    if not state_path.exists():
+        return StartupTipsState()
+    try:
+        with state_path.open(encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except Exception as exc:
+        logger.warning("Failed to load startup tips state %s: %s", state_path, exc)
+        return StartupTipsState()
+    if not isinstance(raw, dict):
+        logger.warning(
+            "Invalid startup tips state payload in %s; using defaults",
+            state_path,
+        )
+        return StartupTipsState()
+    return StartupTipsState(
+        shown_tip_ids=_normalize_shown_tip_ids(raw.get("shown_tip_ids")),
+    )
+
+
+def save_state(state: StartupTipsState, *, path: Path | str | None = None) -> None:
+    """Persist startup tip state atomically."""
+    state_path = Path(path) if path is not None else DEFAULT_STATE_FILE
+    ensure_parent_dir(state_path)
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=state_path.parent,
+        prefix=f".{state_path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        tmp_path = Path(handle.name)
+        json.dump(
+            {"shown_tip_ids": list(state.shown_tip_ids)},
+            handle,
+            indent=2,
+            sort_keys=True,
+        )
+        handle.write("\n")
+    tmp_path.replace(state_path)
+
+
+def select_startup_tip(
+    *,
+    enabled: bool,
+    path: Path | str | None = None,
+    chooser: Callable[[Sequence[StartupTip]], StartupTip] | None = None,
+) -> StartupTip | None:
+    """Select and consume the next startup tip."""
+    if not enabled:
+        return None
+
+    state = load_state(path=path)
+    tip_by_id = {tip.id: tip for tip in STARTUP_TIPS}
+    shown = tuple(tip_id for tip_id in state.shown_tip_ids if tip_id in tip_by_id)
+    shown_set = set(shown)
+
+    if FIRST_TIP_ID not in shown_set:
+        selected = tip_by_id[FIRST_TIP_ID]
+        next_shown = (*shown, selected.id)
+    else:
+        available = [tip for tip in STARTUP_TIPS if tip.id not in shown_set]
+        if not available:
+            available = [tip for tip in STARTUP_TIPS if tip.id != FIRST_TIP_ID]
+            shown = (FIRST_TIP_ID,)
+        selected = (chooser or random.choice)(available)
+        next_shown = (*shown, selected.id)
+
+    save_state(StartupTipsState(shown_tip_ids=_dedupe(next_shown)), path=path)
+    return selected
+
+
+def _normalize_shown_tip_ids(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return _dedupe(
+        item.strip() for item in value if isinstance(item, str) and item.strip()
+    )
+
+
+def _dedupe(values: Sequence[str] | Any) -> tuple[str, ...]:
+    result: list[str] = []
+    for value in values:
+        if value not in result:
+            result.append(value)
+    return tuple(result)

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-06-29 23:05+0200\n"
+"POT-Creation-Date: 2026-07-04 23:25+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,7 +115,7 @@ msgstr ""
 #: docking/applets/runcommand/applet.py:340
 #: docking/applets/sunrise/applet.py:188 docking/applets/trash/applet.py:177
 #: docking/applets/weather/applet.py:271 docking/ui/diagnostics.py:342
-#: docking/ui/menu.py:482
+#: docking/ui/menu.py:439
 msgid "Cancel"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Power Settings"
 msgstr ""
 
-#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:581
+#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:637
 msgid "Mouse"
 msgstr ""
 
@@ -1350,7 +1350,7 @@ msgid "{verb} every {interval}"
 msgstr ""
 
 #: docking/applets/freshness.py:43 docking/applets/freshness.py:50
-#: docking/ui/settings.py:232
+#: docking/ui/settings.py:288
 msgid "Updates"
 msgstr ""
 
@@ -2018,8 +2018,8 @@ msgid "Run with file"
 msgstr ""
 
 #: docking/applets/runcommand/applet.py:341
-#: docking/applets/systemtray/applet.py:254 docking/ui/menu.py:484
-#: docking/ui/menu.py:569
+#: docking/applets/systemtray/applet.py:254 docking/ui/menu.py:441
+#: docking/ui/menu.py:526
 msgid "Open"
 msgstr ""
 
@@ -2784,191 +2784,219 @@ msgstr ""
 
 #: docking/core/tips.py:59
 msgid ""
-"Hold Ctrl and right-click anywhere on the shelf to open the dock menu with "
-"Preferences, Applets, Diagnostics, and Quit."
-msgstr ""
-
-#: docking/core/tips.py:65
-msgid "Start with Preferences"
+"Hold Ctrl and right-click anywhere on the shelf to open the dock menu. This "
+"is the quickest path to Preferences, Applets, Diagnostics, and Quit when "
+"there is no empty space near the icons."
 msgstr ""
 
 #: docking/core/tips.py:67
-msgid ""
-"Use Preferences to adjust position, monitor behavior, icon size, zoom, "
-"hiding, themes, previews, tooltips, and click actions."
+msgid "Start with Preferences"
 msgstr ""
 
-#: docking/core/tips.py:73
+#: docking/core/tips.py:69
+msgid ""
+"Use Preferences to adjust position, monitor behavior, icon size, zoom, "
+"hiding, themes, previews, tooltips, and click actions. It is the best first "
+"stop when the dock does not feel quite right."
+msgstr ""
+
+#: docking/core/tips.py:76
 msgid "Add applets from the dock menu"
 msgstr ""
 
-#: docking/core/tips.py:75
+#: docking/core/tips.py:78
 msgid ""
 "Right-click the shelf background and choose Add Applet to add launchers, "
-"system status, media, productivity, and utility tools."
+"system status, media controls, productivity helpers, and small utility tools "
+"directly to the dock."
 msgstr ""
 
-#: docking/core/tips.py:81
+#: docking/core/tips.py:85
 msgid "Use separators for organization"
 msgstr ""
 
-#: docking/core/tips.py:82
-msgid "Right-click where a divider should go and choose Add Separator."
+#: docking/core/tips.py:87
+msgid ""
+"Right-click where a divider should go and choose Add Separator. Separators "
+"make it easier to keep pinned apps, folders, and applets in clear groups."
 msgstr ""
 
-#: docking/core/tips.py:86
+#: docking/core/tips.py:94
 msgid "Pin running apps"
 msgstr ""
 
-#: docking/core/tips.py:87
-msgid "Right-click a running app and choose Keep in Dock."
+#: docking/core/tips.py:96
+msgid ""
+"Right-click a running app and choose Keep in Dock. The launcher will stay "
+"available after the app closes, so you can start it again with one click."
 msgstr ""
 
-#: docking/core/tips.py:91
+#: docking/core/tips.py:103
 msgid "Remove pinned items quickly"
 msgstr ""
 
-#: docking/core/tips.py:93
+#: docking/core/tips.py:105
 msgid ""
 "Right-click a pinned item and choose Remove from Dock, or drag unlocked "
-"items off the dock."
-msgstr ""
-
-#: docking/core/tips.py:99
-msgid "Drop items onto the dock"
-msgstr ""
-
-#: docking/core/tips.py:101
-msgid ""
-"Drag applications, .desktop files, files, folders, and AppImages onto "
-"Docking to pin them."
-msgstr ""
-
-#: docking/core/tips.py:107
-msgid "Open files with dock apps"
-msgstr ""
-
-#: docking/core/tips.py:108
-msgid "Drag a file onto an application icon to open it with that app."
+"items off the dock. Removing a launcher does not uninstall the application "
+"or delete your files."
 msgstr ""
 
 #: docking/core/tips.py:112
-msgid "Use folder stacks"
+msgid "Drop items onto the dock"
 msgstr ""
 
 #: docking/core/tips.py:114
 msgid ""
-"Pin a folder and click it from the dock to browse its contents without "
-"opening a file manager first."
+"Drag applications, .desktop files, files, folders, and AppImages onto "
+"Docking to pin them. Dropped folders become folder stacks, and dropped "
+"AppImages can get their own launcher."
 msgstr ""
 
-#: docking/core/tips.py:120
-msgid "Tune folder stack behavior"
+#: docking/core/tips.py:121
+msgid "Open files with dock apps"
 msgstr ""
 
-#: docking/core/tips.py:122
+#: docking/core/tips.py:123
 msgid ""
-"Right-click a pinned folder to sort contents, show hidden files, or "
-"customize its icon."
-msgstr ""
-
-#: docking/core/tips.py:128
-msgid "Customize pinned icons"
+"Drag a file onto an application icon to open it with that app. This is "
+"useful when the file manager would otherwise choose the wrong default "
+"application."
 msgstr ""
 
 #: docking/core/tips.py:130
-msgid ""
-"Right-click a pinned app, file, or folder and use Icon -> Choose From File."
+msgid "Use folder stacks"
 msgstr ""
 
-#: docking/core/tips.py:136
-msgid "Use the Applications applet search"
+#: docking/core/tips.py:132
+msgid ""
+"Pin a folder and click it from the dock to browse its contents without "
+"opening a file manager first. It works well for common places like "
+"Downloads, Projects, and screenshots."
 msgstr ""
 
-#: docking/core/tips.py:137
-msgid ""
-"Add the Applications applet, open it, and type to filter installed apps."
+#: docking/core/tips.py:139
+msgid "Tune folder stack behavior"
 msgstr ""
 
 #: docking/core/tips.py:141
-msgid "Use Run Application like Alt+F2"
-msgstr ""
-
-#: docking/core/tips.py:143
 msgid ""
-"Add Run Application to launch commands, apps, and terminal commands from the "
-"dock."
+"Right-click a pinned folder to sort contents, show hidden files, or "
+"customize its icon. These options let each stack behave like the folder it "
+"represents."
 msgstr ""
 
-#: docking/core/tips.py:149
-msgid "Use window previews"
+#: docking/core/tips.py:148
+msgid "Customize pinned icons"
 msgstr ""
 
 #: docking/core/tips.py:150
-msgid "Hover running apps to inspect open windows before switching."
-msgstr ""
-
-#: docking/core/tips.py:154
-msgid "Choose your click behavior"
-msgstr ""
-
-#: docking/core/tips.py:156
 msgid ""
-"Preferences -> Behavior lets left click toggle, cycle, or focus the most "
-"recent window."
+"Right-click a pinned app, file, or folder and use Icon -> Choose From File. "
+"Custom icons are stored in Docking's config, so the original desktop file or "
+"file on disk is left untouched."
 msgstr ""
 
-#: docking/core/tips.py:162
-msgid "Ctrl-click opens a new window"
+#: docking/core/tips.py:157
+msgid "Use the Applications applet search"
 msgstr ""
 
-#: docking/core/tips.py:163
-msgid "Hold Ctrl while clicking an app icon to launch another window."
-msgstr ""
-
-#: docking/core/tips.py:167
-msgid "Use app right-click menus"
-msgstr ""
-
-#: docking/core/tips.py:169
+#: docking/core/tips.py:159
 msgid ""
-"Right-click apps for desktop actions, open windows, recent documents, "
-"pinning, and close actions."
+"Add the Applications applet, open it, and type to filter installed apps. It "
+"gives you a compact launcher menu without leaving the dock."
+msgstr ""
+
+#: docking/core/tips.py:166
+msgid "Use Run Application like Alt+F2"
+msgstr ""
+
+#: docking/core/tips.py:168
+msgid ""
+"Add Run Application to launch commands, apps, and terminal commands from the "
+"dock. As you type, matching applications are shown so you can launch by name "
+"or run a standalone command."
 msgstr ""
 
 #: docking/core/tips.py:175
+msgid "Use window previews"
+msgstr ""
+
+#: docking/core/tips.py:177
+msgid ""
+"Hover running apps to inspect open windows before switching. Previews help "
+"when one application has several windows open."
+msgstr ""
+
+#: docking/core/tips.py:183
+msgid "Choose your click behavior"
+msgstr ""
+
+#: docking/core/tips.py:185
+msgid ""
+"Preferences -> Behavior lets left click toggle, cycle, or focus the most "
+"recent window. Pick the behavior that matches how you switch between running "
+"applications."
+msgstr ""
+
+#: docking/core/tips.py:192
+msgid "Ctrl-click opens a new window"
+msgstr ""
+
+#: docking/core/tips.py:194
+msgid ""
+"Hold Ctrl while clicking an app icon to launch another window. This works "
+"even when the app is already running and a normal click would focus it."
+msgstr ""
+
+#: docking/core/tips.py:201
+msgid "Use app right-click menus"
+msgstr ""
+
+#: docking/core/tips.py:203
+msgid ""
+"Right-click apps for desktop actions, open windows, recent documents, "
+"pinning, and close actions. Many apps expose useful shortcuts there, such as "
+"opening a private window or composing a new message."
+msgstr ""
+
+#: docking/core/tips.py:211
 msgid "Use Recent Files"
 msgstr ""
 
-#: docking/core/tips.py:176
-msgid "Add the Recent Files applet to jump back into recently used documents."
+#: docking/core/tips.py:213
+msgid ""
+"Add the Recent Files applet to jump back into documents you used recently. "
+"It is a faster path when you remember the file, not the folder."
 msgstr ""
 
-#: docking/core/tips.py:180
+#: docking/core/tips.py:220
 msgid "Use System Tray when needed"
 msgstr ""
 
-#: docking/core/tips.py:182
+#: docking/core/tips.py:222
 msgid ""
 "Add System Tray for tray/status apps and use its menu to manage tray "
-"ownership when supported."
+"ownership when supported. This helps with legacy apps that still rely on a "
+"classic notification area."
 msgstr ""
 
-#: docking/core/tips.py:188
+#: docking/core/tips.py:229
 msgid "Use Diagnostics for support"
 msgstr ""
 
-#: docking/core/tips.py:190
+#: docking/core/tips.py:231
 msgid ""
 "Open Diagnostics before filing an issue to copy backend, session, and "
-"feature details."
+"feature details. Including that report makes it much easier to understand "
+"compositor, monitor, and environment-specific problems."
 msgstr ""
 
 #: docking/ui/about.py:68
 msgid "Website"
 msgstr ""
 
-#: docking/ui/diagnostics.py:71 docking/ui/menu.py:736
+#: docking/ui/diagnostics.py:71 docking/ui/menu.py:693
 msgid "Diagnostics"
 msgstr ""
 
@@ -3000,12 +3028,12 @@ msgstr ""
 msgid "Save Report..."
 msgstr ""
 
-#: docking/ui/diagnostics.py:122 docking/ui/menu.py:617
+#: docking/ui/diagnostics.py:122 docking/ui/menu.py:574
 #: docking/ui/startup_tips.py:173
 msgid "Close"
 msgstr ""
 
-#: docking/ui/diagnostics.py:145 docking/ui/dock_window.py:404
+#: docking/ui/diagnostics.py:145 docking/ui/dock_window.py:375
 msgid "Docking"
 msgstr ""
 
@@ -3140,100 +3168,100 @@ msgstr ""
 msgid "%d More in Folder"
 msgstr ""
 
-#: docking/ui/menu.py:429
+#: docking/ui/menu.py:386
 msgid "Docking Icon"
 msgstr ""
 
-#: docking/ui/menu.py:430
+#: docking/ui/menu.py:387
 msgid "System Icon"
 msgstr ""
 
-#: docking/ui/menu.py:438 docking/ui/menu.py:447
+#: docking/ui/menu.py:395 docking/ui/menu.py:404
 msgid "Icon"
 msgstr ""
 
-#: docking/ui/menu.py:450
+#: docking/ui/menu.py:407
 msgid "Default Icon"
 msgstr ""
 
-#: docking/ui/menu.py:454
+#: docking/ui/menu.py:411
 msgid "Choose From File..."
 msgstr ""
 
-#: docking/ui/menu.py:458
+#: docking/ui/menu.py:415
 msgid "Reset Custom Icon"
 msgstr ""
 
-#: docking/ui/menu.py:477
+#: docking/ui/menu.py:434
 msgid "Choose Icon"
 msgstr ""
 
-#: docking/ui/menu.py:500
+#: docking/ui/menu.py:457
 msgid "Images"
 msgstr ""
 
-#: docking/ui/menu.py:513
+#: docking/ui/menu.py:470
 msgid "Could not use selected icon"
 msgstr ""
 
-#: docking/ui/menu.py:556 docking/ui/menu.py:578 docking/ui/menu.py:601
-#: docking/ui/menu.py:652
+#: docking/ui/menu.py:513 docking/ui/menu.py:535 docking/ui/menu.py:558
+#: docking/ui/menu.py:609
 msgid "Remove from Dock"
 msgstr ""
 
-#: docking/ui/menu.py:608
+#: docking/ui/menu.py:565
 msgid "Keep in Dock"
 msgstr ""
 
-#: docking/ui/menu.py:617
+#: docking/ui/menu.py:574
 msgid "Close All"
 msgstr ""
 
-#: docking/ui/menu.py:634
+#: docking/ui/menu.py:591
 msgid "Sort By"
 msgstr ""
 
-#: docking/ui/menu.py:642
+#: docking/ui/menu.py:599
 msgid "Show Hidden Files"
 msgstr ""
 
-#: docking/ui/menu.py:682
+#: docking/ui/menu.py:639
 msgid "Add Applet"
 msgstr ""
 
-#: docking/ui/menu.py:720
+#: docking/ui/menu.py:677
 msgid "No Applets Available"
 msgstr ""
 
-#: docking/ui/menu.py:727
+#: docking/ui/menu.py:684
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:741 docking/ui/settings.py:205
+#: docking/ui/menu.py:698 docking/ui/settings.py:261
 msgid "Preferences"
 msgstr ""
 
-#: docking/ui/menu.py:746
+#: docking/ui/menu.py:703
 msgid "About"
 msgstr ""
 
-#: docking/ui/menu.py:751
+#: docking/ui/menu.py:708
 msgid "Get Support"
 msgstr ""
 
-#: docking/ui/menu.py:758
+#: docking/ui/menu.py:715
 msgid "Quit"
 msgstr ""
 
-#: docking/ui/menu.py:824
+#: docking/ui/menu.py:781
 msgid "Clear Recent Documents"
 msgstr ""
 
-#: docking/ui/menu.py:834 docking/ui/settings.py:683
+#: docking/ui/menu.py:791 docking/ui/settings.py:739
 msgid "Recent Documents"
 msgstr ""
 
-#: docking/ui/menu.py:853
+#: docking/ui/menu.py:810
 msgid "Window"
 msgstr ""
 
@@ -3247,439 +3275,439 @@ msgstr ""
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-#: docking/ui/settings.py:229
+#: docking/ui/settings.py:285
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:230 docking/ui/settings.py:608
+#: docking/ui/settings.py:286 docking/ui/settings.py:664
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:231
+#: docking/ui/settings.py:287
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:255
+#: docking/ui/settings.py:311
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:312
 msgid "Always on Top"
 msgstr ""
 
-#: docking/ui/settings.py:257
+#: docking/ui/settings.py:313
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:314
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:315
 msgid "Dodge Active"
 msgstr ""
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:316
 msgid "Dodge Windows"
 msgstr ""
 
-#: docking/ui/settings.py:261
+#: docking/ui/settings.py:317
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:272
+#: docking/ui/settings.py:328
 msgid "Toggle Focus"
 msgstr ""
 
-#: docking/ui/settings.py:273
+#: docking/ui/settings.py:329
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:274
+#: docking/ui/settings.py:330
 msgid "Most Recent Window"
 msgstr ""
 
-#: docking/ui/settings.py:281
+#: docking/ui/settings.py:337
 msgid "New Window"
 msgstr ""
 
-#: docking/ui/settings.py:282
+#: docking/ui/settings.py:338
 msgid "Minimize Windows"
 msgstr ""
 
-#: docking/ui/settings.py:283
+#: docking/ui/settings.py:339
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:290
+#: docking/ui/settings.py:346
 msgid "Click"
 msgstr ""
 
-#: docking/ui/settings.py:291
+#: docking/ui/settings.py:347
 msgid "Hover"
 msgstr ""
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:354
 msgid "Default"
 msgstr ""
 
-#: docking/ui/settings.py:299
+#: docking/ui/settings.py:355
 msgid "Alphabetical"
 msgstr ""
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:373
 msgid "Daily"
 msgstr ""
 
-#: docking/ui/settings.py:318
+#: docking/ui/settings.py:374
 msgid "Weekly"
 msgstr ""
 
-#: docking/ui/settings.py:339
+#: docking/ui/settings.py:395
 msgid ""
 "When Follow Cursor is enabled, the dock follows the pointer across monitors. "
 "The selected monitor is kept as the fallback."
 msgstr ""
 
-#: docking/ui/settings.py:385
+#: docking/ui/settings.py:441
 msgid "Added on top of the theme's own distance from the edge."
 msgstr ""
 
-#: docking/ui/settings.py:425
+#: docking/ui/settings.py:481
 msgid ""
 "Pixels of cursor pressure against the edge required to reveal a hidden dock. "
 "Higher values mean the dock will not reveal as easily."
 msgstr ""
 
-#: docking/ui/settings.py:447
+#: docking/ui/settings.py:503
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:449
+#: docking/ui/settings.py:505
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:449
+#: docking/ui/settings.py:505
 msgid "Choose the dock color palette."
 msgstr ""
 
-#: docking/ui/settings.py:451
+#: docking/ui/settings.py:507
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:453
+#: docking/ui/settings.py:509
 msgid "Set the base size of dock icons before zoom is applied."
 msgstr ""
 
-#: docking/ui/settings.py:456
+#: docking/ui/settings.py:512
 msgid "Transparency"
 msgstr ""
 
-#: docking/ui/settings.py:458
+#: docking/ui/settings.py:514
 msgid "Adjust how transparent the dock background is."
 msgstr ""
 
-#: docking/ui/settings.py:461
+#: docking/ui/settings.py:517
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:463
+#: docking/ui/settings.py:519
 msgid "Enlarge icons when the pointer hovers over the dock."
 msgstr ""
 
-#: docking/ui/settings.py:466
+#: docking/ui/settings.py:522
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:468
+#: docking/ui/settings.py:524
 msgid "Set how much hovered icons grow when zoom is enabled."
 msgstr ""
 
-#: docking/ui/settings.py:471
+#: docking/ui/settings.py:527
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:473
+#: docking/ui/settings.py:529
 msgid "Show item names and details when hovering over dock items."
 msgstr ""
 
-#: docking/ui/settings.py:476
+#: docking/ui/settings.py:532
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:478
+#: docking/ui/settings.py:534
 msgid "Show window thumbnails when hovering over running apps."
 msgstr ""
 
-#: docking/ui/settings.py:481
+#: docking/ui/settings.py:537
 msgid "Show Window Counts"
 msgstr ""
 
-#: docking/ui/settings.py:484
+#: docking/ui/settings.py:540
 msgid "Show a number on running app indicators when multiple windows are open."
 msgstr ""
 
-#: docking/ui/settings.py:492
+#: docking/ui/settings.py:548
 msgid "Placement"
 msgstr ""
 
-#: docking/ui/settings.py:495
+#: docking/ui/settings.py:551
 msgid "Position"
 msgstr ""
 
-#: docking/ui/settings.py:497
+#: docking/ui/settings.py:553
 msgid "Choose which screen edge the dock uses."
 msgstr ""
 
-#: docking/ui/settings.py:499
+#: docking/ui/settings.py:555
 msgid "Extra Distance from Edge"
 msgstr ""
 
-#: docking/ui/settings.py:501
+#: docking/ui/settings.py:557
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:504
+#: docking/ui/settings.py:560
 msgid "Show running windows only from the active workspace when supported."
 msgstr ""
 
-#: docking/ui/settings.py:512 docking/ui/settings.py:522
+#: docking/ui/settings.py:568 docking/ui/settings.py:578
 msgid "Monitor"
 msgstr ""
 
-#: docking/ui/settings.py:515
+#: docking/ui/settings.py:571
 msgid "Follow Cursor"
 msgstr ""
 
-#: docking/ui/settings.py:518
+#: docking/ui/settings.py:574
 msgid "Move the dock to the monitor where the pointer is currently located."
 msgstr ""
 
-#: docking/ui/settings.py:527
+#: docking/ui/settings.py:583
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:530
+#: docking/ui/settings.py:586
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:533
+#: docking/ui/settings.py:589
 msgid "Prevent dock items from being reordered or removed by drag and drop."
 msgstr ""
 
-#: docking/ui/settings.py:538
+#: docking/ui/settings.py:594
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:540
+#: docking/ui/settings.py:596
 msgid "Keep applets grouped at the end of the dock."
 msgstr ""
 
-#: docking/ui/settings.py:543
+#: docking/ui/settings.py:599
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:545
+#: docking/ui/settings.py:601
 msgid "Keep pinned files and folders grouped at the end of the dock."
 msgstr ""
 
-#: docking/ui/settings.py:584
+#: docking/ui/settings.py:640
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:587
+#: docking/ui/settings.py:643
 msgid ""
 "Choose what happens when clicking a running app with the left mouse button."
 msgstr ""
 
-#: docking/ui/settings.py:592
+#: docking/ui/settings.py:648
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:595
+#: docking/ui/settings.py:651
 msgid "Choose what happens when clicking an app with the middle mouse button."
 msgstr ""
 
-#: docking/ui/settings.py:600
+#: docking/ui/settings.py:656
 msgid "Window List Sort"
 msgstr ""
 
-#: docking/ui/settings.py:602
+#: docking/ui/settings.py:658
 msgid "Choose how open windows are ordered in app context menus."
 msgstr ""
 
-#: docking/ui/settings.py:610
+#: docking/ui/settings.py:666
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:612
+#: docking/ui/settings.py:668
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:615
+#: docking/ui/settings.py:671
 msgid "Set how long the dock waits before hiding after the pointer leaves."
 msgstr ""
 
-#: docking/ui/settings.py:620
+#: docking/ui/settings.py:676
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:623
+#: docking/ui/settings.py:679
 msgid "Set how long the dock waits before showing after the pointer returns."
 msgstr ""
 
-#: docking/ui/settings.py:628
+#: docking/ui/settings.py:684
 msgid "Pressure Reveal"
 msgstr ""
 
-#: docking/ui/settings.py:631
+#: docking/ui/settings.py:687
 msgid ""
 "Require the pointer to push against the screen edge before revealing a "
 "hidden dock."
 msgstr ""
 
-#: docking/ui/settings.py:635
+#: docking/ui/settings.py:691
 msgid "Pressure Threshold"
 msgstr ""
 
-#: docking/ui/settings.py:637
+#: docking/ui/settings.py:693
 msgid "Show Startup Tips"
 msgstr ""
 
-#: docking/ui/settings.py:640
+#: docking/ui/settings.py:696
 msgid ""
 "Show one Docking usage tip after startup, unless a higher-priority startup "
 "notification is visible."
 msgstr ""
 
-#: docking/ui/settings.py:648
+#: docking/ui/settings.py:704
 msgid "Folder Stacks"
 msgstr ""
 
-#: docking/ui/settings.py:651
+#: docking/ui/settings.py:707
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:653
+#: docking/ui/settings.py:709
 msgid "Choose whether folder stacks open on click or while hovering."
 msgstr ""
 
-#: docking/ui/settings.py:659
+#: docking/ui/settings.py:715
 msgid "Recent Apps"
 msgstr ""
 
-#: docking/ui/settings.py:662
+#: docking/ui/settings.py:718
 msgid "Show Recently Used Apps"
 msgstr ""
 
-#: docking/ui/settings.py:665
+#: docking/ui/settings.py:721
 msgid "Show recently closed apps between pinned launchers and running apps."
 msgstr ""
 
-#: docking/ui/settings.py:670
+#: docking/ui/settings.py:726
 msgid "Number of Recent Apps"
 msgstr ""
 
-#: docking/ui/settings.py:672
+#: docking/ui/settings.py:728
 msgid "Maximum recently used app icons to display."
 msgstr ""
 
-#: docking/ui/settings.py:675
+#: docking/ui/settings.py:731
 msgid "Keep Recent Apps For"
 msgstr ""
 
-#: docking/ui/settings.py:677
+#: docking/ui/settings.py:733
 msgid "Remove recent apps after this many days of inactivity."
 msgstr ""
 
-#: docking/ui/settings.py:686
+#: docking/ui/settings.py:742
 msgid "Show Recent Documents"
 msgstr ""
 
-#: docking/ui/settings.py:689
+#: docking/ui/settings.py:745
 msgid "Show a \"Recent Documents\" submenu when right-clicking an app icon."
 msgstr ""
 
-#: docking/ui/settings.py:694
+#: docking/ui/settings.py:750
 msgid "Max Documents Per App"
 msgstr ""
 
-#: docking/ui/settings.py:696
+#: docking/ui/settings.py:752
 msgid "Maximum recent document entries shown per app."
 msgstr ""
 
-#: docking/ui/settings.py:771
+#: docking/ui/settings.py:824
 msgid "Check Now"
 msgstr ""
 
-#: docking/ui/settings.py:773
+#: docking/ui/settings.py:826
 msgid "View Releases"
 msgstr ""
 
-#: docking/ui/settings.py:785
+#: docking/ui/settings.py:838
 msgid "Update Checks"
 msgstr ""
 
-#: docking/ui/settings.py:787
+#: docking/ui/settings.py:840
 msgid "Check Automatically"
 msgstr ""
 
-#: docking/ui/settings.py:788
+#: docking/ui/settings.py:841
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:789
+#: docking/ui/settings.py:842
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:790
+#: docking/ui/settings.py:843
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:1164
+#: docking/ui/settings.py:1286
 msgid "Primary Display"
 msgstr ""
 
-#: docking/ui/settings.py:1305
+#: docking/ui/settings.py:1427
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:1309
+#: docking/ui/settings.py:1431
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:1311
+#: docking/ui/settings.py:1433
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:1392
+#: docking/ui/settings.py:1514
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1394
+#: docking/ui/settings.py:1516
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1397
+#: docking/ui/settings.py:1519
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:1399
+#: docking/ui/settings.py:1521
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1401
+#: docking/ui/settings.py:1523
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1403
+#: docking/ui/settings.py:1525
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1406
+#: docking/ui/settings.py:1528
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-06-23 22:57+0200\n"
+"POT-Creation-Date: 2026-06-29 23:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,7 +115,7 @@ msgstr ""
 #: docking/applets/runcommand/applet.py:340
 #: docking/applets/sunrise/applet.py:188 docking/applets/trash/applet.py:177
 #: docking/applets/weather/applet.py:271 docking/ui/diagnostics.py:342
-#: docking/ui/menu.py:484
+#: docking/ui/menu.py:482
 msgid "Cancel"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Power Settings"
 msgstr ""
 
-#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:579
+#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:581
 msgid "Mouse"
 msgstr ""
 
@@ -1350,7 +1350,7 @@ msgid "{verb} every {interval}"
 msgstr ""
 
 #: docking/applets/freshness.py:43 docking/applets/freshness.py:50
-#: docking/ui/settings.py:231
+#: docking/ui/settings.py:232
 msgid "Updates"
 msgstr ""
 
@@ -2018,8 +2018,8 @@ msgid "Run with file"
 msgstr ""
 
 #: docking/applets/runcommand/applet.py:341
-#: docking/applets/systemtray/applet.py:254 docking/ui/menu.py:486
-#: docking/ui/menu.py:571
+#: docking/applets/systemtray/applet.py:254 docking/ui/menu.py:484
+#: docking/ui/menu.py:569
 msgid "Open"
 msgstr ""
 
@@ -2778,11 +2778,197 @@ msgstr ""
 msgid "Workspaces"
 msgstr ""
 
+#: docking/core/tips.py:57
+msgid "Open the dock menu from anywhere"
+msgstr ""
+
+#: docking/core/tips.py:59
+msgid ""
+"Hold Ctrl and right-click anywhere on the shelf to open the dock menu with "
+"Preferences, Applets, Diagnostics, and Quit."
+msgstr ""
+
+#: docking/core/tips.py:65
+msgid "Start with Preferences"
+msgstr ""
+
+#: docking/core/tips.py:67
+msgid ""
+"Use Preferences to adjust position, monitor behavior, icon size, zoom, "
+"hiding, themes, previews, tooltips, and click actions."
+msgstr ""
+
+#: docking/core/tips.py:73
+msgid "Add applets from the dock menu"
+msgstr ""
+
+#: docking/core/tips.py:75
+msgid ""
+"Right-click the shelf background and choose Add Applet to add launchers, "
+"system status, media, productivity, and utility tools."
+msgstr ""
+
+#: docking/core/tips.py:81
+msgid "Use separators for organization"
+msgstr ""
+
+#: docking/core/tips.py:82
+msgid "Right-click where a divider should go and choose Add Separator."
+msgstr ""
+
+#: docking/core/tips.py:86
+msgid "Pin running apps"
+msgstr ""
+
+#: docking/core/tips.py:87
+msgid "Right-click a running app and choose Keep in Dock."
+msgstr ""
+
+#: docking/core/tips.py:91
+msgid "Remove pinned items quickly"
+msgstr ""
+
+#: docking/core/tips.py:93
+msgid ""
+"Right-click a pinned item and choose Remove from Dock, or drag unlocked "
+"items off the dock."
+msgstr ""
+
+#: docking/core/tips.py:99
+msgid "Drop items onto the dock"
+msgstr ""
+
+#: docking/core/tips.py:101
+msgid ""
+"Drag applications, .desktop files, files, folders, and AppImages onto "
+"Docking to pin them."
+msgstr ""
+
+#: docking/core/tips.py:107
+msgid "Open files with dock apps"
+msgstr ""
+
+#: docking/core/tips.py:108
+msgid "Drag a file onto an application icon to open it with that app."
+msgstr ""
+
+#: docking/core/tips.py:112
+msgid "Use folder stacks"
+msgstr ""
+
+#: docking/core/tips.py:114
+msgid ""
+"Pin a folder and click it from the dock to browse its contents without "
+"opening a file manager first."
+msgstr ""
+
+#: docking/core/tips.py:120
+msgid "Tune folder stack behavior"
+msgstr ""
+
+#: docking/core/tips.py:122
+msgid ""
+"Right-click a pinned folder to sort contents, show hidden files, or "
+"customize its icon."
+msgstr ""
+
+#: docking/core/tips.py:128
+msgid "Customize pinned icons"
+msgstr ""
+
+#: docking/core/tips.py:130
+msgid ""
+"Right-click a pinned app, file, or folder and use Icon -> Choose From File."
+msgstr ""
+
+#: docking/core/tips.py:136
+msgid "Use the Applications applet search"
+msgstr ""
+
+#: docking/core/tips.py:137
+msgid ""
+"Add the Applications applet, open it, and type to filter installed apps."
+msgstr ""
+
+#: docking/core/tips.py:141
+msgid "Use Run Application like Alt+F2"
+msgstr ""
+
+#: docking/core/tips.py:143
+msgid ""
+"Add Run Application to launch commands, apps, and terminal commands from the "
+"dock."
+msgstr ""
+
+#: docking/core/tips.py:149
+msgid "Use window previews"
+msgstr ""
+
+#: docking/core/tips.py:150
+msgid "Hover running apps to inspect open windows before switching."
+msgstr ""
+
+#: docking/core/tips.py:154
+msgid "Choose your click behavior"
+msgstr ""
+
+#: docking/core/tips.py:156
+msgid ""
+"Preferences -> Behavior lets left click toggle, cycle, or focus the most "
+"recent window."
+msgstr ""
+
+#: docking/core/tips.py:162
+msgid "Ctrl-click opens a new window"
+msgstr ""
+
+#: docking/core/tips.py:163
+msgid "Hold Ctrl while clicking an app icon to launch another window."
+msgstr ""
+
+#: docking/core/tips.py:167
+msgid "Use app right-click menus"
+msgstr ""
+
+#: docking/core/tips.py:169
+msgid ""
+"Right-click apps for desktop actions, open windows, recent documents, "
+"pinning, and close actions."
+msgstr ""
+
+#: docking/core/tips.py:175
+msgid "Use Recent Files"
+msgstr ""
+
+#: docking/core/tips.py:176
+msgid "Add the Recent Files applet to jump back into recently used documents."
+msgstr ""
+
+#: docking/core/tips.py:180
+msgid "Use System Tray when needed"
+msgstr ""
+
+#: docking/core/tips.py:182
+msgid ""
+"Add System Tray for tray/status apps and use its menu to manage tray "
+"ownership when supported."
+msgstr ""
+
+#: docking/core/tips.py:188
+msgid "Use Diagnostics for support"
+msgstr ""
+
+#: docking/core/tips.py:190
+msgid ""
+"Open Diagnostics before filing an issue to copy backend, session, and "
+"feature details."
+msgstr ""
+
 #: docking/ui/about.py:68
 msgid "Website"
 msgstr ""
 
-#: docking/ui/diagnostics.py:71 docking/ui/menu.py:738
+#: docking/ui/diagnostics.py:71 docking/ui/menu.py:736
 msgid "Diagnostics"
 msgstr ""
 
@@ -2814,11 +3000,12 @@ msgstr ""
 msgid "Save Report..."
 msgstr ""
 
-#: docking/ui/diagnostics.py:122 docking/ui/menu.py:619
+#: docking/ui/diagnostics.py:122 docking/ui/menu.py:617
+#: docking/ui/startup_tips.py:173
 msgid "Close"
 msgstr ""
 
-#: docking/ui/diagnostics.py:145 docking/ui/dock_window.py:402
+#: docking/ui/diagnostics.py:145 docking/ui/dock_window.py:404
 msgid "Docking"
 msgstr ""
 
@@ -2953,104 +3140,104 @@ msgstr ""
 msgid "%d More in Folder"
 msgstr ""
 
-#: docking/ui/menu.py:431
+#: docking/ui/menu.py:429
 msgid "Docking Icon"
 msgstr ""
 
-#: docking/ui/menu.py:432
+#: docking/ui/menu.py:430
 msgid "System Icon"
 msgstr ""
 
-#: docking/ui/menu.py:440 docking/ui/menu.py:449
+#: docking/ui/menu.py:438 docking/ui/menu.py:447
 msgid "Icon"
 msgstr ""
 
-#: docking/ui/menu.py:452
+#: docking/ui/menu.py:450
 msgid "Default Icon"
 msgstr ""
 
-#: docking/ui/menu.py:456
+#: docking/ui/menu.py:454
 msgid "Choose From File..."
 msgstr ""
 
-#: docking/ui/menu.py:460
+#: docking/ui/menu.py:458
 msgid "Reset Custom Icon"
 msgstr ""
 
-#: docking/ui/menu.py:479
+#: docking/ui/menu.py:477
 msgid "Choose Icon"
 msgstr ""
 
-#: docking/ui/menu.py:502
+#: docking/ui/menu.py:500
 msgid "Images"
 msgstr ""
 
-#: docking/ui/menu.py:515
+#: docking/ui/menu.py:513
 msgid "Could not use selected icon"
 msgstr ""
 
-#: docking/ui/menu.py:558 docking/ui/menu.py:580 docking/ui/menu.py:603
-#: docking/ui/menu.py:654
+#: docking/ui/menu.py:556 docking/ui/menu.py:578 docking/ui/menu.py:601
+#: docking/ui/menu.py:652
 msgid "Remove from Dock"
 msgstr ""
 
-#: docking/ui/menu.py:610
+#: docking/ui/menu.py:608
 msgid "Keep in Dock"
 msgstr ""
 
-#: docking/ui/menu.py:619
+#: docking/ui/menu.py:617
 msgid "Close All"
 msgstr ""
 
-#: docking/ui/menu.py:636
+#: docking/ui/menu.py:634
 msgid "Sort By"
 msgstr ""
 
-#: docking/ui/menu.py:644
+#: docking/ui/menu.py:642
 msgid "Show Hidden Files"
 msgstr ""
 
-#: docking/ui/menu.py:684
+#: docking/ui/menu.py:682
 msgid "Add Applet"
 msgstr ""
 
-#: docking/ui/menu.py:722
+#: docking/ui/menu.py:720
 msgid "No Applets Available"
 msgstr ""
 
-#: docking/ui/menu.py:729
+#: docking/ui/menu.py:727
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:743 docking/ui/settings.py:204
+#: docking/ui/menu.py:741 docking/ui/settings.py:205
 msgid "Preferences"
 msgstr ""
 
-#: docking/ui/menu.py:748
+#: docking/ui/menu.py:746
 msgid "About"
 msgstr ""
 
-#: docking/ui/menu.py:753
+#: docking/ui/menu.py:751
 msgid "Get Support"
 msgstr ""
 
-#: docking/ui/menu.py:760
+#: docking/ui/menu.py:758
 msgid "Quit"
 msgstr ""
 
-#: docking/ui/menu.py:826
+#: docking/ui/menu.py:824
 msgid "Clear Recent Documents"
 msgstr ""
 
-#: docking/ui/menu.py:836 docking/ui/settings.py:673
+#: docking/ui/menu.py:834 docking/ui/settings.py:683
 msgid "Recent Documents"
 msgstr ""
 
-#: docking/ui/menu.py:855
+#: docking/ui/menu.py:853
 msgid "Window"
 msgstr ""
 
-#: docking/ui/new_year.py:176
+#: docking/ui/new_year.py:207
 #, python-brace-format
 msgid "Happy new year {year} !!!"
 msgstr ""
@@ -3060,431 +3247,454 @@ msgstr ""
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-#: docking/ui/settings.py:228
+#: docking/ui/settings.py:229
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:229 docking/ui/settings.py:606
+#: docking/ui/settings.py:230 docking/ui/settings.py:608
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:230
+#: docking/ui/settings.py:231
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:254
+#: docking/ui/settings.py:255
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:255
+#: docking/ui/settings.py:256
 msgid "Always on Top"
 msgstr ""
 
-#: docking/ui/settings.py:256
+#: docking/ui/settings.py:257
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:257
+#: docking/ui/settings.py:258
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:258
+#: docking/ui/settings.py:259
 msgid "Dodge Active"
 msgstr ""
 
-#: docking/ui/settings.py:259
+#: docking/ui/settings.py:260
 msgid "Dodge Windows"
 msgstr ""
 
-#: docking/ui/settings.py:260
+#: docking/ui/settings.py:261
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:271
+#: docking/ui/settings.py:272
 msgid "Toggle Focus"
 msgstr ""
 
-#: docking/ui/settings.py:272
+#: docking/ui/settings.py:273
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:273
+#: docking/ui/settings.py:274
 msgid "Most Recent Window"
 msgstr ""
 
-#: docking/ui/settings.py:280
+#: docking/ui/settings.py:281
 msgid "New Window"
 msgstr ""
 
-#: docking/ui/settings.py:281
+#: docking/ui/settings.py:282
 msgid "Minimize Windows"
 msgstr ""
 
-#: docking/ui/settings.py:282
+#: docking/ui/settings.py:283
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:289
+#: docking/ui/settings.py:290
 msgid "Click"
 msgstr ""
 
-#: docking/ui/settings.py:290
+#: docking/ui/settings.py:291
 msgid "Hover"
 msgstr ""
 
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:298
 msgid "Default"
 msgstr ""
 
-#: docking/ui/settings.py:298
+#: docking/ui/settings.py:299
 msgid "Alphabetical"
 msgstr ""
 
-#: docking/ui/settings.py:315
+#: docking/ui/settings.py:317
 msgid "Daily"
 msgstr ""
 
-#: docking/ui/settings.py:316
+#: docking/ui/settings.py:318
 msgid "Weekly"
 msgstr ""
 
-#: docking/ui/settings.py:337
+#: docking/ui/settings.py:339
 msgid ""
 "When Follow Cursor is enabled, the dock follows the pointer across monitors. "
 "The selected monitor is kept as the fallback."
 msgstr ""
 
-#: docking/ui/settings.py:383
+#: docking/ui/settings.py:385
 msgid "Added on top of the theme's own distance from the edge."
 msgstr ""
 
-#: docking/ui/settings.py:423
+#: docking/ui/settings.py:425
 msgid ""
 "Pixels of cursor pressure against the edge required to reveal a hidden dock. "
 "Higher values mean the dock will not reveal as easily."
 msgstr ""
 
-#: docking/ui/settings.py:445
+#: docking/ui/settings.py:447
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:447
+#: docking/ui/settings.py:449
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:447
+#: docking/ui/settings.py:449
 msgid "Choose the dock color palette."
 msgstr ""
 
-#: docking/ui/settings.py:449
+#: docking/ui/settings.py:451
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:451
+#: docking/ui/settings.py:453
 msgid "Set the base size of dock icons before zoom is applied."
 msgstr ""
 
-#: docking/ui/settings.py:454
+#: docking/ui/settings.py:456
 msgid "Transparency"
 msgstr ""
 
-#: docking/ui/settings.py:456
+#: docking/ui/settings.py:458
 msgid "Adjust how transparent the dock background is."
 msgstr ""
 
-#: docking/ui/settings.py:459
+#: docking/ui/settings.py:461
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:461
+#: docking/ui/settings.py:463
 msgid "Enlarge icons when the pointer hovers over the dock."
 msgstr ""
 
-#: docking/ui/settings.py:464
+#: docking/ui/settings.py:466
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:466
+#: docking/ui/settings.py:468
 msgid "Set how much hovered icons grow when zoom is enabled."
 msgstr ""
 
-#: docking/ui/settings.py:469
+#: docking/ui/settings.py:471
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:471
+#: docking/ui/settings.py:473
 msgid "Show item names and details when hovering over dock items."
 msgstr ""
 
-#: docking/ui/settings.py:474
+#: docking/ui/settings.py:476
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:476
+#: docking/ui/settings.py:478
 msgid "Show window thumbnails when hovering over running apps."
 msgstr ""
 
-#: docking/ui/settings.py:479
+#: docking/ui/settings.py:481
 msgid "Show Window Counts"
 msgstr ""
 
-#: docking/ui/settings.py:482
+#: docking/ui/settings.py:484
 msgid "Show a number on running app indicators when multiple windows are open."
 msgstr ""
 
-#: docking/ui/settings.py:490
+#: docking/ui/settings.py:492
 msgid "Placement"
 msgstr ""
 
-#: docking/ui/settings.py:493
+#: docking/ui/settings.py:495
 msgid "Position"
 msgstr ""
 
-#: docking/ui/settings.py:495
+#: docking/ui/settings.py:497
 msgid "Choose which screen edge the dock uses."
 msgstr ""
 
-#: docking/ui/settings.py:497
+#: docking/ui/settings.py:499
 msgid "Extra Distance from Edge"
 msgstr ""
 
-#: docking/ui/settings.py:499
+#: docking/ui/settings.py:501
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:502
+#: docking/ui/settings.py:504
 msgid "Show running windows only from the active workspace when supported."
 msgstr ""
 
-#: docking/ui/settings.py:510 docking/ui/settings.py:520
+#: docking/ui/settings.py:512 docking/ui/settings.py:522
 msgid "Monitor"
 msgstr ""
 
-#: docking/ui/settings.py:513
+#: docking/ui/settings.py:515
 msgid "Follow Cursor"
 msgstr ""
 
-#: docking/ui/settings.py:516
+#: docking/ui/settings.py:518
 msgid "Move the dock to the monitor where the pointer is currently located."
 msgstr ""
 
-#: docking/ui/settings.py:525
+#: docking/ui/settings.py:527
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:528
+#: docking/ui/settings.py:530
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:531
+#: docking/ui/settings.py:533
 msgid "Prevent dock items from being reordered or removed by drag and drop."
 msgstr ""
 
-#: docking/ui/settings.py:536
+#: docking/ui/settings.py:538
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:538
+#: docking/ui/settings.py:540
 msgid "Keep applets grouped at the end of the dock."
 msgstr ""
 
-#: docking/ui/settings.py:541
+#: docking/ui/settings.py:543
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:543
+#: docking/ui/settings.py:545
 msgid "Keep pinned files and folders grouped at the end of the dock."
 msgstr ""
 
-#: docking/ui/settings.py:582
+#: docking/ui/settings.py:584
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:585
+#: docking/ui/settings.py:587
 msgid ""
 "Choose what happens when clicking a running app with the left mouse button."
 msgstr ""
 
-#: docking/ui/settings.py:590
+#: docking/ui/settings.py:592
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:593
+#: docking/ui/settings.py:595
 msgid "Choose what happens when clicking an app with the middle mouse button."
 msgstr ""
 
-#: docking/ui/settings.py:598
+#: docking/ui/settings.py:600
 msgid "Window List Sort"
 msgstr ""
 
-#: docking/ui/settings.py:600
+#: docking/ui/settings.py:602
 msgid "Choose how open windows are ordered in app context menus."
 msgstr ""
 
-#: docking/ui/settings.py:608
+#: docking/ui/settings.py:610
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:610
+#: docking/ui/settings.py:612
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:613
+#: docking/ui/settings.py:615
 msgid "Set how long the dock waits before hiding after the pointer leaves."
 msgstr ""
 
-#: docking/ui/settings.py:618
+#: docking/ui/settings.py:620
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:621
+#: docking/ui/settings.py:623
 msgid "Set how long the dock waits before showing after the pointer returns."
 msgstr ""
 
-#: docking/ui/settings.py:626
+#: docking/ui/settings.py:628
 msgid "Pressure Reveal"
 msgstr ""
 
-#: docking/ui/settings.py:629
+#: docking/ui/settings.py:631
 msgid ""
 "Require the pointer to push against the screen edge before revealing a "
 "hidden dock."
 msgstr ""
 
-#: docking/ui/settings.py:633
+#: docking/ui/settings.py:635
 msgid "Pressure Threshold"
 msgstr ""
 
-#: docking/ui/settings.py:638
+#: docking/ui/settings.py:637
+msgid "Show Startup Tips"
+msgstr ""
+
+#: docking/ui/settings.py:640
+msgid ""
+"Show one Docking usage tip after startup, unless a higher-priority startup "
+"notification is visible."
+msgstr ""
+
+#: docking/ui/settings.py:648
 msgid "Folder Stacks"
 msgstr ""
 
-#: docking/ui/settings.py:641
+#: docking/ui/settings.py:651
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:643
+#: docking/ui/settings.py:653
 msgid "Choose whether folder stacks open on click or while hovering."
 msgstr ""
 
-#: docking/ui/settings.py:649
+#: docking/ui/settings.py:659
 msgid "Recent Apps"
 msgstr ""
 
-#: docking/ui/settings.py:652
+#: docking/ui/settings.py:662
 msgid "Show Recently Used Apps"
 msgstr ""
 
-#: docking/ui/settings.py:655
+#: docking/ui/settings.py:665
 msgid "Show recently closed apps between pinned launchers and running apps."
 msgstr ""
 
-#: docking/ui/settings.py:660
+#: docking/ui/settings.py:670
 msgid "Number of Recent Apps"
 msgstr ""
 
-#: docking/ui/settings.py:662
+#: docking/ui/settings.py:672
 msgid "Maximum recently used app icons to display."
 msgstr ""
 
-#: docking/ui/settings.py:665
+#: docking/ui/settings.py:675
 msgid "Keep Recent Apps For"
 msgstr ""
 
-#: docking/ui/settings.py:667
+#: docking/ui/settings.py:677
 msgid "Remove recent apps after this many days of inactivity."
 msgstr ""
 
-#: docking/ui/settings.py:676
+#: docking/ui/settings.py:686
 msgid "Show Recent Documents"
 msgstr ""
 
-#: docking/ui/settings.py:679
+#: docking/ui/settings.py:689
 msgid "Show a \"Recent Documents\" submenu when right-clicking an app icon."
 msgstr ""
 
-#: docking/ui/settings.py:684
+#: docking/ui/settings.py:694
 msgid "Max Documents Per App"
 msgstr ""
 
-#: docking/ui/settings.py:686
+#: docking/ui/settings.py:696
 msgid "Maximum recent document entries shown per app."
 msgstr ""
 
-#: docking/ui/settings.py:761
+#: docking/ui/settings.py:771
 msgid "Check Now"
 msgstr ""
 
-#: docking/ui/settings.py:763
+#: docking/ui/settings.py:773
 msgid "View Releases"
 msgstr ""
 
-#: docking/ui/settings.py:775
+#: docking/ui/settings.py:785
 msgid "Update Checks"
 msgstr ""
 
-#: docking/ui/settings.py:777
+#: docking/ui/settings.py:787
 msgid "Check Automatically"
 msgstr ""
 
-#: docking/ui/settings.py:778
+#: docking/ui/settings.py:788
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:779
+#: docking/ui/settings.py:789
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:780
+#: docking/ui/settings.py:790
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:1150
+#: docking/ui/settings.py:1164
 msgid "Primary Display"
 msgstr ""
 
-#: docking/ui/settings.py:1291
+#: docking/ui/settings.py:1305
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:1295
+#: docking/ui/settings.py:1309
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:1297
+#: docking/ui/settings.py:1311
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:1378
+#: docking/ui/settings.py:1392
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1380
+#: docking/ui/settings.py:1394
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1383
+#: docking/ui/settings.py:1397
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:1385
+#: docking/ui/settings.py:1399
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1387
+#: docking/ui/settings.py:1401
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1389
+#: docking/ui/settings.py:1403
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1392
+#: docking/ui/settings.py:1406
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
+msgstr ""
+
+#: docking/ui/startup_tips.py:155
+#, python-brace-format
+msgid "Tip: {title}"
+msgstr ""
+
+#: docking/ui/startup_tips.py:171
+msgid "Never Show Tips"
+msgstr ""
+
+#: docking/ui/startup_tips.py:172
+msgid "Next Tip"
 msgstr ""
 
 #: docking/ui/tooltip.py:221
@@ -3505,24 +3715,24 @@ msgstr ""
 msgid "{age} ago"
 msgstr ""
 
-#: docking/ui/update_popup.py:186
+#: docking/ui/update_popup.py:230
 #, python-brace-format
 msgid "Docking {version} is available"
 msgstr ""
 
-#: docking/ui/update_popup.py:192
+#: docking/ui/update_popup.py:236
 #, python-brace-format
 msgid "You are using {version}."
 msgstr ""
 
-#: docking/ui/update_popup.py:201
+#: docking/ui/update_popup.py:245
 msgid "View Release"
 msgstr ""
 
-#: docking/ui/update_popup.py:202
+#: docking/ui/update_popup.py:246
 msgid "Later"
 msgstr ""
 
-#: docking/ui/update_popup.py:203
+#: docking/ui/update_popup.py:247
 msgid "Ignore"
 msgstr ""

--- a/docking/ui/factory.py
+++ b/docking/ui/factory.py
@@ -43,9 +43,12 @@ from docking.ui.dock_window import DockWindow
 from docking.ui.folder.stack import FolderStackController
 from docking.ui.input_controller import DockInputController
 from docking.ui.menu import MenuHandler
+from docking.ui.new_year import NewYearGreetingController
 from docking.ui.renderer import DockRenderer
 from docking.ui.runtime import DockRuntime
 from docking.ui.settings import SettingsActions, SettingsWindowController
+from docking.ui.startup_popups import StartupPopupCoordinator
+from docking.ui.startup_tips import StartupTipsController
 from docking.ui.update_popup import UpdateCheckController
 
 
@@ -54,17 +57,17 @@ class DockUi:
     """Handle for the composed dock UI graph."""
 
     window: DockWindow
-    update_checker: UpdateCheckController
+    startup_popups: StartupPopupCoordinator
     input_controller: DockInputController
 
     def start(self) -> None:
         """Start the composed dock UI lifecycle."""
         self.input_controller.start()
-        self.update_checker.start()
+        self.startup_popups.start()
 
     def stop(self) -> None:
         """Stop the composed dock UI lifecycle."""
-        self.update_checker.stop()
+        self.startup_popups.stop()
         self.input_controller.stop()
 
 
@@ -148,6 +151,15 @@ def build_dock_window(
         interactions=interactions,
         dnd=dnd,
     )
+    startup_popups = StartupPopupCoordinator()
+    new_year = NewYearGreetingController(window=window)
+    startup_tips = StartupTipsController(
+        window=window,
+        config=config,
+    )
+    startup_popups.register(new_year)
+    startup_popups.register(update_checker)
+    startup_popups.register(startup_tips)
 
     def _get_dock_rect() -> Rect | None:
         if not window.get_realized():
@@ -171,6 +183,6 @@ def build_dock_window(
         dodge_monitor.start()
     return DockUi(
         window=window,
-        update_checker=update_checker,
+        startup_popups=startup_popups,
         input_controller=input_controller,
     )

--- a/docking/ui/new_year.py
+++ b/docking/ui/new_year.py
@@ -45,6 +45,8 @@ from docking.ui.tooltip import compute_tooltip_position
 
 log = get_logger("new_year")
 
+NEW_YEAR_POPUP_ID = "new-year"
+NEW_YEAR_POPUP_PRIORITY = 10
 STARTUP_GREETING_DELAY_S = 5
 NEW_YEAR_GREETING_DURATION_S = 15
 GREETING_GAP_PX = 16
@@ -60,6 +62,10 @@ GREETING_BORDER_RGBA = (1.0, 1.0, 1.0, 0.14)
 class NewYearGreetingController:
     """Schedules and displays the dock's annual New Year greeting."""
 
+    source_id = NEW_YEAR_POPUP_ID
+    priority = NEW_YEAR_POPUP_PRIORITY
+    max_wait_seconds: int | None = None
+
     def __init__(
         self,
         *,
@@ -73,11 +79,20 @@ class NewYearGreetingController:
         self._start_source_id: int = 0
         self._hide_source_id: int = 0
         self._popup: Gtk.Window | None = None
+        self._pending_year: int | None = None
+        self._request_show: Callable[[str], None] | None = None
+        self._visibility_changed: Callable[[str, bool], None] | None = None
 
-    def start(self) -> None:
+    def start(
+        self,
+        request_show: Callable[[str], None] | None = None,
+        visibility_changed: Callable[[str, bool], None] | None = None,
+    ) -> None:
         """Start the delayed startup greeting check once per process."""
         if self._start_source_id:
             return
+        self._request_show = request_show
+        self._visibility_changed = visibility_changed
         log.debug(
             "Scheduling New Year greeting check in %ss",
             STARTUP_GREETING_DELAY_S,
@@ -98,6 +113,7 @@ class NewYearGreetingController:
         if self._popup is not None:
             self._popup.destroy()
             self._popup = None
+        self._notify_visible(False)
 
     def _on_startup_complete(self) -> bool:
         self._start_source_id = 0
@@ -108,13 +124,25 @@ class NewYearGreetingController:
         )
         log.debug("New Year greeting evaluation at %s returned %r", now, year)
         if year is not None:
-            self._show_popup(year=year)
+            self._pending_year = year
+            if self._request_show is not None:
+                self._request_show(self.source_id)
+            else:
+                self.show_pending()
         return False
 
-    def _show_popup(self, *, year: int) -> None:
+    def show_pending(self) -> bool:
+        """Show a pending New Year greeting if one exists."""
+        if self._pending_year is None:
+            return False
+        year = self._pending_year
+        self._pending_year = None
+        return self._show_popup(year=year)
+
+    def _show_popup(self, *, year: int) -> bool:
         if not self._window.get_realized():
             log.debug("Skipping New Year greeting because dock window is not realized")
-            return
+            return False
 
         if self._popup is None:
             popup = Gtk.Window(type=Gtk.WindowType.POPUP)
@@ -130,6 +158,7 @@ class NewYearGreetingController:
             if visual is not None:
                 popup.set_visual(visual)
             popup.connect("draw", self._on_popup_draw)
+            popup.connect("destroy", self._on_popup_destroy)
             self._popup = popup
         else:
             child = self._popup.get_child()
@@ -139,6 +168,7 @@ class NewYearGreetingController:
         log.debug("Showing New Year greeting popup for year %s", year)
         self._popup.add(self._build_popup_content(year=year))
         self._popup.show_all()
+        self._notify_visible(True)
         self._position_popup()
 
         if self._hide_source_id:
@@ -147,6 +177,7 @@ class NewYearGreetingController:
             NEW_YEAR_GREETING_DURATION_S,
             self._hide_popup,
         )
+        return True
 
     def _build_popup_content(self, *, year: int) -> Gtk.Widget:
         pos = self._window.config.pos
@@ -334,7 +365,11 @@ class NewYearGreetingController:
         self._hide_source_id = 0
         if self._popup is not None:
             self._popup.hide()
+        self._notify_visible(False)
         return False
+
+    def _on_popup_destroy(self, _popup: Gtk.Window) -> None:
+        self._notify_visible(False)
 
     def _on_popup_button_press(
         self,
@@ -346,3 +381,7 @@ class NewYearGreetingController:
             self._hide_source_id = 0
         self._hide_popup()
         return True
+
+    def _notify_visible(self, visible: bool) -> None:
+        if self._visibility_changed is not None:
+            self._visibility_changed(self.source_id, visible)

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -235,6 +235,7 @@ class SettingsWindowController:
         self._hide_delay_spin: Any = None
         self._unhide_delay_spin: Any = None
         self._update_check_switch: Any = None
+        self._startup_tips_switch: Any = None
         self._update_interval_combo: Any = None
         self._update_status_label: Any = None
         self._recent_apps_switch: Any = None
@@ -365,6 +366,7 @@ class SettingsWindowController:
         self._anchor_files_switch = self._new_switch()
         self._zoom_enabled_switch = self._new_switch()
         self._update_check_switch = self._new_switch()
+        self._startup_tips_switch = self._new_switch()
 
         self._update_interval_combo = Gtk.ComboBoxText()
         for value, label in [
@@ -687,6 +689,14 @@ class SettingsWindowController:
                     ),
                 ),
                 (_("Pressure Threshold"), pressure_threshold_box, None),
+                (
+                    _("Show Startup Tips"),
+                    self._startup_tips_switch,
+                    _(
+                        "Show one Docking usage tip after startup, unless a "
+                        "higher-priority startup notification is visible."
+                    ),
+                ),
             ],
         )
         self._append_section(
@@ -1063,6 +1073,10 @@ class SettingsWindowController:
             self._register_switch_binding(
                 config_attr="update_check_enabled",
                 widget=self._update_check_switch,
+            ),
+            self._register_switch_binding(
+                config_attr="startup_tips_enabled",
+                widget=self._startup_tips_switch,
             ),
             self._register_numeric_binding(
                 config_attr="update_check_interval_hours",

--- a/docking/ui/startup_popups.py
+++ b/docking/ui/startup_popups.py
@@ -1,0 +1,137 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Startup popup arbitration."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Protocol
+
+import gi
+
+gi.require_version("GLib", "2.0")
+from gi.repository import GLib
+
+
+class StartupPopupSource(Protocol):
+    """Source that can request a startup popup without knowing the coordinator."""
+
+    source_id: str
+    priority: int
+    max_wait_seconds: int | None
+
+    def start(self, request_show, visibility_changed) -> None:
+        """Start source-specific startup work."""
+
+    def stop(self) -> None:
+        """Stop source-specific work."""
+
+    def show_pending(self) -> bool:
+        """Show pending content and return whether a popup became visible."""
+
+
+@dataclass(slots=True)
+class _PendingRequest:
+    requested_at: float
+    expire_source_id: int = 0
+
+
+class StartupPopupCoordinator:
+    """Own startup popup priority and source lifecycle."""
+
+    def __init__(self, *, clock=time.monotonic) -> None:
+        self._clock = clock
+        self._sources: dict[str, StartupPopupSource] = {}
+        self._pending: dict[str, _PendingRequest] = {}
+        self._active_source_id = ""
+
+    def register(self, source: StartupPopupSource) -> None:
+        self._sources[source.source_id] = source
+
+    def start(self) -> None:
+        for source in sorted(self._sources.values(), key=lambda item: item.priority):
+            source.start(self.request_show, self.visibility_changed)
+
+    def stop(self) -> None:
+        for request in self._pending.values():
+            if request.expire_source_id:
+                GLib.source_remove(request.expire_source_id)
+        self._pending.clear()
+        self._active_source_id = ""
+        for source in self._sources.values():
+            source.stop()
+
+    def request_show(self, source_id: str) -> None:
+        source = self._sources.get(source_id)
+        if source is None:
+            return
+        if source_id not in self._pending:
+            self._pending[source_id] = _PendingRequest(requested_at=self._clock())
+            self._schedule_expiry(source=source)
+        self._try_show_next()
+
+    def visibility_changed(self, source_id: str, visible: bool) -> None:
+        if visible:
+            self._active_source_id = source_id
+            self._clear_pending(source_id)
+            return
+        if self._active_source_id == source_id:
+            self._active_source_id = ""
+        self._try_show_next()
+
+    def _try_show_next(self) -> None:
+        if self._active_source_id:
+            return
+        self._drop_expired_requests()
+        while self._pending:
+            source = min(
+                (self._sources[source_id] for source_id in self._pending),
+                key=lambda item: item.priority,
+            )
+            self._clear_pending(source.source_id)
+            if source.show_pending():
+                self._active_source_id = source.source_id
+                return
+
+    def _schedule_expiry(self, *, source: StartupPopupSource) -> None:
+        max_wait_seconds = source.max_wait_seconds
+        if max_wait_seconds is None:
+            return
+        request = self._pending[source.source_id]
+        request.expire_source_id = GLib.timeout_add_seconds(
+            max_wait_seconds,
+            self._expire_source,
+            source.source_id,
+        )
+
+    def _expire_source(self, source_id: str) -> bool:
+        request = self._pending.get(source_id)
+        if request is not None:
+            request.expire_source_id = 0
+        self._clear_pending(source_id)
+        return False
+
+    def _drop_expired_requests(self) -> None:
+        for source_id, request in tuple(self._pending.items()):
+            source = self._sources.get(source_id)
+            if source is None or source.max_wait_seconds is None:
+                continue
+            if self._clock() - request.requested_at >= source.max_wait_seconds:
+                self._clear_pending(source_id)
+
+    def _clear_pending(self, source_id: str) -> None:
+        request = self._pending.pop(source_id, None)
+        if request is not None and request.expire_source_id:
+            GLib.source_remove(request.expire_source_id)

--- a/docking/ui/startup_tips.py
+++ b/docking/ui/startup_tips.py
@@ -1,0 +1,238 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Startup usage tip popup UI."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import gi
+
+gi.require_version("Gdk", "3.0")
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk, GLib, Gtk
+
+from docking.core.position import is_horizontal
+from docking.core.tips import StartupTip, select_startup_tip
+from docking.i18n import _
+from docking.log import get_logger
+from docking.ui.display import clamp_popup, window_screen_position
+from docking.ui.tooltip import compute_tooltip_position
+
+if TYPE_CHECKING:
+    from docking.core.config import Config
+
+log = get_logger("tips")
+
+STARTUP_TIP_POPUP_ID = "startup-tips"
+STARTUP_TIP_POPUP_PRIORITY = 30
+STARTUP_TIP_DELAY_S = 12
+STARTUP_TIP_MAX_PRIORITY_WAIT_S = 30
+STARTUP_TIP_POPUP_GAP_PX = 16
+STARTUP_TIP_SPACING_PX = 10
+STARTUP_TIP_MARGIN_PX = 12
+STARTUP_TIP_WIDTH_CHARS = 48
+
+
+class StartupTipsController:
+    """Schedules and shows one startup usage tip."""
+
+    source_id = STARTUP_TIP_POPUP_ID
+    priority = STARTUP_TIP_POPUP_PRIORITY
+    max_wait_seconds: int | None = STARTUP_TIP_MAX_PRIORITY_WAIT_S
+
+    def __init__(
+        self,
+        *,
+        window: Gtk.Window,
+        config: Config,
+        state_path: Path | str | None = None,
+        chooser: Callable[[Sequence[StartupTip]], StartupTip] | None = None,
+    ) -> None:
+        self._window = window
+        self._config = config
+        self._state_path = Path(state_path) if state_path is not None else None
+        self._chooser = chooser
+        self._start_source_id = 0
+        self._popup: Gtk.Window | None = None
+        self._current_tip: StartupTip | None = None
+        self._request_show: Callable[[str], None] | None = None
+        self._visibility_changed: Callable[[str, bool], None] | None = None
+
+    def start(
+        self,
+        request_show: Callable[[str], None] | None = None,
+        visibility_changed: Callable[[str, bool], None] | None = None,
+    ) -> None:
+        """Schedule the startup tip check once per process."""
+        if self._start_source_id or not self._config.startup_tips_enabled:
+            return
+        self._request_show = request_show
+        self._visibility_changed = visibility_changed
+        self._start_source_id = GLib.timeout_add_seconds(
+            STARTUP_TIP_DELAY_S,
+            self._on_startup_delay_elapsed,
+        )
+
+    def stop(self) -> None:
+        """Cancel pending work and close the popup."""
+        if self._start_source_id:
+            GLib.source_remove(self._start_source_id)
+            self._start_source_id = 0
+        self._destroy_popup()
+
+    def _on_startup_delay_elapsed(self) -> bool:
+        self._start_source_id = 0
+        if not self._config.startup_tips_enabled:
+            return False
+        if self._request_show is not None:
+            self._request_show(self.source_id)
+        else:
+            self.show_pending()
+        return False
+
+    def show_pending(self) -> bool:
+        """Select and show the next startup tip."""
+        if not self._window.get_realized():
+            log.debug("Skipping startup tip because dock window is not realized")
+            return False
+        tip = select_startup_tip(
+            enabled=self._config.startup_tips_enabled,
+            path=self._state_path,
+            chooser=self._chooser,
+        )
+        if tip is None:
+            return False
+        return self._show_popup(tip=tip)
+
+    def _show_popup(self, *, tip: StartupTip) -> bool:
+        if not self._window.get_realized():
+            log.debug("Skipping startup tip because dock window is not realized")
+            return False
+        self._current_tip = tip
+        if self._popup is None:
+            popup = Gtk.Window(type=Gtk.WindowType.POPUP)
+            popup.set_decorated(False)
+            popup.set_skip_taskbar_hint(True)
+            popup.set_resizable(False)
+            popup.set_type_hint(Gdk.WindowTypeHint.NOTIFICATION)
+            popup.set_transient_for(self._window)
+            popup.connect("destroy", self._on_popup_destroy)
+            self._popup = popup
+        else:
+            child = self._popup.get_child()
+            if child is not None:
+                self._popup.remove(child)
+
+        self._popup.add(self._build_popup_content(tip=tip))
+        self._popup.show_all()
+        self._notify_visible(True)
+        self._position_popup()
+        return True
+
+    def _build_popup_content(self, *, tip: StartupTip) -> Gtk.Widget:
+        frame = Gtk.Frame()
+        frame.set_shadow_type(Gtk.ShadowType.OUT)
+        box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=STARTUP_TIP_SPACING_PX,
+        )
+        box.set_border_width(STARTUP_TIP_MARGIN_PX)
+
+        title = Gtk.Label(label=_("Tip: {title}").format(title=tip.title))
+        title.set_xalign(0.0)
+        title.set_line_wrap(True)
+        title.set_max_width_chars(STARTUP_TIP_WIDTH_CHARS)
+        box.pack_start(title, False, False, 0)
+
+        body = Gtk.Label(label=tip.body)
+        body.set_xalign(0.0)
+        body.set_line_wrap(True)
+        body.set_max_width_chars(STARTUP_TIP_WIDTH_CHARS)
+        box.pack_start(body, False, False, 0)
+
+        buttons = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=STARTUP_TIP_SPACING_PX,
+        )
+        never = Gtk.Button(label=_("Never Show Tips"))
+        next_tip = Gtk.Button(label=_("Next Tip"))
+        close = Gtk.Button(label=_("Close"))
+        never.connect("clicked", self._on_never_show)
+        next_tip.connect("clicked", self._on_next_tip)
+        close.connect("clicked", self._on_close)
+        buttons.pack_start(never, False, False, 0)
+        buttons.pack_start(next_tip, False, False, 0)
+        buttons.pack_start(close, False, False, 0)
+        box.pack_start(buttons, False, False, 0)
+
+        frame.add(box)
+        return frame
+
+    def _position_popup(self) -> None:
+        if self._popup is None:
+            return
+        window_pos = window_screen_position(self._window)
+        win_x, win_y = window_pos.x, window_pos.y
+        win_w, win_h = self._window.get_size()
+        pref = self._popup.get_preferred_size()[1]
+        popup_w = max(pref.width, 1)
+        popup_h = max(pref.height, 1)
+        pos = self._window.config.pos
+        if is_horizontal(pos):
+            anchor_x = win_x + win_w / 2
+            anchor_y = win_y if pos.value == "bottom" else win_y + win_h
+        else:
+            anchor_x = win_x + win_w if pos.value == "left" else win_x
+            anchor_y = win_y + win_h / 2
+        popup_x, popup_y = compute_tooltip_position(
+            pos=pos,
+            anchor_x=anchor_x,
+            anchor_y=anchor_y,
+            tooltip_w=popup_w,
+            tooltip_h=popup_h,
+            gap=STARTUP_TIP_POPUP_GAP_PX,
+        )
+        clamped = clamp_popup(self._popup, popup_x, popup_y, popup_w, popup_h)
+        self._popup.move(clamped.x, clamped.y)
+
+    def _on_never_show(self, _button: Gtk.Button) -> None:
+        self._config.startup_tips_enabled = False
+        self._config.save()
+        self._destroy_popup()
+
+    def _on_next_tip(self, _button: Gtk.Button) -> None:
+        self.show_pending()
+
+    def _on_close(self, _button: Gtk.Button) -> None:
+        if self._popup is not None:
+            self._popup.hide()
+        self._notify_visible(False)
+
+    def _on_popup_destroy(self, _popup: Gtk.Window) -> None:
+        self._popup = None
+        self._notify_visible(False)
+
+    def _destroy_popup(self) -> None:
+        if self._popup is not None:
+            popup = self._popup
+            self._popup = None
+            popup.destroy()
+        self._notify_visible(False)
+
+    def _notify_visible(self, visible: bool) -> None:
+        if self._visibility_changed is not None:
+            self._visibility_changed(self.source_id, visible)

--- a/docking/ui/update_popup.py
+++ b/docking/ui/update_popup.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
@@ -48,6 +49,8 @@ if TYPE_CHECKING:
 
 log = get_logger("updates")
 
+UPDATE_POPUP_ID = "updates"
+UPDATE_POPUP_PRIORITY = 20
 UPDATE_CHECK_DELAY_S = 8
 UPDATE_POPUP_GAP_PX = 16
 UPDATE_POPUP_SPACING_PX = 10
@@ -58,22 +61,39 @@ REMIND_LATER_HOURS = 24
 class UpdateCheckController:
     """Schedules release checks and presents update notifications."""
 
+    source_id = UPDATE_POPUP_ID
+    priority = UPDATE_POPUP_PRIORITY
+    max_wait_seconds: int | None = None
+
     def __init__(
         self,
         *,
-        window: Gtk.Window,
         config: Config,
+        window: Gtk.Window | None = None,
     ) -> None:
         self._window = window
         self._config = config
         self._start_source_id: int = 0
         self._popup: Gtk.Window | None = None
         self._latest_release: ReleaseInfo | None = None
+        self._pending_release: ReleaseInfo | None = None
+        self._request_show: Callable[[str], None] | None = None
+        self._visibility_changed: Callable[[str, bool], None] | None = None
 
-    def start(self) -> None:
+    def set_window(self, window: Gtk.Window) -> None:
+        """Attach the dock window used as popup parent and anchor."""
+        self._window = window
+
+    def start(
+        self,
+        request_show: Callable[[str], None] | None = None,
+        visibility_changed: Callable[[str, bool], None] | None = None,
+    ) -> None:
         """Schedule an automatic update check if user preferences allow it."""
         if self._start_source_id or not self._config.update_check_enabled:
             return
+        self._request_show = request_show
+        self._visibility_changed = visibility_changed
         state = load_state()
         if not should_check_for_updates(
             enabled=self._config.update_check_enabled,
@@ -95,10 +115,11 @@ class UpdateCheckController:
         if self._popup is not None:
             self._popup.destroy()
             self._popup = None
+        self._notify_visible(False)
 
     def check_now(self) -> None:
         """Run a manual update check immediately."""
-        self._run_check_in_thread()
+        self._run_check_in_thread(automatic=False)
 
     def open_releases_page(self) -> None:
         """Open the project releases page."""
@@ -106,14 +127,18 @@ class UpdateCheckController:
 
     def _on_startup_delay_elapsed(self) -> bool:
         self._start_source_id = 0
-        self._run_check_in_thread()
+        self._run_check_in_thread(automatic=True)
         return False
 
-    def _run_check_in_thread(self) -> None:
-        thread = threading.Thread(target=self._check_worker, daemon=True)
+    def _run_check_in_thread(self, *, automatic: bool) -> None:
+        thread = threading.Thread(
+            target=self._check_worker,
+            kwargs={"automatic": automatic},
+            daemon=True,
+        )
         thread.start()
 
-    def _check_worker(self) -> None:
+    def _check_worker(self, *, automatic: bool) -> None:
         release: ReleaseInfo | None = None
         error = ""
         try:
@@ -121,12 +146,13 @@ class UpdateCheckController:
         except Exception as exc:
             error = str(exc)
             log.debug("Update check failed: %s", exc)
-        GLib.idle_add(self._on_check_finished, release, error)
+        GLib.idle_add(self._on_check_finished, release, error, automatic)
 
     def _on_check_finished(
         self,
         release: ReleaseInfo | None,
         error: str,
+        automatic: bool = True,
     ) -> bool:
         now = datetime.now(timezone.utc)
         current_state = load_state()
@@ -148,13 +174,28 @@ class UpdateCheckController:
         )
         save_state(state)
         if decision.should_show and decision.release is not None:
-            self._show_popup(release=decision.release)
+            if automatic and self._request_show is not None:
+                self._pending_release = decision.release
+                self._request_show(self.source_id)
+            else:
+                self._show_popup(release=decision.release)
         return False
 
-    def _show_popup(self, *, release: ReleaseInfo) -> None:
+    def show_pending(self) -> bool:
+        """Show a pending automatic update popup if one exists."""
+        if self._pending_release is None:
+            return False
+        release = self._pending_release
+        self._pending_release = None
+        return self._show_popup(release=release)
+
+    def _show_popup(self, *, release: ReleaseInfo) -> bool:
+        if self._window is None:
+            log.debug("Skipping update popup because dock window is unavailable")
+            return False
         if not self._window.get_realized():
             log.debug("Skipping update popup because dock window is not realized")
-            return
+            return False
         self._latest_release = release
         if self._popup is None:
             popup = Gtk.Window(type=Gtk.WindowType.POPUP)
@@ -163,6 +204,7 @@ class UpdateCheckController:
             popup.set_resizable(False)
             popup.set_type_hint(Gdk.WindowTypeHint.NOTIFICATION)
             popup.set_transient_for(self._window)
+            popup.connect("destroy", self._on_popup_destroy)
             self._popup = popup
         else:
             child = self._popup.get_child()
@@ -171,7 +213,9 @@ class UpdateCheckController:
 
         self._popup.add(self._build_popup_content(release=release))
         self._popup.show_all()
+        self._notify_visible(True)
         self._position_popup()
+        return True
 
     def _build_popup_content(self, *, release: ReleaseInfo) -> Gtk.Widget:
         frame = Gtk.Frame()
@@ -212,7 +256,7 @@ class UpdateCheckController:
         return frame
 
     def _position_popup(self) -> None:
-        if self._popup is None:
+        if self._popup is None or self._window is None:
             return
         window_pos = window_screen_position(self._window)
         win_x, win_y = window_pos.x, window_pos.y
@@ -281,9 +325,17 @@ class UpdateCheckController:
     def _hide_popup(self) -> None:
         if self._popup is not None:
             self._popup.hide()
+        self._notify_visible(False)
+
+    def _on_popup_destroy(self, _popup: Gtk.Window) -> None:
+        self._notify_visible(False)
 
     def _open_url(self, url: str) -> None:
         try:
             Gio.AppInfo.launch_default_for_uri(url, None)
         except Exception as exc:
             log.warning("Failed to open release URL: %s", exc)
+
+    def _notify_visible(self, visible: bool) -> None:
+        if self._visibility_changed is not None:
+            self._visibility_changed(self.source_id, visible)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -35,6 +35,7 @@ class TestConfigDefaults:
         assert c.tooltips_enabled is True
         assert c.update_check_enabled is True
         assert c.update_check_interval_hours == 24
+        assert c.startup_tips_enabled is True
         assert c.left_click_action == "toggle"
         assert c.middle_click_action == "new-window"
         assert c.folder_stack_unfold == "hover"
@@ -82,6 +83,7 @@ class TestConfigDefaults:
             active_display="no",
             update_check_enabled="off",
             update_check_interval_hours="bad",
+            startup_tips_enabled="off",
             show_window_count_numbers="on",
             theme="",
         )
@@ -100,6 +102,7 @@ class TestConfigDefaults:
         assert c.active_display is False
         assert c.update_check_enabled is False
         assert c.update_check_interval_hours == 24
+        assert c.startup_tips_enabled is False
         assert c.show_window_count_numbers is True
         assert c.theme == "default"
 
@@ -529,13 +532,18 @@ class TestConfigSave:
 
     def test_save_persists_update_check_preferences(self, tmp_path):
         path = tmp_path / "dock.json"
-        config = Config(update_check_enabled=False, update_check_interval_hours=168)
+        config = Config(
+            update_check_enabled=False,
+            update_check_interval_hours=168,
+            startup_tips_enabled=False,
+        )
 
         config.save(path)
 
         saved = json.loads(path.read_text())
         assert saved["update_check_enabled"] is False
         assert saved["update_check_interval_hours"] == 168
+        assert saved["startup_tips_enabled"] is False
 
     def test_save_persists_typed_pinned_entries(self, tmp_path):
         path = tmp_path / "dock.json"

--- a/tests/core/test_tips.py
+++ b/tests/core/test_tips.py
@@ -1,0 +1,123 @@
+"""Tests for startup tips state and rotation."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import docking.core.tips as tips_mod
+from docking.core.tips import (
+    FIRST_TIP_ID,
+    STARTUP_TIPS,
+    StartupTipsState,
+    load_state,
+    save_state,
+    select_startup_tip,
+)
+
+
+class TestStartupTipsState:
+    def test_missing_file_returns_defaults(self, tmp_path):
+        assert load_state(path=tmp_path / "tips.json") == StartupTipsState()
+
+    def test_invalid_payload_returns_defaults(self, tmp_path, caplog):
+        path = tmp_path / "tips.json"
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="docking.tips"):
+            state = load_state(path=path)
+
+        assert state == StartupTipsState()
+        assert "Invalid startup tips state payload" in caplog.text
+
+    def test_round_trip(self, tmp_path):
+        path = tmp_path / "tips.json"
+        state = StartupTipsState(shown_tip_ids=(FIRST_TIP_ID, "recent-files"))
+
+        save_state(state, path=path)
+
+        assert load_state(path=path) == state
+
+    def test_string_values_are_normalized_and_deduped(self, tmp_path):
+        path = tmp_path / "tips.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "shown_tip_ids": [
+                        FIRST_TIP_ID,
+                        " recent-files ",
+                        FIRST_TIP_ID,
+                        "",
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert load_state(path=path).shown_tip_ids == (
+            FIRST_TIP_ID,
+            "recent-files",
+        )
+
+
+class TestSelectStartupTip:
+    def test_disabled_returns_none_without_creating_state(self, tmp_path):
+        path = tmp_path / "tips.json"
+
+        tip = select_startup_tip(enabled=False, path=path)
+
+        assert tip is None
+        assert not path.exists()
+
+    def test_first_tip_is_fixed(self, tmp_path):
+        path = tmp_path / "tips.json"
+
+        tip = select_startup_tip(
+            enabled=True,
+            path=path,
+            chooser=lambda tips: tips[-1],
+        )
+
+        assert tip is not None
+        assert tip.id == FIRST_TIP_ID
+        assert load_state(path=path).shown_tip_ids == (FIRST_TIP_ID,)
+
+    def test_later_tip_uses_unshown_candidates(self, tmp_path):
+        path = tmp_path / "tips.json"
+        save_state(StartupTipsState(shown_tip_ids=(FIRST_TIP_ID,)), path=path)
+        chosen_candidates = []
+
+        def choose(candidates):
+            chosen_candidates.extend(tip.id for tip in candidates)
+            return candidates[0]
+
+        tip = select_startup_tip(enabled=True, path=path, chooser=choose)
+
+        assert tip is not None
+        assert tip.id != FIRST_TIP_ID
+        assert FIRST_TIP_ID not in chosen_candidates
+        assert tip.id in load_state(path=path).shown_tip_ids
+
+    def test_cycle_resets_after_all_tips_were_shown(self, tmp_path):
+        path = tmp_path / "tips.json"
+        save_state(
+            StartupTipsState(shown_tip_ids=tuple(tip.id for tip in STARTUP_TIPS)),
+            path=path,
+        )
+
+        tip = select_startup_tip(
+            enabled=True,
+            path=path,
+            chooser=lambda candidates: candidates[-1],
+        )
+
+        assert tip is not None
+        assert tip.id != FIRST_TIP_ID
+        assert load_state(path=path).shown_tip_ids == (FIRST_TIP_ID, tip.id)
+
+    def test_catalog_has_exactly_twenty_unique_tips(self):
+        ids = [tip.id for tip in STARTUP_TIPS]
+
+        assert len(STARTUP_TIPS) == 20
+        assert len(ids) == len(set(ids))
+        assert ids[0] == tips_mod.FIRST_TIP_ID

--- a/tests/smoke/test_python314_smoke.py
+++ b/tests/smoke/test_python314_smoke.py
@@ -83,6 +83,15 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
         "docking.ui.new_year": {
             "NewYearGreetingController": type("NewYearGreetingController", (), {}),
         },
+        "docking.ui.startup_popups": {
+            "StartupPopupCoordinator": type("StartupPopupCoordinator", (), {}),
+        },
+        "docking.ui.startup_tips": {
+            "StartupTipsController": type("StartupTipsController", (), {}),
+        },
+        "docking.ui.update_popup": {
+            "UpdateCheckController": type("UpdateCheckController", (), {}),
+        },
         "docking.ui.renderer": {
             "DockRenderer": type("DockRenderer", (), {}),
         },
@@ -236,7 +245,12 @@ def test_about_dialog_controller_smoke(monkeypatch):
 def test_app_main_smoke(monkeypatch):
     app_mod, fake_glib, fake_gtk = _load_app_module(monkeypatch)
 
-    config = SimpleNamespace(theme="default", icon_size=48, transparency=1.0)
+    config = SimpleNamespace(
+        theme="default",
+        icon_size=48,
+        transparency=1.0,
+        startup_tips_enabled=True,
+    )
     theme = MagicMock()
     theme.with_opacity.return_value = object()
     launcher = MagicMock()
@@ -250,8 +264,12 @@ def test_app_main_smoke(monkeypatch):
     backend.previews = preview_service
     backend.visibility = visibility_service
     unity = MagicMock()
-    new_year = MagicMock()
     window = MagicMock()
+    ui = SimpleNamespace(
+        window=window,
+        start=MagicMock(),
+        stop=MagicMock(),
+    )
     items_service = MagicMock()
 
     config_cls = MagicMock()
@@ -271,16 +289,6 @@ def test_app_main_smoke(monkeypatch):
         MagicMock(return_value=backend),
     )
     monkeypatch.setattr(app_mod, "UnityLauncherListener", MagicMock(return_value=unity))
-    monkeypatch.setattr(
-        app_mod,
-        "NewYearGreetingController",
-        MagicMock(return_value=new_year),
-    )
-    ui = SimpleNamespace(
-        window=window,
-        start=MagicMock(),
-        stop=MagicMock(),
-    )
     monkeypatch.setattr(app_mod, "build_dock_window", MagicMock(return_value=ui))
     monkeypatch.setattr(
         app_mod, "DockItemsService", MagicMock(return_value=items_service)
@@ -293,8 +301,6 @@ def test_app_main_smoke(monkeypatch):
 
     app_mod.main()
 
-    new_year.start.assert_called_once()
-    new_year.stop.assert_called_once()
     ui.start.assert_called_once()
     ui.stop.assert_called_once()
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -135,7 +135,6 @@ class TestAppMain:
         backend.idle = None
         backend.screen_capture = None
         unity = MagicMock()
-        new_year = MagicMock()
         window = MagicMock()
         ui = SimpleNamespace(
             window=window,
@@ -148,7 +147,6 @@ class TestAppMain:
         window.show_all.side_effect = lambda: call_order.append("show_all")
         ui.start.side_effect = lambda: call_order.append("ui_start")
         unity.start.side_effect = lambda: call_order.append("unity_start")
-        new_year.start.side_effect = lambda: call_order.append("new_year_start")
         items_service.start.side_effect = lambda: call_order.append("items_start")
         model.start_applets.side_effect = lambda: call_order.append("applets_start")
 
@@ -178,11 +176,6 @@ class TestAppMain:
             app_mod,
             "UnityLauncherListener",
             MagicMock(return_value=unity),
-        )
-        monkeypatch.setattr(
-            app_mod,
-            "NewYearGreetingController",
-            MagicMock(return_value=new_year),
         )
         factory = MagicMock(return_value=ui)
         monkeypatch.setattr(app_mod, "build_dock_window", factory)
@@ -222,8 +215,6 @@ class TestAppMain:
         items_service.stop.assert_called_once()
         unity.start.assert_called_once()
         unity.stop.assert_called_once()
-        new_year.start.assert_called_once()
-        new_year.stop.assert_called_once()
         ui.start.assert_called_once()
         ui.stop.assert_called_once()
         fake_glib.idle_add.assert_called_once_with(
@@ -236,7 +227,6 @@ class TestAppMain:
         assert call_order == [
             "unity_start",
             "show_all",
-            "new_year_start",
             "ui_start",
             "idle_add",
             "items_start",
@@ -271,7 +261,6 @@ class TestAppMain:
         backend.surface = surface_service
         backend.visibility = visibility_service
         unity = MagicMock()
-        new_year = MagicMock()
         window = MagicMock()
         ui = SimpleNamespace(
             window=window,
@@ -284,7 +273,6 @@ class TestAppMain:
         window.show_all.side_effect = lambda: call_order.append("show_all")
         ui.start.side_effect = lambda: call_order.append("ui_start")
         unity.start.side_effect = lambda: call_order.append("unity_start")
-        new_year.start.side_effect = lambda: call_order.append("new_year_start")
         items_service.start.side_effect = lambda: call_order.append("items_start")
         model.start_applets.side_effect = lambda: call_order.append("applets_start")
 
@@ -303,7 +291,6 @@ class TestAppMain:
         renderer_cls = MagicMock(return_value=renderer)
         backend_cls = MagicMock(return_value=backend)
         unity_cls = MagicMock(return_value=unity)
-        new_year_cls = MagicMock(return_value=new_year)
         factory = MagicMock(return_value=ui)
         items_service_cls = MagicMock(return_value=items_service)
 
@@ -325,11 +312,6 @@ class TestAppMain:
         )
         monkeypatch.setattr(
             sys.modules["docking.platform.unity"], "UnityLauncherListener", unity_cls
-        )
-        monkeypatch.setattr(
-            sys.modules["docking.ui.new_year"],
-            "NewYearGreetingController",
-            new_year_cls,
         )
         monkeypatch.setattr(
             sys.modules["docking.ui.factory"], "build_dock_window", factory
@@ -354,14 +336,11 @@ class TestAppMain:
         backend.stop.assert_called_once()
         unity.start.assert_called_once()
         unity.stop.assert_called_once()
-        new_year.start.assert_called_once()
-        new_year.stop.assert_called_once()
         ui.start.assert_called_once()
         ui.stop.assert_called_once()
         assert call_order == [
             "unity_start",
             "show_all",
-            "new_year_start",
             "ui_start",
             "idle_add",
             "items_start",

--- a/tests/ui/test_factory.py
+++ b/tests/ui/test_factory.py
@@ -23,6 +23,9 @@ def _patch_ui_components(monkeypatch):
         settings=MagicMock(),
         diagnostics=MagicMock(),
         update_checker=MagicMock(),
+        startup_popups=MagicMock(),
+        new_year=MagicMock(),
+        startup_tips=MagicMock(),
         runtime=MagicMock(),
         folder_stack=MagicMock(),
         dnd=MagicMock(),
@@ -40,6 +43,21 @@ def _patch_ui_components(monkeypatch):
         factory_mod,
         "UpdateCheckController",
         MagicMock(return_value=components.update_checker),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "StartupPopupCoordinator",
+        MagicMock(return_value=components.startup_popups),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "NewYearGreetingController",
+        MagicMock(return_value=components.new_year),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "StartupTipsController",
+        MagicMock(return_value=components.startup_tips),
     )
     monkeypatch.setattr(
         factory_mod,
@@ -103,7 +121,6 @@ class TestBuildDockWindow:
         surface_service = MagicMock()
         visibility_service = MagicMock()
         session_backend = MagicMock()
-
         window = _window()
         dodge_monitor = MagicMock()
 
@@ -125,7 +142,7 @@ class TestBuildDockWindow:
         )
 
         assert result.window is window
-        assert result.update_checker is components.update_checker
+        assert result.startup_popups is components.startup_popups
         assert result.input_controller is components.input_controller
         factory_mod.DockWindow.assert_called_once_with(
             config=config,
@@ -199,15 +216,27 @@ class TestBuildDockWindow:
             interactions=components.interactions,
             dnd=components.dnd,
         )
+        factory_mod.StartupPopupCoordinator.assert_called_once_with()
+        factory_mod.NewYearGreetingController.assert_called_once_with(window=window)
+        factory_mod.StartupTipsController.assert_called_once_with(
+            window=window,
+            config=config,
+        )
+        components.startup_popups.register.assert_any_call(components.new_year)
+        components.startup_popups.register.assert_any_call(components.update_checker)
+        components.startup_popups.register.assert_any_call(components.startup_tips)
         components.input_controller.start.assert_not_called()
         components.update_checker.start.assert_not_called()
+        components.startup_popups.start.assert_not_called()
 
         result.start()
         components.input_controller.start.assert_called_once_with()
-        components.update_checker.start.assert_called_once_with()
+        components.startup_popups.start.assert_called_once_with()
+        components.update_checker.start.assert_not_called()
 
         result.stop()
-        components.update_checker.stop.assert_called_once_with()
+        components.startup_popups.stop.assert_called_once_with()
+        components.update_checker.stop.assert_not_called()
         components.input_controller.stop.assert_called_once_with()
 
     def test_build_dock_window_allows_unsupported_visibility_service(self, monkeypatch):
@@ -222,7 +251,6 @@ class TestBuildDockWindow:
         visibility_service = MagicMock()
         visibility_service.create_monitor.return_value = None
         session_backend = MagicMock()
-
         window = _window()
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
         _patch_ui_components(monkeypatch)
@@ -256,7 +284,6 @@ class TestBuildDockWindow:
         surface_service = MagicMock()
         visibility_service = MagicMock()
         session_backend = MagicMock()
-
         window = _window()
         window.get_realized.return_value = True
         window.get_position.return_value = (10, 20)
@@ -306,7 +333,6 @@ class TestBuildDockWindow:
         surface_service = MagicMock()
         visibility_service = MagicMock()
         session_backend = MagicMock()
-
         window = _window()
         window.get_realized.return_value = False
         captured: dict[str, object] = {}

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -684,6 +684,7 @@ def _config():
         unhide_delay_ms=0,
         update_check_enabled=True,
         update_check_interval_hours=24,
+        startup_tips_enabled=True,
         additional_distance_from_edge=0,
         pressure_reveal_enabled=False,
         pressure_threshold=50,
@@ -951,6 +952,7 @@ class TestSettingsWindowController:
             "Hide Delay",
             "Unhide Delay",
             "Pressure Reveal",
+            "Show Startup Tips",
             "Open On",
         }
 

--- a/tests/ui/test_startup_popups.py
+++ b/tests/ui/test_startup_popups.py
@@ -1,0 +1,134 @@
+"""Tests for startup popup arbitration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import docking.ui.startup_popups as popups_mod
+from docking.ui.startup_popups import StartupPopupCoordinator
+
+
+class _FakeGLib:
+    def __init__(self) -> None:
+        self.next_id = 100
+        self.scheduled: dict[int, tuple[int, object, tuple[object, ...]]] = {}
+        self.removed: list[int] = []
+
+    def timeout_add_seconds(self, seconds, callback, *args):
+        self.next_id += 1
+        self.scheduled[self.next_id] = (seconds, callback, args)
+        return self.next_id
+
+    def source_remove(self, source_id):
+        self.removed.append(source_id)
+
+
+@dataclass
+class _Source:
+    source_id: str
+    priority: int
+    max_wait_seconds: int | None = None
+    visible: bool = False
+    start_calls: int = 0
+    stop_calls: int = 0
+    show_calls: int = 0
+    request_show: object | None = None
+    visibility_changed: object | None = None
+    events: list[str] = field(default_factory=list)
+
+    def start(self, request_show, visibility_changed) -> None:
+        self.start_calls += 1
+        self.request_show = request_show
+        self.visibility_changed = visibility_changed
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+
+    def show_pending(self) -> bool:
+        self.show_calls += 1
+        self.visible = True
+        self.events.append(f"show:{self.source_id}")
+        self.visibility_changed(self.source_id, True)
+        return True
+
+    def close(self) -> None:
+        self.visible = False
+        self.visibility_changed(self.source_id, False)
+
+
+def test_start_and_stop_delegate_to_sources(monkeypatch):
+    fake_glib = _FakeGLib()
+    monkeypatch.setattr(popups_mod, "GLib", fake_glib)
+    coordinator = StartupPopupCoordinator()
+    new_year = _Source("new-year", 10)
+    updates = _Source("updates", 20)
+
+    coordinator.register(updates)
+    coordinator.register(new_year)
+    coordinator.start()
+    coordinator.stop()
+
+    assert new_year.start_calls == 1
+    assert updates.start_calls == 1
+    assert new_year.stop_calls == 1
+    assert updates.stop_calls == 1
+
+
+def test_higher_priority_pending_source_shows_first(monkeypatch):
+    monkeypatch.setattr(popups_mod, "GLib", _FakeGLib())
+    coordinator = StartupPopupCoordinator()
+    shown: list[str] = []
+    blocker = _Source("blocker", 5, events=shown)
+    new_year = _Source("new-year", 10, events=shown)
+    tips = _Source("startup-tips", 30, events=shown)
+    coordinator.register(blocker)
+    coordinator.register(new_year)
+    coordinator.register(tips)
+    coordinator.start()
+
+    blocker.request_show("blocker")
+    tips.request_show("startup-tips")
+    new_year.request_show("new-year")
+
+    assert shown == ["show:blocker"]
+    blocker.close()
+    assert shown == ["show:blocker", "show:new-year"]
+
+
+def test_lower_priority_waits_while_higher_priority_is_visible(monkeypatch):
+    monkeypatch.setattr(popups_mod, "GLib", _FakeGLib())
+    coordinator = StartupPopupCoordinator()
+    shown: list[str] = []
+    updates = _Source("updates", 20, events=shown)
+    tips = _Source("startup-tips", 30, events=shown)
+    coordinator.register(updates)
+    coordinator.register(tips)
+    coordinator.start()
+
+    updates.request_show("updates")
+    tips.request_show("startup-tips")
+
+    assert shown == ["show:updates"]
+    updates.close()
+    assert shown == ["show:updates", "show:startup-tips"]
+
+
+def test_pending_source_expires(monkeypatch):
+    fake_glib = _FakeGLib()
+    monkeypatch.setattr(popups_mod, "GLib", fake_glib)
+    coordinator = StartupPopupCoordinator()
+    updates = _Source("updates", 20)
+    tips = _Source("startup-tips", 30, max_wait_seconds=30)
+    coordinator.register(updates)
+    coordinator.register(tips)
+    coordinator.start()
+
+    updates.request_show("updates")
+    tips.request_show("startup-tips")
+    timeout_id = next(iter(fake_glib.scheduled))
+    _seconds, callback, args = fake_glib.scheduled[timeout_id]
+
+    assert callback(*args) is False
+    updates.close()
+
+    assert tips.show_calls == 0

--- a/tests/ui/test_startup_tips.py
+++ b/tests/ui/test_startup_tips.py
@@ -1,0 +1,321 @@
+"""Tests for the startup tips popup controller."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import docking.ui.startup_tips as tips_ui
+from docking.core.position import Position
+from docking.core.tips import FIRST_TIP_ID, StartupTip
+from docking.ui.startup_tips import StartupTipsController
+
+
+class _FakeGLib:
+    def __init__(self) -> None:
+        self.next_id = 40
+        self.scheduled: list[tuple[int, object]] = []
+        self.removed: list[int] = []
+
+    def timeout_add_seconds(self, seconds, callback):
+        self.next_id += 1
+        self.scheduled.append((seconds, callback))
+        return self.next_id
+
+    def source_remove(self, source_id):
+        self.removed.append(source_id)
+
+
+class _FakePopup:
+    def __init__(self, *args, **kwargs) -> None:
+        self.child = None
+        self.destroyed = False
+        self.hidden = False
+        self.shown = False
+        self.moved_to = None
+        self.connections = {}
+
+    def set_decorated(self, value):
+        self.decorated = value
+
+    def set_skip_taskbar_hint(self, value):
+        self.skip_taskbar = value
+
+    def set_resizable(self, value):
+        self.resizable = value
+
+    def set_type_hint(self, value):
+        self.type_hint = value
+
+    def set_transient_for(self, window):
+        self.transient_for = window
+
+    def get_transient_for(self):
+        return getattr(self, "transient_for", None)
+
+    def get_screen(self):
+        return SimpleNamespace(get_width=lambda: 800, get_height=lambda: 600)
+
+    def connect(self, signal, callback):
+        self.connections[signal] = callback
+
+    def get_child(self):
+        return self.child
+
+    def remove(self, child):
+        if self.child is child:
+            self.child = None
+
+    def add(self, child):
+        self.child = child
+
+    def show_all(self):
+        self.shown = True
+
+    def get_preferred_size(self):
+        return (None, SimpleNamespace(width=260, height=130))
+
+    def move(self, x, y):
+        self.moved_to = (x, y)
+
+    def hide(self):
+        self.hidden = True
+
+    def destroy(self):
+        self.destroyed = True
+
+
+class _FakeFrame:
+    def set_shadow_type(self, value):
+        self.shadow_type = value
+
+    def add(self, child):
+        self.child = child
+
+
+class _FakeBox:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.children = []
+        self.border_width = 0
+
+    def set_border_width(self, value):
+        self.border_width = value
+
+    def pack_start(self, child, *args):
+        self.children.append(child)
+
+
+class _FakeLabel:
+    def __init__(self, *, label="") -> None:
+        self.label = label
+
+    def set_xalign(self, value):
+        self.xalign = value
+
+    def set_line_wrap(self, value):
+        self.line_wrap = value
+
+    def set_max_width_chars(self, value):
+        self.max_width_chars = value
+
+
+class _FakeButton:
+    def __init__(self, *, label="") -> None:
+        self.label = label
+        self.handlers = {}
+
+    def connect(self, signal, callback):
+        self.handlers[signal] = callback
+
+    def click(self):
+        self.handlers["clicked"](self)
+
+
+class _FakeWindow:
+    def __init__(self, *, realized=True, pos=Position.BOTTOM) -> None:
+        self.realized = realized
+        self.config = SimpleNamespace(pos=pos)
+        self.surface_service = SimpleNamespace(
+            popups_use_parent_relative_coordinates=False,
+        )
+
+    def get_realized(self):
+        return self.realized
+
+    def get_position(self):
+        return (100, 200)
+
+    def get_size(self):
+        return (300, 48)
+
+
+@pytest.fixture
+def fake_gtk(monkeypatch):
+    glib = _FakeGLib()
+    monkeypatch.setattr(tips_ui, "GLib", glib)
+    monkeypatch.setattr(
+        tips_ui,
+        "Gtk",
+        SimpleNamespace(
+            Window=_FakePopup,
+            WindowType=SimpleNamespace(POPUP="popup"),
+            Frame=_FakeFrame,
+            ShadowType=SimpleNamespace(OUT="out"),
+            Box=_FakeBox,
+            Orientation=SimpleNamespace(VERTICAL="vertical", HORIZONTAL="horizontal"),
+            Label=_FakeLabel,
+            Button=_FakeButton,
+        ),
+    )
+    monkeypatch.setattr(
+        tips_ui,
+        "Gdk",
+        SimpleNamespace(WindowTypeHint=SimpleNamespace(NOTIFICATION="notification")),
+    )
+    return glib
+
+
+def _config(*, enabled=True):
+    return SimpleNamespace(startup_tips_enabled=enabled, save=lambda: None)
+
+
+def test_start_is_idempotent_and_stop_cleans_source(fake_gtk):
+    requests = []
+    controller = StartupTipsController(
+        window=_FakeWindow(),
+        config=_config(),
+    )
+
+    controller.start(lambda source_id: requests.append(source_id), lambda *_a: None)
+    controller.start(lambda source_id: requests.append(source_id), lambda *_a: None)
+
+    assert len(fake_gtk.scheduled) == 1
+    source_id = controller._start_source_id
+
+    fake_gtk.scheduled[0][1]()
+    assert requests == [tips_ui.STARTUP_TIP_POPUP_ID]
+
+    controller.stop()
+
+    assert fake_gtk.removed == []
+    assert controller._start_source_id == 0
+
+    controller.start(lambda *_a: None, lambda *_a: None)
+    controller.stop()
+
+    assert fake_gtk.removed == [source_id + 1]
+
+
+def test_start_disabled_does_not_schedule(fake_gtk):
+    controller = StartupTipsController(
+        window=_FakeWindow(),
+        config=_config(enabled=False),
+    )
+
+    controller.start()
+
+    assert fake_gtk.scheduled == []
+
+
+def test_show_popup_skips_unrealized_window(fake_gtk):
+    controller = StartupTipsController(
+        window=_FakeWindow(realized=False),
+        config=_config(),
+    )
+
+    controller._show_popup(
+        tip=StartupTip(FIRST_TIP_ID, "Title", "Body"),
+    )
+
+    assert controller._popup is None
+
+
+def test_show_next_tip_skips_unrealized_window_without_state(fake_gtk, tmp_path):
+    path = tmp_path / "tips.json"
+    controller = StartupTipsController(
+        window=_FakeWindow(realized=False),
+        config=_config(),
+        state_path=path,
+    )
+
+    controller.show_pending()
+
+    assert controller._popup is None
+    assert not path.exists()
+
+
+def test_show_popup_marks_active_and_positions(fake_gtk):
+    visible = []
+    controller = StartupTipsController(
+        window=_FakeWindow(),
+        config=_config(),
+    )
+    controller.start(
+        lambda *_a: None, lambda source_id, state: visible.append((source_id, state))
+    )
+
+    controller._show_popup(tip=StartupTip(FIRST_TIP_ID, "Title", "Body"))
+
+    assert isinstance(controller._popup, _FakePopup)
+    assert controller._popup.shown
+    assert controller._popup.moved_to is not None
+    assert visible[-1] == (tips_ui.STARTUP_TIP_POPUP_ID, True)
+
+
+def test_close_hides_and_deactivates(fake_gtk):
+    visible = []
+    controller = StartupTipsController(
+        window=_FakeWindow(),
+        config=_config(),
+    )
+    controller.start(
+        lambda *_a: None, lambda source_id, state: visible.append((source_id, state))
+    )
+    controller._show_popup(tip=StartupTip(FIRST_TIP_ID, "Title", "Body"))
+
+    controller._on_close(_FakeButton(label="Close"))
+
+    assert controller._popup.hidden
+    assert visible[-1] == (tips_ui.STARTUP_TIP_POPUP_ID, False)
+
+
+def test_never_show_disables_saves_and_destroys(fake_gtk):
+    saved = []
+    config = SimpleNamespace(
+        startup_tips_enabled=True,
+        save=lambda: saved.append(True),
+    )
+    visible = []
+    controller = StartupTipsController(
+        window=_FakeWindow(),
+        config=config,
+    )
+    controller.start(
+        lambda *_a: None, lambda source_id, state: visible.append((source_id, state))
+    )
+    controller._show_popup(tip=StartupTip(FIRST_TIP_ID, "Title", "Body"))
+    popup = controller._popup
+
+    controller._on_never_show(_FakeButton(label="Never"))
+
+    assert config.startup_tips_enabled is False
+    assert saved == [True]
+    assert popup.destroyed
+    assert visible[-1] == (tips_ui.STARTUP_TIP_POPUP_ID, False)
+
+
+def test_next_tip_selects_and_replaces_content(fake_gtk, tmp_path):
+    controller = StartupTipsController(
+        window=_FakeWindow(),
+        config=_config(),
+        state_path=tmp_path / "tips.json",
+        chooser=lambda tips: tips[0],
+    )
+
+    controller.show_pending()
+    first_child = controller._popup.child
+    controller._on_next_tip(_FakeButton(label="Next"))
+
+    assert controller._popup.child is not first_child


### PR DESCRIPTION
## Summary
- add a startup tips catalog and persisted no-repeat tip rotation
- add a startup popup coordinator that arbitrates New Year, update, and tips popups by priority
- add a Preferences toggle to disable or re-enable startup tips