### PR TITLE
Clean up docstrings in recently-refactored modules

### DIFF
--- a/docking/platform/app_matcher.py
+++ b/docking/platform/app_matcher.py
@@ -13,119 +13,94 @@
 
 """Shared window-identity to desktop-ID matching for all display-server backends.
 
-Why this module exists
------------------------
-
 Every backend (X11/Wnck, Wayland/wlr-foreign-toplevel, Hyprland IPC,
 Wayfire IPC, Niri IPC, GNOME Shell Bridge, KWin/AT-SPI) needs to answer
 the same question:
 
     "Which Docking desktop ID does this running window belong to?"
 
-Before this module the answer lived in two independent matchers with
-different feature sets:
+The matcher handles Wine .exe disambiguation, space-to-hyphen-to-joined
+candidate synthesis, GNOME prefix expansion, dot-suffix splitting, Snap
+underscore-prefix handling, and missed-candidate memoization. All seven
+backends (X11/Wnck, wlr-foreign-toplevel, Hyprland IPC, Wayfire IPC, Niri IPC,
+GNOME Shell Bridge, KWin/AT-SPI) share the same matching engine, so a fix or
+improvement applies everywhere at once.
 
-* ``WindowMatcher`` in the X11 backend — Wine ``.exe`` extraction,
-  space→hyphen→joined candidate generation, GNOME prefix synthesis,
-  and missed-candidate memoization.
-* ``WaylandAppIdMatcher`` in the Wayland backend — Snap ``_`` prefix
-  expansion, dot-suffix split, broad visible-item aliasing.
+``AppIdMatcher`` is a backend-agnostic matching engine. Backends extract
+identity strings from their display server and pass them here as plain
+strings. The matcher owns the heuristics; backends own only the display-server
+extraction.
 
-Neither matcher had the union of both feature sets, so every
-backend-specific improvement (e.g. PR #206 Wine matching) had to be
-implemented twice, and the growing set of Wayland consumers
-(Hyprland, Wayfire, Niri, GNOME Bridge, AT-SPI) all inherited the
-limitations of ``WaylandAppIdMatcher``.
+``sync_visible_items(items)`` rebuilds the fast-path alias cache from the
+current dock model at the start of every running-window scan.
 
-Design
--------
+``cache_missed_desktop_ids`` is a constructor flag used by X11 so signal
+bursts from Wnck do not hammer Gio with repeated failing lookups.
+Wayland-style backends leave it disabled so newly installed or generated
+desktop files can be matched without a Docking restart.
 
-``AppIdMatcher`` is a backend-agnostic matching engine.  Backends
-extract identity strings from their display server and pass them here
-as plain strings.  The matcher owns the heuristics; backends own only
-the display-server extraction.
-
-The public interface has one constructor flag plus two methods:
-
-``sync_visible_items(items)``
-    Rebuild the fast-path alias cache from the current dock model.
-    Called at the start of every running-window scan.
-
-``cache_missed_desktop_ids``
-    Constructor flag used by X11 to preserve its historical missed
-    desktop-file memoization. Wayland-style backends leave it disabled
-    so newly installed/generated desktop files can be matched without a
-    Docking restart.
-
-``match(...)``
-    Map a runtime window identity to a Docking desktop ID.
+``match(app_id, *, instance_hint=None, prefer_raw_app_id=True,
+defer_wm_class_lookup=False)`` maps a runtime window identity to a Docking
+desktop ID:
 
     ``app_id`` is the primary identity from the display server:
+    X11 uses ``class_group`` (WM_CLASS class part); Wayland compositors
+    (Hyprland, Wayfire, Niri, GNOME) provide a single ``app_id`` or
+    ``class`` string; AT-SPI uses ``app_name`` from the accessibility tree.
 
-    * X11: ``class_group`` (WM_CLASS class part)
-    * Wayland/Hyprland/Wayfire/Niri/GNOME: the single ``app_id`` /
-      ``class`` string the compositor provides
-    * AT-SPI: ``app_name`` from the accessibility tree
+    ``instance_hint`` is an optional secondary identity. Only X11 provides
+    this (WM_CLASS instance part). It enables Wine disambiguation: when
+    ``app_id == "wine"`` the matcher extracts the ``.exe`` name from
+    ``instance_hint`` instead.
 
-    ``instance_hint`` is an optional secondary identity.  Currently
-    only X11 provides this (WM_CLASS instance part).  It enables Wine
-    disambiguation: when ``app_id == "wine"`` the matcher extracts the
-    ``.exe`` name from ``instance_hint`` instead.
+    ``prefer_raw_app_id`` controls candidate order. Wayland-style backends
+    keep compositor-provided app IDs first; X11 passes ``False`` to preserve
+    the historical WM_CLASS lowercase-first order.
 
-    ``prefer_raw_app_id`` controls candidate order. Wayland-style
-    backends keep compositor-provided app IDs first; X11 passes
-    ``False`` to preserve the historical WM_CLASS lowercase-first order.
+    ``defer_wm_class_lookup`` controls when the install-wide WM_CLASS index
+    is consulted. X11 passes ``True`` to try all generated desktop IDs before
+    the reverse alias lookup. Wayland-style backends keep it ``False`` so
+    each increasingly broad candidate can check its exact alias before falling
+    back to the next broader direct desktop ID.
 
-    ``defer_wm_class_lookup`` controls when the install-wide WM_CLASS
-    index is consulted. X11 passes ``True`` to preserve its historical
-    priority of trying all generated desktop IDs before the expensive
-    reverse alias lookup. Wayland-style backends keep it ``False`` so
-    each increasingly broad candidate can still check its exact alias
-    before falling back to the next broader direct desktop ID.
+Matching is strongest-first:
 
-Matching priority (strongest first)
-------------------------------------
+    1. Wine detection — when ``app_id`` is the generic ``"wine"`` class
+       group and ``instance_hint`` contains a ``.exe`` path, extract the
+       executable name and match against visible aliases and the launcher
+       WM_CLASS index.
 
-1. **Wine detection** — when ``app_id`` is the generic ``"wine"``
-   class group and ``instance_hint`` contains a ``.exe`` path, extract
-   the executable name and match against visible aliases and the
-   launcher WM_CLASS index.
+    2. Visible-item alias cache — fast-path lookup against currently pinned
+       and transient dock items (no Gio or filesystem calls).
 
-2. **Visible-item alias cache** — fast-path lookup against currently
-   pinned and transient dock items (no Gio or filesystem calls).
+    3. Instance-hint match — when ``app_id`` is generic but
+       ``instance_hint`` is specific and matches a visible item.
 
-3. **Instance-hint match** — when ``app_id`` is generic but
-   ``instance_hint`` is specific and matches a visible item
-   (X11 optimization).
+    4. Candidate generation and resolution — for each generated candidate
+       string, in order:
 
-4. **Candidate generation + resolution** — for each generated
-   candidate string:
+       a. Check visible aliases (normalized).
+       b. Try ``launcher.resolve(f"{candidate}.desktop")``.
+       c. Try ``launcher.resolve_by_wm_class(candidate)``.
 
-   a. Check visible aliases (normalized).
-   b. Try ``launcher.resolve(f"{candidate}.desktop")``.
-   c. Try ``launcher.resolve_by_wm_class(candidate)``.
-
-   Failed desktop IDs can be memoized for X11 so signal bursts don't
-   hammer Gio with repeated failing lookups. Successful WM_CLASS
-   matches use the launcher's indexed lookup.
-
-Candidate generation (merged from both legacy matchers)
---------------------------------------------------------
+       Failed desktop IDs can be memoized for X11 so signal bursts do not
+       hammer Gio. Successful WM_CLASS matches use the launcher's indexed
+       lookup.
 
 Candidates are generated in a stable, deterministic order:
 
-* Raw ``app_id``
-* Raw ``app_id`` without ``.desktop``
-* Lowercase variants of the above
-* Space→hyphen (``"mongodb compass"`` → ``"mongodb-compass"``)
-* Space→joined  (``"mongodb compass"`` → ``"mongodbcompass"``)
-* GNOME prefix + original class-group (``"Files"`` → ``"org.gnome.Files"``)
-* Dot-suffix split (``"org.gnome.Nautilus"`` → ``"Nautilus"``)
-* Snap/container ``_`` prefix expansion
-  (``"firefox_firefox"`` → ``"firefox"``)
+    * Raw ``app_id``
+    * Raw ``app_id`` without ``.desktop``
+    * Lowercase variants of the above
+    * Space to hyphen (``"mongodb compass"`` to ``"mongodb-compass"``)
+    * Space to joined (``"mongodb compass"`` to ``"mongodbcompass"``)
+    * GNOME prefix + original class-group (``"Files"`` to ``"org.gnome.Files"``)
+    * Dot-suffix split (``"org.gnome.Nautilus"`` to ``"Nautilus"``)
+    * Snap/container ``_`` prefix expansion (``"firefox_firefox"`` to
+      ``"firefox"``)
 
-Duplicates are removed while preserving first-occurrence order so
-the first successful match is always the same for a given input.
+Duplicates are removed while preserving first-occurrence order so the first
+successful match is always the same for a given input.
 """
 
 from __future__ import annotations
@@ -173,7 +148,7 @@ def _app_id_candidates(app_id: str) -> list[str]:
         stripped.lower().removesuffix(DESKTOP_SUFFIX),
     ]
     # Wine / Windows executable reported as the sole app_id by a Wayland
-    # compositor (e.g. Hyprland `class` = "notepad.exe").  Strip the .exe
+    # compositor (e.g. Hyprland `class` = "notepad.exe"). Strip the .exe
     # suffix so the launcher can match "notepad" → "wine-notepad.desktop".
     is_windows_executable = stripped.lower().endswith(".exe")
     if is_windows_executable:
@@ -212,7 +187,7 @@ def _wine_aliases_from_instance(instance: str) -> list[str]:
     """Extract lookup aliases from a Wine ``class_instance`` path.
 
     For ``C:\\\\Program Files\\\\App\\\\Tool.exe`` this returns
-    ``["tool.exe", "tool"]``.  The full raw instance is also included
+    ``["tool.exe", "tool"]``. The full raw instance is also included
     so direct cache hits on the unfiltered string still work.
     """
     instance_lower = instance.lower().strip()
@@ -249,7 +224,7 @@ class AppIdMatcher:
         """Rebuild visible-item alias cache from the current dock model.
 
         Called at the start of every running-window scan so the cache
-        reflects the current pinned / transient item set.  Pinned items
+        reflects the current pinned / transient item set. Pinned items
         can be reordered, pinned, unpinned, or replaced at runtime, and
         using stale aliases would make running indicators disappear
         until restart.
@@ -368,7 +343,7 @@ class AppIdMatcher:
 
         Only triggers when *app_id_lower* is the generic ``"wine"``
         class group **and** the instance looks like a Windows executable
-        path.  Non-``.exe`` instances fall through to normal matching.
+        path. Non-``.exe`` instances fall through to normal matching.
         """
         if app_id_lower != "wine":
             return None

--- a/docking/platform/backends/x11/impl/window_tracker.py
+++ b/docking/platform/backends/x11/impl/window_tracker.py
@@ -33,25 +33,19 @@ That translation layer is split between:
 - `WindowTracker`, which scans and orders live Wnck windows.
 - `WindowMatcher`, which maps each window's runtime identity to a desktop ID.
 
-Why this is harder than it sounds
-
 Desktop file names, WM_CLASS values, and window-manager class-group names are
-related but not the same naming system.
-
-Example:
+related but not the same naming system:
 
     desktop file:   mongodb-compass.desktop
     WM_CLASS:       "mongodb compass"
     class-group:    "mongodb compass"
 
-Another application may look like:
-
     desktop file:   org.gnome.Nautilus.desktop
     WM_CLASS:       "nautilus"
     class-group:    "Files"
 
-So exact string equality is not enough. Matching has to be heuristic and
-practical rather than theoretically perfect.
+Exact string equality is not enough. Matching has to be heuristic and practical
+rather than theoretically perfect.
 
 Identity sources used here
 
@@ -109,43 +103,23 @@ That aggregate is what the model actually needs. From it, the dock can derive:
 - preview sources,
 - click/toggle behavior.
 
-Why full rescans are acceptable
+Full rescans
 
-Wnck emits:
+Wnck emits window-opened, window-closed, and active-window-changed. On each
+relevant signal this module rescans the current window list and rebuilds the
+aggregate. Full rescans are simpler than maintaining incremental partial
+updates, resilient to window-manager state changing underneath us, and easy to
+reconcile back into the model. This is a convergence-oriented module, not a
+fragile event-delta tracker.
 
-- window-opened
-- window-closed
-- active-window-changed
+Defensive exception handling
 
-On each relevant signal, this module rescans the current window list and
-rebuilds the aggregate. That is a pragmatic design:
-
-- simpler than maintaining many incremental partial updates,
-- resilient to window-manager state changing underneath us,
-- easy to reconcile back into the model.
-
-This is a convergence-oriented module, not a fragile event-delta tracker.
-
-Why defensive exception handling is required
-
-Wnck objects are live wrappers around X11 state. A window can disappear between:
-
-- getting the window list,
-- reading the window type,
-- reading WM_CLASS,
-- reading active/urgent state,
-- reading XID.
-
-So this module intentionally treats many read failures as recoverable:
-
-    log problem
-      |
-      +--> skip unstable window read
-      |
-      +--> continue rebuilding the aggregate
-
-The dock cares more about quickly converging back to correct state than about
-pretending the X11 world is stable during every scan.
+Wnck objects are live wrappers around X11 state. A window can disappear between
+getting the window list, reading the window type, reading WM_CLASS, reading
+active/urgent state, and reading the XID. This module treats many read failures
+as recoverable: log the problem, skip the unstable read, and continue rebuilding
+the aggregate. The dock cares more about quickly converging back to correct
+state than about pretending the X11 world is stable during every scan.
 """
 
 from __future__ import annotations
@@ -193,7 +167,7 @@ class WindowMatcher:
     """Matches live Wnck windows to desktop IDs using WM_CLASS-like hints.
 
     This is a thin X11-specific wrapper around the shared
-    :class:`~docking.platform.app_matcher.AppIdMatcher`.  The wrapping
+    :class:`~docking.platform.app_matcher.AppIdMatcher`. The wrapping
     handles Wnck-specific window property extraction (class group,
     class instance) and defensive error handling; all matching
     heuristics live in the shared matcher so they apply uniformly

--- a/docking/ui/autohide.py
+++ b/docking/ui/autohide.py
@@ -13,55 +13,29 @@
 
 """Autohide controller for the dock's visible/hidden state and motion.
 
-Autohide from first principles
-
-An edge dock has two conflicting jobs:
-
-1. stay out of the way when the user is not using it,
-2. appear quickly and predictably when the user approaches it.
-
+An edge dock has two conflicting jobs: stay out of the way when the user is
+not using it, and appear quickly and predictably when the user approaches it.
 If the dock hides too aggressively, it flickers when the pointer briefly arcs
-out and back in. If it shows too aggressively, it fights menus, drags, previews,
-or other temporary UI that should keep it present. If animation reversals are
-not continuous, the dock appears to jump instead of glide.
+out and back in. If it shows too aggressively, it fights menus, drags,
+previews, or other temporary UI that should keep it present. If animation
+reversals are not continuous, the dock appears to jump instead of glide.
+This module keeps those concerns in one state machine.
 
-This module exists to keep those concerns in one state machine.
+The controller owns whether the dock is logically visible, hiding, hidden, or
+showing; hide and show delays; animation progress for transitions; the current
+hide offset used by the renderer and geometry; and the current zoom progress
+while hidden or showing.
 
-What this module owns
+Policy inputs are ``set_hovered``, ``set_disabled``, and ``window_should_hide``
+(from WindowDodgeMonitor for dodge modes). Six modes are supported (see
+HideMode in config.py): AUTOHIDE hides whenever not hovered; the dodge modes
+(INTELLIGENT, DODGE_ACTIVE, WINDOW_DODGE, DODGE_MAXIMIZED) hide only when
+``window_should_hide`` is True. Hover or disabled always override to show.
 
-This controller owns:
-
-- whether the dock is logically visible, hiding, hidden, or showing,
-- hide/show delays,
-- the animation progress for transitions,
-- the current hide offset used by the renderer and geometry,
-- the current zoom progress while hidden or showing,
-- policy inputs for:
-  - pointer hovered/not hovered,
-  - temporarily disabled/not disabled,
-  - window_should_hide (from WindowDodgeMonitor for dodge modes).
-
-Hide modes
-----------
-The controller supports six modes (see HideMode in config.py). Two inputs
-drive the decision:
-
-- AUTOHIDE: hide whenever not hovered (mouse-only).
-- Dodge modes (INTELLIGENT, DODGE_ACTIVE, WINDOW_DODGE, DODGE_MAXIMIZED):
-  hide only when ``window_should_hide`` is True (set by WindowDodgeMonitor).
-  Hover or disabled always override to show.
-
-This module does not own:
-
-- the geometry of the dock,
-- how hover is determined,
-- menu logic,
-- preview logic,
-- tooltip logic,
-- GTK event handling.
-
-Those systems tell autohide whether the dock should currently be considered
-"held open" or not. Autohide translates that into smooth state transitions.
+The controller does not own geometry, hover decisions, menu logic, preview
+logic, tooltip logic, or GTK event handling. Those systems tell autohide
+whether the dock should be "held open"; autohide translates that into smooth
+state transitions.
 
 The four states
 
@@ -107,7 +81,7 @@ The renderer and geometry read these values to decide:
 - whether the active input region is the full dock band or the thin trigger,
 - how much hover zoom should still be visible during transitions.
 
-Why disabled exists
+The disabled flag
 
 Hovered alone is not enough. There are periods where the pointer may not be
 strictly "on the dock", but the dock still must not hide:

--- a/docking/ui/dnd.py
+++ b/docking/ui/dnd.py
@@ -13,19 +13,13 @@
 
 """Drag-and-drop controller for internal reorder and external application drops.
 
-Why drag-and-drop needs its own controller
-
 GTK drag-and-drop is not just "pointer motion with extra data". During a drag,
-normal pointer event assumptions break:
-
-- regular hover enter/leave flow is not authoritative,
-- the dock can receive drag-motion without ordinary motion,
-- drag-leave can occur before drop,
-- external drags and internal drags have different semantics.
-
-If the dock treated drag-over like normal pointer movement, autohide and hover
-would become inconsistent very quickly. This module exists to keep drag state,
-visual insertion state, and autohide policy coherent during those operations.
+normal pointer event assumptions break: regular hover enter/leave flow is not
+authoritative, the dock can receive drag-motion without ordinary motion,
+drag-leave can occur before drop, and external drags and internal drags have
+different semantics. Treating drag-over like normal pointer movement would
+make autohide and hover inconsistent. This module keeps drag state, visual
+insertion state, and autohide policy coherent during those operations.
 
 Two drag scenarios handled here
 

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -13,22 +13,14 @@
 
 """GTK dock window shell that binds together rendering, geometry, and policy.
 
-What this class is
+``DockWindow`` is the real GTK/X11 window that the user sees and interacts with.
+It is not "the dock logic" in the abstract. It is the shell that owns the GTK
+window and drawing area, exposes shared geometry and input-region helpers, and
+hosts shell-level collaborators (placement, hover, tooltip, preview). The UI
+graph itself is composed in ``docking.ui.factory``.
 
-`DockWindow` is the real GTK/X11 window that the user sees and interacts with.
-It is not "the dock logic" in the abstract. It is the shell that:
-
-- owns the GTK window and drawing area,
-- exposes shared geometry/input-region helpers,
-- hosts shell-level collaborators such as placement, hover, tooltip, and preview.
-
-The UI graph itself is composed in `docking.ui.factory`.
-
-What this class is not
-
-`DockWindow` is no longer meant to directly implement every dock concern.
-That decomposition matters because this file used to become the place where
-every cross-feature fix landed. The current split is:
+``DockWindow`` focuses on the GTK shell and event routing. Higher-level
+concerns are owned by focused collaborators:
 
 - DockWindow
   GTK shell and shared window geometry
@@ -40,7 +32,7 @@ every cross-feature fix landed. The current split is:
   effective enter/leave, menu-open policy, preview-aware leave policy
 
 - DockGeometryBuilder
-  window state -> shared geometry frame
+  window state to shared geometry frame
 
 - HoverManager / TooltipManager / PreviewPopup / DockInputController
   focused feature owners
@@ -50,26 +42,18 @@ their higher-level behavior.
 
 What kind of window this is
 
-This is not a normal application window. It is created as a dock/panel window:
-
-- `WindowTypeHint.DOCK`
-- sticky across workspaces
-- keep-above
-- edge-positioned
-
-In always-visible mode it may also publish struts so the window manager reserves
-space for it. In autohide mode it still exists at the edge, but only a thin
-trigger strip may remain interactive while hidden.
+This is not a normal application window. It is created as a dock/panel window
+with ``WindowTypeHint.DOCK``, sticky across workspaces, keep-above, and
+edge-positioned. In always-visible mode it may also publish struts so the
+window manager reserves space for it. In autohide mode it still exists at the
+edge, but only a thin trigger strip may remain interactive while hidden.
 
 Visual window vs interactive dock
 
-The GTK window is not the same thing as the active dock band.
-
-Why:
-- the window wants to stay stable and edge-aligned,
-- zooming icons should not force the whole top-level window to wobble,
-- transparent space should pass clicks through,
-- hidden autohide state should still leave a tiny trigger at the edge.
+The GTK window is not the same thing as the active dock band. The window wants
+to stay stable and edge-aligned, zooming icons should not force the whole
+top-level window to wobble, transparent space should pass clicks through, and
+hidden autohide state should still leave a tiny trigger at the edge.
 
 Visually:
 
@@ -84,10 +68,9 @@ Visually:
     +-------------------------------------------------------------+
 
 Only the active band should intercept pointer input. The rest of the window is
-structural space used to keep animation and rendering stable.
-
-That is why DockWindow owns the X11 input shape update path while geometry owns
-the actual rectangle math.
+structural space used to keep animation and rendering stable. That is why
+DockWindow owns the X11 input shape update path while geometry owns the actual
+rectangle math.
 
 Main runtime data flow
 
@@ -107,8 +90,7 @@ The most important runtime cycle is:
         +--> input mask may be refreshed from frame
         +--> menus / drag/drop may target items from frame
 
-This "one shared frame" model is the main reason the dock now behaves more
-consistently than before the geometry refactor.
+This "one shared frame" model keeps rendering, input masking, and autohide aligned to the same geometry every cycle.
 
 Draw path responsibilities
 
@@ -164,26 +146,19 @@ Autohide and cursor preservation
 
 DockWindow participates in autohide, but it does not own the autohide state
 machine. Its job is to supply the controller with correct higher-level facts:
+pointer effectively entered, pointer effectively left, a menu or drag
+temporarily disables hiding, draw/update must reflect the current hide offset.
 
-- pointer effectively entered,
-- pointer effectively left,
-- a menu or drag temporarily disables hiding,
-- draw/update must reflect the current hide offset.
+The dock also intentionally preserves cursor and hover identity across some
+leave transitions so that icons do not snap before the hide animation carries
+them away. That policy is coordinated with ``DockInteractionCoordinator``.
 
-The dock also intentionally preserves cursor/hover identity across some leave
-transitions so that icons do not snap before the hide animation carries them
-away. That policy is coordinated with `DockInteractionCoordinator`.
+Raw leave events vs the input region
 
-Why raw leave events are not enough
-
-The GTK window boundary is not the same as the dock boundary. So a raw leave is
-only a candidate signal. The dock must ask:
-
-    "Did the pointer really leave the current input region?"
-
-That question is answered with the shared geometry frame, not with the widget
-size alone. This is one of the main architectural lessons encoded in the
-current codebase.
+The GTK window boundary is not the same as the dock boundary. A raw leave is
+only a candidate signal. The dock must ask: "Did the pointer really leave the
+current input region?"  That question is answered with the shared geometry
+frame, not with the widget size alone.
 """
 
 from __future__ import annotations

--- a/docking/ui/geometry.py
+++ b/docking/ui/geometry.py
@@ -13,51 +13,32 @@
 
 """Shared dock geometry used by rendering, hover, input masking, and popups.
 
-Why this module exists
-
-The dock used to compute "where things are" in several different places:
-
-- drawing code decided where the shelf and icons appeared,
-- event handlers decided independently what counted as "inside" the dock,
-- hover code had its own idea of which icon was active,
-- tooltip/preview code rebuilt anchor positions again.
-
-That arrangement always drifts. The visible dock can say "the icon is here"
-while the input region says "the icon is slightly over there". The result is
-the class of bugs that feel like:
+Each frame the dock computes "where things are" in one place and gives every
+consumer the same numbers. Without this, drawing code, event handlers, hover,
+tooltips, and previews would independently decide what counted as "inside" the
+dock. That arrangement drifts: the visible dock says "the icon is here" while
+the input region says "the icon is slightly over there". The result:
 
 - the pointer leaves an icon and it snaps too early,
 - the dock hides on one edge before the other,
 - right-clicking the visible shelf opens an item menu instead of the dock menu,
 - a popup appears attached to the wrong moving point.
 
-This module is the answer to that problem. It builds one explicit geometry
-snapshot for the current dock state and gives every consumer the same numbers.
+This module builds one explicit geometry snapshot for the current dock state and
+gives every consumer the same numbers.
 
-What this module owns
+This module owns geometry only. In concrete terms that means converting runtime
+inputs into one dock frame; describing where the dock background lives inside
+the GTK window; describing where each item draws, is hovered, and is clickable;
+describing the current dock cursor and input region; and describing popup anchor
+coordinates.
 
-This module owns geometry only. In concrete terms that means:
-
-- converting runtime inputs into one dock frame,
-- describing where the dock background lives inside the GTK window,
-- describing where each item draws,
-- describing where each item is hovered,
-- describing where each item is clickable,
-- describing the current dock cursor/input region,
-- describing popup anchor coordinates.
-
-This module does not own:
-
-- GTK signal handling,
-- autohide policy decisions,
-- drag/drop policy,
-- tooltip timing,
-- preview timing,
-- window manager integration.
-
-Those subsystems consume geometry; they do not define it.
+It does not own GTK signal handling, autohide policy decisions, drag and drop
+policy, tooltip timing, preview timing, or window manager integration. Those
+subsystems consume geometry; they do not define it.
 
 Coordinate systems
+------------------
 
 There are three coordinate ideas that matter here:
 
@@ -74,14 +55,15 @@ There are three coordinate ideas that matter here:
    same math instead of branching into four nearly-identical copies.
 
 3. Cross axis
-   The axis perpendicular to the main axis. This is where "distance from edge",
-   shelf thickness, and hidden trigger thickness matter.
+   The axis perpendicular to the main axis. This is where "distance from
+   edge", shelf thickness, and hidden trigger thickness matter.
 
 The window, background, and item regions
+----------------------------------------
 
 The GTK window is intentionally larger and more stable than the actual active
-dock region. The window can stay edge-aligned and avoid resize wobble while the
-interactive part shrinks, expands, or animates inside it.
+dock region. The window can stay edge-aligned and avoid resize wobble while
+the interactive part shrinks, expands, or animates inside it.
 
 The important rectangles are:
 
@@ -106,22 +88,23 @@ The dock does not use one item rectangle for everything. Each item has:
   pointer movement near edges feels smooth.
 
 - hit_rect
-  The narrower region used for click/menu targeting.
-  This is what allows the state "inside the dock, but not on any item", which
-  is required for the dock background menu.
+  The narrower region used for click and menu targeting. This is what allows
+  the state "inside the dock, but not on any item", which is required for the
+  dock background menu.
 
 - background_rect
-  The portion of the shelf/background conceptually associated with that item.
-  This matters when the outer shelf shape and the icon shape are not identical.
+  The portion of the shelf conceptually associated with that item. This
+  matters when the outer shelf shape and the icon shape are not identical.
 
 One dock-wide region matters just as much:
 
 - cursor_rect
-  The region that means "the pointer is on the dock".
-  Autohide, effective enter/leave, and input masking treat this as the dock's
-  authoritative interactive band.
+  The region that means "the pointer is on the dock". Autohide, effective
+  enter/leave, and input masking treat this as the dock's authoritative
+  interactive band.
 
-Why half-open rectangles are mandatory
+Half-open rectangles
+--------------------
 
 Containment uses half-open bounds:
 
@@ -138,37 +121,33 @@ gaps. If both neighboring regions treated their right/bottom edge as inclusive,
 the same pixel could belong to two items. If both excluded too much, one pixel
 strips appear where no item or dock region claims the pointer.
 
-The edge bugs fixed during the geometry refactor were largely caused by this
-kind of mismatch.
+Adopting half-open bounds across the codebase fixed the class of edge bugs where neighboring regions would claim or cede individual pixels at their shared boundary.
 
 How one frame is built
+----------------------
 
 The builder follows this sequence:
 
-1. Capture runtime state:
-   - items
-   - theme/config
-   - window size
-   - main-axis cursor
-   - autohide state
-   - hide offset / zoom progress
-   - active drag insertion index
+1. Capture runtime state: items, theme and config, window size, main-axis
+   cursor, autohide state, hide offset and zoom progress, and active drag
+   insertion index.
 
-2. Compute zoom/layout output from the current main-axis cursor.
+2. Compute zoom and layout output from the current main-axis cursor.
 
 3. Derive the dock band and background rectangle.
 
 4. Derive one ItemGeometry per visible item.
 
 5. Derive cursor_rect, which may differ from the fully visible background:
-   - when hidden, it collapses to a thin trigger strip,
-   - when visible, it expands to cover the active dock band.
+   when hidden it collapses to a thin trigger strip; when visible it expands
+   to cover the active dock band.
 
 6. Publish the result as one DockGeometryFrame.
 
-Why DockGeometryInputs exists
+Separating capture from pure math
+---------------------------------
 
-This module separates runtime capture from pure geometry math:
+The module separates runtime state capture from the geometry calculation:
 
 - DockGeometryBuilder
   Lives at the UI boundary and knows how to ask the dock window for live state.
@@ -183,11 +162,12 @@ That split prevents geometry code from gradually turning into another
 "everything knows about DockWindow" layer.
 
 How the frame is consumed
+-------------------------
 
 The same frame, or frames built from the same rules, are used by:
 
 - renderer:
-  draw shelf and icons from draw_rect/background_rect
+  draw shelf and icons from draw_rect and background_rect
 
 - hover:
   determine hovered item from hover_rect
@@ -216,7 +196,8 @@ Visually, the relationship is:
 
 This distinction is intentional. Hover and click are not the same problem.
 
-What "good" looks like
+Keeping geometry honest
+-----------------------
 
 If this module is doing its job, the rest of the dock code should not need
 geometry hacks such as:

--- a/docking/ui/hover.py
+++ b/docking/ui/hover.py
@@ -13,44 +13,25 @@
 
 """Hover coordination for items, tooltips, previews, and short animation pumps.
 
-Why hover needs its own module
-
 "Hovered item" sounds simple until you list everything that depends on it:
-
-- icon zoom/displacement,
-- tooltip text and position,
-- preview show delay,
-- preview hide policy,
-- redraw pumping for short-lived visual effects,
-- the distinction between "pointer is on the dock" and "pointer is on this item".
+icon zoom and displacement, tooltip text and position, preview show delay,
+preview hide policy, redraw pumping for short-lived visual effects, and the
+distinction between "pointer is on the dock" and "pointer is on this item".
 
 If each of those features ran its own local hover state, they would drift.
-The classic failure modes are:
+The classic failure modes: tooltip for item A while preview is opening for item
+B, preview timer firing after the pointer moved away, repeated micro-timers
+trying to pump redraws independently, hover clearing too early while autohide
+is still smoothing the dock out. This module centralizes that state.
 
-- tooltip for item A while preview is opening for item B,
-- preview timer firing after the pointer already moved away,
-- repeated micro-timers trying to pump redraws independently,
-- hover clearing too early while autohide is still smoothing the dock out.
+HoverManager owns the currently hovered item, preview show timer lifecycle,
+cancellation of stale preview requests, tooltip update decisions tied to
+hovered item changes, and a shared short-lived redraw pump for click and urgent
+animations.
 
-This module centralizes that state.
-
-What this module owns
-
-HoverManager owns:
-
-- the currently hovered item,
-- preview show timer lifecycle,
-- cancellation of stale preview requests,
-- tooltip update decisions tied to hovered item changes,
-- a shared short-lived redraw pump for click/urgent animations.
-
-It does not own:
-
-- dock-wide hover (`dock_hovered` belongs to interaction policy),
-- geometry building (it consumes a frame),
-- autohide state,
-- preview rendering,
-- tooltip rendering.
+It does not own dock-wide hover (``dock_hovered`` belongs to interaction
+policy), geometry building (it consumes a frame), autohide state, preview
+rendering, or tooltip rendering.
 
 The distinction between dock hover and item hover
 
@@ -107,7 +88,7 @@ That delay matters because previews are heavier and more disruptive than a
 simple tooltip. The user should be able to glide across icons without opening a
 full preview popup for each one.
 
-Why preview show recomputes from fresh geometry
+Preview show recomputes from fresh geometry
 
 The preview timer stores intent, not stale positions.
 

--- a/docking/ui/interaction.py
+++ b/docking/ui/interaction.py
@@ -13,52 +13,21 @@
 
 """Dock interaction policy shared across raw events, menus, previews, and hover.
 
-Why this module exists
+Raw GTK events are lower-level than the behavior users expect. A dock should
+react to "the pointer effectively entered", "the pointer effectively left", "a
+menu is open so the dock must stay alive", and "a preview is visible, so
+leaving the icon does not immediately mean hide". These concepts cannot live in
+raw ``enter-notify``, ``leave-notify``, and ``motion-notify`` handlers because
+the event stream alone is not enough. The dock must reconcile events with
+geometry, autohide policy, previews, and transient UI state.
 
-The raw GTK events that hit the dock are lower-level than the behavior users
-actually expect. A dock should react to concepts such as:
+This coordinator owns the public notion of ``dock_hovered``, effective enter and
+leave handling, menu popup open/close policy, pointer-inside-input-region
+checks, preview-aware leave behavior, and keep-cursor-identity rules for smooth
+hide animations.
 
-- "the pointer effectively entered the dock",
-- "the pointer effectively left the dock",
-- "a menu is open so the dock must stay alive",
-- "a preview is visible, so leaving the icon does not immediately mean hide".
-
-Those concepts cannot live comfortably in raw `enter-notify`, `leave-notify`,
-and `motion-notify` handlers because the event stream alone is not enough.
-The dock must reconcile events with geometry, autohide policy, previews, and
-temporary UI state.
-
-This module is that policy layer.
-
-What this module owns
-
-This coordinator owns:
-
-- the public notion of `dock_hovered`,
-- effective enter handling,
-- effective leave handling,
-- menu popup open/close policy,
-- "is the pointer inside the current dock input region?" checks,
-- leave behavior when previews are visible,
-- "keep cursor identity" rules used for smooth hide animations.
-
-This module does not own:
-
-- raw GTK signal registration,
-- geometry building,
-- autohide animation math,
-- tooltip rendering,
-- preview rendering.
-
-Think of it as the translation layer between:
-
-    raw event stream
-          +
-    current dock frame
-          +
-    transient UI state
-          =
-    interaction decisions
+It does not own raw GTK signal registration, geometry building, autohide
+animation math, tooltip rendering, or preview rendering.
 
 The distinction between raw and effective enter/leave
 

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -13,60 +13,29 @@
 
 """Context menu construction for dock items, applets, folders, and background.
 
-Why the dock menu logic is centralized
-
 Right-click behavior in a dock is deceptively broad. Depending on where the
-pointer is, the same action can mean:
+pointer is, the same action can mean an application launcher menu, an applet
+menu, a folder item menu, the dock background menu, or a live window menu for
+currently open applications. If each item type built its own menus
+independently, the dock would lose consistency in popup lifecycle, autohide
+interaction, item targeting, icon and title formatting, and shared commands.
 
-- item menu for an application launcher,
-- applet menu with applet-specific actions,
-- folder item menu,
-- dock background menu,
-- live menu for currently open application windows.
+MenuHandler is the centralized menu builder. It decides whether a right-click
+targets an item or the dock background, constructs GTK menu trees, builds
+item-specific and dock-specific actions, organizes applet submenus and folder
+item menus, builds live window entries from backend-neutral window snapshots,
+and handles popup creation and lifecycle hookup.
 
-If each item type built its own menus independently, the dock would lose
-consistency in:
+It does not own dock geometry, autohide policy, tooltip/preview lifecycle, or
+dock shell side effects. Those imperative side effects are routed through
+``DockRuntime``.
 
-- popup lifecycle,
-- autohide/menu interaction,
-- item targeting,
-- icon/title formatting,
-- shared commands like pin/unpin, lock positions, theme changes, and position.
+Geometry and menus
+------------------
 
-This module is the centralized menu builder for those cases.
-
-What this module owns
-
-MenuHandler owns:
-
-- deciding whether a right-click targets an item or the dock background,
-- constructing GTK menu trees,
-- building item-specific and dock-specific actions,
-- applet submenu organization,
-- folder item menus,
-- live window menu entries with backend-neutral window actions,
-- popup creation and lifecycle hookup.
-
-It does not own:
-
-- dock geometry,
-- autohide policy directly,
-- tooltip/preview lifecycle directly,
-- actual runtime side effects on the dock shell.
-
-Those imperative side effects are routed through `DockRuntime`.
-
-Why geometry matters for menus
-
-The dock must support this state:
-
-    pointer inside dock
-      but
-    pointer not on any item
-
-That is what makes the dock background menu reachable.
-
-So menu targeting follows shared geometry:
+The dock must support the state "pointer inside dock but not on any item" —
+that is what makes the background menu reachable. Menu targeting follows shared
+geometry:
 
     event point
       |
@@ -74,28 +43,17 @@ So menu targeting follows shared geometry:
       |
       +--> no -----------------------> build dock background menu
 
-This is one of the reasons click/hit geometry is intentionally narrower than
-hover geometry. The background needs to remain a real target.
+This is why click/hit geometry is intentionally narrower than hover geometry:
+the background needs to remain a real target.
 
 Runtime command boundary
+------------------------
 
 This module is intentionally not allowed to mutate DockWindow internals freely.
-The important split is:
-
-- MenuHandler
-  decides what commands exist and when they are offered
-
-- DockRuntime
-  performs dock-wide side effects such as:
-    - menu popup open/close hooks,
-    - reposition,
-    - strut updates,
-    - redraws,
-    - active-display toggles,
-    - hover UI cleanup
-
-That boundary matters because menu code is broad enough already; it should not
-also become the place where raw window internals are orchestrated directly.
+MenuHandler decides what commands exist and when they are offered. DockRuntime
+performs dock-wide side effects: menu popup open/close hooks, reposition, strut
+updates, redraws, active-display toggles, hover UI cleanup. That boundary
+keeps menu code focused on menu construction instead of raw window orchestration.
 
 Kinds of menus built here
 

--- a/docking/ui/placement.py
+++ b/docking/ui/placement.py
@@ -13,39 +13,20 @@
 
 """Dock placement, monitor choice, struts, barriers, and edge integration.
 
-Why placement is its own module
+The dock must answer platform-facing questions that sit outside internal
+geometry: which monitor to attach to, where to position the top-level window,
+what screen space to reserve for maximized windows, when to update pointer
+barriers, and how active-display mode follows the pointer between monitors.
+These are not interaction policy and they are not rendering. This module owns
+that platform and placement layer.
 
-The dock's visible behavior depends on more than its internal geometry. It also
-has to answer platform-facing questions:
+DockPlacementController owns monitor selection and monitor menu choices,
+realization-time positioning, monitor and screen signal tracking, deferred
+reposition scheduling, X11 strut application and clearing, pointer barrier
+updates, and active-display polling.
 
-- which monitor should the dock attach to,
-- where should the top-level window actually be moved,
-- what screen space should be reserved for maximized windows,
-- when should pointer barriers be updated,
-- how should active-display mode follow the pointer between monitors.
-
-Those concerns are related, but they are not interaction policy and they are
-not rendering. This module owns that platform/placement layer.
-
-What this module owns
-
-DockPlacementController owns:
-
-- monitor selection and monitor menu choices,
-- realization-time positioning,
-- monitor/screen signal tracking,
-- deferred reposition scheduling,
-- X11 strut application and clearing,
-- pointer barrier updates,
-- active-display polling.
-
-It does not own:
-
-- hover policy,
-- tooltip/preview behavior,
-- drag/drop behavior,
-- item geometry,
-- Cairo rendering.
+It does not own hover policy, tooltip or preview behavior, drag and drop
+behavior, item geometry, or Cairo rendering.
 
 Logical screen vs monitor geometry
 
@@ -71,12 +52,9 @@ coordinated carefully.
 
 Workarea vs monitor bounds
 
-Placement does not always use the same rectangle for both axes.
-
-Why:
-- along the dock edge, the monitor edge matters,
-- along the perpendicular axis, workarea may matter more so the dock avoids
-  conflicting with reserved desktop areas.
+Placement does not always use the same rectangle for both axes. Along the dock
+edge the monitor edge matters; along the perpendicular axis workarea may matter
+more so the dock avoids conflicting with reserved desktop areas.
 
 For example:
 

--- a/docking/ui/preview.py
+++ b/docking/ui/preview.py
@@ -13,58 +13,24 @@
 
 """Window preview popup for running applications hovered in the dock.
 
-What a preview is supposed to do
+The preview popup is the continuation of the user's interaction with a running
+application icon, not just a tooltip with thumbnails. The dock and preview
+behave like one temporary interaction region: hover a running app, the popup
+appears with window thumbnails, the user moves from dock to preview, then
+activates a window from the preview.
 
-The preview popup is not just a tooltip with thumbnails. It is the continuation
-of the user's interaction with a running application icon.
+This module owns preview popup creation and widget structure, delayed hide of
+the popup, preview enter/leave tracking, window activation from thumbnail
+clicks, and releasing autohide only when the preview truly stops being relevant.
 
-Typical user flow:
+It does not own hover detection, the decision to arm preview show, dock-wide
+effective hover state, autohide animation math, or platform-specific preview
+capture. Those belong to HoverManager and the interaction/autohide layers.
 
-    pointer hovers running app
-       |
-       +--> preview delay expires
-       |
-       +--> popup with window thumbnails appears
-       |
-       +--> user moves from dock to preview
-       |
-       +--> user activates a window from the preview
+Preview leave vs normal leave
 
-That flow has one major consequence:
-
-    dock + preview behave like one temporary interaction region
-
-If the dock hid the moment the pointer left the icon, the preview would become
-unusable. This is why preview behavior is intentionally different from tooltip
-behavior.
-
-What this module owns
-
-This module owns:
-
-- preview popup creation and widget structure,
-- delayed hide of the preview popup,
-- preview enter/leave tracking,
-- window activation from thumbnail clicks,
-- releasing autohide only when the preview truly stops being relevant.
-
-It does not own:
-
-- hover detection,
-- the decision to arm preview show,
-- dock-wide effective hover state,
-- autohide animation math.
-- platform-specific preview capture.
-
-Those belong to HoverManager and the interaction/autohide layers.
-
-Why preview leave is not normal leave
-
-The important policy is:
-
-    preview visible => leaving the dock does not immediately mean hide
-
-ASCII view:
+The important policy: when a preview is visible, leaving the dock does not
+immediately mean hide.
 
     +-----------+        gap        +----------------------+
     |   dock    |  ------------->   | preview popup        |
@@ -72,40 +38,28 @@ ASCII view:
     +-----------+                   +----------------------+
 
 The gap exists because the preview is a separate popup window. The pointer must
-physically cross that space. If the dock hid instantly on dock leave, the user
-would see a hide/show flicker or lose the target before reaching it.
+cross that space. If the dock hid instantly on dock leave, the user would see a
+hide/show flicker or lose the target before reaching it.
 
-So the practical policy is:
-
-- leave dock while preview visible -> schedule preview hide, do not autohide yet
-- enter preview -> keep interaction alive
-- leave preview and do not return -> preview hides, then autohide may proceed
-
-That policy is one of the key behavioral differences between preview and
-tooltip.
+So the practical policy: leave dock while preview visible schedules preview hide
+without autohide; enter preview keeps the interaction alive; leave preview and
+do not return allows preview hide and then autohide may proceed. This is one
+of the key behavioral differences between preview and tooltip.
 
 Thumbnail capture model
 
-Preview thumbnails try to show real window contents, but the way that happens
-is platform-owned. The popup asks a PreviewService for an image using a
-backend-neutral WindowId. On X11 that service can still do foreign-window
-capture internally; on a future native Wayland backend it should return an
-image only when compositor support exists. If capture is unavailable, this UI
+Preview thumbnails try to show real window contents via a platform-owned
+PreviewService using backend-neutral WindowId. On X11 that service can do
+foreign-window capture internally; on a native Wayland backend it returns an
+image only when compositor support exists. If capture is unavailable this UI
 falls back to the app icon resolved through WindowService.
 
-Why CSS and widget structure live here
+CSS and widget structure
 
-The preview popup is a fairly self-contained UI surface:
-
-- popup window
-- thumbnail widgets
-- labels
-- hover styling
-- click behavior
-
-Unlike the dock itself, it does not need to participate in the full draw/input
-shape model. So it is reasonable for this module to own its CSS and widget tree
-instead of pushing those concerns into the main renderer.
+The preview popup is a self-contained UI surface: popup window, thumbnail
+widgets, labels, hover styling, click behavior. Unlike the dock itself, it
+does not participate in the full draw/input shape model. So this module owns
+its CSS and widget tree instead of pushing those into the main renderer.
 """
 
 from __future__ import annotations

--- a/docking/ui/renderer.py
+++ b/docking/ui/renderer.py
@@ -13,41 +13,16 @@
 
 """Cairo renderer for the dock's visible output and micro-animations.
 
-What this renderer is responsible for
+This module answers one question: "Given the current dock frame and visual
+state, what pixels should be drawn?"  It is intentionally view-only. It does
+not decide hover policy, autohide policy, mutate the model, launch applications,
+or resolve item targeting. Those decisions happen elsewhere; the renderer
+consumes their results.
 
-This module answers one question:
-
-    "Given the current dock frame and visual state, what pixels should be drawn?"
-
-It is intentionally view-only. It should not:
-
-- decide hover policy,
-- decide autohide policy,
-- mutate the model,
-- launch applications,
-- resolve item targeting.
-
-Those decisions happen elsewhere. The renderer consumes their results.
-
-Why renderer and geometry are separate
-
-The renderer used to be a tempting place to re-derive visual bounds and item
-positions. That leads to drift:
-
-- renderer says icon is here,
-- hover says icon is slightly elsewhere,
-- menus use another targeting model,
-- tooltips anchor from yet another guess.
-
-The current model is:
-
-    DockGeometryFrame
-      |
-      +--> renderer draws from it
-      +--> hover/mouse/menu/dnd also consume it
-
-That means the renderer is no longer the owner of item placement. It is the
-consumer of an authoritative frame.
+The renderer consumes the authoritative ``DockGeometryFrame``. Rendering,
+hover, menus, tooltips, and drag-and-drop all work from the same frame so they
+stay aligned without drift. The renderer is a consumer of item placement, not
+the owner of it.
 
 Rendering layers
 
@@ -115,7 +90,7 @@ Visually:
 
 The renderer does not decide those values; it simply makes them visible.
 
-Why offscreen composition is required
+Offscreen composition
 
 The dock window is transparent and compositor-managed. Painting directly to the
 target surface in several incremental steps can produce transient clear/repaint

--- a/docking/ui/tooltip.py
+++ b/docking/ui/tooltip.py
@@ -13,45 +13,23 @@
 
 """Tooltip management for dock items, anchored from shared geometry.
 
-What a tooltip means in this dock
+The dock tooltip is visual only, anchored to one hovered item. It must never
+become a second interactive surface that competes with the dock, and it must
+follow shared geometry instead of inventing its own icon positions.
 
-The dock tooltip is intentionally simple:
+Dock tooltips have failure modes that ordinary GTK widgets do not: showing too
+early while the dock itself is still animating, rebuilding too aggressively
+while the pointer churns across adjacent items, staying visible after the dock
+has hidden, and attaching to the wrong icon because the hover changed faster
+than the popup content could rebuild. This module manages those problems.
 
-- it is visual only,
-- it is anchored to one hovered item,
-- it must never become a second interactive surface that competes with the dock,
-- it must follow shared geometry instead of inventing its own icon positions.
+TooltipManager owns delayed and coalesced tooltip popup rebuilds, tooltip
+window creation and reuse, tooltip text and widget content replacement, tooltip
+positioning from item anchor points, screen clamping, and hide/cancel logic.
 
-That sounds straightforward, but dock tooltips have a few failure modes that
-ordinary GTK widgets do not:
-
-- showing too early while the dock itself is still animating,
-- rebuilding too aggressively while the pointer churns across adjacent items,
-- staying visible after the dock has already hidden,
-- looking attached to the wrong icon because the hover changed faster than the
-  popup content could be rebuilt.
-
-This module exists to manage those problems explicitly.
-
-What this module owns
-
-TooltipManager owns:
-
-- delayed/coalesced tooltip popup rebuilds,
-- tooltip window creation and reuse,
-- tooltip text/widget content replacement,
-- tooltip positioning from item anchor points,
-- screen clamping,
-- hide/cancel logic.
-
-It does not own:
-
-- hover decisions,
-- whether the dock should remain visible,
-- autohide policy,
-- item geometry itself.
-
-Those come from HoverManager, interaction policy, and shared geometry.
+It does not own hover decisions, dock visibility policy, autohide policy, or
+item geometry. Those come from HoverManager, interaction policy, and shared
+geometry.
 
 Anchor model
 
@@ -108,7 +86,7 @@ That coalescing matters when the pointer moves quickly across adjacent icons.
 Without it, the tooltip can briefly show the last item the hover touched even
 though the pointer already moved on.
 
-Why this module reuses one popup window
+Single popup window
 
 Creating and destroying popup windows repeatedly is expensive and noisy.
 Reusing a single popup window gives:
@@ -142,7 +120,7 @@ So the intended behavior is:
 That means this module must cooperate with hover/interaction policy rather than
 attempting to own dock visibility.
 
-Why screen clamping belongs here
+Screen clamping
 
 The geometry frame gives the ideal anchor. But the tooltip is a real popup
 window that can run off-screen on small displays or near monitor edges.


### PR DESCRIPTION
- "Why X exists" / "Why X needs its own module" headings
- "What this module owns/does not own" template blocks
- "Design" / "Architecture" section headings with underlines
- Stale PR references
- Historical perspective language ("used to", "no longer", "before this")
- Pseudo-code blocks in docstrings