### PR TITLE
Improve code documentation around refactored modules

### DIFF
--- a/docking/app.py
+++ b/docking/app.py
@@ -171,6 +171,9 @@ def _start_runtime(
 def _quit() -> bool:
     global _FORCE_QUIT_SOURCE_ID
 
+    # Shutdown is intentionally two-stage.  Give GTK, applets, IPC services,
+    # and backend adapters a normal main-loop exit first; if something wedges
+    # during teardown, force the process out after a short grace period.
     Gtk.main_quit()
     if _FORCE_QUIT_SOURCE_ID == 0:
         _FORCE_QUIT_SOURCE_ID = GLib.timeout_add_seconds(3, _force_quit)

--- a/docking/applets/apps.py
+++ b/docking/applets/apps.py
@@ -11,7 +11,13 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 
-"""Shared desktop application discovery helpers for applets."""
+"""Shared desktop application discovery helpers for applets.
+
+The Applications and Run Application applets need the same launchable desktop
+entry list but present it differently. This module keeps that discovery logic
+out of individual applets and adapts host-parsed desktop files to the small
+`Gio.DesktopAppInfo`-like surface those applets already use.
+"""
 
 from __future__ import annotations
 
@@ -28,7 +34,13 @@ from docking.platform.launcher import launch as launch_desktop_id
 
 
 class ApplicationEntry(NamedTuple):
-    """Small app-info adapter for Gio and host-parsed desktop files."""
+    """Small app-info adapter for Gio and host-parsed desktop files.
+
+    Entries discovered through `Gio.AppInfo.get_all()` keep their original
+    `Gio.DesktopAppInfo`. Entries found only by walking desktop directories
+    still expose the same methods so applet filtering, icon loading, and launch
+    code do not need separate branches.
+    """
 
     desktop_id: str
     name: str

--- a/docking/applets/base.py
+++ b/docking/applets/base.py
@@ -23,15 +23,15 @@ Applets split their work into two explicit paths:
 
 1. ``create_icon(size)``: pure visual rendering to pixbuf,
 2. ``refresh_tooltip()``: update user-facing metadata (name/tooltip builder),
-3. ``present()``: perform both and notify the dock model/UI,
-4. ``present()``: explicit first presentation sync after subclass init completes.
+3. ``present()``: perform both paths and notify the dock model/UI.
 
 Why this split matters
 
 The current applet contract keeps rendering and metadata updates explicit.
 ``create_icon()`` is for pixels, ``refresh_tooltip()`` is for user-facing text,
 ``present()`` is the coordinated update path for later state
-changes, and ``present()`` marks the first sync once subclass state is ready.
+changes, and subclasses call ``present()`` once their own initialization state
+is ready.
 This keeps applet behavior predictable and testable:
 
 - icon tests can assert drawing behavior independently,
@@ -55,7 +55,6 @@ This module also centralizes reusable rendering helpers and icon-theme loading:
 
 - theme icon lookup with fallback candidate names,
 - bundled fallback icon for applet identity consistency across distros,
-- canvas-centering helper for non-square icon assets,
 - shared outlined text drawing used by multiple applets.
 
 Keeping these helpers in one place avoids per-applet duplication and ensures
@@ -175,7 +174,13 @@ def _load_bundled_fallback_icon(size: int) -> GdkPixbuf.Pixbuf | None:
 
 
 def load_theme_icon(name: str, size: int) -> GdkPixbuf.Pixbuf | None:
-    """Load an icon by name from the default GTK icon theme."""
+    """Load an icon by name from GTK icon themes with Docking fallbacks.
+
+    Lookup expands known aliases and symbolic variants, then tries the default
+    theme plus Adwaita/hicolor fallbacks for CI and sparse desktop sessions.
+    For built-in applet names that Docking guarantees visually, missing theme
+    icons fall back to the bundled applet placeholder asset.
+    """
     flags = Gtk.IconLookupFlags.FORCE_SIZE
     for icon_name in _icon_name_candidates(name=name):
         for theme in _icon_theme_candidates():
@@ -331,6 +336,7 @@ class Applet(ABC):
     Lifecycle:
       __init__  -> create item
       present() -> initial presentation sync once subclass state is ready
+      present() -> later icon/tooltip redraws after applet state changes
       start()   -> begin timers/monitors (called after dock is ready)
       stop()    -> cleanup (called on removal or shutdown)
     """

--- a/docking/applets/systemtray/dbusmenu.py
+++ b/docking/applets/systemtray/dbusmenu.py
@@ -128,7 +128,12 @@ class DBusMenuClient:
 
 
 def parse_menu_node(raw: object) -> DBusMenuItem | None:
-    """Parse one DBusMenu ``(ia{sv}av)`` node after GLib unpacking."""
+    """Parse one DBusMenu ``(ia{sv}av)`` node after GLib unpacking.
+
+    Children are parsed recursively and malformed child nodes are dropped.
+    Real tray apps vary in how strictly they follow DBusMenu, so callers get a
+    usable partial menu instead of losing the whole tree.
+    """
     raw = _unpack_variant(raw)
     if not isinstance(raw, (tuple, list)) or len(raw) != 3:
         return None

--- a/docking/applets/systemtray/state.py
+++ b/docking/applets/systemtray/state.py
@@ -216,11 +216,12 @@ def tray_item_from_properties(
 
 
 class StatusNotifierBackend:
-    """StatusNotifier watcher/client backend.
+    """StatusNotifier/AppIndicator D-Bus watcher/client backend.
 
     The backend consumes an existing watcher when the desktop provides one. In
     minimal sessions it owns the watcher name and accepts registrations from
-    tray apps started after Docking.
+    tray apps started after Docking. Legacy XEmbed tray icons are not handled
+    here; `XEmbedTrayHost` owns that X11-only selection and embedding path.
     """
 
     def __init__(self) -> None:

--- a/docking/applets/systemtray/xembed.py
+++ b/docking/applets/systemtray/xembed.py
@@ -117,7 +117,14 @@ GdkFilterFunc = ctypes.CFUNCTYPE(
 
 
 class XEmbedTrayHost:
-    """Persistent legacy tray manager, modelled after Cairo-Dock's NaTray."""
+    """X11-only legacy tray selection owner and XEmbed icon host.
+
+    This is separate from the StatusNotifier/AppIndicator D-Bus backend. It
+    claims the classic ``_NET_SYSTEM_TRAY`` manager selection, accepts foreign
+    XEmbed icon windows, and embeds them with `Gtk.Socket`. When requested by
+    the user it may forcibly take over an existing tray owner, matching the
+    behavior used by older docks such as Cairo-Dock.
+    """
 
     def __init__(self, *, icon_size: int, on_changed: Callable[[], None]) -> None:
         self._icon_size = max(16, icon_size)

--- a/docking/core/icons.py
+++ b/docking/core/icons.py
@@ -6,7 +6,13 @@
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 
-"""Shared icon preference values."""
+"""Shared icon preference values.
+
+Docking has several icon-selection surfaces: applet menus, file/folder item
+menus, config persistence, and renderer decisions. Keep the persisted source
+values in core so those layers agree without importing UI or applet modules
+from each other.
+"""
 
 from __future__ import annotations
 
@@ -14,7 +20,11 @@ from enum import Enum
 
 
 class IconSource(str, Enum):
-    """Supported user-selectable icon sources."""
+    """Supported user-selectable icon sources.
+
+    There is no separate "default" value. Callers should omit the preference
+    or fall back to `DOCKING` when a persisted value is missing/invalid.
+    """
 
     DOCKING = "docking"
     SYSTEM = "system"

--- a/docking/platform/backends/selection.py
+++ b/docking/platform/backends/selection.py
@@ -46,8 +46,11 @@ def create_session_backend(
 ) -> SessionBackend:
     """Create the production session backend for the current runtime.
 
-    X11 remains the default on X11 displays. Native Wayland first tries the
-    optional layer-shell backend and falls back to reduced mode when unavailable.
+    Explicit ``DOCKING_BACKEND`` values win first. Without an override, X11
+    remains the default on X11 displays. Native Wayland prefers richer
+    compositor-specific backends before the generic layer-shell path:
+    Hyprland, COSMIC, Niri, Wayfire, KWin, then layer-shell, then the GNOME
+    Shell bridge, then reduced mode.
     """
     requested = os.environ.get("DOCKING_BACKEND", "").strip().lower()
     if requested == "reduced":

--- a/docking/platform/desktop_entries.py
+++ b/docking/platform/desktop_entries.py
@@ -11,7 +11,24 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 
-"""Shared XDG desktop-entry discovery and parsing helpers."""
+"""Shared XDG desktop-entry discovery, parsing, and generation helpers.
+
+Desktop entries are used by several layers: launch resolution, running-window
+matching, Applications/Run Application applets, desktop action menus, and
+drag-to-pin for standalone executables. Keeping the parsing and generated entry
+rules here prevents each caller from inventing a slightly different view of
+`.desktop` files.
+
+Two environments matter:
+
+* normal host sessions, where Gio usually resolves installed desktop IDs;
+* sandboxed/host-mounted sessions, where we may need to walk host desktop
+  directories and parse files directly.
+
+The helpers below prefer Gio when it has the data, then fall back to explicit
+file parsing so features keep working across classic installs, Flatpak-like
+host mounts, Snap desktop exports, and user-generated launchers.
+"""
 
 from __future__ import annotations
 
@@ -159,7 +176,14 @@ def wine_executable_aliases(exec_line: str) -> list[str]:
 
 
 def desktop_match_aliases(info: DesktopInfo) -> list[str]:
-    """Return stable lookup aliases for matching runtime windows to desktop IDs."""
+    """Return stable aliases for matching runtime windows to desktop IDs.
+
+    The order mirrors the strongest identities first: explicit or synthesized
+    ``StartupWMClass``, desktop ID stem, Wine executable aliases when the Exec
+    line launches through Wine, otherwise the normal Exec basename. The
+    launcher and `AppIdMatcher` both rely on this order when resolving running
+    windows back to pinned desktop files.
+    """
     aliases = [
         info.wm_class.lower(),
         info.desktop_id.removesuffix(DESKTOP_SUFFIX).lower(),
@@ -255,7 +279,13 @@ def desktop_info_from_app_info(
 
 
 def wm_class_for_app_info(*, app_info: Gio.DesktopAppInfo, desktop_id: str) -> str:
-    """Return explicit StartupWMClass or the existing executable fallback."""
+    """Return the best runtime matching class for a Gio desktop app.
+
+    A specific ``StartupWMClass`` wins. Missing or generic ``Wine`` classes can
+    be replaced by a Wine ``.exe`` alias extracted from the command line;
+    otherwise fall back to the command basename and finally the desktop ID
+    stem.
+    """
     wm_class = app_info.get_startup_wm_class() or ""
     commandline = app_info.get_commandline() or ""
     wine_aliases = wine_executable_aliases(commandline)
@@ -469,7 +499,13 @@ def desktop_listing_from_app_info(
 
 
 def all_desktop_app_listings() -> list[DesktopAppListing]:
-    """Return launchable desktop applications visible to applet UIs."""
+    """Return launchable desktop applications visible to applet UIs.
+
+    Gio gives the best integration for normal desktop files, but it may miss
+    host-mounted or recently generated entries. Walk desktop directories after
+    Gio and dedupe by desktop ID so applet launchers see both sources without
+    duplicating applications.
+    """
     apps: list[DesktopAppListing] = []
     seen: set[str] = set()
 
@@ -581,7 +617,14 @@ def make_user_executable(path: Path) -> bool:
 def create_desktop_entry_for_executable(
     target: str | Path,
 ) -> GeneratedDesktopEntry | None:
-    """Create or update a generated desktop entry for a launchable local file."""
+    """Create or update a generated desktop entry for a launchable local file.
+
+    Drag-to-pin needs standalone binaries and AppImages to become normal dock
+    launchers. Instead of storing an ad-hoc command in dock config, generate a
+    user-local `.desktop` file with a stable ID derived from the source path.
+    That keeps launching, matching, pinning, and later menu behavior on the
+    same desktop-entry path as installed applications.
+    """
     path = _local_executable_path(target)
     if path is None:
         return None

--- a/docking/ui/factory.py
+++ b/docking/ui/factory.py
@@ -11,11 +11,25 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 
-"""Composition root for building a dock window plus edge-dodge integration.
+"""Composition root for wiring the dock UI object graph.
 
-`DockWindow` now leaves construction already owning its UI collaborators. This
-module stays as the thin bootstrap layer for the extra platform piece that does
-not belong inside the GTK shell itself: the dodge monitor.
+This module is the hand-off point between process startup (`app.py`) and the
+interactive GTK shell. It deliberately owns the wiring that crosses UI
+subsystem boundaries:
+
+* `DockWindow` owns the drawing area and low-level shell services.
+* `DockRuntime` exposes a narrow command surface for broad controllers such as
+  settings and menus, so they do not reach into raw `DockWindow` internals.
+* `MenuHandler`, `SettingsWindowController`, drag-and-drop, folder stacks, and
+  input handling are composed here because they depend on each other but should
+  not construct each other.
+* Startup popup sources are registered with one coordinator here so New Year,
+  update, and tip popups can share priority rules without knowing about each
+  other.
+
+Keeping that graph in one place makes later refactors easier: `app.py` remains
+process bootstrap, `DockWindow` remains the dock surface, and feature
+controllers receive the smallest collaborator set they need.
 """
 
 from __future__ import annotations
@@ -54,7 +68,13 @@ from docking.ui.update_popup import UpdateCheckController
 
 @dataclass(slots=True)
 class DockUi:
-    """Handle for the composed dock UI graph."""
+    """Lifecycle handle for UI pieces that live beside `DockWindow`.
+
+    `DockWindow` is still the GTK window callers need for show/present calls,
+    but it intentionally does not own every controller anymore. This wrapper
+    gives `app.py` a single start/stop surface for the controllers assembled in
+    this module.
+    """
 
     window: DockWindow
     startup_popups: StartupPopupCoordinator
@@ -84,7 +104,11 @@ def build_dock_window(
     launcher: Launcher,
     session_backend: SessionBackend,
 ) -> DockUi:
-    """Build a fully wired dock window and its UI collaborators."""
+    """Build a fully wired dock window and its UI collaborators.
+
+    The function name is kept for existing callers/tests, but the returned
+    object is the composed dock UI handle rather than a bare `DockWindow`.
+    """
     window = DockWindow(
         config=config,
         model=model,
@@ -162,6 +186,9 @@ def build_dock_window(
     startup_popups.register(startup_tips)
 
     def _get_dock_rect() -> Rect | None:
+        # Dodge monitors are backend-owned, but the visible shelf rectangle is
+        # a renderer/geometry concern. Query it lazily so monitor callbacks
+        # always see the current theme, position, zoom, and scale state.
         if not window.get_realized():
             return None
         window_pos = window_screen_position(window)

--- a/docking/ui/runtime.py
+++ b/docking/ui/runtime.py
@@ -11,7 +11,18 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 
-"""Runtime command surfaces exposed by the dock UI shell to handlers."""
+"""Runtime command surface exposed by the dock UI shell to broad controllers.
+
+Menus, settings, folder stacks, and applet helpers often need to trigger
+dock-wide effects, but letting each of them keep a `DockWindow` reference would
+make those modules depend on the full GTK shell. `DockRuntime` is the small
+imperative facade they share instead.
+
+The boundary is intentionally practical rather than abstract: methods are added
+when a controller needs a real dock-level action. It should stay thinner than
+`DockWindow`, but it should not force callers into generic callbacks when a
+named runtime command is clearer and easier to test.
+"""
 
 from __future__ import annotations
 
@@ -25,7 +36,7 @@ if TYPE_CHECKING:
 
 
 class DockRuntime:
-    """Narrow imperative API for subsystems that should not own DockWindow."""
+    """Narrow imperative API for subsystems that should not own `DockWindow`."""
 
     def __init__(
         self,

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -22,11 +22,12 @@ The UI shape is inspired by Plank's preferences window:
     +----------------------------------------------+
     | Preferences                                  |
     |                                              |
-    |  [ Appearance ] [ Applets ]                  |
+    |  [ Appearance ] [ Behavior ] [ Applets ]     |
+    |  [ Updates ]                                 |
     |                                              |
-    |  appearance controls...                      |
+    |  controls for the active tab...              |
     |  or                                          |
-    |  applet enable/disable controls...           |
+    |  applet enable/disable cards...              |
     +----------------------------------------------+
 
 The dock already exposed many of these actions via the context menu. This
@@ -136,7 +137,13 @@ class _ScalarBinding:
 
 
 class SettingsActions:
-    """Facade for preferences-triggered side effects."""
+    """Facade for side effects triggered by the preferences window.
+
+    The settings controller owns widgets and config synchronization, not the
+    dock shell. This object keeps those concerns separate while avoiding a bag
+    of callbacks: every method is a named action the preferences UI is allowed
+    to request from runtime collaborators.
+    """
 
     def __init__(
         self,

--- a/docking/ui/startup_popups.py
+++ b/docking/ui/startup_popups.py
@@ -11,7 +11,21 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 
-"""Startup popup arbitration."""
+"""Startup popup arbitration.
+
+Docking can have several startup-time popup sources active in the same run:
+seasonal greetings, release update notices, and usage tips. They should not
+race each other or build direct dependencies between feature controllers.
+
+The coordinator gives each source two simple hooks:
+
+* `request_show(source_id)` when the source has content ready.
+* `visibility_changed(source_id, visible)` when the popup opens or closes.
+
+Sources stay independent and the coordinator owns the product policy:
+lower numeric priority wins, only one popup is visible at a time, and lower
+priority sources can expire rather than appearing long after startup.
+"""
 
 from __future__ import annotations
 
@@ -26,7 +40,7 @@ from gi.repository import GLib
 
 
 class StartupPopupSource(Protocol):
-    """Source that can request a startup popup without knowing the coordinator."""
+    """Source that can request a startup popup without knowing its peers."""
 
     source_id: str
     priority: int
@@ -49,7 +63,7 @@ class _PendingRequest:
 
 
 class StartupPopupCoordinator:
-    """Own startup popup priority and source lifecycle."""
+    """Own startup popup priority, queueing, and source lifecycle."""
 
     def __init__(self, *, clock=time.monotonic) -> None:
         self._clock = clock
@@ -74,6 +88,7 @@ class StartupPopupCoordinator:
             source.stop()
 
     def request_show(self, source_id: str) -> None:
+        """Queue a source and show it immediately when policy allows."""
         source = self._sources.get(source_id)
         if source is None:
             return
@@ -83,6 +98,7 @@ class StartupPopupCoordinator:
         self._try_show_next()
 
     def visibility_changed(self, source_id: str, visible: bool) -> None:
+        """Track the active popup and release the next queued source on close."""
         if visible:
             self._active_source_id = source_id
             self._clear_pending(source_id)

--- a/docking/ui/startup_tips.py
+++ b/docking/ui/startup_tips.py
@@ -11,7 +11,17 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 
-"""Startup usage tip popup UI."""
+"""Startup usage tip popup UI.
+
+This controller is only one source in the startup popup system. It owns tip
+selection and its GTK surface, while `StartupPopupCoordinator` owns whether the
+tip is allowed to appear now or must wait behind higher-priority startup
+popups.
+
+Tip state is consumed only when the popup is actually shown. That matters when
+updates or seasonal popups win startup arbitration: a skipped or expired tip
+should not be marked as seen.
+"""
 
 from __future__ import annotations
 
@@ -48,7 +58,7 @@ STARTUP_TIP_WIDTH_CHARS = 48
 
 
 class StartupTipsController:
-    """Schedules and shows one startup usage tip."""
+    """Schedule and show one startup usage tip when the coordinator allows it."""
 
     source_id = STARTUP_TIP_POPUP_ID
     priority = STARTUP_TIP_POPUP_PRIORITY
@@ -105,7 +115,7 @@ class StartupTipsController:
         return False
 
     def show_pending(self) -> bool:
-        """Select and show the next startup tip."""
+        """Select, consume, and show the next startup tip."""
         if not self._window.get_realized():
             log.debug("Skipping startup tip because dock window is not realized")
             return False


### PR DESCRIPTION
## Summary
- refresh stale docstrings in recently refactored UI composition and startup popup modules
- document desktop-entry, icon-source, applet, backend-selection, and system-tray boundaries
- add lifecycle comments for dock shutdown and startup popup arbitration