### PR TITLE
Refactor dock UI composition boundary

### DIFF
--- a/docking/app.py
+++ b/docking/app.py
@@ -89,8 +89,7 @@ from docking.platform.environment import apply_tweaks, detect_desktop
 from docking.platform.launcher import Launcher
 from docking.platform.model import DockModel
 from docking.platform.unity import UnityLauncherListener
-from docking.ui.factory import build_dock_window
-from docking.ui.new_year import NewYearGreetingController
+from docking.ui.factory import build_dock_ui
 from docking.ui.renderer import DockRenderer
 
 if TYPE_CHECKING:
@@ -126,7 +125,7 @@ def main() -> None:
     )
     unity = UnityLauncherListener(model=model)
 
-    window = build_dock_window(
+    ui = build_dock_ui(
         config=config,
         model=model,
         renderer=renderer,
@@ -138,8 +137,7 @@ def main() -> None:
         session_backend=backend,
         launcher=launcher,
     )
-    items_service = DockItemsService(model=model, window=window)
-    new_year = NewYearGreetingController(window=window)
+    items_service = DockItemsService(model=model, window=ui.window)
 
     # Graceful shutdown on SIGINT/SIGTERM
     GLib.unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGINT, _quit)
@@ -147,15 +145,13 @@ def main() -> None:
 
     try:
         unity.start()
-        window.show_all()
-        new_year.start()
-        window.start_update_checks()
+        ui.window.show_all()
+        ui.start_startup_ui()
         GLib.idle_add(_start_runtime, items_service, model, backend)
         Gtk.main()
     finally:
         items_service.stop()
-        window.stop_update_checks()
-        new_year.stop()
+        ui.stop_startup_ui()
         unity.stop()
         model.stop_applets()
         backend.stop()

--- a/docking/applets/popup.py
+++ b/docking/applets/popup.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
 
 import gi
 
@@ -26,6 +25,7 @@ from gi.repository import Gdk, Gtk
 
 from docking.core.position import Position
 from docking.ui.display import clamp_popup, clamp_to_screen, get_pointer_position
+from docking.ui.popup import PopupAnchor
 
 _POPUP_CLASS = "applet-popup-surface"
 _POPUP_CSS = f"""
@@ -42,16 +42,6 @@ _popup_css_provider: Gtk.CssProvider | None = None
 DEFAULT_POPUP_CURSOR_GAP_PX = 20
 DEFAULT_DIALOG_CONTENT_SPACING_PX = 8
 DEFAULT_DIALOG_MARGIN_PX = 12
-
-
-@dataclass(frozen=True, slots=True)
-class PopupAnchor:
-    """Screen-space applet popup anchor."""
-
-    x: int
-    y: int
-    position: Position
-    parent: Gtk.Window | None = None
 
 
 def entry_completion_combo(

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -199,7 +199,6 @@ gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk, GLib, Gtk
 
 from docking.applets.identity import is_applet_desktop_id as is_applet
-from docking.applets.popup import PopupAnchor
 from docking.core.config import FolderStackUnfold, LeftClickAction, MiddleClickAction
 from docking.core.items import FILE_KIND, FOLDER_KIND
 from docking.core.position import is_horizontal
@@ -215,9 +214,7 @@ from docking.platform.backends.base import (
 from docking.platform.environment import detect_desktop, log_runtime_snapshot
 from docking.platform.launcher import launch, launch_new_window, open_target
 from docking.ui import geometry
-from docking.ui.about import AboutDialogController
 from docking.ui.autohide import AutoHideController, HideState
-from docking.ui.diagnostics import DiagnosticsDialogController
 from docking.ui.display import window_screen_position
 from docking.ui.dnd import DnDHandler
 from docking.ui.effects import ZoomAnimator
@@ -230,12 +227,11 @@ from docking.ui.hover import HoverManager
 from docking.ui.interaction import DockInteractionCoordinator
 from docking.ui.menu import MenuHandler
 from docking.ui.placement import DockPlacementController
+from docking.ui.popup import PopupAnchor
 from docking.ui.preview import PreviewPopup
 from docking.ui.renderer import RenderState
 from docking.ui.runtime import DockRuntime
-from docking.ui.settings import SettingsWindowController
 from docking.ui.tooltip import TooltipManager
-from docking.ui.update_popup import UpdateCheckController
 
 log = get_logger(name="dock_window")
 
@@ -363,10 +359,9 @@ class DockWindow(Gtk.Window):
         self.cursor_y: float = -1.0
         self.autohide: AutoHideController
         self.dnd: DnDHandler
-        self._menu: MenuHandler
+        self._menu: MenuHandler | None = None
         self.preview: PreviewPopup
         self._menu_popup_visible: bool = False
-        self._update_checker: UpdateCheckController
         self.tooltip = TooltipManager(self, config, model, theme)
         self.geometry = DockGeometryBuilder(self)
 
@@ -381,6 +376,7 @@ class DockWindow(Gtk.Window):
 
         self.placement = DockPlacementController(self, surface_service=surface_service)
         self.interaction = DockInteractionCoordinator(self)
+        self.runtime = DockRuntime(self)
         self._cache = _DockWindowCache.create()
         self._redraw_source_id: int | None = None
         self.dock_hovered: bool = False
@@ -474,14 +470,6 @@ class DockWindow(Gtk.Window):
             self.dodge_monitor = None
         self._disconnect_model()
 
-    def start_update_checks(self) -> None:
-        """Start update-check scheduling owned by the dock shell."""
-        self._update_checker.start()
-
-    def stop_update_checks(self) -> None:
-        """Stop update-check scheduling owned by the dock shell."""
-        self._update_checker.stop()
-
     def set_theme(self, theme: Theme) -> None:
         """Replace the runtime theme and notify collaborators that cache it."""
         self.theme = theme
@@ -492,19 +480,6 @@ class DockWindow(Gtk.Window):
 
     def _build_components(self, *, launcher: Launcher) -> None:
         """Build long-lived UI collaborators that depend on the live window."""
-        self._update_checker = UpdateCheckController(window=self, config=self.config)
-        runtime = DockRuntime(self, update_checker=self._update_checker)
-        about = AboutDialogController(parent=self)
-        settings = SettingsWindowController(
-            parent=self,
-            runtime=runtime,
-            model=self.model,
-            config=self.config,
-        )
-        diagnostics = DiagnosticsDialogController(
-            parent=self,
-            backend=self.session_backend,
-        )
         self.autohide = AutoHideController(self, self.config)
         self.dnd = DnDHandler(
             drawing_area=self.drawing_area,
@@ -516,20 +491,6 @@ class DockWindow(Gtk.Window):
             launcher=launcher,
             geometry_builder=self.geometry,
         )
-        self._menu = MenuHandler(
-            about=about,
-            settings=settings,
-            diagnostics=diagnostics,
-            runtime=runtime,
-            model=self.model,
-            config=self.config,
-            window_tracker=self.window_tracker,
-            preview_service=self.preview_service,
-            geometry_builder=self.geometry,
-            launcher=launcher,
-            dock_window=self,
-        )
-        self._menu.schedule_visible_folder_stack_prewarm(self.model.visible_items())
         self.preview = PreviewPopup(
             window_tracker=self.window_tracker,
             preview_service=self.preview_service,
@@ -538,6 +499,37 @@ class DockWindow(Gtk.Window):
         self.preview.set_pointer_inside_dock_probe(self.is_pointer_inside_dock)
         self.preview.set_autohide(controller=self.autohide)
         self.hover.set_preview(preview=self.preview)
+
+    def set_menu_handler(self, menu: MenuHandler) -> None:
+        """Install the externally composed dock menu handler."""
+        self._menu = menu
+        self._menu.schedule_visible_folder_stack_prewarm(self.model.visible_items())
+
+    def _require_menu(self) -> MenuHandler:
+        if self._menu is None:
+            raise RuntimeError("Dock menu handler has not been installed")
+        return self._menu
+
+    def popup_anchor(self) -> PopupAnchor | None:
+        """Return the current dock-level popup anchor in screen coordinates."""
+        if not self.get_realized():
+            return None
+        window_pos = window_screen_position(self)
+        win_x, win_y = window_pos.x, window_pos.y
+        win_w, win_h = self.get_size()
+        pos = self.config.pos
+        if is_horizontal(pos):
+            anchor_x = int(win_x + win_w / 2)
+            anchor_y = int(win_y if pos.value == "bottom" else win_y + win_h)
+        else:
+            anchor_x = int(win_x + win_w if pos.value == "left" else win_x)
+            anchor_y = int(win_y + win_h / 2)
+        return PopupAnchor(
+            x=anchor_x,
+            y=anchor_y,
+            position=pos,
+            parent=self,
+        )
 
     def is_pointer_inside_dock(self) -> bool:
         """Return True when the current pointer is inside the dock input area."""
@@ -798,12 +790,13 @@ class DockWindow(Gtk.Window):
         frame = self._build_and_store_geometry_frame()
         self.update_input_region(frame=frame)
         self._schedule_redraw()
-        stack_item_id = self._menu.open_folder_stack_item_id()
+        menu = self._require_menu()
+        stack_item_id = menu.open_folder_stack_item_id()
         hovered_item = frame.item_at_point(event.x, event.y)
         if stack_item_id is not None and (
             hovered_item is None or hovered_item.desktop_id != stack_item_id
         ):
-            self._menu.close_folder_stack()
+            menu.close_folder_stack()
         if frame.cursor_rect.contains(event.x, event.y):
             self.interaction.on_effective_enter()
             cursor_main = (
@@ -811,7 +804,7 @@ class DockWindow(Gtk.Window):
             )
             self.hover.update(cursor_main, frame=frame)
             if hovered_item is not None and hovered_item.kind == FOLDER_KIND:
-                self._menu.schedule_folder_stack_prewarm(hovered_item)
+                menu.schedule_folder_stack_prewarm(hovered_item)
             if (
                 self.config.folder_stack_unfold == FolderStackUnfold.HOVER.value
                 and hovered_item is not None
@@ -834,8 +827,9 @@ class DockWindow(Gtk.Window):
 
     def close_open_folder_stack_for_item(self, desktop_id: str) -> None:
         """Close the folder stack if it currently belongs to the given item."""
-        if self._menu.open_folder_stack_item_id() == desktop_id:
-            self._menu.close_folder_stack()
+        menu = self._require_menu()
+        if menu.open_folder_stack_item_id() == desktop_id:
+            menu.close_folder_stack()
 
     def _show_folder_stack_for_item(
         self,
@@ -862,7 +856,7 @@ class DockWindow(Gtk.Window):
             anchor_x = win_x + int(fallback_x)
             anchor_y = win_y + int(fallback_y)
             icon_w = int(self.config.icon_size)
-        self._menu.show_folder_stack(
+        self._require_menu().show_folder_stack(
             item=item,
             anchor_x=anchor_x,
             anchor_y=anchor_y,
@@ -900,7 +894,7 @@ class DockWindow(Gtk.Window):
         if event.button == MOUSE_RIGHT:
             cursor_main = event.x if is_horizontal(pos=self.config.pos) else event.y
             force_background = bool(event.state & Gdk.ModifierType.CONTROL_MASK)
-            self._menu.show(
+            self._require_menu().show(
                 event,
                 cursor_main,
                 force_background=force_background,
@@ -1123,7 +1117,9 @@ class DockWindow(Gtk.Window):
         self._invalidate_current_geometry_frame()
         self.update_input_region()
         self.hover.on_model_changed()
-        self._menu.schedule_visible_folder_stack_prewarm(self.model.visible_items())
+        self._require_menu().schedule_visible_folder_stack_prewarm(
+            self.model.visible_items()
+        )
         # Refresh hover/tooltip state even without mouse motion so applets
         # that update item.name asynchronously (e.g. workspace switcher)
         # show the new tooltip text immediately.

--- a/docking/ui/factory.py
+++ b/docking/ui/factory.py
@@ -11,14 +11,12 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 
-"""Composition root for building a dock window plus edge-dodge integration.
-
-`DockWindow` now leaves construction already owning its UI collaborators. This
-module stays as the thin bootstrap layer for the extra platform piece that does
-not belong inside the GTK shell itself: the dodge monitor.
-"""
+"""Composition root for building the dock UI graph."""
 
 from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
 
 from docking.core.config import Config
 from docking.core.theme import Theme
@@ -32,12 +30,46 @@ from docking.platform.backends.base import (
 )
 from docking.platform.launcher import Launcher
 from docking.platform.model import DockModel
+from docking.ui.about import AboutDialogController
+from docking.ui.diagnostics import DiagnosticsDialogController
 from docking.ui.display import window_screen_position
 from docking.ui.dock_window import DockWindow
+from docking.ui.menu import MenuHandler
+from docking.ui.new_year import NewYearGreetingController
 from docking.ui.renderer import DockRenderer
+from docking.ui.settings import SettingsWindowController
+from docking.ui.update_popup import UpdateCheckController
 
 
-def build_dock_window(
+class StartupLifecycle(Protocol):
+    """Controller with startup UI lifecycle hooks."""
+
+    def start(self) -> None:
+        """Start the controller."""
+
+    def stop(self) -> None:
+        """Stop the controller."""
+
+
+@dataclass(slots=True)
+class DockUi:
+    """Small UI graph handle returned to the application bootstrap."""
+
+    window: DockWindow
+    _startup_controllers: tuple[StartupLifecycle, ...]
+
+    def start_startup_ui(self) -> None:
+        """Start startup UI controllers in their configured order."""
+        for controller in self._startup_controllers:
+            controller.start()
+
+    def stop_startup_ui(self) -> None:
+        """Stop startup UI controllers in reverse order."""
+        for controller in reversed(self._startup_controllers):
+            controller.stop()
+
+
+def build_dock_ui(
     *,
     config: Config,
     model: DockModel,
@@ -49,8 +81,8 @@ def build_dock_window(
     visibility_service: VisibilityService,
     launcher: Launcher,
     session_backend: SessionBackend,
-) -> DockWindow:
-    """Build a fully wired dock window and its UI collaborators."""
+) -> DockUi:
+    """Build a fully wired dock UI graph."""
     window = DockWindow(
         config=config,
         model=model,
@@ -62,6 +94,38 @@ def build_dock_window(
         surface_service=surface_service,
         session_backend=session_backend,
     )
+    runtime = window.runtime
+    update_checker = UpdateCheckController(
+        config=config,
+        anchor_provider=window,
+    )
+    about = AboutDialogController(parent=window)
+    diagnostics = DiagnosticsDialogController(
+        parent=window,
+        backend=session_backend,
+    )
+    settings = SettingsWindowController(
+        parent=window,
+        runtime=runtime,
+        model=model,
+        config=config,
+        updates=update_checker,
+    )
+    menu = MenuHandler(
+        about=about,
+        settings=settings,
+        diagnostics=diagnostics,
+        runtime=runtime,
+        model=model,
+        config=config,
+        window_tracker=window_tracker,
+        preview_service=preview_service,
+        geometry_builder=window.geometry,
+        launcher=launcher,
+        dock_window=window,
+    )
+    window.set_menu_handler(menu)
+    new_year = NewYearGreetingController(anchor_provider=window)
 
     def _get_dock_rect() -> Rect | None:
         if not window.get_realized():
@@ -83,4 +147,7 @@ def build_dock_window(
     window.dodge_monitor = dodge_monitor
     if dodge_monitor is not None:
         dodge_monitor.start()
-    return window
+    return DockUi(
+        window=window,
+        _startup_controllers=(new_year, update_checker),
+    )

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -152,7 +152,7 @@ from __future__ import annotations
 import datetime as dt
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 import gi
 
@@ -186,12 +186,9 @@ from docking.log import get_logger
 from docking.platform import icon_overrides
 from docking.platform.backends.base import DisplayServer
 from docking.platform.recent_docs import recent_docs_for_app
-from docking.ui.about import AboutDialogController
-from docking.ui.diagnostics import DiagnosticsDialogController
 from docking.ui.folder.stack import FolderStackController
 from docking.ui.geometry import DockGeometryBuilder, DockGeometryFrame
 from docking.ui.runtime import DockRuntime
-from docking.ui.settings import SettingsWindowController
 
 if TYPE_CHECKING:
     from docking.core.config import Config
@@ -216,6 +213,14 @@ WINDOW_MENU_CLOSE_LABEL_XALIGN = 0.5
 WINDOW_MENU_CLOSE_MARGIN_END_PX = 12
 FOLDER_MENU_REFRESH_DEBOUNCE_MS = 120
 log = get_logger("menu")
+
+
+class DialogPresenter(Protocol):
+    """Simple presenter for dock-owned dialogs."""
+
+    def show(self) -> None:
+        """Show the dialog."""
+
 
 SUPPORT_URL = "https://github.com/edumucelli/docking/issues"
 
@@ -297,15 +302,15 @@ class MenuHandler:
 
     def __init__(
         self,
-        about: AboutDialogController,
-        settings: SettingsWindowController,
+        about: DialogPresenter,
+        settings: DialogPresenter,
         runtime: DockRuntime,
         model: DockModel,
         config: Config,
         window_tracker: WindowService,
         preview_service: PreviewService,
         geometry_builder: DockGeometryBuilder,
-        diagnostics: DiagnosticsDialogController,
+        diagnostics: DialogPresenter,
         launcher: Launcher | None = None,
         dock_window: Gtk.Window | None = None,
     ) -> None:
@@ -756,7 +761,7 @@ class MenuHandler:
 
         # Quit
         quit_item = Gtk.MenuItem(label=_("Quit"))
-        quit_item.connect("activate", lambda _: self._runtime._window.destroy())
+        quit_item.connect("activate", lambda _: self._runtime.quit())
         menu.append(quit_item)
 
     def _append_desktop_actions(self, menu: Gtk.Menu, desktop_id: str) -> None:

--- a/docking/ui/new_year.py
+++ b/docking/ui/new_year.py
@@ -37,11 +37,14 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, GLib, Gtk
 
 from docking.core.greeting import consume_new_year_greeting
-from docking.core.position import Position, is_horizontal
+from docking.core.position import Position
 from docking.i18n import _
 from docking.log import get_logger
-from docking.ui.display import clamp_popup, window_screen_position
-from docking.ui.tooltip import compute_tooltip_position
+from docking.ui.popup import (
+    PopupAnchor,
+    PopupAnchorProvider,
+    position_popup_near_anchor,
+)
 
 log = get_logger("new_year")
 
@@ -63,16 +66,17 @@ class NewYearGreetingController:
     def __init__(
         self,
         *,
-        window: Gtk.Window,
+        anchor_provider: PopupAnchorProvider,
         state_path: Path | str | None = None,
         now_fn: Callable[[], datetime] | None = None,
     ) -> None:
-        self._window = window
+        self._anchor_provider = anchor_provider
         self._state_path = Path(state_path) if state_path else None
         self._now_fn = now_fn or datetime.now
         self._start_source_id: int = 0
         self._hide_source_id: int = 0
         self._popup: Gtk.Window | None = None
+        self._popup_position = Position.BOTTOM
 
     def start(self) -> None:
         """Start the delayed startup greeting check once per process."""
@@ -112,9 +116,11 @@ class NewYearGreetingController:
         return False
 
     def _show_popup(self, *, year: int) -> None:
-        if not self._window.get_realized():
-            log.debug("Skipping New Year greeting because dock window is not realized")
+        anchor = self._anchor_provider.popup_anchor()
+        if anchor is None:
+            log.debug("Skipping New Year greeting because dock anchor is unavailable")
             return
+        self._popup_position = anchor.position
 
         if self._popup is None:
             popup = Gtk.Window(type=Gtk.WindowType.POPUP)
@@ -123,7 +129,6 @@ class NewYearGreetingController:
             popup.set_resizable(False)
             popup.set_type_hint(Gdk.WindowTypeHint.NOTIFICATION)
             popup.set_app_paintable(True)
-            popup.set_transient_for(self._window)
             popup.connect("button-press-event", self._on_popup_button_press)
             screen = popup.get_screen()
             visual = screen.get_rgba_visual()
@@ -136,10 +141,12 @@ class NewYearGreetingController:
             if child is not None:
                 self._popup.remove(child)
 
+        if anchor.parent is not None:
+            self._popup.set_transient_for(anchor.parent)
         log.debug("Showing New Year greeting popup for year %s", year)
-        self._popup.add(self._build_popup_content(year=year))
+        self._popup.add(self._build_popup_content(year=year, position=anchor.position))
         self._popup.show_all()
-        self._position_popup()
+        self._position_popup(anchor=anchor)
 
         if self._hide_source_id:
             GLib.source_remove(self._hide_source_id)
@@ -148,8 +155,8 @@ class NewYearGreetingController:
             self._hide_popup,
         )
 
-    def _build_popup_content(self, *, year: int) -> Gtk.Widget:
-        pos = self._window.config.pos
+    def _build_popup_content(self, *, year: int, position: Position) -> Gtk.Widget:
+        pos = position
         box = Gtk.Box(
             orientation=Gtk.Orientation.HORIZONTAL,
             spacing=GREETING_CONTENT_SPACING_PX,
@@ -180,53 +187,24 @@ class NewYearGreetingController:
         box.pack_start(label, False, False, 0)
         return box
 
-    def _position_popup(self) -> None:
+    def _position_popup(self, *, anchor: PopupAnchor) -> None:
         if self._popup is None:
             return
-
-        window_pos = window_screen_position(self._window)
-        win_x, win_y = window_pos.x, window_pos.y
-        win_w, win_h = self._window.get_size()
-        pref = self._popup.get_preferred_size()[1]
-        popup_w = max(pref.width, 1)
-        popup_h = max(pref.height, 1)
-        pos = self._window.config.pos
-
-        if is_horizontal(pos):
-            anchor_x = win_x + win_w / 2
-            anchor_y = win_y if pos.value == "bottom" else win_y + win_h
-        else:
-            anchor_x = win_x + win_w if pos.value == "left" else win_x
-            anchor_y = win_y + win_h / 2
-
-        popup_x, popup_y = compute_tooltip_position(
-            pos=pos,
-            anchor_x=anchor_x,
-            anchor_y=anchor_y,
-            tooltip_w=popup_w,
-            tooltip_h=popup_h,
-            gap=GREETING_GAP_PX,
+        position_popup_near_anchor(
+            window=self._popup,
+            anchor=anchor,
+            gap_px=GREETING_GAP_PX,
         )
-
-        clamped = clamp_popup(self._popup, popup_x, popup_y, popup_w, popup_h)
         log.debug(
-            "Positioned New Year greeting popup at (%s, %s) "
-            "size=%sx%s dock=(%s,%s %sx%s pos=%s)",
-            clamped.x,
-            clamped.y,
-            popup_w,
-            popup_h,
-            win_x,
-            win_y,
-            win_w,
-            win_h,
-            pos.value,
+            "Positioned New Year greeting popup at anchor=(%s,%s pos=%s)",
+            anchor.x,
+            anchor.y,
+            anchor.position.value,
         )
-        self._popup.move(clamped.x, clamped.y)
 
     def _on_popup_draw(self, widget: Gtk.Widget, cr) -> bool:
         alloc = widget.get_allocation()
-        pos = self._window.config.pos
+        pos = self._popup_position
         width = alloc.width
         height = alloc.height
         radius = GREETING_CORNER_RADIUS_PX

--- a/docking/ui/popup.py
+++ b/docking/ui/popup.py
@@ -1,0 +1,67 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Shared popup anchoring types for dock-owned secondary UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+from docking.core.position import Position
+from docking.ui.display import clamp_popup
+from docking.ui.tooltip import compute_tooltip_position
+
+
+@dataclass(frozen=True, slots=True)
+class PopupAnchor:
+    """Screen-space anchor for a popup tied to the dock or an item."""
+
+    x: int
+    y: int
+    position: Position
+    parent: Gtk.Window | None = None
+
+
+class PopupAnchorProvider(Protocol):
+    """Provider for the current dock-level popup anchor."""
+
+    def popup_anchor(self) -> PopupAnchor | None:
+        """Return the current popup anchor, or None when unavailable."""
+
+
+def position_popup_near_anchor(
+    *,
+    window: Gtk.Window,
+    anchor: PopupAnchor,
+    gap_px: int,
+) -> None:
+    """Position a popup near an anchor, clamped to the current screen."""
+    pref = window.get_preferred_size()[1]
+    popup_w = max(pref.width, 1)
+    popup_h = max(pref.height, 1)
+    popup_x, popup_y = compute_tooltip_position(
+        pos=anchor.position,
+        anchor_x=anchor.x,
+        anchor_y=anchor.y,
+        tooltip_w=popup_w,
+        tooltip_h=popup_h,
+        gap=gap_px,
+    )
+    clamped = clamp_popup(window, popup_x, popup_y, popup_w, popup_h)
+    window.move(clamped.x, clamped.y)

--- a/docking/ui/runtime.py
+++ b/docking/ui/runtime.py
@@ -21,20 +21,13 @@ if TYPE_CHECKING:
     from docking.core.theme import Theme
     from docking.ui.dock_window import DockWindow
     from docking.ui.placement import MonitorChoice
-    from docking.ui.update_popup import UpdateCheckController
 
 
 class DockRuntime:
     """Narrow imperative API for subsystems that should not own DockWindow."""
 
-    def __init__(
-        self,
-        window: DockWindow,
-        *,
-        update_checker: UpdateCheckController,
-    ) -> None:
+    def __init__(self, window: DockWindow) -> None:
         self._window = window
-        self._update_checker = update_checker
 
     def menu_popup_opened(self) -> None:
         self._window.interaction.menu_popup_opened()
@@ -89,8 +82,5 @@ class DockRuntime:
     def set_theme(self, theme: Theme) -> None:
         self._window.set_theme(theme)
 
-    def check_for_updates_now(self) -> None:
-        self._update_checker.check_now()
-
-    def open_releases_page(self) -> None:
-        self._update_checker.open_releases_page()
+    def quit(self) -> None:
+        self._window.destroy()

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -37,7 +37,7 @@ settings a persistent, easier-to-scan home.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 
 import gi
 
@@ -82,6 +82,16 @@ if TYPE_CHECKING:
     from docking.core.config import Config
     from docking.platform.model import DockModel
     from docking.ui.runtime import DockRuntime
+
+
+class UpdateActions(Protocol):
+    """Update commands exposed to the preferences window."""
+
+    def check_now(self) -> None:
+        """Run an update check immediately."""
+
+    def open_releases_page(self) -> None:
+        """Open the project releases page."""
 
 
 APPLET_LIST_ICON_PX = 32
@@ -141,11 +151,13 @@ class SettingsWindowController:
         runtime: DockRuntime,
         model: DockModel,
         config: Config,
+        updates: UpdateActions,
     ) -> None:
         self._parent = parent
         self._runtime = runtime
         self._model = model
         self._config = config
+        self._updates = updates
         self._window: Gtk.Window | None = None
         self._syncing_widgets = False
 
@@ -1298,10 +1310,10 @@ class SettingsWindowController:
         self._update_status_label.set_label(text)
 
     def _on_check_updates_now(self, _button: Gtk.Button) -> None:
-        self._runtime.check_for_updates_now()
+        self._updates.check_now()
 
     def _on_view_releases(self, _button: Gtk.Button) -> None:
-        self._runtime.open_releases_page()
+        self._updates.open_releases_page()
 
     def _on_monitor_combo_changed(self, widget: Gtk.ComboBoxText) -> None:
         if self._syncing_widgets:

--- a/docking/ui/update_popup.py
+++ b/docking/ui/update_popup.py
@@ -26,7 +26,6 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, Gio, GLib, Gtk
 
 from docking import __version__
-from docking.core.position import is_horizontal
 from docking.core.updates import (
     PROJECT_RELEASES_URL,
     ReleaseInfo,
@@ -40,8 +39,11 @@ from docking.core.updates import (
 )
 from docking.i18n import _
 from docking.log import get_logger
-from docking.ui.display import clamp_popup, window_screen_position
-from docking.ui.tooltip import compute_tooltip_position
+from docking.ui.popup import (
+    PopupAnchor,
+    PopupAnchorProvider,
+    position_popup_near_anchor,
+)
 
 if TYPE_CHECKING:
     from docking.core.config import Config
@@ -61,11 +63,11 @@ class UpdateCheckController:
     def __init__(
         self,
         *,
-        window: Gtk.Window,
         config: Config,
+        anchor_provider: PopupAnchorProvider,
     ) -> None:
-        self._window = window
         self._config = config
+        self._anchor_provider = anchor_provider
         self._start_source_id: int = 0
         self._popup: Gtk.Window | None = None
         self._latest_release: ReleaseInfo | None = None
@@ -152,8 +154,9 @@ class UpdateCheckController:
         return False
 
     def _show_popup(self, *, release: ReleaseInfo) -> None:
-        if not self._window.get_realized():
-            log.debug("Skipping update popup because dock window is not realized")
+        anchor = self._anchor_provider.popup_anchor()
+        if anchor is None:
+            log.debug("Skipping update popup because dock anchor is unavailable")
             return
         self._latest_release = release
         if self._popup is None:
@@ -162,16 +165,17 @@ class UpdateCheckController:
             popup.set_skip_taskbar_hint(True)
             popup.set_resizable(False)
             popup.set_type_hint(Gdk.WindowTypeHint.NOTIFICATION)
-            popup.set_transient_for(self._window)
             self._popup = popup
         else:
             child = self._popup.get_child()
             if child is not None:
                 self._popup.remove(child)
 
+        if anchor.parent is not None:
+            self._popup.set_transient_for(anchor.parent)
         self._popup.add(self._build_popup_content(release=release))
         self._popup.show_all()
-        self._position_popup()
+        self._position_popup(anchor=anchor)
 
     def _build_popup_content(self, *, release: ReleaseInfo) -> Gtk.Widget:
         frame = Gtk.Frame()
@@ -211,32 +215,14 @@ class UpdateCheckController:
         frame.add(box)
         return frame
 
-    def _position_popup(self) -> None:
+    def _position_popup(self, *, anchor: PopupAnchor) -> None:
         if self._popup is None:
             return
-        window_pos = window_screen_position(self._window)
-        win_x, win_y = window_pos.x, window_pos.y
-        win_w, win_h = self._window.get_size()
-        pref = self._popup.get_preferred_size()[1]
-        popup_w = max(pref.width, 1)
-        popup_h = max(pref.height, 1)
-        pos = self._window.config.pos
-        if is_horizontal(pos):
-            anchor_x = win_x + win_w / 2
-            anchor_y = win_y if pos.value == "bottom" else win_y + win_h
-        else:
-            anchor_x = win_x + win_w if pos.value == "left" else win_x
-            anchor_y = win_y + win_h / 2
-        popup_x, popup_y = compute_tooltip_position(
-            pos=pos,
-            anchor_x=anchor_x,
-            anchor_y=anchor_y,
-            tooltip_w=popup_w,
-            tooltip_h=popup_h,
-            gap=UPDATE_POPUP_GAP_PX,
+        position_popup_near_anchor(
+            window=self._popup,
+            anchor=anchor,
+            gap_px=UPDATE_POPUP_GAP_PX,
         )
-        clamped = clamp_popup(self._popup, popup_x, popup_y, popup_w, popup_h)
-        self._popup.move(clamped.x, clamped.y)
 
     def _on_view_release(self, _button: Gtk.Button) -> None:
         if self._latest_release is not None:

--- a/tests/smoke/test_python314_smoke.py
+++ b/tests/smoke/test_python314_smoke.py
@@ -78,10 +78,7 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
             "UnityLauncherListener": type("UnityLauncherListener", (), {}),
         },
         "docking.ui.factory": {
-            "build_dock_window": lambda **_kwargs: None,
-        },
-        "docking.ui.new_year": {
-            "NewYearGreetingController": type("NewYearGreetingController", (), {}),
+            "build_dock_ui": lambda **_kwargs: None,
         },
         "docking.ui.renderer": {
             "DockRenderer": type("DockRenderer", (), {}),
@@ -250,8 +247,12 @@ def test_app_main_smoke(monkeypatch):
     backend.previews = preview_service
     backend.visibility = visibility_service
     unity = MagicMock()
-    new_year = MagicMock()
     window = MagicMock()
+    ui = SimpleNamespace(
+        window=window,
+        start_startup_ui=MagicMock(),
+        stop_startup_ui=MagicMock(),
+    )
     items_service = MagicMock()
 
     config_cls = MagicMock()
@@ -271,12 +272,7 @@ def test_app_main_smoke(monkeypatch):
         MagicMock(return_value=backend),
     )
     monkeypatch.setattr(app_mod, "UnityLauncherListener", MagicMock(return_value=unity))
-    monkeypatch.setattr(
-        app_mod,
-        "NewYearGreetingController",
-        MagicMock(return_value=new_year),
-    )
-    monkeypatch.setattr(app_mod, "build_dock_window", MagicMock(return_value=window))
+    monkeypatch.setattr(app_mod, "build_dock_ui", MagicMock(return_value=ui))
     monkeypatch.setattr(
         app_mod, "DockItemsService", MagicMock(return_value=items_service)
     )
@@ -288,10 +284,8 @@ def test_app_main_smoke(monkeypatch):
 
     app_mod.main()
 
-    new_year.start.assert_called_once()
-    new_year.stop.assert_called_once()
-    window.start_update_checks.assert_called_once()
-    window.stop_update_checks.assert_called_once()
+    ui.start_startup_ui.assert_called_once()
+    ui.stop_startup_ui.assert_called_once()
 
     fake_gtk.main.assert_called_once()
     assert fake_glib.unix_signal_add.call_count == 2

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -63,10 +63,7 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
             "UnityLauncherListener": type("UnityLauncherListener", (), {}),
         },
         "docking.ui.factory": {
-            "build_dock_window": lambda **_kwargs: None,
-        },
-        "docking.ui.new_year": {
-            "NewYearGreetingController": type("NewYearGreetingController", (), {}),
+            "build_dock_ui": lambda **_kwargs: None,
         },
         "docking.ui.renderer": {
             "DockRenderer": type("DockRenderer", (), {}),
@@ -135,17 +132,18 @@ class TestAppMain:
         backend.idle = None
         backend.screen_capture = None
         unity = MagicMock()
-        new_year = MagicMock()
         window = MagicMock()
+        ui = SimpleNamespace(
+            window=window,
+            start_startup_ui=MagicMock(),
+            stop_startup_ui=MagicMock(),
+        )
         items_service = MagicMock()
         call_order: list[str] = []
 
         window.show_all.side_effect = lambda: call_order.append("show_all")
-        window.start_update_checks.side_effect = lambda: call_order.append(
-            "updates_start"
-        )
+        ui.start_startup_ui.side_effect = lambda: call_order.append("startup_ui_start")
         unity.start.side_effect = lambda: call_order.append("unity_start")
-        new_year.start.side_effect = lambda: call_order.append("new_year_start")
         items_service.start.side_effect = lambda: call_order.append("items_start")
         model.start_applets.side_effect = lambda: call_order.append("applets_start")
 
@@ -176,13 +174,8 @@ class TestAppMain:
             "UnityLauncherListener",
             MagicMock(return_value=unity),
         )
-        monkeypatch.setattr(
-            app_mod,
-            "NewYearGreetingController",
-            MagicMock(return_value=new_year),
-        )
-        factory = MagicMock(return_value=window)
-        monkeypatch.setattr(app_mod, "build_dock_window", factory)
+        factory = MagicMock(return_value=ui)
+        monkeypatch.setattr(app_mod, "build_dock_ui", factory)
         monkeypatch.setattr(
             app_mod, "DockItemsService", MagicMock(return_value=items_service)
         )
@@ -219,10 +212,8 @@ class TestAppMain:
         items_service.stop.assert_called_once()
         unity.start.assert_called_once()
         unity.stop.assert_called_once()
-        new_year.start.assert_called_once()
-        new_year.stop.assert_called_once()
-        window.start_update_checks.assert_called_once()
-        window.stop_update_checks.assert_called_once()
+        ui.start_startup_ui.assert_called_once()
+        ui.stop_startup_ui.assert_called_once()
         fake_glib.idle_add.assert_called_once_with(
             app_mod._start_runtime,
             items_service,
@@ -233,8 +224,7 @@ class TestAppMain:
         assert call_order == [
             "unity_start",
             "show_all",
-            "new_year_start",
-            "updates_start",
+            "startup_ui_start",
             "idle_add",
             "items_start",
             "applets_start",
@@ -268,17 +258,18 @@ class TestAppMain:
         backend.surface = surface_service
         backend.visibility = visibility_service
         unity = MagicMock()
-        new_year = MagicMock()
         window = MagicMock()
+        ui = SimpleNamespace(
+            window=window,
+            start_startup_ui=MagicMock(),
+            stop_startup_ui=MagicMock(),
+        )
         items_service = MagicMock()
         call_order: list[str] = []
 
         window.show_all.side_effect = lambda: call_order.append("show_all")
-        window.start_update_checks.side_effect = lambda: call_order.append(
-            "updates_start"
-        )
+        ui.start_startup_ui.side_effect = lambda: call_order.append("startup_ui_start")
         unity.start.side_effect = lambda: call_order.append("unity_start")
-        new_year.start.side_effect = lambda: call_order.append("new_year_start")
         items_service.start.side_effect = lambda: call_order.append("items_start")
         model.start_applets.side_effect = lambda: call_order.append("applets_start")
 
@@ -297,8 +288,7 @@ class TestAppMain:
         renderer_cls = MagicMock(return_value=renderer)
         backend_cls = MagicMock(return_value=backend)
         unity_cls = MagicMock(return_value=unity)
-        new_year_cls = MagicMock(return_value=new_year)
-        factory = MagicMock(return_value=window)
+        factory = MagicMock(return_value=ui)
         items_service_cls = MagicMock(return_value=items_service)
 
         monkeypatch.setattr(sys.modules["docking.core.config"], "Config", config_cls)
@@ -320,14 +310,7 @@ class TestAppMain:
         monkeypatch.setattr(
             sys.modules["docking.platform.unity"], "UnityLauncherListener", unity_cls
         )
-        monkeypatch.setattr(
-            sys.modules["docking.ui.new_year"],
-            "NewYearGreetingController",
-            new_year_cls,
-        )
-        monkeypatch.setattr(
-            sys.modules["docking.ui.factory"], "build_dock_window", factory
-        )
+        monkeypatch.setattr(sys.modules["docking.ui.factory"], "build_dock_ui", factory)
         monkeypatch.setattr(
             sys.modules["docking.ipc"], "DockItemsService", items_service_cls
         )
@@ -348,15 +331,12 @@ class TestAppMain:
         backend.stop.assert_called_once()
         unity.start.assert_called_once()
         unity.stop.assert_called_once()
-        new_year.start.assert_called_once()
-        new_year.stop.assert_called_once()
-        window.start_update_checks.assert_called_once()
-        window.stop_update_checks.assert_called_once()
+        ui.start_startup_ui.assert_called_once()
+        ui.stop_startup_ui.assert_called_once()
         assert call_order == [
             "unity_start",
             "show_all",
-            "new_year_start",
-            "updates_start",
+            "startup_ui_start",
             "idle_add",
             "items_start",
             "applets_start",

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -76,6 +76,7 @@ def _bind_geometry_signature(stub):
     stub._popup_anchor_for_item = MethodType(
         dock_window_mod.DockWindow._popup_anchor_for_item, stub
     )
+    stub._require_menu = MethodType(dock_window_mod.DockWindow._require_menu, stub)
     return stub
 
 

--- a/tests/ui/test_edges.py
+++ b/tests/ui/test_edges.py
@@ -199,6 +199,9 @@ def _attach_runtime_methods(harness: _Harness) -> None:
     harness._invalidate_current_geometry_frame = MethodType(
         dock_window_mod.DockWindow._invalidate_current_geometry_frame, harness
     )
+    harness._require_menu = MethodType(
+        dock_window_mod.DockWindow._require_menu, harness
+    )
 
 
 def _motion_event(x: float, y: float) -> SimpleNamespace:

--- a/tests/ui/test_factory.py
+++ b/tests/ui/test_factory.py
@@ -10,108 +10,157 @@ from unittest.mock import MagicMock
 import docking.ui.factory as factory_mod
 
 
-class TestBuildDockWindow:
-    def test_build_dock_window_constructs_window_and_starts_dodge_monitor(
+def _inputs() -> dict[str, MagicMock]:
+    return {
+        "config": MagicMock(),
+        "model": MagicMock(),
+        "renderer": MagicMock(),
+        "theme": MagicMock(),
+        "window_tracker": MagicMock(),
+        "preview_service": MagicMock(),
+        "surface_service": MagicMock(),
+        "visibility_service": MagicMock(),
+        "launcher": MagicMock(),
+        "session_backend": MagicMock(),
+    }
+
+
+def _window() -> MagicMock:
+    window = MagicMock()
+    window.runtime = MagicMock()
+    window.autohide = MagicMock()
+    window.geometry = MagicMock()
+    return window
+
+
+class TestBuildDockUi:
+    def test_build_dock_ui_wires_window_controllers_and_dodge_monitor(
         self, monkeypatch
     ):
-        config = MagicMock()
-        model = MagicMock()
-        renderer = MagicMock()
-        theme = MagicMock()
-        tracker = MagicMock()
-        launcher = MagicMock()
-        preview_service = MagicMock()
-        surface_service = MagicMock()
-        visibility_service = MagicMock()
-        session_backend = MagicMock()
-
-        window = MagicMock()
-        window.autohide = MagicMock()
+        inputs = _inputs()
+        window = _window()
+        update_checker = MagicMock()
+        about = MagicMock()
+        diagnostics = MagicMock()
+        settings = MagicMock()
+        menu = MagicMock()
+        new_year = MagicMock()
         dodge_monitor = MagicMock()
+        inputs["visibility_service"].create_monitor.return_value = dodge_monitor
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
-        visibility_service.create_monitor.return_value = dodge_monitor
-
-        result = factory_mod.build_dock_window(
-            config=config,
-            model=model,
-            renderer=renderer,
-            theme=theme,
-            window_tracker=tracker,
-            preview_service=preview_service,
-            surface_service=surface_service,
-            visibility_service=visibility_service,
-            launcher=launcher,
-            session_backend=session_backend,
+        monkeypatch.setattr(
+            factory_mod,
+            "UpdateCheckController",
+            MagicMock(return_value=update_checker),
+        )
+        monkeypatch.setattr(
+            factory_mod,
+            "AboutDialogController",
+            MagicMock(return_value=about),
+        )
+        monkeypatch.setattr(
+            factory_mod,
+            "DiagnosticsDialogController",
+            MagicMock(return_value=diagnostics),
+        )
+        monkeypatch.setattr(
+            factory_mod,
+            "SettingsWindowController",
+            MagicMock(return_value=settings),
+        )
+        monkeypatch.setattr(factory_mod, "MenuHandler", MagicMock(return_value=menu))
+        monkeypatch.setattr(
+            factory_mod,
+            "NewYearGreetingController",
+            MagicMock(return_value=new_year),
         )
 
-        assert result is window
+        result = factory_mod.build_dock_ui(**inputs)
+
+        assert result.window is window
         factory_mod.DockWindow.assert_called_once_with(
-            config=config,
-            model=model,
-            renderer=renderer,
-            theme=theme,
-            window_tracker=tracker,
-            launcher=launcher,
-            preview_service=preview_service,
-            surface_service=surface_service,
-            session_backend=session_backend,
+            config=inputs["config"],
+            model=inputs["model"],
+            renderer=inputs["renderer"],
+            theme=inputs["theme"],
+            window_tracker=inputs["window_tracker"],
+            launcher=inputs["launcher"],
+            preview_service=inputs["preview_service"],
+            surface_service=inputs["surface_service"],
+            session_backend=inputs["session_backend"],
         )
-        kwargs = visibility_service.create_monitor.call_args.kwargs
+        factory_mod.UpdateCheckController.assert_called_once_with(
+            config=inputs["config"],
+            anchor_provider=window,
+        )
+        factory_mod.AboutDialogController.assert_called_once_with(parent=window)
+        factory_mod.DiagnosticsDialogController.assert_called_once_with(
+            parent=window,
+            backend=inputs["session_backend"],
+        )
+        factory_mod.SettingsWindowController.assert_called_once_with(
+            parent=window,
+            runtime=window.runtime,
+            model=inputs["model"],
+            config=inputs["config"],
+            updates=update_checker,
+        )
+        factory_mod.MenuHandler.assert_called_once_with(
+            about=about,
+            settings=settings,
+            diagnostics=diagnostics,
+            runtime=window.runtime,
+            model=inputs["model"],
+            config=inputs["config"],
+            window_tracker=inputs["window_tracker"],
+            preview_service=inputs["preview_service"],
+            geometry_builder=window.geometry,
+            launcher=inputs["launcher"],
+            dock_window=window,
+        )
+        window.set_menu_handler.assert_called_once_with(menu)
+        factory_mod.NewYearGreetingController.assert_called_once_with(
+            anchor_provider=window
+        )
+
+        kwargs = inputs["visibility_service"].create_monitor.call_args.kwargs
         assert callable(kwargs["get_dock_rect"])
         assert kwargs["on_change"] is window.autohide.set_window_should_hide
         dodge_monitor.start.assert_called_once_with()
         assert window.dodge_monitor is dodge_monitor
 
-    def test_build_dock_window_allows_unsupported_visibility_service(self, monkeypatch):
-        config = MagicMock()
-        model = MagicMock()
-        renderer = MagicMock()
-        theme = MagicMock()
-        tracker = MagicMock()
-        launcher = MagicMock()
-        preview_service = MagicMock()
-        surface_service = MagicMock()
-        visibility_service = MagicMock()
-        visibility_service.create_monitor.return_value = None
-        session_backend = MagicMock()
+        result.start_startup_ui()
+        new_year.start.assert_called_once_with()
+        update_checker.start.assert_called_once_with()
 
-        window = MagicMock()
-        window.autohide = MagicMock()
+        result.stop_startup_ui()
+        update_checker.stop.assert_called_once_with()
+        new_year.stop.assert_called_once_with()
+
+    def test_build_dock_ui_allows_unsupported_visibility_service(self, monkeypatch):
+        inputs = _inputs()
+        window = _window()
+        inputs["visibility_service"].create_monitor.return_value = None
+
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
+        monkeypatch.setattr(factory_mod, "UpdateCheckController", MagicMock())
+        monkeypatch.setattr(factory_mod, "AboutDialogController", MagicMock())
+        monkeypatch.setattr(factory_mod, "DiagnosticsDialogController", MagicMock())
+        monkeypatch.setattr(factory_mod, "SettingsWindowController", MagicMock())
+        monkeypatch.setattr(factory_mod, "MenuHandler", MagicMock())
+        monkeypatch.setattr(factory_mod, "NewYearGreetingController", MagicMock())
 
-        result = factory_mod.build_dock_window(
-            config=config,
-            model=model,
-            renderer=renderer,
-            theme=theme,
-            window_tracker=tracker,
-            preview_service=preview_service,
-            surface_service=surface_service,
-            visibility_service=visibility_service,
-            launcher=launcher,
-            session_backend=session_backend,
-        )
+        result = factory_mod.build_dock_ui(**inputs)
 
-        assert result is window
+        assert result.window is window
         assert window.dodge_monitor is None
 
-    def test_build_dock_window_exposes_realized_dock_rect_to_dodge_monitor(
+    def test_build_dock_ui_exposes_realized_dock_rect_to_dodge_monitor(
         self, monkeypatch
     ):
-        config = MagicMock()
-        model = MagicMock()
-        renderer = MagicMock()
-        theme = MagicMock()
-        tracker = MagicMock()
-        launcher = MagicMock()
-        preview_service = MagicMock()
-        surface_service = MagicMock()
-        visibility_service = MagicMock()
-        session_backend = MagicMock()
-
-        window = MagicMock()
-        window.autohide = MagicMock()
+        inputs = _inputs()
+        window = _window()
         window.get_realized.return_value = True
         window.get_position.return_value = (10, 20)
         window.geometry.build_frame.return_value.background_rect = SimpleNamespace(
@@ -129,39 +178,23 @@ class TestBuildDockWindow:
             return monitor
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
-        visibility_service.create_monitor.side_effect = _make_dodge_monitor
+        monkeypatch.setattr(factory_mod, "UpdateCheckController", MagicMock())
+        monkeypatch.setattr(factory_mod, "AboutDialogController", MagicMock())
+        monkeypatch.setattr(factory_mod, "DiagnosticsDialogController", MagicMock())
+        monkeypatch.setattr(factory_mod, "SettingsWindowController", MagicMock())
+        monkeypatch.setattr(factory_mod, "MenuHandler", MagicMock())
+        monkeypatch.setattr(factory_mod, "NewYearGreetingController", MagicMock())
+        inputs["visibility_service"].create_monitor.side_effect = _make_dodge_monitor
 
-        factory_mod.build_dock_window(
-            config=config,
-            model=model,
-            renderer=renderer,
-            theme=theme,
-            window_tracker=tracker,
-            preview_service=preview_service,
-            surface_service=surface_service,
-            visibility_service=visibility_service,
-            launcher=launcher,
-            session_backend=session_backend,
-        )
+        factory_mod.build_dock_ui(**inputs)
 
         get_dock_rect = cast(Callable[[], object], captured["get_dock_rect"])
         dock_rect = get_dock_rect()
         assert dock_rect == factory_mod.Rect(x=110, y=50, width=300, height=40)
 
-    def test_build_dock_window_returns_none_rect_until_realized(self, monkeypatch):
-        config = MagicMock()
-        model = MagicMock()
-        renderer = MagicMock()
-        theme = MagicMock()
-        tracker = MagicMock()
-        launcher = MagicMock()
-        preview_service = MagicMock()
-        surface_service = MagicMock()
-        visibility_service = MagicMock()
-        session_backend = MagicMock()
-
-        window = MagicMock()
-        window.autohide = MagicMock()
+    def test_build_dock_ui_returns_none_rect_until_realized(self, monkeypatch):
+        inputs = _inputs()
+        window = _window()
         window.get_realized.return_value = False
         captured: dict[str, object] = {}
 
@@ -172,20 +205,15 @@ class TestBuildDockWindow:
             return monitor
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
-        visibility_service.create_monitor.side_effect = _make_dodge_monitor
+        monkeypatch.setattr(factory_mod, "UpdateCheckController", MagicMock())
+        monkeypatch.setattr(factory_mod, "AboutDialogController", MagicMock())
+        monkeypatch.setattr(factory_mod, "DiagnosticsDialogController", MagicMock())
+        monkeypatch.setattr(factory_mod, "SettingsWindowController", MagicMock())
+        monkeypatch.setattr(factory_mod, "MenuHandler", MagicMock())
+        monkeypatch.setattr(factory_mod, "NewYearGreetingController", MagicMock())
+        inputs["visibility_service"].create_monitor.side_effect = _make_dodge_monitor
 
-        factory_mod.build_dock_window(
-            config=config,
-            model=model,
-            renderer=renderer,
-            theme=theme,
-            window_tracker=tracker,
-            preview_service=preview_service,
-            surface_service=surface_service,
-            visibility_service=visibility_service,
-            launcher=launcher,
-            session_backend=session_backend,
-        )
+        factory_mod.build_dock_ui(**inputs)
 
         get_dock_rect = cast(Callable[[], object], captured["get_dock_rect"])
         assert get_dock_rect() is None

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -1348,7 +1348,7 @@ class TestDockMenu:
     ):
         # Given
         menu = FakeMenu()
-        handler._runtime._window.destroy.reset_mock()
+        handler._runtime.quit.reset_mock()
         handler._model.pinned_items = [DockItem(desktop_id="applet://clock")]
         monkeypatch.setattr(
             menu_mod,
@@ -1395,15 +1395,15 @@ class TestDockMenu:
         handler._about.show = show_about
         show_diagnostics = MagicMock()
         handler._diagnostics.show = show_diagnostics
-        show_settings = MagicMock()
-        handler._settings.show = show_settings
+        show_preferences = MagicMock()
+        handler._settings.show = show_preferences
         open_target = MagicMock()
         menu_mod.launcher_mod.open_target = open_target
         next(mi for mi in menu.children if mi.get_label() == "Diagnostics").activate()
         show_diagnostics.assert_called_once()
 
         next(mi for mi in menu.children if mi.get_label() == "Preferences").activate()
-        show_settings.assert_called_once()
+        show_preferences.assert_called_once()
 
         next(mi for mi in menu.children if mi.get_label() == "About").activate()
         show_about.assert_called_once()
@@ -1412,7 +1412,7 @@ class TestDockMenu:
         open_target.assert_called_once_with(menu_mod.SUPPORT_URL)
 
         next(mi for mi in menu.children if mi.get_label() == "Quit").activate()
-        handler._runtime._window.destroy.assert_called_once()
+        handler._runtime.quit.assert_called_once()
 
         applets_item = next(
             mi for mi in menu.children if mi.get_label() == menu_mod._("Add Applet")

--- a/tests/ui/test_new_year.py
+++ b/tests/ui/test_new_year.py
@@ -8,6 +8,7 @@ import pytest
 import docking.ui.new_year as new_year_mod
 from docking.core.position import Position
 from docking.ui.new_year import NewYearGreetingController
+from docking.ui.popup import PopupAnchor
 
 
 class _FakeGLib:
@@ -173,6 +174,18 @@ class _FakeWindow:
     def get_size(self):
         return (300, 48)
 
+    def popup_anchor(self):
+        if not self.realized:
+            return None
+        x = 250 if self.config.pos in (Position.BOTTOM, Position.TOP) else 100
+        y = 200 if self.config.pos in (Position.BOTTOM, Position.RIGHT) else 248
+        return PopupAnchor(
+            x=x,
+            y=y,
+            position=self.config.pos,
+            parent=self,
+        )
+
 
 class _FakeCr:
     def __init__(self) -> None:
@@ -216,7 +229,7 @@ def fake_gtk(monkeypatch):
 
 
 def test_start_is_idempotent_and_stop_cleans_sources(fake_gtk):
-    controller = NewYearGreetingController(window=_FakeWindow())
+    controller = NewYearGreetingController(anchor_provider=_FakeWindow())
     controller._popup = _FakePopup()
 
     controller.start()
@@ -236,7 +249,7 @@ def test_start_is_idempotent_and_stop_cleans_sources(fake_gtk):
 
 def test_startup_complete_consumes_greeting_and_shows_popup(monkeypatch):
     controller = NewYearGreetingController(
-        window=_FakeWindow(),
+        anchor_provider=_FakeWindow(),
         state_path="/tmp/state.json",
         now_fn=lambda: datetime(2026, 1, 2),
     )
@@ -256,7 +269,7 @@ def test_startup_complete_consumes_greeting_and_shows_popup(monkeypatch):
 
 
 def test_startup_complete_noops_when_not_due(monkeypatch):
-    controller = NewYearGreetingController(window=_FakeWindow())
+    controller = NewYearGreetingController(anchor_provider=_FakeWindow())
     monkeypatch.setattr(new_year_mod, "consume_new_year_greeting", lambda **_k: None)
     monkeypatch.setattr(
         controller,
@@ -268,7 +281,7 @@ def test_startup_complete_noops_when_not_due(monkeypatch):
 
 
 def test_show_popup_skips_unrealized_window(fake_gtk):
-    controller = NewYearGreetingController(window=_FakeWindow(realized=False))
+    controller = NewYearGreetingController(anchor_provider=_FakeWindow(realized=False))
 
     controller._show_popup(year=2026)
 
@@ -277,7 +290,9 @@ def test_show_popup_skips_unrealized_window(fake_gtk):
 
 
 def test_show_popup_builds_positions_and_reuses_popup(fake_gtk):
-    controller = NewYearGreetingController(window=_FakeWindow(pos=Position.BOTTOM))
+    controller = NewYearGreetingController(
+        anchor_provider=_FakeWindow(pos=Position.BOTTOM)
+    )
 
     controller._show_popup(year=2026)
     popup = controller._popup
@@ -306,9 +321,9 @@ def test_show_popup_builds_positions_and_reuses_popup(fake_gtk):
     ],
 )
 def test_build_popup_content_margins_by_position(fake_gtk, pos, margin_key):
-    controller = NewYearGreetingController(window=_FakeWindow(pos=pos))
+    controller = NewYearGreetingController(anchor_provider=_FakeWindow(pos=pos))
 
-    box = controller._build_popup_content(year=2026)
+    box = controller._build_popup_content(year=2026, position=pos)
 
     assert isinstance(box, _FakeBox)
     assert box.margins[margin_key] == (
@@ -319,25 +334,25 @@ def test_build_popup_content_margins_by_position(fake_gtk, pos, margin_key):
 
 @pytest.mark.parametrize("pos", list(Position))
 def test_position_popup_handles_all_edges(fake_gtk, pos):
-    controller = NewYearGreetingController(window=_FakeWindow(pos=pos))
+    controller = NewYearGreetingController(anchor_provider=_FakeWindow(pos=pos))
     controller._popup = _FakePopup()
 
-    controller._position_popup()
+    controller._position_popup(anchor=_FakeWindow(pos=pos).popup_anchor())
 
     assert controller._popup.moved_to is not None
 
 
 def test_position_popup_noops_without_popup(fake_gtk):
-    controller = NewYearGreetingController(window=_FakeWindow())
+    controller = NewYearGreetingController(anchor_provider=_FakeWindow())
 
-    controller._position_popup()
+    controller._position_popup(anchor=_FakeWindow().popup_anchor())
 
     assert controller._popup is None
 
 
 @pytest.mark.parametrize("pos", list(Position))
 def test_draw_popup_handles_all_tips(fake_gtk, pos):
-    controller = NewYearGreetingController(window=_FakeWindow(pos=pos))
+    controller = NewYearGreetingController(anchor_provider=_FakeWindow(pos=pos))
     cr = _FakeCr()
     widget = SimpleNamespace(
         get_allocation=lambda: SimpleNamespace(width=180, height=64)
@@ -351,7 +366,7 @@ def test_draw_popup_handles_all_tips(fake_gtk, pos):
 
 
 def test_hide_and_button_press_remove_timer(fake_gtk):
-    controller = NewYearGreetingController(window=_FakeWindow())
+    controller = NewYearGreetingController(anchor_provider=_FakeWindow())
     controller._popup = _FakePopup()
     controller._hide_source_id = 99
 

--- a/tests/ui/test_pointer_scenarios.py
+++ b/tests/ui/test_pointer_scenarios.py
@@ -195,6 +195,7 @@ class _ScenarioHarness:
         self._invalidate_current_geometry_frame = MethodType(
             dock_window_mod.DockWindow._invalidate_current_geometry_frame, self
         )
+        self._require_menu = MethodType(dock_window_mod.DockWindow._require_menu, self)
 
     def get_size(self) -> tuple[int, int]:
         if self.config.pos in (Position.LEFT, Position.RIGHT):
@@ -424,10 +425,7 @@ class TestMenuLifecycleScenarios:
                     insertion_index_for_main=lambda *_args, **_kwargs: 0,
                 )
 
-        runtime = DockRuntime(
-            cast(Any, harness),
-            update_checker=MagicMock(),
-        )
+        runtime = DockRuntime(cast(Any, harness))
         handler = MenuHandler(
             about=MagicMock(),
             settings=MagicMock(),

--- a/tests/ui/test_runtime.py
+++ b/tests/ui/test_runtime.py
@@ -57,20 +57,14 @@ def _make_window():
         get_size=MagicMock(return_value=(320, 88)),
         on_hide_mode_changed=MagicMock(),
         queue_redraw=MagicMock(),
-    )
-
-
-def _make_update_checker():
-    return SimpleNamespace(
-        check_now=MagicMock(),
-        open_releases_page=MagicMock(),
+        destroy=MagicMock(),
     )
 
 
 class TestDockRuntime:
     def test_menu_popup_hooks_delegate_to_interaction(self):
         window = _make_window()
-        runtime = DockRuntime(window, update_checker=_make_update_checker())
+        runtime = DockRuntime(window)
 
         runtime.menu_popup_opened()
         runtime.menu_popup_closed()
@@ -80,7 +74,7 @@ class TestDockRuntime:
 
     def test_placement_commands_delegate_to_placement(self):
         window = _make_window()
-        runtime = DockRuntime(window, update_checker=_make_update_checker())
+        runtime = DockRuntime(window)
 
         assert runtime.get_monitor_menu_choices() == [("Display 1", 0)]
         assert runtime.current_monitor_choice() == 1
@@ -98,8 +92,7 @@ class TestDockRuntime:
 
     def test_ui_commands_delegate_to_window_subsystems(self):
         window = _make_window()
-        update_checker = _make_update_checker()
-        runtime = DockRuntime(window, update_checker=update_checker)
+        runtime = DockRuntime(window)
 
         runtime.on_hide_mode_changed()
         runtime.set_icons_locked(True)
@@ -108,8 +101,7 @@ class TestDockRuntime:
         runtime.hide_tooltip()
         runtime.hide_hover_ui()
         runtime.set_theme(cast(Theme, "new-theme"))
-        runtime.check_for_updates_now()
-        runtime.open_releases_page()
+        runtime.quit()
 
         window.on_hide_mode_changed.assert_called_once()
         window.dnd.set_locked.assert_called_once_with(True)
@@ -119,6 +111,5 @@ class TestDockRuntime:
         )
         assert window.tooltip.hide.call_count == 2
         window.preview.hide.assert_called_once()
-        update_checker.check_now.assert_called_once()
-        update_checker.open_releases_page.assert_called_once()
         window.set_theme.assert_called_once_with("new-theme")
+        window.destroy.assert_called_once()

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -637,6 +637,13 @@ def _config():
     )
 
 
+def _updates():
+    return SimpleNamespace(
+        check_now=MagicMock(),
+        open_releases_page=MagicMock(),
+    )
+
+
 class TestSettingsWindowController:
     def test_show_reuses_single_window_and_builds_four_tabs(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
@@ -650,6 +657,7 @@ class TestSettingsWindowController:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
+            updates=_updates(),
         )
 
         controller.show()
@@ -717,6 +725,7 @@ class TestSettingsWindowController:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
+            updates=_updates(),
         )
 
         controller.show()
@@ -747,6 +756,7 @@ class TestSettingsWindowController:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
+            updates=_updates(),
         )
 
         controller.show()
@@ -796,6 +806,7 @@ class TestSettingsWindowController:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
+            updates=_updates(),
         )
 
         controller.show()
@@ -888,6 +899,7 @@ class TestSettingsWindowController:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller.show()
@@ -922,6 +934,7 @@ class TestSettingsWindowController:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller.show()
@@ -947,6 +960,7 @@ class TestSettingsWindowController:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
+            updates=_updates(),
         )
 
         controller.show()
@@ -1015,6 +1029,7 @@ class TestSettingsWindowController:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller.show()
@@ -1046,6 +1061,7 @@ class TestSettingsWindowController:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller.show()
@@ -1072,6 +1088,7 @@ class TestSettingsWindowController:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller.show()
@@ -1098,6 +1115,7 @@ class TestSettingsWindowController:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller.show()
@@ -1121,6 +1139,7 @@ class TestSettingsWindowController:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller.show()
@@ -1147,6 +1166,7 @@ class TestSettingsWindowController:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller.show()
@@ -1172,6 +1192,7 @@ class TestSettingsWindowController:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller.show()
@@ -1196,6 +1217,7 @@ class TestSettingsWindowController:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller.show()
@@ -1220,6 +1242,7 @@ class TestSettingsWindowController:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller.show()
@@ -1241,6 +1264,7 @@ class TestSettingsWindowController:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller.show()
@@ -1265,12 +1289,14 @@ class TestSettingsWindowController:
             lambda: SimpleNamespace(last_seen_version="", last_checked_at=""),
         )
         runtime = MagicMock()
+        updates = _updates()
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=object(),
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=updates,
         )
 
         controller.show()
@@ -1291,8 +1317,8 @@ class TestSettingsWindowController:
         check_now.click()
         view_releases.click()
 
-        runtime.check_for_updates_now.assert_called_once()
-        runtime.open_releases_page.assert_called_once()
+        updates.check_now.assert_called_once()
+        updates.open_releases_page.assert_called_once()
 
     def test_applet_toggle_adds_and_removes_items(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
@@ -1317,6 +1343,7 @@ class TestSettingsWindowController:
             runtime=MagicMock(),
             model=model,
             config=_config(),
+            updates=_updates(),
         )
 
         on_widget = FakeCheckButton(label="Clock")
@@ -1357,6 +1384,7 @@ class TestSettingsWindowController:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
+            updates=_updates(),
         )
 
         controller.show()
@@ -1424,6 +1452,7 @@ class TestSettingsWindowController:
             runtime=MagicMock(),
             model=model,
             config=_config(),
+            updates=_updates(),
         )
 
         controller.show()
@@ -1461,6 +1490,7 @@ class TestSettingsWindowController:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
+            updates=_updates(),
         )
 
         controller.show()
@@ -1493,6 +1523,7 @@ class TestSettingsWindowController:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
+            updates=_updates(),
         )
 
         with patch.object(
@@ -1529,6 +1560,7 @@ class TestRecentSettingsBehavior:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
         controller.show()
 
@@ -1556,6 +1588,7 @@ class TestBindingEdgeCases:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
+            updates=_updates(),
         )
         controller._window = None
         # Should not raise
@@ -1574,6 +1607,7 @@ class TestBindingEdgeCases:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
         original = config.icon_size
         binding = MagicMock()
@@ -1599,6 +1633,7 @@ class TestBindingEdgeCases:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
         binding = MagicMock()
         binding.config_attr = "icon_size"
@@ -1622,6 +1657,7 @@ class TestBindingEdgeCases:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
         controller._syncing_widgets = True
         binding = MagicMock()
@@ -1646,6 +1682,7 @@ class TestSettingsRuntimeCallbacks:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller._after_icon_size_changed(64)
@@ -1667,6 +1704,7 @@ class TestSettingsRuntimeCallbacks:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller._after_tooltips_changed(False)
@@ -1687,6 +1725,7 @@ class TestSettingsRuntimeCallbacks:
             runtime=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
+            updates=_updates(),
         )
 
         controller._after_tooltips_changed(True)
@@ -1705,6 +1744,7 @@ class TestSettingsRuntimeCallbacks:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
+            updates=_updates(),
         )
         controller._hide_mode_combo = None
         # Should not raise
@@ -1722,6 +1762,7 @@ class TestSettingsRuntimeCallbacks:
             runtime=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
+            updates=_updates(),
         )
         controller._update_status_label = None
         # Should not raise

--- a/tests/ui/test_update_popup.py
+++ b/tests/ui/test_update_popup.py
@@ -5,13 +5,26 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from docking.core.position import Position
 from docking.core.updates import ReleaseInfo, UpdateState
+from docking.ui.popup import PopupAnchor
 from docking.ui.update_popup import (
     REMIND_LATER_HOURS,
     UPDATE_CHECK_DELAY_S,
     UPDATE_POPUP_GAP_PX,
     UpdateCheckController,
 )
+
+
+def _anchor_provider(anchor: PopupAnchor | None = None):
+    provider = MagicMock()
+    provider.popup_anchor.return_value = anchor or PopupAnchor(
+        x=100,
+        y=200,
+        position=Position.BOTTOM,
+        parent=MagicMock(),
+    )
+    return provider
 
 
 class TestUpdateCheckConstants:
@@ -22,11 +35,14 @@ class TestUpdateCheckConstants:
 
 
 class TestUpdateCheckControllerInit:
-    def test_init_sets_window_and_config(self):
-        window = MagicMock()
+    def test_init_sets_anchor_provider_and_config(self):
+        anchor_provider = _anchor_provider()
         config = MagicMock()
-        controller = UpdateCheckController(window=window, config=config)
-        assert controller._window is window
+        controller = UpdateCheckController(
+            config=config,
+            anchor_provider=anchor_provider,
+        )
+        assert controller._anchor_provider is anchor_provider
         assert controller._config is config
         assert controller._popup is None
         assert controller._latest_release is None
@@ -35,30 +51,33 @@ class TestUpdateCheckControllerInit:
 
 class TestUpdateCheckControllerStart:
     def test_start_already_scheduled_returns(self):
-        window = MagicMock()
         config = MagicMock()
         config.update_check_enabled = True
-        controller = UpdateCheckController(window=window, config=config)
+        controller = UpdateCheckController(
+            config=config, anchor_provider=_anchor_provider()
+        )
         controller._start_source_id = 42
         controller.start()
         assert controller._start_source_id == 42
 
     def test_start_disabled_returns(self):
-        window = MagicMock()
         config = MagicMock()
         config.update_check_enabled = False
-        controller = UpdateCheckController(window=window, config=config)
+        controller = UpdateCheckController(
+            config=config, anchor_provider=_anchor_provider()
+        )
         controller.start()
         assert controller._start_source_id == 0
 
     def test_start_schedules_timeout(self, monkeypatch):
         import docking.ui.update_popup as mod
 
-        window = MagicMock()
         config = MagicMock()
         config.update_check_enabled = True
         config.update_check_interval_hours = 24
-        controller = UpdateCheckController(window=window, config=config)
+        controller = UpdateCheckController(
+            config=config, anchor_provider=_anchor_provider()
+        )
 
         monkeypatch.setattr(
             mod, "load_state", lambda: SimpleNamespace(last_checked_at=None)
@@ -73,9 +92,10 @@ class TestUpdateCheckControllerStart:
 
 class TestUpdateCheckHideAndDismiss:
     def test_hide_popup_hides_window(self):
-        window = MagicMock()
         config = MagicMock()
-        controller = UpdateCheckController(window=window, config=config)
+        controller = UpdateCheckController(
+            config=config, anchor_provider=_anchor_provider()
+        )
         fake_popup = MagicMock()
         controller._popup = fake_popup
 
@@ -84,18 +104,20 @@ class TestUpdateCheckHideAndDismiss:
         fake_popup.hide.assert_called_once()
 
     def test_hide_popup_no_popup_no_error(self):
-        window = MagicMock()
         config = MagicMock()
-        controller = UpdateCheckController(window=window, config=config)
+        controller = UpdateCheckController(
+            config=config, anchor_provider=_anchor_provider()
+        )
         controller._popup = None
         controller._hide_popup()  # Should not raise
 
     def test_open_url_calls_gio_launch(self, monkeypatch):
         import docking.ui.update_popup as mod
 
-        window = MagicMock()
         config = MagicMock()
-        controller = UpdateCheckController(window=window, config=config)
+        controller = UpdateCheckController(
+            config=config, anchor_provider=_anchor_provider()
+        )
         monkeypatch.setattr(mod.Gio.AppInfo, "launch_default_for_uri", MagicMock())
 
         controller._open_url("https://example.com")
@@ -107,9 +129,10 @@ class TestUpdateCheckHideAndDismiss:
     def test_on_view_release_hides_and_opens_url(self, monkeypatch):
         import docking.ui.update_popup as mod
 
-        window = MagicMock()
         config = MagicMock()
-        controller = UpdateCheckController(window=window, config=config)
+        controller = UpdateCheckController(
+            config=config, anchor_provider=_anchor_provider()
+        )
         controller._latest_release = ReleaseInfo(
             version="3.0.0",
             name="v3.0.0",
@@ -126,9 +149,10 @@ class TestUpdateCheckHideAndDismiss:
     def test_on_later_saves_reminder_and_hides(self, monkeypatch):
         import docking.ui.update_popup as mod
 
-        window = MagicMock()
         config = MagicMock()
-        controller = UpdateCheckController(window=window, config=config)
+        controller = UpdateCheckController(
+            config=config, anchor_provider=_anchor_provider()
+        )
         controller._latest_release = ReleaseInfo(
             version="3.0.0",
             name="v3.0.0",
@@ -148,9 +172,10 @@ class TestUpdateCheckHideAndDismiss:
     def test_on_ignore_saves_and_hides(self, monkeypatch):
         import docking.ui.update_popup as mod
 
-        window = MagicMock()
         config = MagicMock()
-        controller = UpdateCheckController(window=window, config=config)
+        controller = UpdateCheckController(
+            config=config, anchor_provider=_anchor_provider()
+        )
         controller._latest_release = ReleaseInfo(
             version="3.0.0",
             name="v3.0.0",
@@ -169,9 +194,10 @@ class TestUpdateCheckHideAndDismiss:
     def test_on_check_finished_no_release_no_popup(self, monkeypatch):
         import docking.ui.update_popup as mod
 
-        window = MagicMock()
         config = MagicMock()
-        controller = UpdateCheckController(window=window, config=config)
+        controller = UpdateCheckController(
+            config=config, anchor_provider=_anchor_provider()
+        )
         save_called = []
 
         def _save(s):


### PR DESCRIPTION
## Summary
- move dock UI composition for menus, settings, diagnostics, updates, and startup popups into the UI factory
- keep DockWindow focused on dock shell mechanics and expose popup anchoring/menu installation hooks
- decouple runtime/settings/menu/update popup wiring and share popup anchor helpers
- update bootstrap and tests for the new DockUi lifecycle handle