### PR TITLE
Round startup popup surfaces

### DIFF
--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-07-04 23:25+0200\n"
+"POT-Creation-Date: 2026-07-05 14:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3029,7 +3029,7 @@ msgid "Save Report..."
 msgstr ""
 
 #: docking/ui/diagnostics.py:122 docking/ui/menu.py:574
-#: docking/ui/startup_tips.py:173
+#: docking/ui/startup_tips.py:207
 msgid "Close"
 msgstr ""
 
@@ -3712,16 +3712,15 @@ msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
 
-#: docking/ui/startup_tips.py:155
-#, python-brace-format
-msgid "Tip: {title}"
+#: docking/ui/startup_tips.py:178
+msgid "Tip of the day"
 msgstr ""
 
-#: docking/ui/startup_tips.py:171
-msgid "Never Show Tips"
+#: docking/ui/startup_tips.py:203
+msgid "Show tips on startup"
 msgstr ""
 
-#: docking/ui/startup_tips.py:172
+#: docking/ui/startup_tips.py:206
 msgid "Next Tip"
 msgstr ""
 
@@ -3743,24 +3742,24 @@ msgstr ""
 msgid "{age} ago"
 msgstr ""
 
-#: docking/ui/update_popup.py:230
+#: docking/ui/update_popup.py:233
 #, python-brace-format
 msgid "Docking {version} is available"
 msgstr ""
 
-#: docking/ui/update_popup.py:236
+#: docking/ui/update_popup.py:239
 #, python-brace-format
 msgid "You are using {version}."
 msgstr ""
 
-#: docking/ui/update_popup.py:245
+#: docking/ui/update_popup.py:248
 msgid "View Release"
 msgstr ""
 
-#: docking/ui/update_popup.py:246
+#: docking/ui/update_popup.py:249
 msgid "Later"
 msgstr ""
 
-#: docking/ui/update_popup.py:247
+#: docking/ui/update_popup.py:250
 msgid "Ignore"
 msgstr ""

--- a/docking/ui/popup_surface.py
+++ b/docking/ui/popup_surface.py
@@ -1,0 +1,85 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Shared themed surfaces for small dock-owned popup windows."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import gi
+
+gi.require_version("Gdk", "3.0")
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk, Gtk
+
+STARTUP_POPUP_WINDOW_CLASS = "dock-startup-popup-window"
+STARTUP_POPUP_SURFACE_CLASS = "dock-startup-popup-surface"
+STARTUP_POPUP_CSS = f"""
+.{STARTUP_POPUP_WINDOW_CLASS} {{
+    background-color: transparent;
+}}
+
+.{STARTUP_POPUP_SURFACE_CLASS} {{
+    background-color: @theme_bg_color;
+    color: @theme_fg_color;
+    border: 1px solid alpha(@theme_fg_color, 0.16);
+    border-radius: 12px;
+}}
+""".encode()
+
+
+@lru_cache(maxsize=1)
+def ensure_startup_popup_css() -> Gtk.CssProvider | None:
+    """Install rounded startup-popup CSS once per screen."""
+    screen = Gdk.Screen.get_default()
+    if screen is None:
+        return None
+
+    provider = Gtk.CssProvider()
+    provider.load_from_data(STARTUP_POPUP_CSS)
+    Gtk.StyleContext.add_provider_for_screen(
+        screen,
+        provider,
+        Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+    )
+    return provider
+
+
+def configure_transparent_startup_popup_window(window: Gtk.Window) -> None:
+    """Make an undecorated popup window transparent behind rounded content."""
+    ensure_startup_popup_css()
+
+    window.set_app_paintable(True)
+
+    screen = window.get_screen()
+    rgba_visual = None
+    if screen is not None:
+        rgba_visual = screen.get_rgba_visual()
+    if rgba_visual is not None:
+        window.set_visual(rgba_visual)
+
+    window.override_background_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(0, 0, 0, 0))
+
+    window.get_style_context().add_class(STARTUP_POPUP_WINDOW_CLASS)
+
+
+def wrap_startup_popup_content(content: Gtk.Widget) -> Gtk.Frame:
+    """Wrap popup content in the shared rounded dock-startup surface."""
+    ensure_startup_popup_css()
+
+    frame = Gtk.Frame()
+    frame.set_shadow_type(Gtk.ShadowType.NONE)
+    frame.get_style_context().add_class(STARTUP_POPUP_SURFACE_CLASS)
+    frame.add(content)
+    return frame

--- a/docking/ui/startup_tips.py
+++ b/docking/ui/startup_tips.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from html import escape
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -30,6 +31,10 @@ from docking.core.tips import StartupTip, select_startup_tip
 from docking.i18n import _
 from docking.log import get_logger
 from docking.ui.display import clamp_popup, window_screen_position
+from docking.ui.popup_surface import (
+    configure_transparent_startup_popup_window,
+    wrap_startup_popup_content,
+)
 from docking.ui.tooltip import compute_tooltip_position
 
 if TYPE_CHECKING:
@@ -43,8 +48,10 @@ STARTUP_TIP_DELAY_S = 12
 STARTUP_TIP_MAX_PRIORITY_WAIT_S = 30
 STARTUP_TIP_POPUP_GAP_PX = 16
 STARTUP_TIP_SPACING_PX = 10
-STARTUP_TIP_MARGIN_PX = 12
+STARTUP_TIP_MARGIN_PX = 14
 STARTUP_TIP_WIDTH_CHARS = 48
+STARTUP_TIP_ICON_NAME = "help-hint"
+STARTUP_TIP_ICON_FALLBACK = "dialog-information"
 
 
 class StartupTipsController:
@@ -69,6 +76,7 @@ class StartupTipsController:
         self._start_source_id = 0
         self._popup: Gtk.Window | None = None
         self._current_tip: StartupTip | None = None
+        self._show_on_startup_check: Gtk.CheckButton | None = None
         self._request_show: Callable[[str], None] | None = None
         self._visibility_changed: Callable[[str, bool], None] | None = None
 
@@ -129,6 +137,7 @@ class StartupTipsController:
             popup.set_skip_taskbar_hint(True)
             popup.set_resizable(False)
             popup.set_type_hint(Gdk.WindowTypeHint.NOTIFICATION)
+            configure_transparent_startup_popup_window(popup)
             popup.set_transient_for(self._window)
             popup.connect("destroy", self._on_popup_destroy)
             self._popup = popup
@@ -144,43 +153,76 @@ class StartupTipsController:
         return True
 
     def _build_popup_content(self, *, tip: StartupTip) -> Gtk.Widget:
-        frame = Gtk.Frame()
-        frame.set_shadow_type(Gtk.ShadowType.OUT)
         box = Gtk.Box(
             orientation=Gtk.Orientation.VERTICAL,
-            spacing=STARTUP_TIP_SPACING_PX,
+            spacing=STARTUP_TIP_SPACING_PX + 2,
         )
         box.set_border_width(STARTUP_TIP_MARGIN_PX)
+        self._add_style_class(box, "startup-tip-content")
 
-        title = Gtk.Label(label=_("Tip: {title}").format(title=tip.title))
+        header = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
+            spacing=STARTUP_TIP_SPACING_PX + 2,
+        )
+        icon = self._build_tip_icon()
+        icon.set_valign(Gtk.Align.START)
+        header.pack_start(icon, False, False, 0)
+
+        text = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=max(4, STARTUP_TIP_SPACING_PX // 2),
+        )
+        text.set_hexpand(True)
+
+        eyebrow = Gtk.Label(label=_("Tip of the day"))
+        eyebrow.set_xalign(0.0)
+        self._add_style_class(eyebrow, "dim-label")
+        text.pack_start(eyebrow, False, False, 0)
+
+        title = Gtk.Label()
         title.set_xalign(0.0)
         title.set_line_wrap(True)
         title.set_max_width_chars(STARTUP_TIP_WIDTH_CHARS)
-        box.pack_start(title, False, False, 0)
+        title.set_markup(f"<b>{escape(tip.title)}</b>")
+        text.pack_start(title, False, False, 0)
 
         body = Gtk.Label(label=tip.body)
         body.set_xalign(0.0)
         body.set_line_wrap(True)
         body.set_max_width_chars(STARTUP_TIP_WIDTH_CHARS)
-        box.pack_start(body, False, False, 0)
+        text.pack_start(body, False, False, 0)
+
+        header.pack_start(text, True, True, 0)
+        box.pack_start(header, False, False, 0)
 
         buttons = Gtk.Box(
             orientation=Gtk.Orientation.HORIZONTAL,
             spacing=STARTUP_TIP_SPACING_PX,
         )
-        never = Gtk.Button(label=_("Never Show Tips"))
+        show_on_startup = Gtk.CheckButton(label=_("Show tips on startup"))
+        show_on_startup.set_active(True)
+        self._show_on_startup_check = show_on_startup
         next_tip = Gtk.Button(label=_("Next Tip"))
         close = Gtk.Button(label=_("Close"))
-        never.connect("clicked", self._on_never_show)
         next_tip.connect("clicked", self._on_next_tip)
         close.connect("clicked", self._on_close)
-        buttons.pack_start(never, False, False, 0)
+        buttons.pack_start(show_on_startup, True, True, 0)
         buttons.pack_start(next_tip, False, False, 0)
         buttons.pack_start(close, False, False, 0)
         box.pack_start(buttons, False, False, 0)
 
-        frame.add(box)
-        return frame
+        return wrap_startup_popup_content(box)
+
+    def _build_tip_icon(self) -> Gtk.Image:
+        icon_theme = Gtk.IconTheme.get_default()
+        icon_name = STARTUP_TIP_ICON_NAME
+        if icon_theme is not None and not icon_theme.has_icon(icon_name):
+            icon_name = STARTUP_TIP_ICON_FALLBACK
+        return Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.DIALOG)
+
+    @staticmethod
+    def _add_style_class(widget: Gtk.Widget, class_name: str) -> None:
+        widget.get_style_context().add_class(class_name)
 
     def _position_popup(self) -> None:
         if self._popup is None:
@@ -218,6 +260,7 @@ class StartupTipsController:
         self.show_pending()
 
     def _on_close(self, _button: Gtk.Button) -> None:
+        self._save_startup_tip_visibility_choice()
         if self._popup is not None:
             self._popup.hide()
         self._notify_visible(False)
@@ -232,6 +275,14 @@ class StartupTipsController:
             self._popup = None
             popup.destroy()
         self._notify_visible(False)
+
+    def _save_startup_tip_visibility_choice(self) -> None:
+        if self._show_on_startup_check is None:
+            return
+        if self._show_on_startup_check.get_active():
+            return
+        self._config.startup_tips_enabled = False
+        self._config.save()
 
     def _notify_visible(self, visible: bool) -> None:
         if self._visibility_changed is not None:

--- a/docking/ui/update_popup.py
+++ b/docking/ui/update_popup.py
@@ -42,6 +42,10 @@ from docking.core.updates import (
 from docking.i18n import _
 from docking.log import get_logger
 from docking.ui.display import clamp_popup, window_screen_position
+from docking.ui.popup_surface import (
+    configure_transparent_startup_popup_window,
+    wrap_startup_popup_content,
+)
 from docking.ui.tooltip import compute_tooltip_position
 
 if TYPE_CHECKING:
@@ -203,6 +207,7 @@ class UpdateCheckController:
             popup.set_skip_taskbar_hint(True)
             popup.set_resizable(False)
             popup.set_type_hint(Gdk.WindowTypeHint.NOTIFICATION)
+            configure_transparent_startup_popup_window(popup)
             popup.set_transient_for(self._window)
             popup.connect("destroy", self._on_popup_destroy)
             self._popup = popup
@@ -218,8 +223,6 @@ class UpdateCheckController:
         return True
 
     def _build_popup_content(self, *, release: ReleaseInfo) -> Gtk.Widget:
-        frame = Gtk.Frame()
-        frame.set_shadow_type(Gtk.ShadowType.OUT)
         box = Gtk.Box(
             orientation=Gtk.Orientation.VERTICAL,
             spacing=UPDATE_POPUP_SPACING_PX,
@@ -252,8 +255,7 @@ class UpdateCheckController:
         buttons.pack_start(later, False, False, 0)
         buttons.pack_start(ignore, False, False, 0)
         box.pack_start(buttons, False, False, 0)
-        frame.add(box)
-        return frame
+        return wrap_startup_popup_content(box)
 
     def _position_popup(self) -> None:
         if self._popup is None or self._window is None:

--- a/tests/ui/test_startup_tips.py
+++ b/tests/ui/test_startup_tips.py
@@ -99,26 +99,53 @@ class _FakeBox:
         self.kwargs = kwargs
         self.children = []
         self.border_width = 0
+        self.hexpand = False
+        self.style_context = _FakeStyleContext()
 
     def set_border_width(self, value):
         self.border_width = value
 
+    def set_hexpand(self, value):
+        self.hexpand = value
+
     def pack_start(self, child, *args):
         self.children.append(child)
+
+    def get_style_context(self):
+        return self.style_context
+
+
+class _FakeStyleContext:
+    def __init__(self) -> None:
+        self.classes = []
+
+    def add_class(self, class_name):
+        self.classes.append(class_name)
 
 
 class _FakeLabel:
     def __init__(self, *, label="") -> None:
         self.label = label
+        self.markup = ""
+        self.style_context = _FakeStyleContext()
 
     def set_xalign(self, value):
         self.xalign = value
+
+    def set_yalign(self, value):
+        self.yalign = value
 
     def set_line_wrap(self, value):
         self.line_wrap = value
 
     def set_max_width_chars(self, value):
         self.max_width_chars = value
+
+    def set_markup(self, value):
+        self.markup = value
+
+    def get_style_context(self):
+        return self.style_context
 
 
 class _FakeButton:
@@ -131,6 +158,40 @@ class _FakeButton:
 
     def click(self):
         self.handlers["clicked"](self)
+
+
+class _FakeCheckButton(_FakeButton):
+    def __init__(self, *, label="") -> None:
+        super().__init__(label=label)
+        self.active = False
+
+    def set_active(self, value):
+        self.active = value
+
+    def get_active(self):
+        return self.active
+
+
+class _FakeImage:
+    def __init__(self, icon_name, icon_size) -> None:
+        self.icon_name = icon_name
+        self.icon_size = icon_size
+
+    @classmethod
+    def new_from_icon_name(cls, icon_name, icon_size):
+        return cls(icon_name, icon_size)
+
+    def set_valign(self, value):
+        self.valign = value
+
+
+class _FakeIconTheme:
+    @staticmethod
+    def get_default():
+        return _FakeIconTheme()
+
+    def has_icon(self, icon_name):
+        return icon_name == tips_ui.STARTUP_TIP_ICON_NAME
 
 
 class _FakeWindow:
@@ -165,8 +226,13 @@ def fake_gtk(monkeypatch):
             ShadowType=SimpleNamespace(OUT="out"),
             Box=_FakeBox,
             Orientation=SimpleNamespace(VERTICAL="vertical", HORIZONTAL="horizontal"),
+            Align=SimpleNamespace(START="start"),
+            IconSize=SimpleNamespace(DIALOG="dialog"),
+            IconTheme=_FakeIconTheme,
+            Image=_FakeImage,
             Label=_FakeLabel,
             Button=_FakeButton,
+            CheckButton=_FakeCheckButton,
         ),
     )
     monkeypatch.setattr(
@@ -174,7 +240,19 @@ def fake_gtk(monkeypatch):
         "Gdk",
         SimpleNamespace(WindowTypeHint=SimpleNamespace(NOTIFICATION="notification")),
     )
+    monkeypatch.setattr(
+        tips_ui,
+        "configure_transparent_startup_popup_window",
+        lambda _popup: None,
+    )
+    monkeypatch.setattr(tips_ui, "wrap_startup_popup_content", _wrap_fake_popup)
     return glib
+
+
+def _wrap_fake_popup(content):
+    frame = _FakeFrame()
+    frame.add(content)
+    return frame
 
 
 def _config(*, enabled=True):
@@ -279,6 +357,25 @@ def test_close_hides_and_deactivates(fake_gtk):
 
     assert controller._popup.hidden
     assert visible[-1] == (tips_ui.STARTUP_TIP_POPUP_ID, False)
+
+
+def test_close_with_startup_checkbox_disabled_saves_preference(fake_gtk):
+    saved = []
+    config = SimpleNamespace(
+        startup_tips_enabled=True,
+        save=lambda: saved.append(True),
+    )
+    controller = StartupTipsController(
+        window=_FakeWindow(),
+        config=config,
+    )
+    controller._show_popup(tip=StartupTip(FIRST_TIP_ID, "Title", "Body"))
+    controller._show_on_startup_check.set_active(False)
+
+    controller._on_close(_FakeButton(label="Close"))
+
+    assert config.startup_tips_enabled is False
+    assert saved == [True]
 
 
 def test_never_show_disables_saves_and_destroys(fake_gtk):


### PR DESCRIPTION
## Summary
- add a shared rounded surface helper for dock-owned startup popups
- make startup tip and update popup windows transparent behind their rounded content
- keep the New Year popup unchanged because it already custom-paints a rounded surface