### PR TITLE
Refactor dock UI composition

### DIFF
--- a/docking/app.py
+++ b/docking/app.py
@@ -126,7 +126,7 @@ def main() -> None:
     )
     unity = UnityLauncherListener(model=model)
 
-    window = build_dock_window(
+    ui = build_dock_window(
         config=config,
         model=model,
         renderer=renderer,
@@ -138,6 +138,7 @@ def main() -> None:
         session_backend=backend,
         launcher=launcher,
     )
+    window = ui.window
     items_service = DockItemsService(model=model, window=window)
     new_year = NewYearGreetingController(window=window)
 
@@ -149,12 +150,12 @@ def main() -> None:
         unity.start()
         window.show_all()
         new_year.start()
-        window.start_update_checks()
+        ui.start()
         GLib.idle_add(_start_runtime, items_service, model, backend)
         Gtk.main()
     finally:
         items_service.stop()
-        window.stop_update_checks()
+        ui.stop()
         new_year.stop()
         unity.stop()
         model.stop_applets()

--- a/docking/ui/dnd.py
+++ b/docking/ui/dnd.py
@@ -177,6 +177,7 @@ if TYPE_CHECKING:
     from docking.platform.launcher import Launcher
     from docking.platform.model import DockModel
     from docking.ui.dock_window import DockWindow
+    from docking.ui.folder.stack import FolderStackController
     from docking.ui.renderer import DockRenderer
 
 log = get_logger(name="dnd")
@@ -206,6 +207,7 @@ class DnDHandler:
         theme: Theme,
         launcher: Launcher,
         geometry_builder: DockGeometryBuilder,
+        folder_stack: FolderStackController,
     ) -> None:
         self._drawing_area = drawing_area
         self._window = window
@@ -215,6 +217,7 @@ class DnDHandler:
         self._theme = theme
         self._launcher = launcher
         self._geometry_builder = geometry_builder
+        self._folder_stack = folder_stack
 
         self.drag_index: int = -1
         self._drag_from: int = -1
@@ -722,7 +725,8 @@ class DnDHandler:
                         item.name,
                         item.is_running,
                     )
-                    self._window.close_open_folder_stack_for_item(item.desktop_id)
+                    if self._folder_stack.open_item_id() == item.desktop_id:
+                        self._folder_stack.close()
                     show_poof(x=int(screen_x), y=int(screen_y))
                     # Clear slide state to avoid stale offsets
                     self._renderer.slide_offsets.clear()

--- a/docking/ui/dock_interactions.py
+++ b/docking/ui/dock_interactions.py
@@ -1,0 +1,122 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Secondary dock UI interactions composed outside the dock window.
+
+`DockWindow` owns raw GTK events and geometry. This coordinator owns the
+secondary UI consequences of those events: context menus and folder-stack
+popups. Keeping this layer between the window shell and `MenuHandler` lets the
+menu builder focus on menu contents instead of becoming part of the window's
+event contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import gi
+
+gi.require_version("Gdk", "3.0")
+from gi.repository import Gdk
+
+if TYPE_CHECKING:
+    from docking.core.items import DockItem
+    from docking.core.position import Position
+    from docking.ui.folder.stack import FolderStackController
+    from docking.ui.geometry import DockGeometryFrame
+    from docking.ui.menu import MenuHandler
+
+
+@dataclass(frozen=True, slots=True)
+class FolderStackAnchor:
+    """Screen-space anchor for a folder-stack popup."""
+
+    x: int
+    y: int
+    icon_w: int
+    position: Position
+
+
+class DockInteractions:
+    """Coordinate menu and folder-stack interactions for the dock shell."""
+
+    def __init__(
+        self,
+        *,
+        menu: MenuHandler,
+        folder_stack: FolderStackController,
+    ) -> None:
+        self._menu = menu
+        self._folder_stack = folder_stack
+
+    def show_context_menu(
+        self,
+        *,
+        event: Gdk.EventButton,
+        cursor_main: float,
+        frame: DockGeometryFrame,
+        force_background: bool = False,
+    ) -> None:
+        """Show the dock context menu using the event's current geometry frame."""
+        self._folder_stack.close()
+        self._menu.show(
+            event=event,
+            cursor_main=cursor_main,
+            frame=frame,
+            force_background=force_background,
+        )
+
+    def show_folder_stack(
+        self,
+        *,
+        item: DockItem,
+        anchor: FolderStackAnchor,
+        toggle_if_same_item: bool = True,
+    ) -> None:
+        """Show a folder stack popup for the provided dock item."""
+        self._folder_stack.show(
+            item=item,
+            anchor_x=anchor.x,
+            anchor_y=anchor.y,
+            icon_w=anchor.icon_w,
+            position=anchor.position,
+            toggle_if_same_item=toggle_if_same_item,
+        )
+
+    def close_folder_stack_for_item(self, desktop_id: str) -> None:
+        """Close the stack only when it currently belongs to the item."""
+        if self._folder_stack.open_item_id() == desktop_id:
+            self._folder_stack.close()
+
+    def close_folder_stack_unless_target(self, hovered_item: DockItem | None) -> None:
+        """Close the visible stack when the pointer leaves its source folder."""
+        open_item_id = self._folder_stack.open_item_id()
+        if open_item_id is None:
+            return
+        if hovered_item is not None and hovered_item.desktop_id == open_item_id:
+            return
+        self._folder_stack.close()
+
+    def prewarm_folder_stack(self, item: DockItem) -> None:
+        """Queue a single folder stack layout warm-up."""
+        self._folder_stack.schedule_prewarm(item)
+
+    def prewarm_visible_folder_stacks(self, items: Sequence[DockItem]) -> None:
+        """Warm folder stack layouts for all visible folder items."""
+        self._folder_stack.schedule_visible_prewarm(items)
+
+    def folder_stack_item_id(self) -> str | None:
+        """Return the desktop id that owns the currently visible folder stack."""
+        return self._folder_stack.open_item_id()

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -19,11 +19,10 @@ What this class is
 It is not "the dock logic" in the abstract. It is the shell that:
 
 - owns the GTK window and drawing area,
-- receives raw pointer/button/scroll/crossing events,
-- owns long-lived UI collaborators,
-- turns raw events into calls to the right subsystem.
+- exposes shared geometry/input-region helpers,
+- hosts shell-level collaborators such as placement, hover, tooltip, and preview.
 
-It is intentionally the composition root of the runtime UI layer.
+The UI graph itself is composed in `docking.ui.factory`.
 
 What this class is not
 
@@ -32,7 +31,7 @@ That decomposition matters because this file used to become the place where
 every cross-feature fix landed. The current split is:
 
 - DockWindow
-  GTK shell and event adapter
+  GTK shell and shared window geometry
 
 - DockPlacementController
   monitor choice, reposition, struts, barriers, active-display polling
@@ -43,10 +42,11 @@ every cross-feature fix landed. The current split is:
 - DockGeometryBuilder
   window state -> shared geometry frame
 
-- HoverManager / TooltipManager / PreviewPopup / DnDHandler / MenuHandler
+- HoverManager / TooltipManager / PreviewPopup / DockInputController
   focused feature owners
 
-The point of this file is to connect those pieces, not to replace them.
+The point of this file is to provide the shell those pieces use, not to own
+their higher-level behavior.
 
 What kind of window this is
 
@@ -191,20 +191,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-import cairo
 import gi
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk, GLib, Gtk
 
-from docking.applets.identity import is_applet_desktop_id as is_applet
 from docking.applets.popup import PopupAnchor
-from docking.core.config import FolderStackUnfold, LeftClickAction, MiddleClickAction
-from docking.core.items import FILE_KIND, FOLDER_KIND
-from docking.core.position import is_horizontal
 from docking.i18n import _
-from docking.log import get_logger
 from docking.platform.backends.base import (
     PreviewService,
     Rect,
@@ -213,13 +207,9 @@ from docking.platform.backends.base import (
     WindowService,
 )
 from docking.platform.environment import detect_desktop, log_runtime_snapshot
-from docking.platform.launcher import launch, launch_new_window, open_target
 from docking.ui import geometry
-from docking.ui.about import AboutDialogController
 from docking.ui.autohide import AutoHideController, HideState
-from docking.ui.diagnostics import DiagnosticsDialogController
 from docking.ui.display import window_screen_position
-from docking.ui.dnd import DnDHandler
 from docking.ui.effects import ZoomAnimator
 from docking.ui.geometry import (
     DockGeometryBuilder,
@@ -228,16 +218,9 @@ from docking.ui.geometry import (
 )
 from docking.ui.hover import HoverManager
 from docking.ui.interaction import DockInteractionCoordinator
-from docking.ui.menu import MenuHandler
 from docking.ui.placement import DockPlacementController
 from docking.ui.preview import PreviewPopup
-from docking.ui.renderer import RenderState
-from docking.ui.runtime import DockRuntime
-from docking.ui.settings import SettingsWindowController
 from docking.ui.tooltip import TooltipManager
-from docking.ui.update_popup import UpdateCheckController
-
-log = get_logger(name="dock_window")
 
 # Re-exported for existing callers/tests.
 TRIGGER_PX = geometry.TRIGGER_PX
@@ -249,7 +232,6 @@ if TYPE_CHECKING:
     from docking.core.items import DockItem
     from docking.core.theme import Theme
     from docking.platform.backends.base import VisibilityMonitor
-    from docking.platform.launcher import Launcher
     from docking.platform.model import DockModel
     from docking.ui.renderer import DockRenderer
 
@@ -327,15 +309,11 @@ MOUSE_RIGHT = 3
 
 
 class DockWindow(Gtk.Window):
-    """Top-level dock window that owns event routing and edge integration.
+    """Top-level dock shell that owns window geometry and edge integration.
 
-    DockWindow acts as the composition root for runtime UI behavior: it keeps
-    references to model, renderer, hover manager, tooltip manager, preview,
-    dnd, menu, and autohide controller, then coordinates them from
-    GTK event callbacks.
-
-    In short: renderer draws pixels, model owns item state, and DockWindow
-    turns pointer/window-manager events into the right calls between them.
+    Runtime UI controllers are composed outside this class. DockWindow keeps the
+    GTK surface, placement, geometry, hover, tooltip, preview, and rendering
+    state they share.
     """
 
     def __init__(
@@ -345,7 +323,6 @@ class DockWindow(Gtk.Window):
         renderer: DockRenderer,
         theme: Theme,
         window_tracker: WindowService,
-        launcher: Launcher,
         preview_service: PreviewService,
         surface_service: SurfaceService,
         session_backend: SessionBackend,
@@ -362,11 +339,8 @@ class DockWindow(Gtk.Window):
         self.cursor_x: float = -1.0
         self.cursor_y: float = -1.0
         self.autohide: AutoHideController
-        self.dnd: DnDHandler
-        self._menu: MenuHandler
         self.preview: PreviewPopup
         self._menu_popup_visible: bool = False
-        self._update_checker: UpdateCheckController
         self.tooltip = TooltipManager(self, config, model, theme)
         self.geometry = DockGeometryBuilder(self)
 
@@ -390,8 +364,7 @@ class DockWindow(Gtk.Window):
         self._setup_window()
         self._setup_drawing_area()
         self.zoom_animator = ZoomAnimator(self.drawing_area)
-        self._build_components(launcher=launcher)
-        self._connect_model()
+        self._build_components()
 
     def _setup_window(self) -> None:
         """Configure GTK window as an X11 dock.
@@ -446,90 +419,24 @@ class DockWindow(Gtk.Window):
             | Gdk.EventMask.SCROLL_MASK
             | Gdk.EventMask.SMOOTH_SCROLL_MASK
         )
-        self.drawing_area.connect("draw", self._on_draw)
-        self.drawing_area.connect("motion-notify-event", self._on_motion)
-        self.drawing_area.connect("button-press-event", self._on_button_press)
-        self.drawing_area.connect("button-release-event", self._on_button_release)
-        self.drawing_area.connect("leave-notify-event", self._on_leave)
-        self.drawing_area.connect("enter-notify-event", self._on_enter)
-        self.drawing_area.connect("scroll-event", self._on_scroll)
         self.add(self.drawing_area)
-
-        self._click_x: float = -1.0
-        self._click_y: float = -1.0
-        self._click_button: int = 0
-
-    def _connect_model(self) -> None:
-        """Listen for model changes to trigger redraws."""
-        self.model.add_change_listener(self._on_model_changed)
-
-    def _disconnect_model(self) -> None:
-        """Remove model listener during shutdown."""
-        self.model.remove_change_listener(self._on_model_changed)
 
     def _on_destroy(self, _window: Gtk.Window) -> None:
         """Release model subscriptions owned by the dock shell."""
         if self.dodge_monitor is not None:
             self.dodge_monitor.stop()
             self.dodge_monitor = None
-        self._disconnect_model()
-
-    def start_update_checks(self) -> None:
-        """Start update-check scheduling owned by the dock shell."""
-        self._update_checker.start()
-
-    def stop_update_checks(self) -> None:
-        """Stop update-check scheduling owned by the dock shell."""
-        self._update_checker.stop()
 
     def set_theme(self, theme: Theme) -> None:
         """Replace the runtime theme and notify collaborators that cache it."""
         self.theme = theme
         self.tooltip.set_theme(theme)
         self.hover.set_theme(theme)
-        self.dnd.set_theme(theme)
         self._invalidate_current_geometry_frame()
 
-    def _build_components(self, *, launcher: Launcher) -> None:
+    def _build_components(self) -> None:
         """Build long-lived UI collaborators that depend on the live window."""
-        self._update_checker = UpdateCheckController(window=self, config=self.config)
-        runtime = DockRuntime(self, update_checker=self._update_checker)
-        about = AboutDialogController(parent=self)
-        settings = SettingsWindowController(
-            parent=self,
-            runtime=runtime,
-            model=self.model,
-            config=self.config,
-        )
-        diagnostics = DiagnosticsDialogController(
-            parent=self,
-            backend=self.session_backend,
-        )
         self.autohide = AutoHideController(self, self.config)
-        self.dnd = DnDHandler(
-            drawing_area=self.drawing_area,
-            window=self,
-            model=self.model,
-            config=self.config,
-            renderer=self.renderer,
-            theme=self.theme,
-            launcher=launcher,
-            geometry_builder=self.geometry,
-        )
-        self._menu = MenuHandler(
-            about=about,
-            settings=settings,
-            diagnostics=diagnostics,
-            runtime=runtime,
-            model=self.model,
-            config=self.config,
-            window_tracker=self.window_tracker,
-            preview_service=self.preview_service,
-            geometry_builder=self.geometry,
-            launcher=launcher,
-            dock_window=self,
-        )
-        self._menu.schedule_visible_folder_stack_prewarm(self.model.visible_items())
         self.preview = PreviewPopup(
             window_tracker=self.window_tracker,
             preview_service=self.preview_service,
@@ -668,341 +575,7 @@ class DockWindow(Gtk.Window):
         if self.dodge_monitor is not None:
             self.dodge_monitor.evaluate_now()
 
-    def _on_draw(self, widget: Gtk.DrawingArea, cr: cairo.Context) -> bool:
-        """GTK draw signal handler -- orchestrates each frame.
-
-        Delegates rendering to the DockRenderer, then updates the input
-        region (which may change during hide animation), resets cursor
-        after hide completes, and re-schedules redraws for urgent glow.
-        """
-        self._clear_scheduled_redraw()
-        hide_offset = self.autohide.hide_offset
-        # zoom_progress for debug logging only -- the geometry layer
-        # composes hover zoom * autohide zoom in capture_geometry_inputs().
-        autohide_zoom = self.autohide.zoom_progress if self.autohide.enabled else 1.0
-        zoom_progress = self.zoom_animator.progress * autohide_zoom
-        drag_index = self.dnd.drag_index
-        drop_insert = self.dnd.drop_insert_index
-        drop_target = self.dnd.drop_target_id
-        hovered_id = (
-            self.hover.hovered_item.desktop_id
-            if self.hover and self.hover.hovered_item
-            else ""
-        )
-        current_autohide_state = None
-        if self.autohide.enabled:
-            current_autohide_state = self.autohide.state
-            log.debug(
-                (
-                    "draw: state=%s hide_offset=%.3f zoom_progress=%.3f "
-                    "hovered=%s cursor=(%.0f,%.0f)"
-                ),
-                self.autohide.state.value,
-                hide_offset,
-                zoom_progress,
-                hovered_id or "-",
-                self.cursor_x,
-                self.cursor_y,
-            )
-        # Advance insert/remove animations; request another draw if active
-        if self.model.tick_animations():
-            self._schedule_redraw()
-
-        frame = self._current_or_build_geometry_frame(
-            drop_insert_index=drop_insert,
-        )
-        if current_autohide_state is not None:
-            item_positions = [
-                (
-                    f"{geometry.item.desktop_id}@"
-                    f"({geometry.draw_rect.x},{geometry.draw_rect.y},"
-                    f"{geometry.draw_rect.w}x{geometry.draw_rect.h})"
-                )
-                for geometry in frame.item_geometries
-            ]
-            log.debug("draw items: %s", " | ".join(item_positions) or "<none>")
-        self._sync_background_blur_hint(frame=frame)
-        cursor_main_axis = (
-            self.cursor_x if is_horizontal(pos=self.config.pos) else self.cursor_y
-        )
-        render_state = RenderState(
-            hide_offset=hide_offset,
-            drag_index=drag_index,
-            drop_insert_index=drop_insert,
-            hovered_id=hovered_id,
-            drop_target_id=drop_target,
-            cursor_main=cursor_main_axis,
-        )
-        self.renderer.draw(
-            cr,
-            widget,
-            frame,
-            self.config,
-            self.theme,
-            render_state,
-        )
-        # Update input region as hide state changes (shrink when hidden)
-        self.update_input_region(frame=frame)
-
-        # Reset cursor/hover after hide completes
-        if self.autohide.state == HideState.HIDDEN:
-            self.cursor_x = -1.0
-            self.cursor_y = -1.0
-            self.hover.hovered_item = None
-            self.dock_hovered = False
-            self.tooltip.hide()
-        elif (
-            self._last_autohide_state == HideState.SHOWING
-            and current_autohide_state == HideState.VISIBLE
-            and self.dock_hovered
-            and self.hover.hovered_item is not None
-        ):
-            cursor_main = (
-                self.cursor_x if is_horizontal(pos=self.config.pos) else self.cursor_y
-            )
-            self.hover.update(cursor_main, frame=frame)
-            if (
-                self.config.folder_stack_unfold == FolderStackUnfold.HOVER.value
-                and self.hover.hovered_item is not None
-                and self.hover.hovered_item.kind == FOLDER_KIND
-            ):
-                self._show_folder_stack_for_item(
-                    item=self.hover.hovered_item,
-                    frame=frame,
-                    fallback_x=self.cursor_x,
-                    fallback_y=self.cursor_y,
-                    toggle_if_same_item=False,
-                )
-
-        # Keep redraw pump alive while urgent glow is visible (dock hidden)
-        if self.renderer.has_active_urgent_glow(
-            model=self.model,
-            theme=self.theme,
-            autohide_state=current_autohide_state,
-            now_us=GLib.get_monotonic_time(),
-        ):
-            self._schedule_redraw()
-
-        self._last_autohide_state = current_autohide_state
-
-        return True
-
-    def _on_motion(self, widget: Gtk.DrawingArea, event: Gdk.EventMotion) -> bool:
-        """Update cursor position, trigger zoom redraw, and refresh hover state.
-
-        Returns False to propagate the event so GTK's drag source can
-        detect the drag threshold and initiate DnD when appropriate.
-        """
-        self.cursor_x = event.x
-        self.cursor_y = event.y
-        frame = self._build_and_store_geometry_frame()
-        self.update_input_region(frame=frame)
-        self._schedule_redraw()
-        stack_item_id = self._menu.open_folder_stack_item_id()
-        hovered_item = frame.item_at_point(event.x, event.y)
-        if stack_item_id is not None and (
-            hovered_item is None or hovered_item.desktop_id != stack_item_id
-        ):
-            self._menu.close_folder_stack()
-        if frame.cursor_rect.contains(event.x, event.y):
-            self.interaction.on_effective_enter()
-            cursor_main = (
-                self.cursor_x if is_horizontal(pos=self.config.pos) else self.cursor_y
-            )
-            self.hover.update(cursor_main, frame=frame)
-            if hovered_item is not None and hovered_item.kind == FOLDER_KIND:
-                self._menu.schedule_folder_stack_prewarm(hovered_item)
-            if (
-                self.config.folder_stack_unfold == FolderStackUnfold.HOVER.value
-                and hovered_item is not None
-                and hovered_item.kind == FOLDER_KIND
-                and (
-                    not self.autohide.enabled
-                    or self.autohide.state == HideState.VISIBLE
-                )
-            ):
-                self._show_folder_stack_for_item(
-                    item=hovered_item,
-                    frame=frame,
-                    fallback_x=event.x,
-                    fallback_y=event.y,
-                    toggle_if_same_item=False,
-                )
-        elif self.dock_hovered:
-            self.interaction.on_effective_leave(widget)
-        return False  # Propagate so GTK drag source can detect drag threshold
-
-    def close_open_folder_stack_for_item(self, desktop_id: str) -> None:
-        """Close the folder stack if it currently belongs to the given item."""
-        if self._menu.open_folder_stack_item_id() == desktop_id:
-            self._menu.close_folder_stack()
-
-    def _show_folder_stack_for_item(
-        self,
-        *,
-        item: DockItem,
-        frame,
-        fallback_x: float,
-        fallback_y: float,
-        toggle_if_same_item: bool,
-    ) -> None:
-        item_geometry = frame.geometry_for_item(item)
-        if item_geometry is not None:
-            window_pos = window_screen_position(self)
-            win_x, win_y = window_pos.x, window_pos.y
-            anchor_x, anchor_y = item_geometry.anchor_point(
-                win_x=win_x,
-                win_y=win_y,
-                position=self.config.pos,
-            )
-            icon_w = int(item_geometry.draw_rect.w)
-        else:
-            window_pos = window_screen_position(self)
-            win_x, win_y = window_pos.x, window_pos.y
-            anchor_x = win_x + int(fallback_x)
-            anchor_y = win_y + int(fallback_y)
-            icon_w = int(self.config.icon_size)
-        self._menu.show_folder_stack(
-            item=item,
-            anchor_x=anchor_x,
-            anchor_y=anchor_y,
-            icon_w=icon_w,
-            position=self.config.pos,
-            toggle_if_same_item=toggle_if_same_item,
-        )
-
-    def _on_button_press(
-        self, _widget: Gtk.DrawingArea, event: Gdk.EventButton
-    ) -> bool:
-        """Record press position for click-vs-drag discrimination.
-
-        The actual click action fires on button-release, not here. This
-        handler only stores the press coordinates so _on_button_release
-        can compare them and distinguish clicks from drags.
-        """
-        self._click_x = event.x
-        self._click_y = event.y
-        self._click_button = event.button
-        return False  # Propagate so DnD can still work
-
-    def _on_button_release(
-        self, _widget: Gtk.DrawingArea, event: Gdk.EventButton
-    ) -> bool:
-        """Handle clicks on dock items (on release to avoid DnD conflicts)."""
-        # Only act if release is near the press point (not a drag)
-        if is_horizontal(pos=self.config.pos):
-            drag_delta = abs(event.x - self._click_x)
-        else:
-            drag_delta = abs(event.y - self._click_y)
-        if drag_delta > CLICK_DRAG_THRESHOLD:
-            return False
-
-        if event.button == MOUSE_RIGHT:
-            cursor_main = event.x if is_horizontal(pos=self.config.pos) else event.y
-            force_background = bool(event.state & Gdk.ModifierType.CONTROL_MASK)
-            self._menu.show(
-                event,
-                cursor_main,
-                force_background=force_background,
-            )
-            return True
-
-        if event.button in (MOUSE_LEFT, MOUSE_MIDDLE):
-            frame = self._build_and_store_geometry_frame(
-                cursor_x=event.x,
-                cursor_y=event.y,
-            )
-            item = frame.item_at_point(event.x, event.y)
-            if item is None:
-                return True
-
-            # Animation trigger chain:
-            #
-            # Every click sets last_clicked, which triggers the click
-            # darken animation (sine pulse, 300ms). The renderer reads
-            # this timestamp each frame and computes the darken amount.
-            #
-            # If the click also launches the app (not already running,
-            # or force-launch via middle-click/Ctrl+click), we also set
-            # last_launched. This triggers the launch bounce animation
-            # (600ms, two bounces). Both animations run simultaneously --
-            # the icon darkens AND bounces at the same time.
-            #
-            # The two timestamps are independent fields on DockItem.
-            # Setting last_clicked does not affect last_launched, and
-            # vice versa. The renderer evaluates each independently.
-            #
-            # The anim pump duration is set to cover the longer of the
-            # two animations plus a small margin for the final frame.
-            now = GLib.get_monotonic_time()
-            item.last_clicked = now
-
-            # Applets handle their own click
-
-            if is_applet(desktop_id=item.desktop_id):
-                applet = self.model.get_applet(item.desktop_id)
-                if applet:
-                    applet.set_popup_anchor(self._popup_anchor_for_item(item, frame))
-                    applet.on_clicked()
-                    # Refresh tooltip immediately so applet name/tooltip
-                    # changes are visible without waiting for pointer motion.
-                    self.tooltip.update(item, frame)
-                    self.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
-                    return True
-
-            if item.kind == FOLDER_KIND:
-                self._show_folder_stack_for_item(
-                    item=item,
-                    frame=frame,
-                    fallback_x=event.x,
-                    fallback_y=event.y,
-                    toggle_if_same_item=(
-                        self.config.folder_stack_unfold != FolderStackUnfold.HOVER.value
-                    ),
-                )
-                self.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
-                return True
-
-            if item.kind == FILE_KIND:
-                item.last_launched = now
-                open_target(item.target)
-                self.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
-                return True
-
-            action = (
-                self.config.middle_click_action
-                if event.button == MOUSE_MIDDLE
-                else self.config.left_click_action
-            )
-            if event.state & Gdk.ModifierType.CONTROL_MASK:
-                action = MiddleClickAction.NEW_WINDOW.value
-
-            if action == MiddleClickAction.NEW_WINDOW.value or not item.is_running:
-                item.last_launched = now
-                if action == MiddleClickAction.NEW_WINDOW.value:
-                    launch_new_window(desktop_id=item.desktop_id)
-                else:
-                    launch(desktop_id=item.desktop_id)
-                self.hover.start_anim_pump(BOUNCE_ANIMATION_PUMP_MS)
-            elif action == LeftClickAction.CYCLE.value:
-                self.window_tracker.cycle(item.desktop_id)
-                self.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
-            elif action == LeftClickAction.MOST_RECENT.value:
-                self.window_tracker.activate_most_recent(item.desktop_id)
-                self.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
-            elif action == MiddleClickAction.MINIMIZE.value:
-                self.window_tracker.minimize_all(item.desktop_id)
-                self.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
-            elif action == MiddleClickAction.CLOSE_FOCUSED.value:
-                self.window_tracker.close_focused(item.desktop_id)
-                self.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
-            else:
-                self.window_tracker.toggle_focus(item.desktop_id)
-                self.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
-
-        return True
-
-    def _popup_anchor_for_item(
+    def popup_anchor_for_item(
         self,
         item: DockItem,
         frame: DockGeometryFrame,
@@ -1023,116 +596,6 @@ class DockWindow(Gtk.Window):
             position=self.config.pos,
             parent=self,
         )
-
-    def _on_scroll(self, _widget: Gtk.DrawingArea, event: Gdk.EventScroll) -> bool:
-        """Forward scroll events to the applet under the cursor, if any.
-
-        Hit-tests the cursor against the current layout to find the target
-        item. If it's an applet, delegates to its on_scroll() and refreshes
-        the tooltip (applet name/state may change on scroll, e.g. clippy).
-        """
-        frame = self._build_and_store_geometry_frame(
-            cursor_x=event.x,
-            cursor_y=event.y,
-        )
-        item = frame.item_at_point(event.x, event.y)
-        if item and is_applet(desktop_id=item.desktop_id):
-            applet = self.model.get_applet(item.desktop_id)
-            if applet:
-                direction_up = _scroll_direction_up(event=event)
-                if direction_up is None:
-                    return False
-                applet.on_scroll(direction_up)
-                # Refresh tooltip immediately (item.name may have changed)
-                self.tooltip.update(item, frame)
-                return True
-        return False
-
-    def _on_leave(self, widget: Gtk.DrawingArea, event: Gdk.EventCrossing) -> bool:
-        """Handle mouse leaving the dock area.
-
-        This is the most complex event handler in the dock because it
-        coordinates several subsystems: zoom state, preview popups,
-        autohide, and cursor tracking.
-        """
-        log.debug(
-            "leave: detail=%s mode=%s x=%.0f y=%.0f",
-            event.detail,
-            event.mode,
-            event.x,
-            event.y,
-        )
-        if event.detail == Gdk.NotifyType.INFERIOR:
-            return False
-
-        # Spurious leave filter: when the tooltip popup appears, GTK
-        # generates a NONLINEAR leave even though the cursor is still
-        # inside the dock's current cursor region. Ignore those leaves
-        # using the same half-open region semantics as the rest of the
-        # shared geometry layer.
-        current_entry = self._cache.geometry_frame
-        frame = (
-            current_entry.frame if current_entry is not None else None
-        ) or self._cache.applied_input_frame
-        input_rect = current_input_rect(frame)
-        if input_rect is not None and self.interaction.point_inside_event_frame(
-            x=event.x, y=event.y
-        ):
-            return False
-
-        if not self.dock_hovered:
-            return False
-
-        # Preview/autohide policy in simple terms:
-        #
-        # - preview visible => dock stays visible
-        # - preview hidden => dock may autohide
-        # - leaving dock should schedule preview hide when preview is visible
-        # - autohide should trigger when the preview actually finishes hiding,
-        #   not at the first dock leave
-        #
-        # This keeps the preview reachable. A user moving from the dock toward
-        # the preview should not make the dock immediately hide underneath the
-        # interaction. When a preview is visible, dock leave only schedules the
-        # preview to disappear after its grace period; the preview layer decides
-        # whether autohide should proceed once that timer actually completes.
-        self.interaction.on_effective_leave(widget)
-        return True
-
-    def _on_enter(self, _widget: Gtk.DrawingArea, event: Gdk.EventCrossing) -> bool:
-        """Handle mouse entering the dock -- trigger reveal and capture cursor.
-
-        Cursor position must be set here (not just in motion events)
-        because during the SHOWING animation the zoom engine needs a
-        valid cursor to compute the expanding displacement effect.
-        Without this, cursor stays at -1 from the HIDDEN reset and
-        compute_layout produces rest-only positions (no expansion).
-        """
-        self.cursor_x = event.x
-        self.cursor_y = event.y
-        frame = self._build_and_store_geometry_frame(
-            cursor_x=event.x,
-            cursor_y=event.y,
-        )
-        if frame.cursor_rect.contains(event.x, event.y):
-            self.interaction.on_effective_enter()
-        return True
-
-    def _on_model_changed(self) -> None:
-        """Reposition and redraw when the model changes."""
-        self._invalidate_current_geometry_frame()
-        self.update_input_region()
-        self.hover.on_model_changed()
-        self._menu.schedule_visible_folder_stack_prewarm(self.model.visible_items())
-        # Refresh hover/tooltip state even without mouse motion so applets
-        # that update item.name asynchronously (e.g. workspace switcher)
-        # show the new tooltip text immediately.
-        if self.hover.hovered_item is not None:
-            cursor_main = (
-                self.cursor_x if is_horizontal(pos=self.config.pos) else self.cursor_y
-            )
-            self.hover.update(cursor_main)
-        self._schedule_redraw()
 
     def update_input_region(self, frame: DockGeometryFrame | None = None) -> None:
         """Define which part of the window responds to mouse events.
@@ -1218,17 +681,3 @@ class DockWindow(Gtk.Window):
         """Convenience for external controllers to trigger redraw."""
         self._invalidate_current_geometry_frame()
         self._schedule_redraw()
-
-
-def _scroll_direction_up(*, event: Gdk.EventScroll) -> bool | None:
-    """Normalize GTK discrete and smooth scroll events to one applet direction."""
-    if event.direction == Gdk.ScrollDirection.UP:
-        return True
-    if event.direction == Gdk.ScrollDirection.DOWN:
-        return False
-    if event.direction == Gdk.ScrollDirection.SMOOTH:
-        has_deltas, _dx, dy = event.get_scroll_deltas()
-        if not has_deltas or dy == 0:
-            return None
-        return dy < 0
-    return None

--- a/docking/ui/factory.py
+++ b/docking/ui/factory.py
@@ -20,6 +20,8 @@ not belong inside the GTK shell itself: the dodge monitor.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from docking.core.config import Config
 from docking.core.theme import Theme
 from docking.platform.backends.base import (
@@ -32,9 +34,38 @@ from docking.platform.backends.base import (
 )
 from docking.platform.launcher import Launcher
 from docking.platform.model import DockModel
+from docking.ui.about import AboutDialogController
+from docking.ui.diagnostics import DiagnosticsDialogController
 from docking.ui.display import window_screen_position
+from docking.ui.dnd import DnDHandler
+from docking.ui.dock_interactions import DockInteractions
 from docking.ui.dock_window import DockWindow
+from docking.ui.folder.stack import FolderStackController
+from docking.ui.input_controller import DockInputController
+from docking.ui.menu import MenuHandler
 from docking.ui.renderer import DockRenderer
+from docking.ui.runtime import DockRuntime
+from docking.ui.settings import SettingsActions, SettingsWindowController
+from docking.ui.update_popup import UpdateCheckController
+
+
+@dataclass(slots=True)
+class DockUi:
+    """Handle for the composed dock UI graph."""
+
+    window: DockWindow
+    update_checker: UpdateCheckController
+    input_controller: DockInputController
+
+    def start(self) -> None:
+        """Start the composed dock UI lifecycle."""
+        self.input_controller.start()
+        self.update_checker.start()
+
+    def stop(self) -> None:
+        """Stop the composed dock UI lifecycle."""
+        self.update_checker.stop()
+        self.input_controller.stop()
 
 
 def build_dock_window(
@@ -49,7 +80,7 @@ def build_dock_window(
     visibility_service: VisibilityService,
     launcher: Launcher,
     session_backend: SessionBackend,
-) -> DockWindow:
+) -> DockUi:
     """Build a fully wired dock window and its UI collaborators."""
     window = DockWindow(
         config=config,
@@ -57,10 +88,65 @@ def build_dock_window(
         renderer=renderer,
         theme=theme,
         window_tracker=window_tracker,
-        launcher=launcher,
         preview_service=preview_service,
         surface_service=surface_service,
         session_backend=session_backend,
+    )
+    update_checker = UpdateCheckController(window=window, config=config)
+    runtime = DockRuntime(window, update_checker=update_checker)
+    about = AboutDialogController(parent=window)
+    diagnostics = DiagnosticsDialogController(
+        parent=window,
+        backend=session_backend,
+    )
+    folder_stack = FolderStackController(
+        config=config,
+        runtime=runtime,
+        launcher=launcher,
+        dock_window=window,
+    )
+    dnd = DnDHandler(
+        drawing_area=window.drawing_area,
+        window=window,
+        model=model,
+        config=config,
+        renderer=renderer,
+        theme=theme,
+        launcher=launcher,
+        geometry_builder=window.geometry,
+        folder_stack=folder_stack,
+    )
+    settings_actions = SettingsActions(
+        runtime=runtime,
+        dnd=dnd,
+    )
+    settings = SettingsWindowController(
+        parent=window,
+        actions=settings_actions,
+        model=model,
+        config=config,
+    )
+    menu = MenuHandler(
+        about=about,
+        settings=settings,
+        diagnostics=diagnostics,
+        runtime=runtime,
+        model=model,
+        config=config,
+        window_tracker=window_tracker,
+        preview_service=preview_service,
+        folder_stack=folder_stack,
+        launcher=launcher,
+        dock_window=window,
+    )
+    interactions = DockInteractions(
+        menu=menu,
+        folder_stack=folder_stack,
+    )
+    input_controller = DockInputController(
+        window=window,
+        interactions=interactions,
+        dnd=dnd,
     )
 
     def _get_dock_rect() -> Rect | None:
@@ -83,4 +169,8 @@ def build_dock_window(
     window.dodge_monitor = dodge_monitor
     if dodge_monitor is not None:
         dodge_monitor.start()
-    return window
+    return DockUi(
+        window=window,
+        update_checker=update_checker,
+        input_controller=input_controller,
+    )

--- a/docking/ui/input_controller.py
+++ b/docking/ui/input_controller.py
@@ -1,0 +1,508 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Raw dock input routing for the GTK dock shell."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import gi
+
+gi.require_version("Gdk", "3.0")
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk, GLib, Gtk
+
+from docking.applets.identity import is_applet_desktop_id as is_applet
+from docking.core.config import FolderStackUnfold, LeftClickAction, MiddleClickAction
+from docking.core.items import FILE_KIND, FOLDER_KIND
+from docking.core.position import is_horizontal
+from docking.log import get_logger
+from docking.platform.launcher import launch, launch_new_window, open_target
+from docking.ui.autohide import HideState
+from docking.ui.display import window_screen_position
+from docking.ui.dnd import DnDHandler
+from docking.ui.dock_interactions import DockInteractions, FolderStackAnchor
+from docking.ui.geometry import current_input_rect
+from docking.ui.renderer import RenderState
+
+if TYPE_CHECKING:
+    import cairo
+
+    from docking.core.items import DockItem
+    from docking.ui.dnd import DnDHandler
+    from docking.ui.dock_window import DockWindow
+    from docking.ui.geometry import DockGeometryFrame
+
+
+log = get_logger(name="input_controller")
+
+CLICK_DRAG_THRESHOLD = 10
+REDRAW_FRAME_INTERVAL_MS = 16
+SHORT_ANIMATION_PUMP_MS = 350
+BOUNCE_ANIMATION_PUMP_MS = 700
+MOUSE_LEFT = 1
+MOUSE_MIDDLE = 2
+MOUSE_RIGHT = 3
+
+
+class DockInputController:
+    """Own raw GTK event routing for a dock window."""
+
+    def __init__(
+        self,
+        *,
+        window: DockWindow,
+        interactions: DockInteractions,
+        dnd: DnDHandler,
+    ) -> None:
+        self._window = window
+        self._interactions = interactions
+        self._click_x: float = -1.0
+        self._click_y: float = -1.0
+        self._click_button: int = 0
+        self.dnd = dnd
+        self._started = False
+        self._signal_handlers: list[tuple[object, int]] = []
+
+    def set_theme(self, theme) -> None:
+        """Update collaborators owned by this controller when the theme changes."""
+        self.dnd.set_theme(theme)
+
+    def start(self) -> None:
+        """Start input routing and model-listener lifecycle."""
+        if self._started:
+            return
+        self._started = True
+        self._connect_signals()
+        self._connect_model()
+        self._interactions.prewarm_visible_folder_stacks(
+            self._window.model.visible_items()
+        )
+
+    def stop(self) -> None:
+        """Stop input routing and release signal/model listeners."""
+        if not self._started:
+            return
+        self._disconnect_signals()
+        self._disconnect_model()
+        self._started = False
+
+    def _connect_signals(self) -> None:
+        drawing_area = self._window.drawing_area
+        for obj, signal, callback in (
+            (drawing_area, "draw", self._on_draw),
+            (drawing_area, "motion-notify-event", self._on_motion),
+            (drawing_area, "button-press-event", self._on_button_press),
+            (drawing_area, "button-release-event", self._on_button_release),
+            (drawing_area, "leave-notify-event", self._on_leave),
+            (drawing_area, "enter-notify-event", self._on_enter),
+            (drawing_area, "scroll-event", self._on_scroll),
+            (self._window, "destroy", self._on_destroy),
+        ):
+            handler_id = obj.connect(signal, callback)
+            self._signal_handlers.append((obj, handler_id))
+
+    def _disconnect_signals(self) -> None:
+        for obj, handler_id in self._signal_handlers:
+            obj.disconnect(handler_id)
+        self._signal_handlers = []
+
+    def _connect_model(self) -> None:
+        self._window.model.add_change_listener(self._on_model_changed)
+
+    def _disconnect_model(self) -> None:
+        self._window.model.remove_change_listener(self._on_model_changed)
+
+    def _on_destroy(self, _window: Gtk.Window) -> None:
+        self.stop()
+
+    def _on_draw(self, widget: Gtk.DrawingArea, cr: cairo.Context) -> bool:
+        window = self._window
+        window._clear_scheduled_redraw()
+        hide_offset = window.autohide.hide_offset
+        autohide_zoom = (
+            window.autohide.zoom_progress if window.autohide.enabled else 1.0
+        )
+        zoom_progress = window.zoom_animator.progress * autohide_zoom
+        drag_index = self.dnd.drag_index
+        drop_insert = self.dnd.drop_insert_index
+        drop_target = self.dnd.drop_target_id
+        hovered_id = (
+            window.hover.hovered_item.desktop_id
+            if window.hover and window.hover.hovered_item
+            else ""
+        )
+        current_autohide_state = None
+        if window.autohide.enabled:
+            current_autohide_state = window.autohide.state
+            log.debug(
+                (
+                    "draw: state=%s hide_offset=%.3f zoom_progress=%.3f "
+                    "hovered=%s cursor=(%.0f,%.0f)"
+                ),
+                window.autohide.state.value,
+                hide_offset,
+                zoom_progress,
+                hovered_id or "-",
+                window.cursor_x,
+                window.cursor_y,
+            )
+        if window.model.tick_animations():
+            window._schedule_redraw()
+
+        frame = window._current_or_build_geometry_frame(drop_insert_index=drop_insert)
+        if current_autohide_state is not None:
+            item_positions = [
+                (
+                    f"{geometry.item.desktop_id}@"
+                    f"({geometry.draw_rect.x},{geometry.draw_rect.y},"
+                    f"{geometry.draw_rect.w}x{geometry.draw_rect.h})"
+                )
+                for geometry in frame.item_geometries
+            ]
+            log.debug("draw items: %s", " | ".join(item_positions) or "<none>")
+        window._sync_background_blur_hint(frame=frame)
+        cursor_main_axis = (
+            window.cursor_x if is_horizontal(pos=window.config.pos) else window.cursor_y
+        )
+        render_state = RenderState(
+            hide_offset=hide_offset,
+            drag_index=drag_index,
+            drop_insert_index=drop_insert,
+            hovered_id=hovered_id,
+            drop_target_id=drop_target,
+            cursor_main=cursor_main_axis,
+        )
+        window.renderer.draw(
+            cr,
+            widget,
+            frame,
+            window.config,
+            window.theme,
+            render_state,
+        )
+        window.update_input_region(frame=frame)
+
+        if window.autohide.state == HideState.HIDDEN:
+            window.cursor_x = -1.0
+            window.cursor_y = -1.0
+            window.hover.hovered_item = None
+            window.dock_hovered = False
+            window.tooltip.hide()
+        elif (
+            window._last_autohide_state == HideState.SHOWING
+            and current_autohide_state == HideState.VISIBLE
+            and window.dock_hovered
+            and window.hover.hovered_item is not None
+        ):
+            cursor_main = (
+                window.cursor_x
+                if is_horizontal(pos=window.config.pos)
+                else window.cursor_y
+            )
+            window.hover.update(cursor_main, frame=frame)
+            if (
+                window.config.folder_stack_unfold == FolderStackUnfold.HOVER.value
+                and window.hover.hovered_item is not None
+                and window.hover.hovered_item.kind == FOLDER_KIND
+            ):
+                self._show_folder_stack_for_item(
+                    item=window.hover.hovered_item,
+                    frame=frame,
+                    fallback_x=window.cursor_x,
+                    fallback_y=window.cursor_y,
+                    toggle_if_same_item=False,
+                )
+
+        if window.renderer.has_active_urgent_glow(
+            model=window.model,
+            theme=window.theme,
+            autohide_state=current_autohide_state,
+            now_us=GLib.get_monotonic_time(),
+        ):
+            window._schedule_redraw()
+
+        window._last_autohide_state = current_autohide_state
+        return True
+
+    def _on_motion(self, widget: Gtk.DrawingArea, event: Gdk.EventMotion) -> bool:
+        window = self._window
+        window.cursor_x = event.x
+        window.cursor_y = event.y
+        frame = window._build_and_store_geometry_frame()
+        window.update_input_region(frame=frame)
+        window._schedule_redraw()
+        hovered_item = frame.item_at_point(event.x, event.y)
+        self._interactions.close_folder_stack_unless_target(hovered_item)
+        if frame.cursor_rect.contains(event.x, event.y):
+            window.interaction.on_effective_enter()
+            cursor_main = (
+                window.cursor_x
+                if is_horizontal(pos=window.config.pos)
+                else window.cursor_y
+            )
+            window.hover.update(cursor_main, frame=frame)
+            if hovered_item is not None and hovered_item.kind == FOLDER_KIND:
+                self._interactions.prewarm_folder_stack(hovered_item)
+            if (
+                window.config.folder_stack_unfold == FolderStackUnfold.HOVER.value
+                and hovered_item is not None
+                and hovered_item.kind == FOLDER_KIND
+                and (
+                    not window.autohide.enabled
+                    or window.autohide.state == HideState.VISIBLE
+                )
+            ):
+                self._show_folder_stack_for_item(
+                    item=hovered_item,
+                    frame=frame,
+                    fallback_x=event.x,
+                    fallback_y=event.y,
+                    toggle_if_same_item=False,
+                )
+        elif window.dock_hovered:
+            window.interaction.on_effective_leave(widget)
+        return False
+
+    def _show_folder_stack_for_item(
+        self,
+        *,
+        item: DockItem,
+        frame: DockGeometryFrame,
+        fallback_x: float,
+        fallback_y: float,
+        toggle_if_same_item: bool,
+    ) -> None:
+        window = self._window
+        item_geometry = frame.geometry_for_item(item)
+        if item_geometry is not None:
+            window_pos = window_screen_position(window)
+            win_x, win_y = window_pos.x, window_pos.y
+            anchor_x, anchor_y = item_geometry.anchor_point(
+                win_x=win_x,
+                win_y=win_y,
+                position=window.config.pos,
+            )
+            icon_w = int(item_geometry.draw_rect.w)
+        else:
+            window_pos = window_screen_position(window)
+            win_x, win_y = window_pos.x, window_pos.y
+            anchor_x = win_x + int(fallback_x)
+            anchor_y = win_y + int(fallback_y)
+            icon_w = int(window.config.icon_size)
+        self._interactions.show_folder_stack(
+            item=item,
+            anchor=FolderStackAnchor(
+                x=anchor_x,
+                y=anchor_y,
+                icon_w=icon_w,
+                position=window.config.pos,
+            ),
+            toggle_if_same_item=toggle_if_same_item,
+        )
+
+    def _on_button_press(
+        self, _widget: Gtk.DrawingArea, event: Gdk.EventButton
+    ) -> bool:
+        self._click_x = event.x
+        self._click_y = event.y
+        self._click_button = event.button
+        return False
+
+    def _on_button_release(
+        self, _widget: Gtk.DrawingArea, event: Gdk.EventButton
+    ) -> bool:
+        window = self._window
+        if is_horizontal(pos=window.config.pos):
+            drag_delta = abs(event.x - self._click_x)
+        else:
+            drag_delta = abs(event.y - self._click_y)
+        if drag_delta > CLICK_DRAG_THRESHOLD:
+            return False
+
+        if event.button == MOUSE_RIGHT:
+            cursor_main = event.x if is_horizontal(pos=window.config.pos) else event.y
+            force_background = bool(event.state & Gdk.ModifierType.CONTROL_MASK)
+            frame = window._build_and_store_geometry_frame(
+                cursor_x=event.x,
+                cursor_y=event.y,
+            )
+            self._interactions.show_context_menu(
+                event=event,
+                cursor_main=cursor_main,
+                frame=frame,
+                force_background=force_background,
+            )
+            return True
+
+        if event.button in (MOUSE_LEFT, MOUSE_MIDDLE):
+            frame = window._build_and_store_geometry_frame(
+                cursor_x=event.x,
+                cursor_y=event.y,
+            )
+            item = frame.item_at_point(event.x, event.y)
+            if item is None:
+                return True
+
+            now = GLib.get_monotonic_time()
+            item.last_clicked = now
+
+            if is_applet(desktop_id=item.desktop_id):
+                applet = window.model.get_applet(item.desktop_id)
+                if applet:
+                    applet.set_popup_anchor(window.popup_anchor_for_item(item, frame))
+                    applet.on_clicked()
+                    window.tooltip.update(item, frame)
+                    window.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
+                    return True
+
+            if item.kind == FOLDER_KIND:
+                self._show_folder_stack_for_item(
+                    item=item,
+                    frame=frame,
+                    fallback_x=event.x,
+                    fallback_y=event.y,
+                    toggle_if_same_item=(
+                        window.config.folder_stack_unfold
+                        != FolderStackUnfold.HOVER.value
+                    ),
+                )
+                window.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
+                return True
+
+            if item.kind == FILE_KIND:
+                item.last_launched = now
+                open_target(item.target)
+                window.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
+                return True
+
+            action = (
+                window.config.middle_click_action
+                if event.button == MOUSE_MIDDLE
+                else window.config.left_click_action
+            )
+            if event.state & Gdk.ModifierType.CONTROL_MASK:
+                action = MiddleClickAction.NEW_WINDOW.value
+
+            if action == MiddleClickAction.NEW_WINDOW.value or not item.is_running:
+                item.last_launched = now
+                if action == MiddleClickAction.NEW_WINDOW.value:
+                    launch_new_window(desktop_id=item.desktop_id)
+                else:
+                    launch(desktop_id=item.desktop_id)
+                window.hover.start_anim_pump(BOUNCE_ANIMATION_PUMP_MS)
+            elif action == LeftClickAction.CYCLE.value:
+                window.window_tracker.cycle(item.desktop_id)
+                window.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
+            elif action == LeftClickAction.MOST_RECENT.value:
+                window.window_tracker.activate_most_recent(item.desktop_id)
+                window.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
+            elif action == MiddleClickAction.MINIMIZE.value:
+                window.window_tracker.minimize_all(item.desktop_id)
+                window.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
+            elif action == MiddleClickAction.CLOSE_FOCUSED.value:
+                window.window_tracker.close_focused(item.desktop_id)
+                window.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
+            else:
+                window.window_tracker.toggle_focus(item.desktop_id)
+                window.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
+
+        return True
+
+    def _on_scroll(self, _widget: Gtk.DrawingArea, event: Gdk.EventScroll) -> bool:
+        window = self._window
+        frame = window._build_and_store_geometry_frame(
+            cursor_x=event.x,
+            cursor_y=event.y,
+        )
+        item = frame.item_at_point(event.x, event.y)
+        if item and is_applet(desktop_id=item.desktop_id):
+            applet = window.model.get_applet(item.desktop_id)
+            if applet:
+                direction_up = _scroll_direction_up(event=event)
+                if direction_up is None:
+                    return False
+                applet.on_scroll(direction_up)
+                window.tooltip.update(item, frame)
+                return True
+        return False
+
+    def _on_leave(self, widget: Gtk.DrawingArea, event: Gdk.EventCrossing) -> bool:
+        window = self._window
+        log.debug(
+            "leave: detail=%s mode=%s x=%.0f y=%.0f",
+            event.detail,
+            event.mode,
+            event.x,
+            event.y,
+        )
+        if event.detail == Gdk.NotifyType.INFERIOR:
+            return False
+
+        current_entry = window._cache.geometry_frame
+        frame = (
+            current_entry.frame if current_entry is not None else None
+        ) or window._cache.applied_input_frame
+        input_rect = current_input_rect(frame)
+        if input_rect is not None and window.interaction.point_inside_event_frame(
+            x=event.x, y=event.y
+        ):
+            return False
+
+        if not window.dock_hovered:
+            return False
+
+        window.interaction.on_effective_leave(widget)
+        return True
+
+    def _on_enter(self, _widget: Gtk.DrawingArea, event: Gdk.EventCrossing) -> bool:
+        window = self._window
+        window.cursor_x = event.x
+        window.cursor_y = event.y
+        frame = window._build_and_store_geometry_frame(
+            cursor_x=event.x,
+            cursor_y=event.y,
+        )
+        if frame.cursor_rect.contains(event.x, event.y):
+            window.interaction.on_effective_enter()
+        return True
+
+    def _on_model_changed(self) -> None:
+        window = self._window
+        window._invalidate_current_geometry_frame()
+        window.update_input_region()
+        window.hover.on_model_changed()
+        self._interactions.prewarm_visible_folder_stacks(window.model.visible_items())
+        if window.hover.hovered_item is not None:
+            cursor_main = (
+                window.cursor_x
+                if is_horizontal(pos=window.config.pos)
+                else window.cursor_y
+            )
+            window.hover.update(cursor_main)
+        window._schedule_redraw()
+
+
+def _scroll_direction_up(*, event: Gdk.EventScroll) -> bool | None:
+    """Normalize GTK discrete and smooth scroll events to one applet direction."""
+    if event.direction == Gdk.ScrollDirection.UP:
+        return True
+    if event.direction == Gdk.ScrollDirection.DOWN:
+        return False
+    if event.direction == Gdk.ScrollDirection.SMOOTH:
+        has_deltas, _dx, dy = event.get_scroll_deltas()
+        if not has_deltas or dy == 0:
+            return None
+        return dy < 0
+    return None

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -189,7 +189,7 @@ from docking.platform.recent_docs import recent_docs_for_app
 from docking.ui.about import AboutDialogController
 from docking.ui.diagnostics import DiagnosticsDialogController
 from docking.ui.folder.stack import FolderStackController
-from docking.ui.geometry import DockGeometryBuilder, DockGeometryFrame
+from docking.ui.geometry import DockGeometryFrame
 from docking.ui.runtime import DockRuntime
 from docking.ui.settings import SettingsWindowController
 
@@ -304,10 +304,10 @@ class MenuHandler:
         config: Config,
         window_tracker: WindowService,
         preview_service: PreviewService,
-        geometry_builder: DockGeometryBuilder,
+        folder_stack: FolderStackController,
         diagnostics: DiagnosticsDialogController,
-        launcher: Launcher | None = None,
-        dock_window: Gtk.Window | None = None,
+        launcher: Launcher,
+        dock_window: Gtk.Window,
     ) -> None:
         self._about = about
         self._settings = settings
@@ -318,32 +318,19 @@ class MenuHandler:
         self._tracker = window_tracker
         self._preview_service = preview_service
         self._launcher = launcher
-        self._geometry_builder = geometry_builder
         self._dock_window = dock_window
-        self._folder_stack = FolderStackController(
-            config=config,
-            runtime=runtime,
-            launcher=launcher,
-            dock_window=dock_window,
-        )
+        self._folder_stack = folder_stack
         self._folder_menu_monitors: dict[int, Gio.FileMonitor] = {}
         self._folder_menu_context: dict[int, tuple[Gtk.Menu, DockItem, str, bool]] = {}
         self._folder_menu_refresh_sources: dict[int, int] = {}
         self._folder_menu_signal_connected: set[int] = set()
-
-    def schedule_folder_stack_prewarm(self, item: DockItem) -> None:
-        """Queue a folder stack warm-up during idle time."""
-        self._folder_stack.schedule_prewarm(item)
-
-    def schedule_visible_folder_stack_prewarm(self, items: Sequence[DockItem]) -> None:
-        """Warm visible folder stacks so hover-open can render from cache."""
-        self._folder_stack.schedule_visible_prewarm(items)
 
     def show(
         self,
         event: Gdk.EventButton,
         cursor_main: float,
         *,
+        frame: DockGeometryFrame,
         force_background: bool = False,
     ) -> None:
         """Build and show the right-click context menu.
@@ -354,9 +341,7 @@ class MenuHandler:
         is true, the background menu is shown even if the pointer is over an
         item; this makes the global dock menu reachable from any shelf point.
         """
-        frame = self._geometry_builder.build_frame(cursor_x=event.x, cursor_y=event.y)
         item = None if force_background else frame.item_at_point(event.x, event.y)
-        self._folder_stack.close()
 
         if item:
             menu = self._new_popup_menu()
@@ -368,34 +353,6 @@ class MenuHandler:
 
         menu.show_all()
         menu.popup_at_pointer(event)
-
-    def show_folder_stack(
-        self,
-        *,
-        item: DockItem,
-        anchor_x: int,
-        anchor_y: int,
-        icon_w: int,
-        position: Any,
-        toggle_if_same_item: bool = True,
-    ) -> None:
-        """Show a folder stack popup, or optionally toggle it closed."""
-        self._folder_stack.show(
-            item=item,
-            anchor_x=anchor_x,
-            anchor_y=anchor_y,
-            icon_w=icon_w,
-            position=position,
-            toggle_if_same_item=toggle_if_same_item,
-        )
-
-    def close_folder_stack(self) -> None:
-        """Close the left-click folder stack if it is currently visible."""
-        self._folder_stack.close()
-
-    def open_folder_stack_item_id(self) -> str | None:
-        """Return the folder item id that currently owns the visible stack."""
-        return self._folder_stack.open_item_id()
 
     def _invalidate_folder_target_cache(self, target: str) -> None:
         self._folder_stack.invalidate_target(target)

--- a/docking/ui/runtime.py
+++ b/docking/ui/runtime.py
@@ -69,9 +69,6 @@ class DockRuntime:
     def refresh_pressure_handler(self) -> None:
         self._window.placement.refresh_pressure_handler()
 
-    def set_icons_locked(self, locked: bool) -> None:
-        self._window.dnd.set_locked(locked)
-
     def queue_draw(self) -> None:
         self._window.queue_redraw()
 

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -81,6 +81,8 @@ from docking.log import get_logger
 if TYPE_CHECKING:
     from docking.core.config import Config
     from docking.platform.model import DockModel
+    from docking.ui.dnd import DnDHandler
+    from docking.ui.placement import MonitorChoice
     from docking.ui.runtime import DockRuntime
 
 
@@ -133,6 +135,58 @@ class _ScalarBinding:
     on_change: Any = None
 
 
+class SettingsActions:
+    """Facade for preferences-triggered side effects."""
+
+    def __init__(
+        self,
+        *,
+        runtime: DockRuntime,
+        dnd: DnDHandler,
+    ) -> None:
+        self._runtime = runtime
+        self._dnd = dnd
+
+    def on_hide_mode_changed(self) -> None:
+        self._runtime.on_hide_mode_changed()
+
+    def get_monitor_choices(self) -> list[MonitorChoice]:
+        return self._runtime.get_monitor_choices()
+
+    def current_monitor_choice(self) -> int:
+        return self._runtime.current_monitor_choice()
+
+    def reposition(self) -> None:
+        self._runtime.reposition()
+
+    def set_active_display(self, enabled: bool) -> None:
+        self._runtime.set_active_display(enabled)
+
+    def refresh_pressure_handler(self) -> None:
+        self._runtime.refresh_pressure_handler()
+
+    def set_icons_locked(self, locked: bool) -> None:
+        self._dnd.set_locked(locked)
+
+    def queue_draw(self) -> None:
+        self._runtime.queue_draw()
+
+    def set_current_workspace_only(self, enabled: bool) -> None:
+        self._runtime.set_current_workspace_only(enabled)
+
+    def hide_tooltip(self) -> None:
+        self._runtime.hide_tooltip()
+
+    def set_theme(self, theme: Theme) -> None:
+        self._runtime.set_theme(theme)
+
+    def check_for_updates_now(self) -> None:
+        self._runtime.check_for_updates_now()
+
+    def open_releases_page(self) -> None:
+        self._runtime.open_releases_page()
+
+
 class SettingsWindowController:
     """Owns the dock preferences window lifecycle and widget synchronization."""
 
@@ -140,12 +194,12 @@ class SettingsWindowController:
         self,
         *,
         parent: Gtk.Window,
-        runtime: DockRuntime,
+        actions: SettingsActions,
         model: DockModel,
         config: Config,
     ) -> None:
         self._parent = parent
-        self._runtime = runtime
+        self._actions = actions
         self._model = model
         self._config = config
         self._window: Gtk.Window | None = None
@@ -965,7 +1019,7 @@ class SettingsWindowController:
             self._register_switch_binding(
                 config_attr="show_window_count_numbers",
                 widget=self._window_count_numbers_switch,
-                on_change=lambda _value: self._runtime.queue_draw(),
+                on_change=lambda _value: self._actions.queue_draw(),
             ),
             self._register_switch_binding(
                 config_attr="previews_enabled",
@@ -979,12 +1033,12 @@ class SettingsWindowController:
             self._register_switch_binding(
                 config_attr="lock_icons",
                 widget=self._lock_icons_switch,
-                on_change=self._runtime.set_icons_locked,
+                on_change=self._actions.set_icons_locked,
             ),
             self._register_switch_binding(
                 config_attr="current_workspace_only",
                 widget=self._workspace_only_switch,
-                on_change=self._runtime.set_current_workspace_only,
+                on_change=self._actions.set_current_workspace_only,
             ),
             self._register_switch_binding(
                 config_attr="active_display",
@@ -994,17 +1048,17 @@ class SettingsWindowController:
             self._register_switch_binding(
                 config_attr="anchor_applets",
                 widget=self._anchor_applets_switch,
-                on_change=lambda _value: self._runtime.queue_draw(),
+                on_change=lambda _value: self._actions.queue_draw(),
             ),
             self._register_switch_binding(
                 config_attr="anchor_files",
                 widget=self._anchor_files_switch,
-                on_change=lambda _value: self._runtime.queue_draw(),
+                on_change=lambda _value: self._actions.queue_draw(),
             ),
             self._register_switch_binding(
                 config_attr="zoom_enabled",
                 widget=self._zoom_enabled_switch,
-                on_change=lambda _value: self._runtime.queue_draw(),
+                on_change=lambda _value: self._actions.queue_draw(),
             ),
             self._register_switch_binding(
                 config_attr="update_check_enabled",
@@ -1027,7 +1081,7 @@ class SettingsWindowController:
             self._register_choice_binding(
                 config_attr="position",
                 widget=self._position_combo,
-                on_change=lambda _value: self._runtime.reposition(),
+                on_change=lambda _value: self._actions.reposition(),
             ),
             self._register_int_binding(
                 config_attr="icon_size",
@@ -1067,7 +1121,7 @@ class SettingsWindowController:
                     float(value) * ZOOM_PERCENT_SCALE
                 ),
                 signal="value-changed",
-                on_change=lambda _value: self._runtime.queue_draw(),
+                on_change=lambda _value: self._actions.queue_draw(),
             ),
             self._register_int_binding(
                 config_attr="hide_delay_ms",
@@ -1096,7 +1150,7 @@ class SettingsWindowController:
             self._register_int_binding(
                 config_attr="recent_apps_max",
                 widget=self._recent_apps_max_spin,
-                on_change=lambda _value: self._runtime.queue_draw(),
+                on_change=lambda _value: self._actions.queue_draw(),
             ),
             self._register_numeric_binding(
                 config_attr="recent_apps_retention_days",
@@ -1108,7 +1162,7 @@ class SettingsWindowController:
                     self._recent_apps_retention_combo.set_active_id(str(value))
                 ),
                 signal="changed",
-                on_change=lambda _value: self._runtime.queue_draw(),
+                on_change=lambda _value: self._actions.queue_draw(),
             ),
             # Recent Documents
             self._register_switch_binding(
@@ -1220,11 +1274,11 @@ class SettingsWindowController:
             return
         for choice in choices:
             self._monitor_combo.append(str(choice.index), choice.label)
-        self._monitor_combo.set_active_id(str(self._runtime.current_monitor_choice()))
+        self._monitor_combo.set_active_id(str(self._actions.current_monitor_choice()))
 
     def _monitor_choices(self) -> list[Any]:
         try:
-            choices = self._runtime.get_monitor_choices()
+            choices = self._actions.get_monitor_choices()
         except Exception:
             return []
         if not isinstance(choices, list):
@@ -1366,10 +1420,10 @@ class SettingsWindowController:
         self._update_status_label.set_label(text)
 
     def _on_check_updates_now(self, _button: Gtk.Button) -> None:
-        self._runtime.check_for_updates_now()
+        self._actions.check_for_updates_now()
 
     def _on_view_releases(self, _button: Gtk.Button) -> None:
-        self._runtime.open_releases_page()
+        self._actions.open_releases_page()
 
     def _on_monitor_combo_changed(self, widget: Gtk.ComboBoxText) -> None:
         if self._syncing_widgets:
@@ -1399,34 +1453,34 @@ class SettingsWindowController:
         self._config.monitor_connector = connector
         self._config.save()
         if not self._config.active_display:
-            self._runtime.reposition()
+            self._actions.reposition()
 
     def _apply_runtime_theme(self) -> None:
         theme = Theme.load(self._config.theme, self._config.icon_size).with_opacity(
             self._config.transparency
         )
-        self._runtime.set_theme(theme)
+        self._actions.set_theme(theme)
 
     def _after_theme_changed(self, _name: str) -> None:
         self._apply_runtime_theme()
-        self._runtime.reposition()
-        self._runtime.queue_draw()
+        self._actions.reposition()
+        self._actions.queue_draw()
 
     def _after_icon_size_changed(self, _value: int) -> None:
         self._apply_runtime_theme()
-        self._runtime.reposition()
-        self._runtime.queue_draw()
+        self._actions.reposition()
+        self._actions.queue_draw()
 
     def _after_transparency_changed(self, _value: float) -> None:
         self._apply_runtime_theme()
-        self._runtime.queue_draw()
+        self._actions.queue_draw()
 
     def _after_additional_distance_changed(self, _value: int) -> None:
-        self._runtime.reposition()
-        self._runtime.queue_draw()
+        self._actions.reposition()
+        self._actions.queue_draw()
 
     def _after_pressure_reveal_changed(self, _value) -> None:
-        self._runtime.refresh_pressure_handler()
+        self._actions.refresh_pressure_handler()
         self._update_dependent_sensitivity()
 
     def _after_show_recent_apps_changed(self, _value) -> None:
@@ -1434,11 +1488,11 @@ class SettingsWindowController:
         if not self._config.show_recent_apps:
             self._config.recent_apps.clear()
             self._config.save()
-        self._runtime.queue_draw()
+        self._actions.queue_draw()
         self._update_dependent_sensitivity()
 
     def _after_hide_mode_changed(self, mode: str) -> None:
-        self._runtime.on_hide_mode_changed()
+        self._actions.on_hide_mode_changed()
         self._update_hide_mode_description()
         self._update_dependent_sensitivity()
 
@@ -1473,11 +1527,11 @@ class SettingsWindowController:
 
     def _after_tooltips_changed(self, active: bool) -> None:
         if not active:
-            self._runtime.hide_tooltip()
+            self._actions.hide_tooltip()
 
     def _after_active_display_changed(self, active: bool) -> None:
-        self._runtime.set_active_display(active)
-        self._runtime.reposition()
+        self._actions.set_active_display(active)
+        self._actions.reposition()
 
     def _update_dependent_sensitivity(self) -> None:
         if self._zoom_percent_spin is not None:

--- a/tests/bdd_support/harness.py
+++ b/tests/bdd_support/harness.py
@@ -10,6 +10,7 @@ import docking.ui.autohide as autohide_mod
 import docking.ui.dnd as dnd_mod
 import docking.ui.dock_window as dock_window_mod
 import docking.ui.hover as hover_mod
+import docking.ui.input_controller as input_controller_mod
 import docking.ui.preview as preview_mod
 from docking.core.config import PinnedEntry
 from docking.core.items import FOLDER_KIND, DockItem
@@ -131,10 +132,27 @@ def _bind_dock_window_helpers(stub) -> SimpleNamespace:
     stub._invalidate_current_geometry_frame = MethodType(
         dock_window_mod.DockWindow._invalidate_current_geometry_frame, stub
     )
-    stub._show_folder_stack_for_item = MethodType(
-        dock_window_mod.DockWindow._show_folder_stack_for_item, stub
-    )
     return stub
+
+
+def _controller(stub) -> SimpleNamespace:
+    controller = SimpleNamespace(
+        _window=stub,
+        _interactions=stub._interactions,
+        _click_x=getattr(stub, "_click_x", -1.0),
+        _click_y=getattr(stub, "_click_y", -1.0),
+        _click_button=getattr(stub, "_click_button", 0),
+        dnd=getattr(
+            stub,
+            "dnd",
+            SimpleNamespace(drag_index=-1, drop_insert_index=-1, drop_target_id=""),
+        ),
+    )
+    controller._show_folder_stack_for_item = MethodType(
+        input_controller_mod.DockInputController._show_folder_stack_for_item,
+        controller,
+    )
+    return controller
 
 
 class DockHarness:
@@ -162,9 +180,12 @@ class DockHarness:
         self._other_item = DockItem(desktop_id="firefox.desktop")
         self._folder_stack_open_for: str | None = None
         self._folder_menu = MagicMock()
-        self._folder_menu.open_folder_stack_item_id.return_value = None
-        self._folder_menu.close_folder_stack = MagicMock(
-            side_effect=self._close_folder_stack
+        self._folder_menu.folder_stack_item_id.return_value = None
+        self._folder_menu.close_folder_stack_for_item = MagicMock(
+            side_effect=lambda _desktop_id: self._close_folder_stack()
+        )
+        self._folder_menu.close_folder_stack_unless_target = MagicMock(
+            side_effect=self._close_folder_stack_unless_target
         )
         self._folder_menu.show_folder_stack = MagicMock(
             side_effect=self._open_folder_stack
@@ -187,7 +208,7 @@ class DockHarness:
                 update_input_region=MagicMock(),
                 drawing_area=MagicMock(),
                 hover=SimpleNamespace(update=MagicMock(), start_anim_pump=MagicMock()),
-                _menu=self._folder_menu,
+                _interactions=self._folder_menu,
                 autohide=SimpleNamespace(
                     enabled=False,
                     state=HideState.VISIBLE,
@@ -289,8 +310,8 @@ class DockHarness:
             button=dock_window_mod.MOUSE_LEFT,
             state=0,
         )
-        dock_window_mod.DockWindow._on_button_release(
-            self._folder_stub,
+        input_controller_mod.DockInputController._on_button_release(
+            _controller(self._folder_stub),
             MagicMock(),
             event,
         )
@@ -303,7 +324,9 @@ class DockHarness:
         )
         self._folder_frame.item_at_point.return_value = target
         event = SimpleNamespace(x=12.0, y=9.0)
-        dock_window_mod.DockWindow._on_motion(self._folder_stub, MagicMock(), event)
+        input_controller_mod.DockInputController._on_motion(
+            _controller(self._folder_stub), MagicMock(), event
+        )
 
     @property
     def folder_stack_open_for(self) -> str | None:
@@ -379,6 +402,7 @@ class DockHarness:
         # Simulate GTK drag-leave having fired during the drag so the
         # _internal_drag_left_dock gate in _on_drag_end passes.
         self._drag_handler._internal_drag_left_dock = True
+        self._drag_folder_stack.open_item_id.return_value = desktop_id
         self._drag_pointer.get_position.return_value = (None, 200, 50)
         self._drag_window.get_position.return_value = (100, 200)
         self._drag_window.get_size.return_value = (400, 60)
@@ -488,13 +512,15 @@ class DockHarness:
             cursor_y=8.0,
             autohide=autohide,
             is_pointer_inside_dock=MagicMock(return_value=False),
-            close_open_folder_stack_for_item=MagicMock(),
             get_display=MagicMock(return_value=display),
             get_position=MagicMock(return_value=(0, 0)),
             get_size=MagicMock(return_value=(400, 60)),
         )
+        folder_stack = MagicMock()
+        folder_stack.open_item_id.return_value = None
         self._drag_pointer = pointer
         self._drag_window = window
+        self._drag_folder_stack = folder_stack
         self._drag_handler = dnd_mod.DnDHandler(
             drawing_area,
             window,
@@ -506,6 +532,7 @@ class DockHarness:
             geometry_builder=SimpleNamespace(
                 build_frame=lambda **_kwargs: self._dnd_frame
             ),
+            folder_stack=folder_stack,
         )
 
     def _mark_drag_reorder(self, *_args, **_kwargs) -> None:
@@ -516,11 +543,19 @@ class DockHarness:
 
     def _open_folder_stack(self, *, item: DockItem, **_kwargs) -> None:
         self._folder_stack_open_for = item.desktop_id
-        self._folder_menu.open_folder_stack_item_id.return_value = item.desktop_id
+        self._folder_menu.folder_stack_item_id.return_value = item.desktop_id
 
     def _close_folder_stack(self) -> None:
         self._folder_stack_open_for = None
-        self._folder_menu.open_folder_stack_item_id.return_value = None
+        self._folder_menu.folder_stack_item_id.return_value = None
+
+    def _close_folder_stack_unless_target(self, hovered_item: DockItem | None) -> None:
+        if (
+            hovered_item is not None
+            and hovered_item.desktop_id == self._folder_stack_open_for
+        ):
+            return
+        self._close_folder_stack()
 
     def _build_hover_harness(self) -> None:
         self._tooltip_updated = False

--- a/tests/bdd_support/test_harness.py
+++ b/tests/bdd_support/test_harness.py
@@ -94,8 +94,6 @@ class TestDockHarnessDnDContracts:
             harness.drag_outside_and_release("a.desktop")
 
             assert harness.drag_removed_desktop_id == "a.desktop"
-            harness._drag_window.close_open_folder_stack_for_item.assert_called_once_with(
-                "a.desktop"
-            )
+            harness._drag_folder_stack.close.assert_called_once_with()
         finally:
             harness.stop()

--- a/tests/smoke/test_python314_smoke.py
+++ b/tests/smoke/test_python314_smoke.py
@@ -276,7 +276,12 @@ def test_app_main_smoke(monkeypatch):
         "NewYearGreetingController",
         MagicMock(return_value=new_year),
     )
-    monkeypatch.setattr(app_mod, "build_dock_window", MagicMock(return_value=window))
+    ui = SimpleNamespace(
+        window=window,
+        start=MagicMock(),
+        stop=MagicMock(),
+    )
+    monkeypatch.setattr(app_mod, "build_dock_window", MagicMock(return_value=ui))
     monkeypatch.setattr(
         app_mod, "DockItemsService", MagicMock(return_value=items_service)
     )
@@ -290,8 +295,8 @@ def test_app_main_smoke(monkeypatch):
 
     new_year.start.assert_called_once()
     new_year.stop.assert_called_once()
-    window.start_update_checks.assert_called_once()
-    window.stop_update_checks.assert_called_once()
+    ui.start.assert_called_once()
+    ui.stop.assert_called_once()
 
     fake_gtk.main.assert_called_once()
     assert fake_glib.unix_signal_add.call_count == 2

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -137,13 +137,16 @@ class TestAppMain:
         unity = MagicMock()
         new_year = MagicMock()
         window = MagicMock()
+        ui = SimpleNamespace(
+            window=window,
+            start=MagicMock(),
+            stop=MagicMock(),
+        )
         items_service = MagicMock()
         call_order: list[str] = []
 
         window.show_all.side_effect = lambda: call_order.append("show_all")
-        window.start_update_checks.side_effect = lambda: call_order.append(
-            "updates_start"
-        )
+        ui.start.side_effect = lambda: call_order.append("ui_start")
         unity.start.side_effect = lambda: call_order.append("unity_start")
         new_year.start.side_effect = lambda: call_order.append("new_year_start")
         items_service.start.side_effect = lambda: call_order.append("items_start")
@@ -181,7 +184,7 @@ class TestAppMain:
             "NewYearGreetingController",
             MagicMock(return_value=new_year),
         )
-        factory = MagicMock(return_value=window)
+        factory = MagicMock(return_value=ui)
         monkeypatch.setattr(app_mod, "build_dock_window", factory)
         monkeypatch.setattr(
             app_mod, "DockItemsService", MagicMock(return_value=items_service)
@@ -221,8 +224,8 @@ class TestAppMain:
         unity.stop.assert_called_once()
         new_year.start.assert_called_once()
         new_year.stop.assert_called_once()
-        window.start_update_checks.assert_called_once()
-        window.stop_update_checks.assert_called_once()
+        ui.start.assert_called_once()
+        ui.stop.assert_called_once()
         fake_glib.idle_add.assert_called_once_with(
             app_mod._start_runtime,
             items_service,
@@ -234,7 +237,7 @@ class TestAppMain:
             "unity_start",
             "show_all",
             "new_year_start",
-            "updates_start",
+            "ui_start",
             "idle_add",
             "items_start",
             "applets_start",
@@ -270,13 +273,16 @@ class TestAppMain:
         unity = MagicMock()
         new_year = MagicMock()
         window = MagicMock()
+        ui = SimpleNamespace(
+            window=window,
+            start=MagicMock(),
+            stop=MagicMock(),
+        )
         items_service = MagicMock()
         call_order: list[str] = []
 
         window.show_all.side_effect = lambda: call_order.append("show_all")
-        window.start_update_checks.side_effect = lambda: call_order.append(
-            "updates_start"
-        )
+        ui.start.side_effect = lambda: call_order.append("ui_start")
         unity.start.side_effect = lambda: call_order.append("unity_start")
         new_year.start.side_effect = lambda: call_order.append("new_year_start")
         items_service.start.side_effect = lambda: call_order.append("items_start")
@@ -298,7 +304,7 @@ class TestAppMain:
         backend_cls = MagicMock(return_value=backend)
         unity_cls = MagicMock(return_value=unity)
         new_year_cls = MagicMock(return_value=new_year)
-        factory = MagicMock(return_value=window)
+        factory = MagicMock(return_value=ui)
         items_service_cls = MagicMock(return_value=items_service)
 
         monkeypatch.setattr(sys.modules["docking.core.config"], "Config", config_cls)
@@ -350,13 +356,13 @@ class TestAppMain:
         unity.stop.assert_called_once()
         new_year.start.assert_called_once()
         new_year.stop.assert_called_once()
-        window.start_update_checks.assert_called_once()
-        window.stop_update_checks.assert_called_once()
+        ui.start.assert_called_once()
+        ui.stop.assert_called_once()
         assert call_order == [
             "unity_start",
             "show_all",
             "new_year_start",
-            "updates_start",
+            "ui_start",
             "idle_add",
             "items_start",
             "applets_start",

--- a/tests/ui/test_dnd_integration.py
+++ b/tests/ui/test_dnd_integration.py
@@ -87,14 +87,15 @@ def _make_handler(monkeypatch, lock_icons: bool = False):
         cursor_x=20.0,
         cursor_y=8.0,
         autohide=autohide,
-        close_open_folder_stack_for_item=MagicMock(),
         is_pointer_inside_dock=MagicMock(return_value=False),
         get_display=MagicMock(return_value=display),
         get_position=MagicMock(return_value=(0, 0)),
         get_size=MagicMock(return_value=(400, 60)),
     )
+    folder_stack = MagicMock()
+    folder_stack.open_item_id.return_value = None
     monkeypatch.setattr(dnd_mod, "show_poof", MagicMock())
-    return dnd_mod.DnDHandler(
+    handler = dnd_mod.DnDHandler(
         drawing_area,
         window,
         model,
@@ -103,7 +104,10 @@ def _make_handler(monkeypatch, lock_icons: bool = False):
         theme,
         launcher,
         geometry_builder=SimpleNamespace(build_frame=lambda **_kwargs: default_frame),
+        folder_stack=folder_stack,
     )
+    handler._test_folder_stack = folder_stack
+    return handler
 
 
 class _FakeResponseDialog:
@@ -885,10 +889,9 @@ class TestDragLeaveEnd:
         pointer.get_pointer.return_value.get_position.return_value = (None, 200, 50)
         handler._window.get_position.return_value = (100, 200)
         handler._window.get_size.return_value = (400, 60)
+        handler._test_folder_stack.open_item_id.return_value = folder.desktop_id
 
         handler._on_drag_end(handler._drawing_area, MagicMock())
 
-        handler._window.close_open_folder_stack_for_item.assert_called_once_with(
-            folder.desktop_id
-        )
+        handler._test_folder_stack.close.assert_called_once_with()
         handler._model.unpin_item.assert_called_once_with(folder.desktop_id)

--- a/tests/ui/test_dock_interactions.py
+++ b/tests/ui/test_dock_interactions.py
@@ -1,0 +1,90 @@
+"""Tests for the DockInteractions coordinator."""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import docking.ui.dock_window as dock_window_mod
+from docking.core.position import Position
+from docking.ui.dock_interactions import DockInteractions, FolderStackAnchor
+
+
+def test_context_menu_uses_current_frame_and_closes_folder_stack():
+    menu = MagicMock()
+    folder_stack = MagicMock()
+    interactions = DockInteractions(menu=menu, folder_stack=folder_stack)
+    event = SimpleNamespace(x=12.0, y=8.0)
+    frame = MagicMock()
+
+    interactions.show_context_menu(
+        event=event,
+        cursor_main=12.0,
+        frame=frame,
+        force_background=True,
+    )
+
+    folder_stack.close.assert_called_once_with()
+    menu.show.assert_called_once_with(
+        event=event,
+        cursor_main=12.0,
+        frame=frame,
+        force_background=True,
+    )
+
+
+def test_folder_stack_uses_anchor_value_object():
+    menu = MagicMock()
+    folder_stack = MagicMock()
+    interactions = DockInteractions(menu=menu, folder_stack=folder_stack)
+    item = MagicMock()
+    anchor = FolderStackAnchor(x=100, y=200, icon_w=48, position=Position.BOTTOM)
+
+    interactions.show_folder_stack(
+        item=item,
+        anchor=anchor,
+        toggle_if_same_item=False,
+    )
+
+    folder_stack.show.assert_called_once_with(
+        item=item,
+        anchor_x=100,
+        anchor_y=200,
+        icon_w=48,
+        position=Position.BOTTOM,
+        toggle_if_same_item=False,
+    )
+
+
+def test_folder_stack_closes_when_hover_leaves_source_item():
+    menu = MagicMock()
+    folder_stack = MagicMock()
+    folder_stack.open_item_id.return_value = "file:///tmp/docs"
+    interactions = DockInteractions(menu=menu, folder_stack=folder_stack)
+
+    interactions.close_folder_stack_unless_target(
+        SimpleNamespace(desktop_id="firefox.desktop")
+    )
+
+    folder_stack.close.assert_called_once_with()
+
+
+def test_folder_stack_stays_open_while_hovering_source_item():
+    menu = MagicMock()
+    folder_stack = MagicMock()
+    folder_stack.open_item_id.return_value = "file:///tmp/docs"
+    interactions = DockInteractions(menu=menu, folder_stack=folder_stack)
+
+    interactions.close_folder_stack_unless_target(
+        SimpleNamespace(desktop_id="file:///tmp/docs")
+    )
+
+    folder_stack.close.assert_not_called()
+
+
+def test_dock_window_does_not_import_menu_handler():
+    source = inspect.getsource(dock_window_mod)
+
+    assert "from docking.ui.menu import MenuHandler" not in source
+    assert "MenuHandler(" not in source

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -6,6 +6,7 @@ from types import MethodType, SimpleNamespace
 from unittest.mock import MagicMock
 
 import docking.ui.dock_window as dock_window_mod
+import docking.ui.input_controller as input_controller_mod
 import docking.ui.renderer as renderer_mod
 from docking.core.items import FILE_KIND, FOLDER_KIND
 from docking.core.position import Position
@@ -70,13 +71,34 @@ def _bind_geometry_signature(stub):
     stub._invalidate_current_geometry_frame = MethodType(
         dock_window_mod.DockWindow._invalidate_current_geometry_frame, stub
     )
-    stub._show_folder_stack_for_item = MethodType(
-        dock_window_mod.DockWindow._show_folder_stack_for_item, stub
-    )
-    stub._popup_anchor_for_item = MethodType(
-        dock_window_mod.DockWindow._popup_anchor_for_item, stub
+    stub.popup_anchor_for_item = MethodType(
+        dock_window_mod.DockWindow.popup_anchor_for_item, stub
     )
     return stub
+
+
+def _controller(stub):
+    controller = SimpleNamespace(
+        _window=stub,
+        _interactions=getattr(stub, "_interactions", MagicMock()),
+        _click_x=getattr(stub, "_click_x", -1.0),
+        _click_y=getattr(stub, "_click_y", -1.0),
+        _click_button=getattr(stub, "_click_button", 0),
+        dnd=getattr(
+            stub,
+            "dnd",
+            SimpleNamespace(
+                drag_index=-1,
+                drop_insert_index=-1,
+                drop_target_id="",
+            ),
+        ),
+    )
+    controller._show_folder_stack_for_item = MethodType(
+        input_controller_mod.DockInputController._show_folder_stack_for_item,
+        controller,
+    )
+    return controller
 
 
 def _make_stub(item: DockItem | None = None):
@@ -102,9 +124,7 @@ def _make_stub(item: DockItem | None = None):
         item_padding=8, horizontal_padding=10, urgent_glow_time_ms=500
     )
     stub.window_tracker = MagicMock()
-    stub._menu = MagicMock()
-    stub._menu.open_folder_stack_item_id.return_value = None
-    stub._menu.close_folder_stack = MagicMock()
+    stub._interactions = MagicMock()
     stub.tooltip = MagicMock()
     stub.hover = MagicMock()
     stub.hover.hovered_item = item
@@ -147,14 +167,15 @@ class TestButtonReleaseFlow:
         )
 
         # When
-        handled = dock_window_mod.DockWindow._on_button_release(
-            stub, MagicMock(), event
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
         )
         # Then
         assert handled is True
-        stub._menu.show.assert_called_once_with(
-            event,
-            12.0,
+        stub._interactions.show_context_menu.assert_called_once_with(
+            event=event,
+            cursor_main=12.0,
+            frame=stub._test_geometry_frame,
             force_background=False,
         )
 
@@ -169,14 +190,15 @@ class TestButtonReleaseFlow:
         )
 
         # When
-        handled = dock_window_mod.DockWindow._on_button_release(
-            stub, MagicMock(), event
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
         )
         # Then
         assert handled is True
-        stub._menu.show.assert_called_once_with(
-            event,
-            12.0,
+        stub._interactions.show_context_menu.assert_called_once_with(
+            event=event,
+            cursor_main=12.0,
+            frame=stub._test_geometry_frame,
             force_background=True,
         )
 
@@ -194,15 +216,17 @@ class TestButtonReleaseFlow:
             x=12.0, y=6.0, button=dock_window_mod.MOUSE_LEFT, state=0
         )
         monkeypatch.setattr(
-            dock_window_mod,
+            input_controller_mod,
             "is_applet",
             lambda desktop_id: desktop_id.startswith("applet://"),
         )
-        monkeypatch.setattr(dock_window_mod.GLib, "get_monotonic_time", lambda: 999)
+        monkeypatch.setattr(
+            input_controller_mod.GLib, "get_monotonic_time", lambda: 999
+        )
 
         # When
-        handled = dock_window_mod.DockWindow._on_button_release(
-            stub, MagicMock(), event
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
         )
         # Then
         assert handled is True
@@ -222,12 +246,14 @@ class TestButtonReleaseFlow:
         event = SimpleNamespace(
             x=12.0, y=6.0, button=dock_window_mod.MOUSE_LEFT, state=0
         )
-        monkeypatch.setattr(dock_window_mod, "is_applet", lambda desktop_id: False)
-        monkeypatch.setattr(dock_window_mod.GLib, "get_monotonic_time", lambda: 1010)
+        monkeypatch.setattr(input_controller_mod, "is_applet", lambda desktop_id: False)
+        monkeypatch.setattr(
+            input_controller_mod.GLib, "get_monotonic_time", lambda: 1010
+        )
 
         # When
-        handled = dock_window_mod.DockWindow._on_button_release(
-            stub, MagicMock(), event
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
         )
         # Then
         assert handled is True
@@ -243,16 +269,18 @@ class TestButtonReleaseFlow:
             x=12.0, y=6.0, button=dock_window_mod.MOUSE_MIDDLE, state=0
         )
         launch_calls: list[str] = []
-        monkeypatch.setattr(dock_window_mod, "is_applet", lambda desktop_id: False)
-        monkeypatch.setattr(dock_window_mod.GLib, "get_monotonic_time", lambda: 2020)
+        monkeypatch.setattr(input_controller_mod, "is_applet", lambda desktop_id: False)
         monkeypatch.setattr(
-            dock_window_mod,
+            input_controller_mod.GLib, "get_monotonic_time", lambda: 2020
+        )
+        monkeypatch.setattr(
+            input_controller_mod,
             "launch_new_window",
             lambda desktop_id: launch_calls.append(desktop_id),
         )
 
-        handled = dock_window_mod.DockWindow._on_button_release(
-            stub, MagicMock(), event
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
         )
 
         assert handled is True
@@ -267,11 +295,13 @@ class TestButtonReleaseFlow:
         event = SimpleNamespace(
             x=12.0, y=6.0, button=dock_window_mod.MOUSE_LEFT, state=0
         )
-        monkeypatch.setattr(dock_window_mod, "is_applet", lambda desktop_id: False)
-        monkeypatch.setattr(dock_window_mod.GLib, "get_monotonic_time", lambda: 1111)
+        monkeypatch.setattr(input_controller_mod, "is_applet", lambda desktop_id: False)
+        monkeypatch.setattr(
+            input_controller_mod.GLib, "get_monotonic_time", lambda: 1111
+        )
 
-        handled = dock_window_mod.DockWindow._on_button_release(
-            stub, MagicMock(), event
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
         )
 
         assert handled is True
@@ -287,11 +317,13 @@ class TestButtonReleaseFlow:
         event = SimpleNamespace(
             x=12.0, y=6.0, button=dock_window_mod.MOUSE_LEFT, state=0
         )
-        monkeypatch.setattr(dock_window_mod, "is_applet", lambda desktop_id: False)
-        monkeypatch.setattr(dock_window_mod.GLib, "get_monotonic_time", lambda: 1313)
+        monkeypatch.setattr(input_controller_mod, "is_applet", lambda desktop_id: False)
+        monkeypatch.setattr(
+            input_controller_mod.GLib, "get_monotonic_time", lambda: 1313
+        )
 
-        handled = dock_window_mod.DockWindow._on_button_release(
-            stub, MagicMock(), event
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
         )
 
         assert handled is True
@@ -308,11 +340,13 @@ class TestButtonReleaseFlow:
         event = SimpleNamespace(
             x=12.0, y=6.0, button=dock_window_mod.MOUSE_MIDDLE, state=0
         )
-        monkeypatch.setattr(dock_window_mod, "is_applet", lambda desktop_id: False)
-        monkeypatch.setattr(dock_window_mod.GLib, "get_monotonic_time", lambda: 2121)
+        monkeypatch.setattr(input_controller_mod, "is_applet", lambda desktop_id: False)
+        monkeypatch.setattr(
+            input_controller_mod.GLib, "get_monotonic_time", lambda: 2121
+        )
 
-        handled = dock_window_mod.DockWindow._on_button_release(
-            stub, MagicMock(), event
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
         )
 
         assert handled is True
@@ -327,11 +361,13 @@ class TestButtonReleaseFlow:
         event = SimpleNamespace(
             x=12.0, y=6.0, button=dock_window_mod.MOUSE_MIDDLE, state=0
         )
-        monkeypatch.setattr(dock_window_mod, "is_applet", lambda desktop_id: False)
-        monkeypatch.setattr(dock_window_mod.GLib, "get_monotonic_time", lambda: 2222)
+        monkeypatch.setattr(input_controller_mod, "is_applet", lambda desktop_id: False)
+        monkeypatch.setattr(
+            input_controller_mod.GLib, "get_monotonic_time", lambda: 2222
+        )
 
-        handled = dock_window_mod.DockWindow._on_button_release(
-            stub, MagicMock(), event
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
         )
 
         assert handled is True
@@ -350,16 +386,18 @@ class TestButtonReleaseFlow:
             state=dock_window_mod.Gdk.ModifierType.CONTROL_MASK,
         )
         launch_calls: list[str] = []
-        monkeypatch.setattr(dock_window_mod, "is_applet", lambda desktop_id: False)
-        monkeypatch.setattr(dock_window_mod.GLib, "get_monotonic_time", lambda: 2323)
+        monkeypatch.setattr(input_controller_mod, "is_applet", lambda desktop_id: False)
         monkeypatch.setattr(
-            dock_window_mod,
+            input_controller_mod.GLib, "get_monotonic_time", lambda: 2323
+        )
+        monkeypatch.setattr(
+            input_controller_mod,
             "launch_new_window",
             lambda desktop_id: launch_calls.append(desktop_id),
         )
 
-        handled = dock_window_mod.DockWindow._on_button_release(
-            stub, MagicMock(), event
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
         )
 
         assert handled is True
@@ -377,14 +415,16 @@ class TestButtonReleaseFlow:
         event = SimpleNamespace(
             x=12.0, y=6.0, button=dock_window_mod.MOUSE_LEFT, state=0
         )
-        monkeypatch.setattr(dock_window_mod.GLib, "get_monotonic_time", lambda: 3030)
+        monkeypatch.setattr(
+            input_controller_mod.GLib, "get_monotonic_time", lambda: 3030
+        )
         opened: list[str] = []
         monkeypatch.setattr(
-            dock_window_mod, "open_target", lambda target: opened.append(target)
+            input_controller_mod, "open_target", lambda target: opened.append(target)
         )
 
-        handled = dock_window_mod.DockWindow._on_button_release(
-            stub, MagicMock(), event
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
         )
 
         assert handled is True
@@ -405,20 +445,24 @@ class TestButtonReleaseFlow:
         event = SimpleNamespace(
             x=12.0, y=6.0, button=dock_window_mod.MOUSE_LEFT, state=0
         )
-        monkeypatch.setattr(dock_window_mod.GLib, "get_monotonic_time", lambda: 4040)
+        monkeypatch.setattr(
+            input_controller_mod.GLib, "get_monotonic_time", lambda: 4040
+        )
 
-        handled = dock_window_mod.DockWindow._on_button_release(
-            stub, MagicMock(), event
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
         )
 
         assert handled is True
-        stub._menu.show_folder_stack.assert_called_once()
-        kwargs = stub._menu.show_folder_stack.call_args.kwargs
+        stub._interactions.show_folder_stack.assert_called_once()
+        kwargs = stub._interactions.show_folder_stack.call_args.kwargs
         assert kwargs["item"] is item
-        assert kwargs["anchor_x"] == 104
-        assert kwargs["anchor_y"] == 205
-        assert kwargs["icon_w"] == 48
-        assert kwargs["position"] == Position.BOTTOM
+        assert kwargs["anchor"] == input_controller_mod.FolderStackAnchor(
+            x=104,
+            y=205,
+            icon_w=48,
+            position=Position.BOTTOM,
+        )
         assert kwargs["toggle_if_same_item"] is True
 
     def test_hover_folder_item_opens_folder_stack_when_enabled(self):
@@ -432,12 +476,14 @@ class TestButtonReleaseFlow:
         widget = MagicMock()
         event = SimpleNamespace(x=12.0, y=9.0)
 
-        handled = dock_window_mod.DockWindow._on_motion(stub, widget, event)
+        handled = input_controller_mod.DockInputController._on_motion(
+            _controller(stub), widget, event
+        )
 
         assert handled is False
-        stub._menu.schedule_folder_stack_prewarm.assert_called_once_with(item)
-        stub._menu.show_folder_stack.assert_called_once()
-        kwargs = stub._menu.show_folder_stack.call_args.kwargs
+        stub._interactions.prewarm_folder_stack.assert_called_once_with(item)
+        stub._interactions.show_folder_stack.assert_called_once()
+        kwargs = stub._interactions.show_folder_stack.call_args.kwargs
         assert kwargs["item"] is item
         assert kwargs["toggle_if_same_item"] is False
 
@@ -453,11 +499,13 @@ class TestButtonReleaseFlow:
         widget = MagicMock()
         event = SimpleNamespace(x=12.0, y=9.0)
 
-        handled = dock_window_mod.DockWindow._on_motion(stub, widget, event)
+        handled = input_controller_mod.DockInputController._on_motion(
+            _controller(stub), widget, event
+        )
 
         assert handled is False
-        stub._menu.schedule_folder_stack_prewarm.assert_called_once_with(item)
-        stub._menu.show_folder_stack.assert_not_called()
+        stub._interactions.prewarm_folder_stack.assert_called_once_with(item)
+        stub._interactions.show_folder_stack.assert_not_called()
 
     def test_motion_prewarms_hovered_folder_item_in_click_mode(self):
         item = DockItem(
@@ -469,11 +517,13 @@ class TestButtonReleaseFlow:
         widget = MagicMock()
         event = SimpleNamespace(x=12.0, y=9.0)
 
-        handled = dock_window_mod.DockWindow._on_motion(stub, widget, event)
+        handled = input_controller_mod.DockInputController._on_motion(
+            _controller(stub), widget, event
+        )
 
         assert handled is False
-        stub._menu.schedule_folder_stack_prewarm.assert_called_once_with(item)
-        stub._menu.show_folder_stack.assert_not_called()
+        stub._interactions.prewarm_folder_stack.assert_called_once_with(item)
+        stub._interactions.show_folder_stack.assert_not_called()
 
     def test_drag_delta_above_threshold_is_ignored(self):
         # Given
@@ -483,12 +533,12 @@ class TestButtonReleaseFlow:
             x=40.0, y=6.0, button=dock_window_mod.MOUSE_LEFT, state=0
         )
         # When
-        handled = dock_window_mod.DockWindow._on_button_release(
-            stub, MagicMock(), event
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
         )
         # Then
         assert handled is False
-        stub._menu.show.assert_not_called()
+        stub._interactions.show_context_menu.assert_not_called()
 
 
 class TestScrollAndHoverFlow:
@@ -504,13 +554,15 @@ class TestScrollAndHoverFlow:
             direction=dock_window_mod.Gdk.ScrollDirection.UP,
         )
         monkeypatch.setattr(
-            dock_window_mod,
+            input_controller_mod,
             "is_applet",
             lambda desktop_id: desktop_id.startswith("applet://"),
         )
 
         # When
-        handled = dock_window_mod.DockWindow._on_scroll(stub, MagicMock(), event)
+        handled = input_controller_mod.DockInputController._on_scroll(
+            _controller(stub), MagicMock(), event
+        )
         # Then
         assert handled is True
         applet.on_scroll.assert_called_once_with(True)
@@ -528,12 +580,14 @@ class TestScrollAndHoverFlow:
             get_scroll_deltas=lambda: (True, 0.0, -1.0),
         )
         monkeypatch.setattr(
-            dock_window_mod,
+            input_controller_mod,
             "is_applet",
             lambda desktop_id: desktop_id.startswith("applet://"),
         )
 
-        handled = dock_window_mod.DockWindow._on_scroll(stub, MagicMock(), event)
+        handled = input_controller_mod.DockInputController._on_scroll(
+            _controller(stub), MagicMock(), event
+        )
 
         assert handled is True
         applet.on_scroll.assert_called_once_with(True)
@@ -551,12 +605,14 @@ class TestScrollAndHoverFlow:
             get_scroll_deltas=lambda: (True, 1.0, 0.0),
         )
         monkeypatch.setattr(
-            dock_window_mod,
+            input_controller_mod,
             "is_applet",
             lambda desktop_id: desktop_id.startswith("applet://"),
         )
 
-        handled = dock_window_mod.DockWindow._on_scroll(stub, MagicMock(), event)
+        handled = input_controller_mod.DockInputController._on_scroll(
+            _controller(stub), MagicMock(), event
+        )
 
         assert handled is False
         applet.on_scroll.assert_not_called()
@@ -570,10 +626,12 @@ class TestScrollAndHoverFlow:
             y=5.0,
             direction=dock_window_mod.Gdk.ScrollDirection.DOWN,
         )
-        monkeypatch.setattr(dock_window_mod, "is_applet", lambda desktop_id: False)
+        monkeypatch.setattr(input_controller_mod, "is_applet", lambda desktop_id: False)
 
         # When
-        handled = dock_window_mod.DockWindow._on_scroll(stub, MagicMock(), event)
+        handled = input_controller_mod.DockInputController._on_scroll(
+            _controller(stub), MagicMock(), event
+        )
         # Then
         assert handled is False
 
@@ -589,7 +647,9 @@ class TestLeaveEnterFlow:
             y=2.0,
         )
         # When
-        handled = dock_window_mod.DockWindow._on_leave(stub, MagicMock(), event)
+        handled = input_controller_mod.DockInputController._on_leave(
+            _controller(stub), MagicMock(), event
+        )
         # Then
         assert handled is False
 
@@ -607,7 +667,9 @@ class TestLeaveEnterFlow:
         )
 
         # When
-        handled = dock_window_mod.DockWindow._on_leave(stub, MagicMock(), event)
+        handled = input_controller_mod.DockInputController._on_leave(
+            _controller(stub), MagicMock(), event
+        )
         # Then
         assert handled is False
         stub.interaction.point_inside_event_frame.assert_called_once_with(
@@ -631,7 +693,9 @@ class TestLeaveEnterFlow:
         )
 
         # When
-        handled = dock_window_mod.DockWindow._on_leave(stub, widget, event)
+        handled = input_controller_mod.DockInputController._on_leave(
+            _controller(stub), widget, event
+        )
         # Then
         assert handled is True
         stub.interaction.on_effective_leave.assert_called_once_with(widget)
@@ -651,7 +715,9 @@ class TestLeaveEnterFlow:
             y=200.0,
         )
 
-        handled = dock_window_mod.DockWindow._on_leave(stub, widget, event)
+        handled = input_controller_mod.DockInputController._on_leave(
+            _controller(stub), widget, event
+        )
 
         assert handled is True
         stub.interaction.on_effective_leave.assert_called_once_with(widget)
@@ -669,7 +735,9 @@ class TestLeaveEnterFlow:
             y=200.0,
         )
 
-        handled = dock_window_mod.DockWindow._on_leave(stub, widget, event)
+        handled = input_controller_mod.DockInputController._on_leave(
+            _controller(stub), widget, event
+        )
 
         assert handled is True
         stub.interaction.on_effective_leave.assert_called_once_with(widget)
@@ -681,7 +749,9 @@ class TestLeaveEnterFlow:
         stub.dock_hovered = False
         event = SimpleNamespace(x=44.0, y=11.0)
         # When
-        handled = dock_window_mod.DockWindow._on_enter(stub, MagicMock(), event)
+        handled = input_controller_mod.DockInputController._on_enter(
+            _controller(stub), MagicMock(), event
+        )
         # Then
         assert handled is True
         assert stub.cursor_x == 44.0
@@ -696,7 +766,9 @@ class TestLeaveEnterFlow:
         stub._test_geometry_frame = outside_frame
         event = SimpleNamespace(x=556.0, y=3.0)
 
-        handled = dock_window_mod.DockWindow._on_enter(stub, MagicMock(), event)
+        handled = input_controller_mod.DockInputController._on_enter(
+            _controller(stub), MagicMock(), event
+        )
 
         assert handled is True
         assert stub.cursor_x == 556.0
@@ -739,7 +811,9 @@ class TestLeaveEnterFlow:
             y=float(frame.cursor_rect.y + 1),
         )
 
-        handled = dock_window_mod.DockWindow._on_enter(stub, MagicMock(), event)
+        handled = input_controller_mod.DockInputController._on_enter(
+            _controller(stub), MagicMock(), event
+        )
 
         assert handled is True
         stub.interaction.on_effective_enter.assert_called_once()
@@ -787,15 +861,15 @@ class TestModelChangedFlow:
         # Given
         stub, _item = _make_stub()
         timeout_add = MagicMock(return_value=55)
-        monkeypatch.setattr(dock_window_mod.GLib, "timeout_add", timeout_add)
+        monkeypatch.setattr(input_controller_mod.GLib, "timeout_add", timeout_add)
 
         # When
-        dock_window_mod.DockWindow._on_model_changed(stub)
+        input_controller_mod.DockInputController._on_model_changed(_controller(stub))
 
         # Then
         stub.update_input_region.assert_called_once()
         stub.hover.on_model_changed.assert_called_once()
-        stub._menu.schedule_visible_folder_stack_prewarm.assert_called_once_with(
+        stub._interactions.prewarm_visible_folder_stacks.assert_called_once_with(
             stub.model.visible_items.return_value
         )
         stub.hover.update.assert_called_once_with(12.0)
@@ -807,15 +881,15 @@ class TestModelChangedFlow:
         stub, _item = _make_stub()
         stub.hover.hovered_item = None
         timeout_add = MagicMock(return_value=66)
-        monkeypatch.setattr(dock_window_mod.GLib, "timeout_add", timeout_add)
+        monkeypatch.setattr(input_controller_mod.GLib, "timeout_add", timeout_add)
 
         # When
-        dock_window_mod.DockWindow._on_model_changed(stub)
+        input_controller_mod.DockInputController._on_model_changed(_controller(stub))
 
         # Then
         stub.update_input_region.assert_called_once()
         stub.hover.on_model_changed.assert_called_once()
-        stub._menu.schedule_visible_folder_stack_prewarm.assert_called_once_with(
+        stub._interactions.prewarm_visible_folder_stacks.assert_called_once_with(
             stub.model.visible_items.return_value
         )
         stub.hover.update.assert_not_called()
@@ -897,13 +971,6 @@ class TestDockWindowSetupAndGeometry:
         )
         stub = SimpleNamespace(
             add=MagicMock(),
-            _on_draw=MagicMock(),
-            _on_motion=MagicMock(),
-            _on_button_press=MagicMock(),
-            _on_button_release=MagicMock(),
-            _on_leave=MagicMock(),
-            _on_enter=MagicMock(),
-            _on_scroll=MagicMock(),
             _cache=_window_cache(
                 current_geometry_frame="sentinel-current",
                 applied_input_frame="sentinel-applied",
@@ -919,29 +986,13 @@ class TestDockWindowSetupAndGeometry:
         assert (
             stub.drawing_area.events & dock_window_mod.Gdk.EventMask.SMOOTH_SCROLL_MASK
         )
-        assert "draw" in stub.drawing_area.connected
-        assert "scroll-event" in stub.drawing_area.connected
+        assert stub.drawing_area.connected == []
         assert stub._cache.geometry_frame.frame == "sentinel-current"
         assert stub._cache.applied_input_frame == "sentinel-applied"
 
-    def test_connect_model_registers_change_listener(self):
-        # Given
-        add_change_listener = MagicMock()
-        stub = SimpleNamespace(
-            model=SimpleNamespace(add_change_listener=add_change_listener),
-            _on_model_changed=lambda: None,
-        )
-
-        # When
-        dock_window_mod.DockWindow._connect_model(stub)
-
-        # Then
-        add_change_listener.assert_called_once_with(stub._on_model_changed)
-
-    def test_on_destroy_disconnects_model_listener(self):
+    def test_on_destroy_stops_dodge_monitor(self):
         dodge_monitor = MagicMock()
         stub = SimpleNamespace(
-            _disconnect_model=MagicMock(),
             dodge_monitor=dodge_monitor,
         )
 
@@ -949,18 +1000,6 @@ class TestDockWindowSetupAndGeometry:
 
         dodge_monitor.stop.assert_called_once_with()
         assert stub.dodge_monitor is None
-        stub._disconnect_model.assert_called_once_with()
-
-    def test_disconnect_model_unregisters_change_listener(self):
-        remove_change_listener = MagicMock()
-        stub = SimpleNamespace(
-            model=SimpleNamespace(remove_change_listener=remove_change_listener),
-            _on_model_changed=lambda: None,
-        )
-
-        dock_window_mod.DockWindow._disconnect_model(stub)
-
-        remove_change_listener.assert_called_once_with(stub._on_model_changed)
 
     def test_set_theme_propagates_to_theme_holders_and_invalidates_geometry(self):
         old_theme = object()
@@ -986,7 +1025,6 @@ class TestDockWindowSetupAndGeometry:
         assert stub.theme is new_theme
         stub.tooltip.set_theme.assert_called_once_with(new_theme)
         stub.hover.set_theme.assert_called_once_with(new_theme)
-        stub.dnd.set_theme.assert_called_once_with(new_theme)
         assert stub._cache.geometry_frame is None
 
 
@@ -1174,7 +1212,9 @@ class TestDockWindowDrawAndHelpers:
         geometry.build_frame.side_effect = lambda **_kwargs: stub._test_geometry_frame
 
         # When
-        result = dock_window_mod.DockWindow._on_draw(stub, MagicMock(), MagicMock())
+        result = input_controller_mod.DockInputController._on_draw(
+            _controller(stub), MagicMock(), MagicMock()
+        )
 
         # Then
         assert result is True
@@ -1231,7 +1271,9 @@ class TestDockWindowDrawAndHelpers:
             )
         )
 
-        dock_window_mod.DockWindow._on_draw(stub, MagicMock(), MagicMock())
+        input_controller_mod.DockInputController._on_draw(
+            _controller(stub), MagicMock(), MagicMock()
+        )
 
         geometry.build_frame.assert_called_once_with(
             drop_insert_index=3,
@@ -1327,7 +1369,9 @@ class TestDockWindowDrawAndHelpers:
         )
         stub.model.visible_items.return_value = []
 
-        result = dock_window_mod.DockWindow._on_draw(stub, MagicMock(), MagicMock())
+        result = input_controller_mod.DockInputController._on_draw(
+            _controller(stub), MagicMock(), MagicMock()
+        )
 
         assert result is True
         stub.renderer.draw.assert_called_once()
@@ -1370,7 +1414,9 @@ class TestDockWindowDrawAndHelpers:
         )
 
         # When
-        dock_window_mod.DockWindow._on_draw(stub, MagicMock(), MagicMock())
+        input_controller_mod.DockInputController._on_draw(
+            _controller(stub), MagicMock(), MagicMock()
+        )
 
         # Then
         assert stub.cursor_x == -1.0
@@ -1412,7 +1458,9 @@ class TestDockWindowDrawAndHelpers:
             )
         )
 
-        dock_window_mod.DockWindow._on_draw(stub, MagicMock(), MagicMock())
+        input_controller_mod.DockInputController._on_draw(
+            _controller(stub), MagicMock(), MagicMock()
+        )
 
         stub.hover.update.assert_called_once_with(25.0, frame=frame)
         assert stub._last_autohide_state == HideState.VISIBLE
@@ -1453,7 +1501,7 @@ class TestDockWindowDrawAndHelpers:
                 ),
                 theme=MagicMock(),
                 tooltip=MagicMock(),
-                _menu=MagicMock(),
+                _interactions=MagicMock(),
                 _test_geometry_frame=frame,
                 update_input_region=MagicMock(),
                 cursor_x=25.0,
@@ -1468,22 +1516,27 @@ class TestDockWindowDrawAndHelpers:
             )
         )
 
-        dock_window_mod.DockWindow._on_draw(stub, MagicMock(), MagicMock())
+        input_controller_mod.DockInputController._on_draw(
+            _controller(stub), MagicMock(), MagicMock()
+        )
 
-        stub._menu.show_folder_stack.assert_called_once()
-        kwargs = stub._menu.show_folder_stack.call_args.kwargs
+        stub._interactions.show_folder_stack.assert_called_once()
+        kwargs = stub._interactions.show_folder_stack.call_args.kwargs
         assert kwargs["item"] is hovered
-        assert kwargs["anchor_x"] == 104
-        assert kwargs["anchor_y"] == 205
+        assert kwargs["anchor"] == input_controller_mod.FolderStackAnchor(
+            x=104,
+            y=205,
+            icon_w=48,
+            position=Position.BOTTOM,
+        )
         assert kwargs["toggle_if_same_item"] is False
 
     def test_on_motion_updates_cursor_and_hover(self, monkeypatch):
         # Given
         widget = MagicMock()
         timeout_add = MagicMock(return_value=77)
-        monkeypatch.setattr(dock_window_mod.GLib, "timeout_add", timeout_add)
-        menu = MagicMock()
-        menu.open_folder_stack_item_id.return_value = None
+        monkeypatch.setattr(input_controller_mod.GLib, "timeout_add", timeout_add)
+        interactions = MagicMock()
         stub = _bind_geometry_signature(
             SimpleNamespace(
                 cursor_x=-1.0,
@@ -1499,7 +1552,7 @@ class TestDockWindowDrawAndHelpers:
                 ),
                 update_input_region=MagicMock(),
                 hover=SimpleNamespace(update=MagicMock()),
-                _menu=menu,
+                _interactions=interactions,
                 autohide=_autohide(enabled=False),
                 zoom_animator=MagicMock(),
                 geometry=SimpleNamespace(
@@ -1513,7 +1566,9 @@ class TestDockWindowDrawAndHelpers:
         event = SimpleNamespace(x=7.0, y=9.0)
 
         # When
-        handled = dock_window_mod.DockWindow._on_motion(stub, widget, event)
+        handled = input_controller_mod.DockInputController._on_motion(
+            _controller(stub), widget, event
+        )
 
         # Then
         assert handled is False
@@ -1525,17 +1580,12 @@ class TestDockWindowDrawAndHelpers:
         assert stub._redraw_source_id == 77
         widget.queue_draw.assert_not_called()
         timeout_add.assert_called_once()
+        interactions.close_folder_stack_unless_target.assert_called_once_with(None)
 
     def test_on_motion_closes_folder_stack_after_leaving_source_folder(self):
-        item = DockItem(
-            desktop_id="file:///tmp/docs",
-            kind=FOLDER_KIND,
-            target="file:///tmp/docs",
-        )
         other_item = DockItem(desktop_id="firefox.desktop")
         widget = MagicMock()
-        menu = MagicMock()
-        menu.open_folder_stack_item_id.return_value = item.desktop_id
+        interactions = MagicMock()
         frame = SimpleNamespace(
             cursor_rect=Rect(0, 0, 100, 100),
             item_at_point=MagicMock(return_value=other_item),
@@ -1552,7 +1602,7 @@ class TestDockWindowDrawAndHelpers:
                 _test_geometry_frame=frame,
                 update_input_region=MagicMock(),
                 hover=SimpleNamespace(update=MagicMock()),
-                _menu=menu,
+                _interactions=interactions,
                 autohide=_autohide(enabled=False),
                 zoom_animator=MagicMock(),
                 geometry=SimpleNamespace(build_frame=lambda **_kwargs: frame),
@@ -1563,24 +1613,31 @@ class TestDockWindowDrawAndHelpers:
         stub.interaction = DockInteractionCoordinator(stub)
         event = SimpleNamespace(x=12.0, y=9.0)
 
-        handled = dock_window_mod.DockWindow._on_motion(stub, widget, event)
+        handled = input_controller_mod.DockInputController._on_motion(
+            _controller(stub), widget, event
+        )
 
         assert handled is False
-        menu.close_folder_stack.assert_called_once_with()
+        interactions.close_folder_stack_unless_target.assert_called_once_with(
+            other_item
+        )
 
     def test_on_button_press_records_click_state(self):
         # Given
         stub = SimpleNamespace(_click_x=0.0, _click_y=0.0, _click_button=0)
+        controller = _controller(stub)
         event = SimpleNamespace(x=11.0, y=22.0, button=3)
 
         # When
-        handled = dock_window_mod.DockWindow._on_button_press(stub, MagicMock(), event)
+        handled = input_controller_mod.DockInputController._on_button_press(
+            controller, MagicMock(), event
+        )
 
         # Then
         assert handled is False
-        assert stub._click_x == 11.0
-        assert stub._click_y == 22.0
-        assert stub._click_button == 3
+        assert controller._click_x == 11.0
+        assert controller._click_y == 22.0
+        assert controller._click_button == 3
 
     def test_queue_redraw(self):
         timeout_add = MagicMock(return_value=99)
@@ -1592,7 +1649,7 @@ class TestDockWindowDrawAndHelpers:
                 _redraw_source_id=None,
             )
         )
-        dock_window_mod.GLib.timeout_add = timeout_add
+        input_controller_mod.GLib.timeout_add = timeout_add
 
         dock_window_mod.DockWindow.queue_redraw(stub)
 
@@ -1603,7 +1660,7 @@ class TestDockWindowDrawAndHelpers:
     def test_schedule_redraw_coalesces_multiple_requests(self):
         timeout_add = MagicMock(return_value=77)
         stub = _bind_geometry_signature(SimpleNamespace(_redraw_source_id=None))
-        dock_window_mod.GLib.timeout_add = timeout_add
+        input_controller_mod.GLib.timeout_add = timeout_add
 
         dock_window_mod.DockWindow._schedule_redraw(stub)
         dock_window_mod.DockWindow._schedule_redraw(stub)

--- a/tests/ui/test_edges.py
+++ b/tests/ui/test_edges.py
@@ -14,6 +14,7 @@ from types import MethodType, SimpleNamespace
 from unittest.mock import MagicMock
 
 import docking.ui.dock_window as dock_window_mod
+import docking.ui.input_controller as input_controller_mod
 from docking.core.position import Position
 from docking.platform.model import DockItem
 from docking.ui.autohide import HideState
@@ -125,9 +126,7 @@ class _Harness:
         self._cache = dock_window_mod._DockWindowCache.create()
         self._redraw_source_id = None
         self.preview = None
-        self._menu = MagicMock()
-        self._menu.open_folder_stack_item_id.return_value = None
-        self._menu.close_folder_stack = MagicMock()
+        self._interactions = MagicMock()
         self._menu_popup_visible = False
         self._click_x = 0.0
         self._click_y = 0.0
@@ -201,6 +200,17 @@ def _attach_runtime_methods(harness: _Harness) -> None:
     )
 
 
+def _controller(harness: _Harness):
+    return SimpleNamespace(
+        _window=harness,
+        _interactions=harness._interactions,
+        _click_x=getattr(harness, "_click_x", -1.0),
+        _click_y=getattr(harness, "_click_y", -1.0),
+        _click_button=getattr(harness, "_click_button", 0),
+        dnd=SimpleNamespace(drag_index=-1, drop_insert_index=-1, drop_target_id=""),
+    )
+
+
 def _motion_event(x: float, y: float) -> SimpleNamespace:
     return SimpleNamespace(x=x, y=y)
 
@@ -219,7 +229,9 @@ def hover_first_item(harness: _Harness, widget: MagicMock) -> tuple[float, float
     first = frame.item_geometries[0]
     x = float(first.draw_rect.x + first.draw_rect.w // 2)
     y = float(first.draw_rect.y + first.draw_rect.h - 1)
-    dock_window_mod.DockWindow._on_motion(harness, widget, _motion_event(x=x, y=y))
+    input_controller_mod.DockInputController._on_motion(
+        _controller(harness), widget, _motion_event(x=x, y=y)
+    )
     assert harness.hover.hovered_item is first.item
     return x, y
 
@@ -229,7 +241,9 @@ def hover_last_item(harness: _Harness, widget: MagicMock) -> tuple[float, float]
     last = frame.item_geometries[-1]
     x = float(last.draw_rect.x + last.draw_rect.w // 2)
     y = float(last.draw_rect.y + last.draw_rect.h - 1)
-    dock_window_mod.DockWindow._on_motion(harness, widget, _motion_event(x=x, y=y))
+    input_controller_mod.DockInputController._on_motion(
+        _controller(harness), widget, _motion_event(x=x, y=y)
+    )
     assert harness.hover.hovered_item is last.item
     return x, y
 
@@ -295,8 +309,8 @@ class TestDockOuterEdgeBehavior:
             - 1
         )
 
-        dock_window_mod.DockWindow._on_motion(
-            harness,
+        input_controller_mod.DockInputController._on_motion(
+            _controller(harness),
             widget,
             _motion_event(x=float(exit_x), y=float(y)),
         )
@@ -319,16 +333,16 @@ class TestDockOuterEdgeBehavior:
             - 1
         )
 
-        dock_window_mod.DockWindow._on_motion(
-            harness,
+        input_controller_mod.DockInputController._on_motion(
+            _controller(harness),
             widget,
             _motion_event(x=float(exit_x), y=float(y)),
         )
 
         assert harness.autohide.on_mouse_leave.call_count == 1
 
-        handled = dock_window_mod.DockWindow._on_leave(
-            harness,
+        handled = input_controller_mod.DockInputController._on_leave(
+            _controller(harness),
             widget,
             _leave_event(x=float(exit_x), y=float(y)),
         )
@@ -351,16 +365,16 @@ class TestDockOuterEdgeBehavior:
             - 1
         )
 
-        dock_window_mod.DockWindow._on_motion(
-            harness,
+        input_controller_mod.DockInputController._on_motion(
+            _controller(harness),
             widget,
             _motion_event(x=float(exit_x), y=float(y)),
         )
 
         assert harness.autohide.on_mouse_leave.call_count == 1
 
-        handled = dock_window_mod.DockWindow._on_leave(
-            harness,
+        handled = input_controller_mod.DockInputController._on_leave(
+            _controller(harness),
             widget,
             _leave_event(x=float(exit_x), y=float(y)),
         )

--- a/tests/ui/test_factory.py
+++ b/tests/ui/test_factory.py
@@ -10,6 +10,85 @@ from unittest.mock import MagicMock
 import docking.ui.factory as factory_mod
 
 
+def _window():
+    window = MagicMock()
+    window.autohide = MagicMock()
+    window.geometry = MagicMock()
+    return window
+
+
+def _patch_ui_components(monkeypatch):
+    components = SimpleNamespace(
+        about=MagicMock(),
+        settings=MagicMock(),
+        diagnostics=MagicMock(),
+        update_checker=MagicMock(),
+        runtime=MagicMock(),
+        folder_stack=MagicMock(),
+        dnd=MagicMock(),
+        settings_actions=MagicMock(),
+        menu=MagicMock(),
+        interactions=MagicMock(),
+        input_controller=MagicMock(),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "AboutDialogController",
+        MagicMock(return_value=components.about),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "UpdateCheckController",
+        MagicMock(return_value=components.update_checker),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "DockRuntime",
+        MagicMock(return_value=components.runtime),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "SettingsWindowController",
+        MagicMock(return_value=components.settings),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "DiagnosticsDialogController",
+        MagicMock(return_value=components.diagnostics),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "FolderStackController",
+        MagicMock(return_value=components.folder_stack),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "DnDHandler",
+        MagicMock(return_value=components.dnd),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "SettingsActions",
+        MagicMock(return_value=components.settings_actions),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "MenuHandler",
+        MagicMock(return_value=components.menu),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "DockInteractions",
+        MagicMock(return_value=components.interactions),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "DockInputController",
+        MagicMock(return_value=components.input_controller),
+    )
+    return components
+
+
 class TestBuildDockWindow:
     def test_build_dock_window_constructs_window_and_starts_dodge_monitor(
         self, monkeypatch
@@ -25,11 +104,11 @@ class TestBuildDockWindow:
         visibility_service = MagicMock()
         session_backend = MagicMock()
 
-        window = MagicMock()
-        window.autohide = MagicMock()
+        window = _window()
         dodge_monitor = MagicMock()
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
+        components = _patch_ui_components(monkeypatch)
         visibility_service.create_monitor.return_value = dodge_monitor
 
         result = factory_mod.build_dock_window(
@@ -45,14 +124,15 @@ class TestBuildDockWindow:
             session_backend=session_backend,
         )
 
-        assert result is window
+        assert result.window is window
+        assert result.update_checker is components.update_checker
+        assert result.input_controller is components.input_controller
         factory_mod.DockWindow.assert_called_once_with(
             config=config,
             model=model,
             renderer=renderer,
             theme=theme,
             window_tracker=tracker,
-            launcher=launcher,
             preview_service=preview_service,
             surface_service=surface_service,
             session_backend=session_backend,
@@ -62,6 +142,73 @@ class TestBuildDockWindow:
         assert kwargs["on_change"] is window.autohide.set_window_should_hide
         dodge_monitor.start.assert_called_once_with()
         assert window.dodge_monitor is dodge_monitor
+        factory_mod.UpdateCheckController.assert_called_once_with(
+            window=window,
+            config=config,
+        )
+        factory_mod.DockRuntime.assert_called_once_with(
+            window,
+            update_checker=components.update_checker,
+        )
+        factory_mod.FolderStackController.assert_called_once_with(
+            config=config,
+            runtime=components.runtime,
+            launcher=launcher,
+            dock_window=window,
+        )
+        factory_mod.DnDHandler.assert_called_once_with(
+            drawing_area=window.drawing_area,
+            window=window,
+            model=model,
+            config=config,
+            renderer=renderer,
+            theme=theme,
+            launcher=launcher,
+            geometry_builder=window.geometry,
+            folder_stack=components.folder_stack,
+        )
+        factory_mod.SettingsActions.assert_called_once_with(
+            runtime=components.runtime,
+            dnd=components.dnd,
+        )
+        factory_mod.SettingsWindowController.assert_called_once_with(
+            parent=window,
+            actions=components.settings_actions,
+            model=model,
+            config=config,
+        )
+        factory_mod.MenuHandler.assert_called_once_with(
+            about=components.about,
+            settings=components.settings,
+            diagnostics=components.diagnostics,
+            runtime=components.runtime,
+            model=model,
+            config=config,
+            window_tracker=tracker,
+            preview_service=preview_service,
+            folder_stack=components.folder_stack,
+            launcher=launcher,
+            dock_window=window,
+        )
+        factory_mod.DockInteractions.assert_called_once_with(
+            menu=components.menu,
+            folder_stack=components.folder_stack,
+        )
+        factory_mod.DockInputController.assert_called_once_with(
+            window=window,
+            interactions=components.interactions,
+            dnd=components.dnd,
+        )
+        components.input_controller.start.assert_not_called()
+        components.update_checker.start.assert_not_called()
+
+        result.start()
+        components.input_controller.start.assert_called_once_with()
+        components.update_checker.start.assert_called_once_with()
+
+        result.stop()
+        components.update_checker.stop.assert_called_once_with()
+        components.input_controller.stop.assert_called_once_with()
 
     def test_build_dock_window_allows_unsupported_visibility_service(self, monkeypatch):
         config = MagicMock()
@@ -76,9 +223,9 @@ class TestBuildDockWindow:
         visibility_service.create_monitor.return_value = None
         session_backend = MagicMock()
 
-        window = MagicMock()
-        window.autohide = MagicMock()
+        window = _window()
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
+        _patch_ui_components(monkeypatch)
 
         result = factory_mod.build_dock_window(
             config=config,
@@ -93,7 +240,7 @@ class TestBuildDockWindow:
             session_backend=session_backend,
         )
 
-        assert result is window
+        assert result.window is window
         assert window.dodge_monitor is None
 
     def test_build_dock_window_exposes_realized_dock_rect_to_dodge_monitor(
@@ -110,8 +257,7 @@ class TestBuildDockWindow:
         visibility_service = MagicMock()
         session_backend = MagicMock()
 
-        window = MagicMock()
-        window.autohide = MagicMock()
+        window = _window()
         window.get_realized.return_value = True
         window.get_position.return_value = (10, 20)
         window.geometry.build_frame.return_value.background_rect = SimpleNamespace(
@@ -129,6 +275,7 @@ class TestBuildDockWindow:
             return monitor
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
+        _patch_ui_components(monkeypatch)
         visibility_service.create_monitor.side_effect = _make_dodge_monitor
 
         factory_mod.build_dock_window(
@@ -160,8 +307,7 @@ class TestBuildDockWindow:
         visibility_service = MagicMock()
         session_backend = MagicMock()
 
-        window = MagicMock()
-        window.autohide = MagicMock()
+        window = _window()
         window.get_realized.return_value = False
         captured: dict[str, object] = {}
 
@@ -172,6 +318,7 @@ class TestBuildDockWindow:
             return monitor
 
         monkeypatch.setattr(factory_mod, "DockWindow", MagicMock(return_value=window))
+        _patch_ui_components(monkeypatch)
         visibility_service.create_monitor.side_effect = _make_dodge_monitor
 
         factory_mod.build_dock_window(

--- a/tests/ui/test_input_controller.py
+++ b/tests/ui/test_input_controller.py
@@ -1,0 +1,83 @@
+"""Tests for DockInputController lifecycle."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from docking.ui.input_controller import DockInputController
+
+
+class _SignalObject:
+    def __init__(self) -> None:
+        self.connected: list[tuple[str, object, int]] = []
+        self.disconnected: list[int] = []
+        self._next_handler_id = 1
+
+    def connect(self, signal: str, callback) -> int:
+        handler_id = self._next_handler_id
+        self._next_handler_id += 1
+        self.connected.append((signal, callback, handler_id))
+        return handler_id
+
+    def disconnect(self, handler_id: int) -> None:
+        self.disconnected.append(handler_id)
+
+
+def _window() -> SimpleNamespace:
+    drawing_area = _SignalObject()
+    window = _SignalObject()
+    window.drawing_area = drawing_area
+    window.model = SimpleNamespace(
+        visible_items=MagicMock(return_value=["folder"]),
+        add_change_listener=MagicMock(),
+        remove_change_listener=MagicMock(),
+    )
+    return window
+
+
+def test_start_connects_signals_model_listener_and_prewarms_once():
+    window = _window()
+    interactions = MagicMock()
+    controller = DockInputController(
+        window=window,
+        interactions=interactions,
+        dnd=MagicMock(),
+    )
+
+    controller.start()
+    controller.start()
+
+    assert [signal for signal, _callback, _id in window.drawing_area.connected] == [
+        "draw",
+        "motion-notify-event",
+        "button-press-event",
+        "button-release-event",
+        "leave-notify-event",
+        "enter-notify-event",
+        "scroll-event",
+    ]
+    assert [signal for signal, _callback, _id in window.connected] == ["destroy"]
+    window.model.add_change_listener.assert_called_once_with(
+        controller._on_model_changed
+    )
+    interactions.prewarm_visible_folder_stacks.assert_called_once_with(["folder"])
+
+
+def test_stop_disconnects_signals_and_model_listener_once():
+    window = _window()
+    controller = DockInputController(
+        window=window,
+        interactions=MagicMock(),
+        dnd=MagicMock(),
+    )
+
+    controller.start()
+    controller.stop()
+    controller.stop()
+
+    assert window.drawing_area.disconnected == [1, 2, 3, 4, 5, 6, 7]
+    assert window.disconnected == [1]
+    window.model.remove_change_listener.assert_called_once_with(
+        controller._on_model_changed
+    )

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -726,7 +726,6 @@ def handler(monkeypatch):
     settings = MagicMock()
     runtime = MagicMock()
     runtime.cursor_position.return_value = (20.0, 8.0)
-    frame = _frame()
 
     model = MagicMock()
     model.pinned_items = []
@@ -761,6 +760,11 @@ def handler(monkeypatch):
     preview_service.thumbnail.return_value = None
     launcher = MagicMock()
     launcher.default_directory_app_name.return_value = None
+    folder_stack = folder_stack_mod.FolderStackController(
+        config=config,
+        runtime=runtime,
+        launcher=launcher,
+    )
     return menu_mod.MenuHandler(
         about=about,
         settings=settings,
@@ -769,9 +773,10 @@ def handler(monkeypatch):
         config=config,
         window_tracker=tracker,
         preview_service=preview_service,
+        folder_stack=folder_stack,
         diagnostics=MagicMock(),
         launcher=launcher,
-        geometry_builder=SimpleNamespace(build_frame=lambda **_kwargs: frame),
+        dock_window=MagicMock(),
     )
 
 
@@ -1433,7 +1438,6 @@ class TestDockMenu:
         # Given
         event = SimpleNamespace(x=10.0, y=5.0)
         frame = _frame(item=None, insert_index=1)
-        handler._geometry_builder = SimpleNamespace(build_frame=lambda **_kwargs: frame)
         captured_menu = None
 
         class CaptureMenu(FakeMenu):
@@ -1459,7 +1463,7 @@ class TestDockMenu:
         )
 
         # When
-        handler.show(event=event, cursor_main=10.0)
+        handler.show(event=event, cursor_main=10.0, frame=frame)
         # Then
         assert captured_menu is not None
         assert captured_menu.shown is True
@@ -1512,9 +1516,7 @@ class TestMenuCallbacks:
     def test_show_builds_item_menu(self, handler, monkeypatch):
         event = SimpleNamespace(x=20.0, y=9.0)
         item = DockItem(desktop_id="firefox.desktop")
-        handler._geometry_builder = SimpleNamespace(
-            build_frame=lambda **_kwargs: _frame(item=item)
-        )
+        frame = _frame(item=item)
         built: list[tuple[str, object]] = []
 
         def capture_build(*, menu, item):
@@ -1522,7 +1524,7 @@ class TestMenuCallbacks:
 
         monkeypatch.setattr(handler, "_build_item_menu", capture_build)
 
-        handler.show(event=event, cursor_main=20.0)
+        handler.show(event=event, cursor_main=20.0, frame=frame)
 
         assert built == [("item", item)]
         assert handler._runtime.menu_popup_opened.call_count == 1
@@ -1530,9 +1532,7 @@ class TestMenuCallbacks:
     def test_show_can_force_background_menu_over_item(self, handler, monkeypatch):
         event = SimpleNamespace(x=20.0, y=9.0)
         item = DockItem(desktop_id="firefox.desktop")
-        handler._geometry_builder = SimpleNamespace(
-            build_frame=lambda **_kwargs: _frame(item=item, insert_index=2)
-        )
+        frame = _frame(item=item, insert_index=2)
         built: list[tuple[str, object]] = []
 
         monkeypatch.setattr(
@@ -1546,7 +1546,12 @@ class TestMenuCallbacks:
             lambda *, menu, insert_index: built.append(("dock", insert_index)),
         )
 
-        handler.show(event=event, cursor_main=20.0, force_background=True)
+        handler.show(
+            event=event,
+            cursor_main=20.0,
+            frame=frame,
+            force_background=True,
+        )
 
         assert built == [("dock", 2)]
         assert handler._runtime.menu_popup_opened.call_count == 1
@@ -1642,130 +1647,6 @@ class TestMenuCallbacks:
         assert result is False
         assert called == ["file:///tmp/docs"]
         assert menu.shown is True
-
-    def test_show_folder_stack_builds_popup_window(self, handler, monkeypatch):
-        item = DockItem(
-            desktop_id="file:///tmp/docs",
-            kind=FOLDER_KIND,
-            target="file:///tmp/docs",
-        )
-        monkeypatch.setattr(menu_mod.GLib, "timeout_add", lambda *_args: 1)
-        monkeypatch.setattr(
-            handler._folder_stack._browser, "target_state", lambda _target: "ok"
-        )
-        monkeypatch.setattr(
-            handler._folder_stack,
-            "_list_directory_rows",
-            lambda **_kwargs: [
-                {
-                    "target": "file:///tmp/docs/readme.txt",
-                    "name": "readme.txt",
-                    "is_dir": False,
-                    "icon": None,
-                }
-            ],
-        )
-        tracked: list[str] = []
-        monkeypatch.setattr(
-            handler._folder_stack,
-            "_track_folder_stack",
-            lambda target: tracked.append(target),
-        )
-
-        handler.show_folder_stack(
-            item=item,
-            anchor_x=120,
-            anchor_y=800,
-            icon_w=48,
-            position="bottom",
-        )
-
-        window = FakeWindow.last_created
-        assert window is not None
-        assert window.visible is True
-        assert window.moved_to is not None
-        assert tracked == ["file:///tmp/docs"]
-        handler._runtime.menu_popup_opened.assert_called_once()
-        handler._runtime.hide_hover_ui.assert_called_once()
-
-    def test_show_folder_stack_second_click_toggles_closed(self, handler, monkeypatch):
-        item = DockItem(
-            desktop_id="file:///tmp/docs",
-            kind=FOLDER_KIND,
-            target="file:///tmp/docs",
-        )
-        monkeypatch.setattr(menu_mod.GLib, "timeout_add", lambda *_args: 1)
-        monkeypatch.setattr(
-            handler._folder_stack._browser, "target_state", lambda _target: "ok"
-        )
-        monkeypatch.setattr(
-            handler._folder_stack, "_list_directory_rows", lambda **_kwargs: []
-        )
-        monkeypatch.setattr(
-            handler._folder_stack, "_track_folder_stack", lambda target: None
-        )
-
-        handler.show_folder_stack(
-            item=item,
-            anchor_x=120,
-            anchor_y=800,
-            icon_w=48,
-            position="bottom",
-        )
-        window = FakeWindow.last_created
-
-        handler.show_folder_stack(
-            item=item,
-            anchor_x=120,
-            anchor_y=800,
-            icon_w=48,
-            position="bottom",
-        )
-
-        assert window is not None
-        assert window.visible is False
-        assert handler._runtime.menu_popup_opened.call_count == 1
-
-    def test_show_folder_stack_same_item_can_stay_open(self, handler, monkeypatch):
-        item = DockItem(
-            desktop_id="file:///tmp/docs",
-            kind=FOLDER_KIND,
-            target="file:///tmp/docs",
-        )
-        monkeypatch.setattr(menu_mod.GLib, "timeout_add", lambda *_args: 1)
-        monkeypatch.setattr(
-            handler._folder_stack._browser, "target_state", lambda _target: "ok"
-        )
-        monkeypatch.setattr(
-            handler._folder_stack, "_list_directory_rows", lambda **_kwargs: []
-        )
-        monkeypatch.setattr(
-            handler._folder_stack, "_track_folder_stack", lambda target: None
-        )
-
-        handler.show_folder_stack(
-            item=item,
-            anchor_x=120,
-            anchor_y=800,
-            icon_w=48,
-            position="bottom",
-            toggle_if_same_item=False,
-        )
-        window = FakeWindow.last_created
-
-        handler.show_folder_stack(
-            item=item,
-            anchor_x=120,
-            anchor_y=800,
-            icon_w=48,
-            position="bottom",
-            toggle_if_same_item=False,
-        )
-
-        assert window is not None
-        assert window.visible is True
-        assert handler._runtime.menu_popup_opened.call_count == 1
-        handler._runtime.menu_popup_closed.assert_not_called()
 
     def test_folder_stack_cards_reuse_cached_layout(self, handler, monkeypatch):
         item = DockItem(
@@ -2138,8 +2019,8 @@ class TestMenuCallbacks:
             menu_mod.GLib, "idle_add", lambda callback: idle_calls.append(callback) or 9
         )
 
-        handler.schedule_folder_stack_prewarm(item)
-        handler.schedule_folder_stack_prewarm(item)
+        handler._folder_stack.schedule_prewarm(item)
+        handler._folder_stack.schedule_prewarm(item)
 
         assert len(idle_calls) == 1
         assert len(handler._folder_stack._folder_stack_cache.prewarm_queue) == 1

--- a/tests/ui/test_pointer_scenarios.py
+++ b/tests/ui/test_pointer_scenarios.py
@@ -24,6 +24,7 @@ import pytest
 import docking.ui.autohide as autohide_mod
 import docking.ui.dnd as dnd_mod
 import docking.ui.dock_window as dock_window_mod
+import docking.ui.input_controller as input_controller_mod
 import docking.ui.menu as menu_mod
 import docking.ui.placement as placement_mod
 from docking.core.config import PinnedEntry
@@ -31,6 +32,7 @@ from docking.core.position import Position
 from docking.platform.model import DockItem
 from docking.ui.autohide import AutoHideController, HideState
 from docking.ui.dnd import DnDHandler
+from docking.ui.folder.stack import FolderStackController
 from docking.ui.geometry import DockGeometryBuilder
 from docking.ui.hover import HoverManager
 from docking.ui.interaction import DockInteractionCoordinator
@@ -117,9 +119,7 @@ class _ScenarioHarness:
         self.dock_hovered = False
         self._cache = dock_window_mod._DockWindowCache.create()
         self._redraw_source_id = None
-        self._menu = MagicMock()
-        self._menu.open_folder_stack_item_id.return_value = None
-        self._menu.close_folder_stack = MagicMock()
+        self._interactions = MagicMock()
         self._menu_popup_visible = False
         self._click_x = 0.0
         self._click_y = 0.0
@@ -164,6 +164,7 @@ class _ScenarioHarness:
             theme=cast(Any, self.theme),
             launcher=self.launcher,
             geometry_builder=self.geometry,
+            folder_stack=self._interactions,
         )
         self.update_input_region = MethodType(
             dock_window_mod.DockWindow.update_input_region, self
@@ -258,20 +259,20 @@ class _ScenarioHarness:
 
     def move_to(self, x: float, y: float):
         self.local_to_screen(x, y)
-        return dock_window_mod.DockWindow._on_motion(
-            cast(Any, self), self.drawing_area, SimpleNamespace(x=x, y=y)
+        return input_controller_mod.DockInputController._on_motion(
+            _controller(self), self.drawing_area, SimpleNamespace(x=x, y=y)
         )
 
     def enter_at(self, x: float, y: float):
         self.local_to_screen(x, y)
-        return dock_window_mod.DockWindow._on_enter(
-            cast(Any, self), self.drawing_area, SimpleNamespace(x=x, y=y)
+        return input_controller_mod.DockInputController._on_enter(
+            _controller(self), self.drawing_area, SimpleNamespace(x=x, y=y)
         )
 
     def leave_at(self, x: float, y: float):
         self.local_to_screen(x, y)
-        return dock_window_mod.DockWindow._on_leave(
-            cast(Any, self),
+        return input_controller_mod.DockInputController._on_leave(
+            _controller(self),
             self.drawing_area,
             SimpleNamespace(
                 x=x,
@@ -280,6 +281,17 @@ class _ScenarioHarness:
                 mode=dock_window_mod.Gdk.CrossingMode.NORMAL,
             ),
         )
+
+
+def _controller(harness: _ScenarioHarness):
+    return SimpleNamespace(
+        _window=harness,
+        _interactions=harness._interactions,
+        _click_x=getattr(harness, "_click_x", -1.0),
+        _click_y=getattr(harness, "_click_y", -1.0),
+        _click_button=getattr(harness, "_click_button", 0),
+        dnd=harness.dnd,
+    )
 
 
 class TestPointerScenarios:
@@ -417,16 +429,14 @@ class TestMenuLifecycleScenarios:
             set_hovered=MagicMock(),
         )
 
-        class _GeometryBuilder:
-            def build_frame(self, **_kwargs: object) -> SimpleNamespace:
-                return SimpleNamespace(
-                    item_at_point=lambda *_args: None,
-                    insertion_index_for_main=lambda *_args, **_kwargs: 0,
-                )
-
         runtime = DockRuntime(
             cast(Any, harness),
             update_checker=MagicMock(),
+        )
+        folder_stack = FolderStackController(
+            config=cast(Any, harness.config),
+            runtime=runtime,
+            launcher=harness.launcher,
         )
         handler = MenuHandler(
             about=MagicMock(),
@@ -436,8 +446,10 @@ class TestMenuLifecycleScenarios:
             config=cast(Any, harness.config),
             window_tracker=harness.window_tracker,
             preview_service=MagicMock(),
-            geometry_builder=cast(Any, _GeometryBuilder()),
+            folder_stack=folder_stack,
             diagnostics=MagicMock(),
+            launcher=harness.launcher,
+            dock_window=cast(Any, harness),
         )
         created: list[_FakePopupMenu] = []
 
@@ -451,7 +463,11 @@ class TestMenuLifecycleScenarios:
         )
 
         event = SimpleNamespace(x=10.0, y=5.0)
-        handler.show(event=event, cursor_main=10.0)
+        frame = SimpleNamespace(
+            item_at_point=lambda *_args: None,
+            insertion_index_for_main=lambda *_args, **_kwargs: 0,
+        )
+        handler.show(event=event, cursor_main=10.0, frame=frame)
         menu = created[0]
 
         assert harness._menu_popup_visible is True

--- a/tests/ui/test_runtime.py
+++ b/tests/ui/test_runtime.py
@@ -102,7 +102,6 @@ class TestDockRuntime:
         runtime = DockRuntime(window, update_checker=update_checker)
 
         runtime.on_hide_mode_changed()
-        runtime.set_icons_locked(True)
         runtime.queue_draw()
         runtime.set_current_workspace_only(True)
         runtime.hide_tooltip()
@@ -112,7 +111,6 @@ class TestDockRuntime:
         runtime.open_releases_page()
 
         window.on_hide_mode_changed.assert_called_once()
-        window.dnd.set_locked.assert_called_once_with(True)
         assert window.queue_redraw.call_count == 2
         window.surface_service.set_workspace_scope.assert_called_once_with(
             current_workspace_only=True

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -707,7 +707,7 @@ class TestSettingsWindowController:
         monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
         )
@@ -794,7 +794,7 @@ class TestSettingsWindowController:
         )
         controller = settings_mod.SettingsWindowController(
             parent=parent,
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
         )
@@ -816,7 +816,7 @@ class TestSettingsWindowController:
         FakeGtkSettings.current = None
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
         )
@@ -846,7 +846,7 @@ class TestSettingsWindowController:
         monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
         )
@@ -895,7 +895,7 @@ class TestSettingsWindowController:
         monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
         )
@@ -987,7 +987,7 @@ class TestSettingsWindowController:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1021,7 +1021,7 @@ class TestSettingsWindowController:
         config.monitor_connector = "DP-1"
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1046,7 +1046,7 @@ class TestSettingsWindowController:
         monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
         )
@@ -1114,7 +1114,7 @@ class TestSettingsWindowController:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1145,7 +1145,7 @@ class TestSettingsWindowController:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1171,7 +1171,7 @@ class TestSettingsWindowController:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1197,7 +1197,7 @@ class TestSettingsWindowController:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1220,7 +1220,7 @@ class TestSettingsWindowController:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1246,7 +1246,7 @@ class TestSettingsWindowController:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1271,7 +1271,7 @@ class TestSettingsWindowController:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1295,7 +1295,7 @@ class TestSettingsWindowController:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1319,7 +1319,7 @@ class TestSettingsWindowController:
         config.zoom_enabled = False
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1340,7 +1340,7 @@ class TestSettingsWindowController:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1370,7 +1370,7 @@ class TestSettingsWindowController:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1416,7 +1416,7 @@ class TestSettingsWindowController:
         model.get_applet.return_value = None
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=model,
             config=_config(),
         )
@@ -1456,7 +1456,7 @@ class TestSettingsWindowController:
         )
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
         )
@@ -1523,7 +1523,7 @@ class TestSettingsWindowController:
         )
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=model,
             config=_config(),
         )
@@ -1560,7 +1560,7 @@ class TestSettingsWindowController:
         )
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
         )
@@ -1592,7 +1592,7 @@ class TestSettingsWindowController:
         )
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
         )
@@ -1628,7 +1628,7 @@ class TestRecentSettingsBehavior:
         runtime = MagicMock()
         controller = settings_mod.SettingsWindowController(
             parent=MagicMock(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1655,7 +1655,7 @@ class TestBindingEdgeCases:
         monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
         controller = settings_mod.SettingsWindowController(
             parent=MagicMock(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
         )
@@ -1673,7 +1673,7 @@ class TestBindingEdgeCases:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=MagicMock(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1698,7 +1698,7 @@ class TestBindingEdgeCases:
         config.save.reset_mock()
         controller = settings_mod.SettingsWindowController(
             parent=MagicMock(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1721,7 +1721,7 @@ class TestBindingEdgeCases:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=MagicMock(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1745,7 +1745,7 @@ class TestSettingsRuntimeCallbacks:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=MagicMock(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1766,7 +1766,7 @@ class TestSettingsRuntimeCallbacks:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=MagicMock(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1786,7 +1786,7 @@ class TestSettingsRuntimeCallbacks:
         config = _config()
         controller = settings_mod.SettingsWindowController(
             parent=MagicMock(),
-            runtime=runtime,
+            actions=runtime,
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=config,
         )
@@ -1804,7 +1804,7 @@ class TestSettingsRuntimeCallbacks:
         monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
         controller = settings_mod.SettingsWindowController(
             parent=MagicMock(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
         )
@@ -1821,7 +1821,7 @@ class TestSettingsRuntimeCallbacks:
         monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
         controller = settings_mod.SettingsWindowController(
             parent=MagicMock(),
-            runtime=MagicMock(),
+            actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
         )

--- a/tests/ui/test_settings_actions.py
+++ b/tests/ui/test_settings_actions.py
@@ -1,0 +1,34 @@
+"""Tests for preferences action delegation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from docking.ui.settings import SettingsActions
+
+
+def test_settings_actions_delegate_dnd_locking_to_dnd_handler():
+    runtime = MagicMock()
+    dnd = MagicMock()
+    actions = SettingsActions(runtime=runtime, dnd=dnd)
+
+    actions.set_icons_locked(True)
+
+    dnd.set_locked.assert_called_once_with(True)
+    runtime.set_icons_locked.assert_not_called()
+
+
+def test_settings_actions_delegate_shell_actions_to_runtime():
+    runtime = MagicMock()
+    dnd = MagicMock()
+    actions = SettingsActions(runtime=runtime, dnd=dnd)
+
+    actions.reposition()
+    actions.queue_draw()
+    actions.set_theme("theme")
+    actions.check_for_updates_now()
+
+    runtime.reposition.assert_called_once_with()
+    runtime.queue_draw.assert_called_once_with()
+    runtime.set_theme.assert_called_once_with("theme")
+    runtime.check_for_updates_now.assert_called_once_with()

--- a/tests/visual/render_cases.py
+++ b/tests/visual/render_cases.py
@@ -18,6 +18,7 @@ from docking.core.position import Position
 from docking.core.theme import Theme
 from docking.platform.backends.base import PreviewImage, WindowId, WindowSnapshot
 from docking.ui.autohide import HideState
+from docking.ui.folder.stack import FolderStackController
 from docking.ui.geometry import build_geometry_frame
 from docking.ui.menu import MenuHandler
 from docking.ui.preview import THUMB_H, THUMB_W, PreviewPopup
@@ -222,17 +223,24 @@ def _folder_stack_handler() -> MenuHandler:
     )
     launcher = MagicMock()
     launcher.default_directory_app_name.return_value = "Caja"
+    runtime = MagicMock()
+    folder_stack = FolderStackController(
+        config=config,
+        runtime=runtime,
+        launcher=launcher,
+    )
     handler = MenuHandler(
         about=MagicMock(),
         settings=MagicMock(),
-        runtime=MagicMock(),
+        runtime=runtime,
         model=MagicMock(),
         config=config,
         window_tracker=MagicMock(),
         preview_service=MagicMock(),
-        geometry_builder=MagicMock(),
+        folder_stack=folder_stack,
         diagnostics=MagicMock(),
         launcher=launcher,
+        dock_window=MagicMock(),
     )
     handler._folder_stack._folder_stack_position_value = "bottom"
     handler._folder_stack._browser.target_state = lambda _target: "ok"


### PR DESCRIPTION
Summary:
- move dock input/menu/folder-stack coordination out of DockWindow into focused UI collaborators
- add SettingsActions as the preferences side-effect facade
- update harness, integration, and UI tests for the new composition graph