### PR TITLE
Refocus compositor warning on transparency loss

### DIFF
--- a/docking/platform/diagnostics.py
+++ b/docking/platform/diagnostics.py
@@ -337,7 +337,7 @@ def _diagnostic_checks(
                     detail="No active X11 compositor was detected.",
                     fix_hint=(
                         "Enable desktop compositing or run a compositor such as picom "
-                        "for transparency and stacking behavior."
+                        "so the dock renders with transparency instead of opaque."
                     ),
                 )
             )

--- a/docking/platform/environment/environment.py
+++ b/docking/platform/environment/environment.py
@@ -300,8 +300,9 @@ def _check_compositor() -> None:
 
     log.warning(
         "no compositing manager detected (it may have crashed) -- "
-        "dock may appear behind maximized windows and transparency may not work; "
-        "enable compositing in your desktop settings or install a compositor "
+        "dock transparency and opacity settings will not render "
+        "(the dock will appear opaque); enable compositing in your "
+        "desktop settings or install a compositor "
         "(picom, compton, xcompmgr)"
     )
 


### PR DESCRIPTION
The old warning emphasized stacking behavior ("dock may appear behind maximized windows"), which most modern window managers handle correctly with `Gdk.WindowTypeHint.DOCK` + `set_keep_above(True)` regardless of compositing.

The real and consistently visible degradation without a compositor is that all theme alpha values are silently ignored, the dock renders fully opaque, and the opacity slider has no effect.