### PR TITLE
Isolate applet lifecycle failures

### DIFF
--- a/docking/platform/model.py
+++ b/docking/platform/model.py
@@ -726,7 +726,12 @@ class DockModel:
         applet.item.prefs_key = desktop_id
         applet.item.insert_factor = 0.0
         self.pinned_items.append(applet.item)
-        applet.start(notify=self.notify)
+        if not self._start_applet(desktop_id=desktop_id, applet=applet):
+            self._stop_applet(desktop_id=desktop_id, applet=applet)
+            self._applets.pop(desktop_id, None)
+            if applet.item in self.pinned_items:
+                self.pinned_items.remove(applet.item)
+            return
         self.sync_pinned_to_config()
         self._config.save()
         self.notify()
@@ -763,7 +768,12 @@ class DockModel:
             self.pinned_items.append(applet.item)
         else:
             self.pinned_items.insert(index, applet.item)
-        applet.start(notify=self.notify)
+        if not self._start_applet(desktop_id=desktop_id, applet=applet):
+            self._stop_applet(desktop_id=desktop_id, applet=applet)
+            self._applets.pop(desktop_id, None)
+            if applet.item in self.pinned_items:
+                self.pinned_items.remove(applet.item)
+            return
         self.sync_pinned_to_config()
         self._config.save()
         self.notify()
@@ -772,7 +782,7 @@ class DockModel:
         """Stop and remove a applet from the dock (animated)."""
         applet = self._applets.pop(desktop_id, None)
         if applet:
-            applet.stop()
+            self._stop_applet(desktop_id=desktop_id, applet=applet)
             if applet.item in self.pinned_items:
                 applet.item.removal_index = self.visible_items().index(applet.item)
                 self.pinned_items.remove(applet.item)
@@ -783,13 +793,35 @@ class DockModel:
 
     def start_applets(self) -> None:
         """Start all active applets (call after dock is ready)."""
-        for applet in self._applets.values():
-            applet.start(notify=self.notify)
+        for desktop_id, applet in list(self._applets.items()):
+            self._start_applet(desktop_id=desktop_id, applet=applet)
 
     def stop_applets(self) -> None:
         """Stop all active applets (call on shutdown)."""
-        for applet in self._applets.values():
+        for desktop_id, applet in list(self._applets.items()):
+            self._stop_applet(desktop_id=desktop_id, applet=applet)
+
+    def _start_applet(self, *, desktop_id: str, applet: Applet) -> bool:
+        """Start one applet without letting it break the dock lifecycle."""
+        try:
+            applet.start(notify=self.notify)
+        except Exception:
+            log.bind(applet_id=desktop_id, action="start_applet").exception(
+                "Failed to start applet",
+            )
+            return False
+        return True
+
+    def _stop_applet(self, *, desktop_id: str, applet: Applet) -> bool:
+        """Stop one applet without blocking removal or process shutdown."""
+        try:
             applet.stop()
+        except Exception:
+            log.bind(applet_id=desktop_id, action="stop_applet").exception(
+                "Failed to stop applet",
+            )
+            return False
+        return True
 
     def visible_items(self) -> list[DockItem]:
         """All items to display with optional independent anchoring rules.

--- a/tests/platform/test_model.py
+++ b/tests/platform/test_model.py
@@ -644,6 +644,125 @@ class TestAppletLifecycleIntegration:
         applet.stop.assert_called_once()
         assert found is applet
 
+    def test_start_applets_continues_after_failure(self):
+        config = _make_config([])
+        launcher = _make_launcher()
+        model = DockModel(config, launcher, AppletServices())
+        failing = MagicMock()
+        failing.item = DockItem(desktop_id="applet://bad", name="Bad")
+        failing.start.side_effect = RuntimeError("boom")
+        working = MagicMock()
+        working.item = DockItem(desktop_id="applet://good", name="Good")
+        model._applets["applet://bad"] = failing
+        model._applets["applet://good"] = working
+
+        model.start_applets()
+
+        failing.start.assert_called_once()
+        working.start.assert_called_once()
+
+    def test_stop_applets_continues_after_failure(self):
+        config = _make_config([])
+        launcher = _make_launcher()
+        model = DockModel(config, launcher, AppletServices())
+        failing = MagicMock()
+        failing.item = DockItem(desktop_id="applet://bad", name="Bad")
+        failing.stop.side_effect = RuntimeError("boom")
+        working = MagicMock()
+        working.item = DockItem(desktop_id="applet://good", name="Good")
+        model._applets["applet://bad"] = failing
+        model._applets["applet://good"] = working
+
+        model.stop_applets()
+
+        failing.stop.assert_called_once()
+        working.stop.assert_called_once()
+
+    def test_add_applet_start_failure_rolls_back_without_persisting(self, monkeypatch):
+        config = _make_config([])
+        launcher = _make_launcher()
+        model = DockModel(config, launcher, AppletServices())
+        fake_item = DockItem(desktop_id="applet://session", name="Session")
+        fake_applet = MagicMock()
+        fake_applet.item = fake_item
+        fake_applet.start.side_effect = RuntimeError("boom")
+
+        class FakeAppletClass:
+            def __new__(cls, icon_size, config):
+                return fake_applet
+
+        import docking.applets as applets_mod
+
+        monkeypatch.setattr(
+            applets_mod,
+            "get_applet_catalog",
+            lambda: {"session": object()},
+        )
+        monkeypatch.setattr(
+            applets_mod,
+            "load_applet_class",
+            lambda applet_id: FakeAppletClass if applet_id == "session" else None,
+        )
+
+        model.add_applet("session")
+
+        fake_applet.start.assert_called_once()
+        fake_applet.stop.assert_called_once()
+        assert model.get_applet("applet://session") is None
+        assert model.pinned_items == []
+        config.save.assert_not_called()
+
+    def test_add_separator_start_failure_rolls_back_without_persisting(
+        self, monkeypatch
+    ):
+        config = _make_config([])
+        launcher = _make_launcher()
+        model = DockModel(config, launcher, AppletServices())
+        fake_item = DockItem(desktop_id="applet://separator", name="Separator")
+        fake_applet = MagicMock()
+        fake_applet.item = fake_item
+        fake_applet.start.side_effect = RuntimeError("boom")
+
+        class FakeSeparatorClass:
+            def __new__(cls, icon_size, config):
+                return fake_applet
+
+        import docking.applets as applets_mod
+
+        monkeypatch.setattr(
+            applets_mod,
+            "load_applet_class",
+            lambda applet_id: FakeSeparatorClass if applet_id == "separator" else None,
+        )
+
+        model.add_separator(index=0)
+
+        fake_applet.start.assert_called_once()
+        fake_applet.stop.assert_called_once()
+        assert model.pinned_items == []
+        assert model._applets == {}
+        config.save.assert_not_called()
+
+    def test_remove_applet_continues_when_stop_fails(self):
+        config = _make_config([])
+        launcher = _make_launcher()
+        model = DockModel(config, launcher, AppletServices())
+        callback = MagicMock()
+        model.add_change_listener(callback)
+        applet = MagicMock()
+        applet.item = DockItem(desktop_id="applet://bad", name="Bad")
+        applet.stop.side_effect = RuntimeError("boom")
+        model._applets["applet://bad"] = applet
+        model.pinned_items.append(applet.item)
+
+        model.remove_applet("applet://bad")
+
+        applet.stop.assert_called_once()
+        assert model.get_applet("applet://bad") is None
+        assert applet.item not in model.pinned_items
+        config.save.assert_called_once()
+        callback.assert_called_once()
+
     def test_start_applets_passes_notify_callback(self):
         # Given
         config = _make_config([])


### PR DESCRIPTION
## Summary
- add guarded DockModel helpers for starting and stopping individual applets
- keep startup/shutdown/removal moving when one applet start/stop raises
- roll back newly added applets and separators when their start hook fails before persisting config