### PR TITLE
Fix MATE trash count fallback

### DIFF
--- a/docking/applets/trash/applet.py
+++ b/docking/applets/trash/applet.py
@@ -55,7 +55,9 @@ class TrashApplet(Applet):
         self._desktop = detect_desktop()
         self._backend: TrashBackend = select_trash_backend(desktop=self._desktop)
         self._item_count = self._backend.count_items()
-        self._monitor: Gio.FileMonitor | None = None
+        self._monitors: list[Gio.FileMonitor] = []
+        self._volume_monitor: Gio.VolumeMonitor | None = None
+        self._volume_monitor_handlers: list[int] = []
         super().__init__(icon_size, config)
         self.present()
 
@@ -122,28 +124,51 @@ class TrashApplet(Applet):
     def start(self, notify: Callable[[], None]) -> None:
         """Start trash monitoring for real-time icon updates."""
         super().start(notify)
-        try:
-            self._monitor = self._backend.monitor_file().monitor(
-                Gio.FileMonitorFlags.NONE, None
-            )
-            self._monitor.connect("changed", self._on_trash_changed)
-        except GLib.Error as exc:
-            log.bind(action="monitor_trash").warning(
-                "Could not start file monitor for trash: %s",
-                exc,
-            )
+        self._start_trash_monitors()
+        self._volume_monitor = Gio.VolumeMonitor.get()
+        self._volume_monitor_handlers = [
+            self._volume_monitor.connect("mount-added", self._on_mounts_changed),
+            self._volume_monitor.connect("mount-removed", self._on_mounts_changed),
+        ]
 
     def stop(self) -> None:
         """Cancel the trash file monitor."""
-        if self._monitor:
-            self._monitor.cancel()
-            self._monitor = None
+        self._cancel_trash_monitors()
+        if self._volume_monitor is not None:
+            for handler_id in self._volume_monitor_handlers:
+                self._volume_monitor.disconnect(handler_id)
+            self._volume_monitor = None
+            self._volume_monitor_handlers = []
         super().stop()
+
+    def _start_trash_monitors(self) -> None:
+        for file in self._backend.monitor_files():
+            try:
+                monitor = file.monitor(Gio.FileMonitorFlags.NONE, None)
+            except GLib.Error as exc:
+                log.bind(action="monitor_trash").warning(
+                    "Could not start file monitor for trash: %s",
+                    exc,
+                )
+                continue
+            monitor.connect("changed", self._on_trash_changed)
+            self._monitors.append(monitor)
+
+    def _cancel_trash_monitors(self) -> None:
+        for monitor in self._monitors:
+            monitor.cancel()
+        self._monitors = []
 
     def _on_trash_changed(self, *_args: object) -> None:
         """File monitor callback: re-count items and update icon."""
         self._item_count = self._backend.count_items()
         self.present()
+
+    def _on_mounts_changed(self, *_args: object) -> None:
+        """Mount changes can add or remove per-volume trash directories."""
+        self._cancel_trash_monitors()
+        self._start_trash_monitors()
+        self._on_trash_changed()
 
     def _empty_trash(self) -> None:
         """Empty trash through the selected backend."""

--- a/docking/applets/trash/backend.py
+++ b/docking/applets/trash/backend.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import configparser
+import os
 import shutil
 import subprocess
 from collections.abc import Callable
@@ -53,7 +54,7 @@ class TrashBackend(Protocol):
 
     def count_items(self) -> int: ...
 
-    def monitor_file(self) -> Gio.File: ...
+    def monitor_files(self) -> tuple[Gio.File, ...]: ...
 
     def open(self) -> None: ...
 
@@ -69,6 +70,12 @@ def _host_user_data_home() -> Path:
     return Path.home() / ".local" / "share"
 
 
+def _visible_trash_directory() -> Path:
+    if is_flatpak():
+        return _host_user_data_home() / "Trash"
+    return xdg_data_home() / "Trash"
+
+
 def _kde_trash_directory() -> Path:
     return xdg_data_home() / "Trash"
 
@@ -82,9 +89,100 @@ def _kde_trash_info_directory() -> Path:
 
 
 def _visible_trash_files_directory() -> Path:
-    if is_flatpak():
-        return _host_user_data_home() / "Trash" / "files"
-    return xdg_data_home() / "Trash" / "files"
+    return _visible_trash_directory() / "files"
+
+
+def _visible_trash_info_directory() -> Path:
+    return _visible_trash_directory() / "info"
+
+
+def _decode_mountinfo_path(value: str) -> str:
+    decoded = ""
+    index = 0
+    while index < len(value):
+        if (
+            value[index] == "\\"
+            and index + 3 < len(value)
+            and all(char in "01234567" for char in value[index + 1 : index + 4])
+        ):
+            decoded += chr(int(value[index + 1 : index + 4], 8))
+            index += 4
+            continue
+        decoded += value[index]
+        index += 1
+    return decoded
+
+
+def _mount_points() -> tuple[Path, ...]:
+    try:
+        lines = Path("/proc/self/mountinfo").read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        log.bind(action="discover_trash_roots").debug(
+            "Could not read mountinfo: %s",
+            exc,
+        )
+        return ()
+
+    mount_points: list[Path] = []
+    for line in lines:
+        fields = line.split()
+        if len(fields) < 5:
+            continue
+        mount_point = Path(_decode_mountinfo_path(fields[4]))
+        if mount_point not in mount_points:
+            mount_points.append(mount_point)
+    return tuple(mount_points)
+
+
+def _path_exists(path: Path) -> bool:
+    try:
+        return path.exists()
+    except OSError as exc:
+        log.bind(action="discover_trash_roots").debug(
+            "Could not stat trash path %s: %s",
+            path,
+            exc,
+        )
+        return False
+
+
+def _volume_trash_directories() -> tuple[Path, ...]:
+    uid = os.getuid()
+    directories: list[Path] = []
+    for mount_point in _mount_points():
+        for directory in (
+            mount_point / f".Trash-{uid}",
+            mount_point / ".Trash" / str(uid),
+        ):
+            if _path_exists(directory) and directory not in directories:
+                directories.append(directory)
+    return tuple(directories)
+
+
+def _visible_trash_directories() -> tuple[Path, ...]:
+    directories = [_visible_trash_directory()]
+    for directory in _volume_trash_directories():
+        if directory not in directories:
+            directories.append(directory)
+    return tuple(directories)
+
+
+def _visible_trash_files_directories() -> tuple[Path, ...]:
+    return tuple(directory / "files" for directory in _visible_trash_directories())
+
+
+def _visible_trash_info_directories() -> tuple[Path, ...]:
+    return tuple(directory / "info" for directory in _visible_trash_directories())
+
+
+def _count_visible_trash_files(*, action: str) -> int:
+    count = 0
+    for files_dir in _visible_trash_files_directories():
+        try:
+            count += sum(1 for _child in files_dir.iterdir())
+        except OSError as exc:
+            log.bind(action=action).debug("Could not enumerate trash files: %s", exc)
+    return count
 
 
 def _kde_kiorc_file() -> Path:
@@ -205,6 +303,7 @@ class GioTrashBackend:
 
     name = "gio"
     uri = "trash:///"
+    use_visible_trash_files = False
     confirm_trash_key = "confirm-trash"
     dbus_targets: tuple[tuple[str, str], ...] = (
         ("org.mate.Caja", "/org/mate/Caja"),
@@ -214,15 +313,8 @@ class GioTrashBackend:
     open_commands: tuple[tuple[str, ...], ...] = ()
 
     def count_items(self) -> int:
-        if is_flatpak():
-            files_dir = _visible_trash_files_directory()
-            try:
-                return sum(1 for _child in files_dir.iterdir())
-            except OSError as exc:
-                log.bind(action="count_items").debug(
-                    "Could not enumerate visible trash files: %s", exc
-                )
-                return 0
+        if is_flatpak() or self.use_visible_trash_files:
+            return _count_visible_trash_files(action="count_items")
 
         trash = Gio.File.new_for_uri(self.uri)
         try:
@@ -233,7 +325,7 @@ class GioTrashBackend:
             log.bind(action="count_items").debug(
                 "Could not enumerate trash items: %s", exc
             )
-            return 0
+            return _count_visible_trash_files(action="count_items_fallback")
 
         count = 0
         while enumerator.next_file(None) is not None:
@@ -241,10 +333,13 @@ class GioTrashBackend:
         enumerator.close(None)
         return count
 
-    def monitor_file(self) -> Gio.File:
-        if is_flatpak():
-            return Gio.File.new_for_path(str(_visible_trash_files_directory()))
-        return Gio.File.new_for_uri(self.uri)
+    def monitor_files(self) -> tuple[Gio.File, ...]:
+        if is_flatpak() or self.use_visible_trash_files:
+            return tuple(
+                Gio.File.new_for_path(str(path))
+                for path in _visible_trash_files_directories()
+            )
+        return (Gio.File.new_for_uri(self.uri),)
 
     def open(self) -> None:
         _open_trash_uri(self.uri, fallback_commands=self.open_commands)
@@ -318,6 +413,10 @@ class GioTrashBackend:
         return False
 
     def _delete_contents(self) -> None:
+        if self.use_visible_trash_files:
+            self._delete_visible_trash_contents()
+            return
+
         trash = Gio.File.new_for_uri(self.uri)
         try:
             enumerator = trash.enumerate_children(
@@ -328,6 +427,7 @@ class GioTrashBackend:
                 "Could not enumerate trash for deletion: %s",
                 exc,
             )
+            self._delete_visible_trash_contents()
             return
 
         while True:
@@ -345,6 +445,43 @@ class GioTrashBackend:
                 )
         enumerator.close(None)
 
+    def _delete_visible_trash_contents(self) -> None:
+        for directory in _visible_trash_files_directories():
+            self._delete_directory_contents(directory)
+        for directory in _visible_trash_info_directories():
+            self._delete_directory_contents(directory)
+
+    def _delete_directory_contents(self, directory: Path) -> None:
+        try:
+            children = list(directory.iterdir())
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            log.bind(action="empty_trash_delete").debug(
+                "Could not enumerate trash directory %s: %s",
+                directory,
+                exc,
+            )
+            return
+
+        for child in children:
+            self._delete_path(child)
+
+    def _delete_path(self, path: Path) -> None:
+        try:
+            if path.is_dir() and not path.is_symlink():
+                for child in path.iterdir():
+                    self._delete_path(child)
+                path.rmdir()
+            else:
+                path.unlink()
+        except OSError as exc:
+            log.bind(action="empty_trash_delete").debug(
+                "Could not delete trash item %s: %s",
+                path,
+                exc,
+            )
+
 
 class GnomeTrashBackend(GioTrashBackend):
     """Trash backend for GNOME/Nautilus sessions."""
@@ -358,6 +495,7 @@ class MateTrashBackend(GioTrashBackend):
     """Trash backend for MATE/Caja sessions."""
 
     name = "mate"
+    use_visible_trash_files = True
     dbus_targets = (("org.mate.Caja", "/org/mate/Caja"),)
     open_commands = (("caja", "trash:///"),)
     confirmation_schema = (
@@ -394,26 +532,13 @@ class KdeTrashBackend:
     )
 
     def count_items(self) -> int:
-        # Inside Flatpak, trash:/// enumeration can report the sandbox trash.
-        # The host trash files are visible through home access, so count them.
-        files_dir = (
-            _visible_trash_files_directory()
-            if is_flatpak()
-            else _kde_trash_files_directory()
-        )
-        try:
-            return sum(1 for _child in files_dir.iterdir())
-        except OSError as exc:
-            log.bind(action="count_kde_items").debug(
-                "Could not enumerate KDE trash items: %s",
-                exc,
-            )
-            return 0
+        return _count_visible_trash_files(action="count_kde_items")
 
-    def monitor_file(self) -> Gio.File:
-        if is_flatpak():
-            return Gio.File.new_for_path(str(_visible_trash_files_directory()))
-        return Gio.File.new_for_path(str(_kde_trash_files_directory()))
+    def monitor_files(self) -> tuple[Gio.File, ...]:
+        return tuple(
+            Gio.File.new_for_path(str(path))
+            for path in _visible_trash_files_directories()
+        )
 
     def open(self) -> None:
         command = self._available_open_command()
@@ -480,8 +605,10 @@ class KdeTrashBackend:
         return None
 
     def _delete_contents(self) -> None:
-        self._delete_directory_contents(_kde_trash_files_directory())
-        self._delete_directory_contents(_kde_trash_info_directory())
+        for directory in _visible_trash_files_directories():
+            self._delete_directory_contents(directory)
+        for directory in _visible_trash_info_directories():
+            self._delete_directory_contents(directory)
 
     def _delete_directory_contents(self, directory: Path) -> None:
         try:

--- a/tests/applets/test_trash.py
+++ b/tests/applets/test_trash.py
@@ -15,11 +15,15 @@ from docking.applets.trash.backend import (
     GnomeTrashBackend,
     KdeTrashBackend,
     MateTrashBackend,
+    _decode_mountinfo_path,
     _empty_host_trash,
     _host_user_data_home,
     _kde_kiorc_file,
     _open_trash_uri,
+    _visible_trash_files_directories,
     _visible_trash_files_directory,
+    _visible_trash_info_directories,
+    _visible_trash_info_directory,
     select_trash_backend,
 )
 from docking.platform.environment import Desktop
@@ -34,6 +38,81 @@ class TestHelperFunctions:
         monkeypatch.setattr("docking.applets.trash.backend.is_flatpak", lambda: False)
         result = _visible_trash_files_directory()
         assert result == Path("/tmp/test-xdg/data") / "Trash" / "files"
+
+    def test_visible_trash_info_directory_not_flatpak(self, monkeypatch):
+        monkeypatch.setenv("XDG_DATA_HOME", "/tmp/test-xdg/data")
+        monkeypatch.setattr("docking.applets.trash.backend.is_flatpak", lambda: False)
+        result = _visible_trash_info_directory()
+        assert result == Path("/tmp/test-xdg/data") / "Trash" / "info"
+
+    def test_decode_mountinfo_path(self):
+        assert _decode_mountinfo_path("/media/User\\040Disk") == "/media/User Disk"
+        assert (
+            _decode_mountinfo_path("/tmp/backslash\\134path") == "/tmp/backslash\\path"
+        )
+
+    def test_visible_trash_directories_include_mounted_volume_trash(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        mount = tmp_path / "media" / "ARCHIVES"
+        volume_trash = mount / ".Trash-1000"
+        volume_trash.mkdir(parents=True)
+        monkeypatch.setenv("XDG_DATA_HOME", str(home))
+        monkeypatch.setattr("docking.applets.trash.backend.is_flatpak", lambda: False)
+        monkeypatch.setattr("docking.applets.trash.backend.os.getuid", lambda: 1000)
+        monkeypatch.setattr(
+            "docking.applets.trash.backend._mount_points",
+            lambda: (mount,),
+        )
+
+        assert _visible_trash_files_directories() == (
+            home / "Trash" / "files",
+            volume_trash / "files",
+        )
+        assert _visible_trash_info_directories() == (
+            home / "Trash" / "info",
+            volume_trash / "info",
+        )
+
+    def test_visible_trash_directories_include_shared_volume_trash(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        mount = tmp_path / "media" / "SHARED"
+        volume_trash = mount / ".Trash" / "1000"
+        volume_trash.mkdir(parents=True)
+        monkeypatch.setenv("XDG_DATA_HOME", str(home))
+        monkeypatch.setattr("docking.applets.trash.backend.is_flatpak", lambda: False)
+        monkeypatch.setattr("docking.applets.trash.backend.os.getuid", lambda: 1000)
+        monkeypatch.setattr(
+            "docking.applets.trash.backend._mount_points",
+            lambda: (mount,),
+        )
+
+        assert _visible_trash_files_directories() == (
+            home / "Trash" / "files",
+            volume_trash / "files",
+        )
+
+    def test_visible_trash_directories_ignore_unstatable_mounts(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        bad_mount = tmp_path / "media" / "bad"
+        monkeypatch.setenv("XDG_DATA_HOME", str(home))
+        monkeypatch.setattr("docking.applets.trash.backend.is_flatpak", lambda: False)
+        monkeypatch.setattr("docking.applets.trash.backend.os.getuid", lambda: 1000)
+        monkeypatch.setattr(
+            "docking.applets.trash.backend._mount_points",
+            lambda: (bad_mount,),
+        )
+        monkeypatch.setattr(
+            "docking.applets.trash.backend.Path.exists",
+            lambda self: (_ for _ in ()).throw(OSError("stale mount")),
+        )
+
+        assert _visible_trash_files_directories() == (home / "Trash" / "files",)
 
     def test_kde_kiorc_file_not_flatpak(self, monkeypatch):
         monkeypatch.setenv("XDG_CONFIG_HOME", "/tmp/test-xdg/config")
@@ -212,17 +291,70 @@ class TestGioTrashBackend:
         # Then
         assert count == 3
 
-    def test_returns_zero_on_count_error(self):
+    def test_returns_zero_on_count_error(self, tmp_path):
         # Given enumerate_children raises
         from gi.repository import GLib
 
+        missing_files_dir = tmp_path / "missing" / "Trash" / "files"
         mock_file = MagicMock()
         mock_file.enumerate_children.side_effect = GLib.Error("fail")
 
-        with patch(
-            "docking.applets.trash.backend.Gio.File.new_for_uri", return_value=mock_file
+        with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=False),
+            patch(
+                "docking.applets.trash.backend._visible_trash_files_directories",
+                return_value=(missing_files_dir,),
+            ),
+            patch(
+                "docking.applets.trash.backend.Gio.File.new_for_uri",
+                return_value=mock_file,
+            ),
         ):
             assert GioTrashBackend().count_items() == 0
+
+    def test_falls_back_to_visible_trash_files_on_count_error(self, tmp_path):
+        from gi.repository import GLib
+
+        files_dir = tmp_path / "Trash" / "files"
+        files_dir.mkdir(parents=True)
+        (files_dir / "a.txt").write_text("a")
+        (files_dir / "b.txt").write_text("b")
+        mock_file = MagicMock()
+        mock_file.enumerate_children.side_effect = GLib.Error("unsupported")
+
+        with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=False),
+            patch(
+                "docking.applets.trash.backend._visible_trash_files_directories",
+                return_value=(files_dir,),
+            ),
+            patch(
+                "docking.applets.trash.backend.Gio.File.new_for_uri",
+                return_value=mock_file,
+            ),
+        ):
+            assert GioTrashBackend().count_items() == 2
+
+    def test_mate_counts_visible_trash_files_directly(self, tmp_path):
+        files_dir = tmp_path / "Trash" / "files"
+        volume_files_dir = tmp_path / "Volume" / ".Trash-1000" / "files"
+        files_dir.mkdir(parents=True)
+        volume_files_dir.mkdir(parents=True)
+        (files_dir / "a.txt").write_text("a")
+        (files_dir / "b.txt").write_text("b")
+        (volume_files_dir / "c.txt").write_text("c")
+
+        with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=False),
+            patch(
+                "docking.applets.trash.backend._visible_trash_files_directories",
+                return_value=(files_dir, volume_files_dir),
+            ),
+            patch("docking.applets.trash.backend.Gio.File.new_for_uri") as new_for_uri,
+        ):
+            assert MateTrashBackend().count_items() == 3
+
+        new_for_uri.assert_not_called()
 
     def test_counts_visible_trash_files_in_flatpak(self, tmp_path):
         files_dir = tmp_path / "Trash" / "files"
@@ -233,8 +365,8 @@ class TestGioTrashBackend:
         with (
             patch("docking.applets.trash.backend.is_flatpak", return_value=True),
             patch(
-                "docking.applets.trash.backend._visible_trash_files_directory",
-                return_value=files_dir,
+                "docking.applets.trash.backend._visible_trash_files_directories",
+                return_value=(files_dir,),
             ),
             patch("docking.applets.trash.backend.Gio.File.new_for_uri") as new_for_uri,
         ):
@@ -246,15 +378,32 @@ class TestGioTrashBackend:
         with (
             patch("docking.applets.trash.backend.is_flatpak", return_value=True),
             patch(
-                "docking.applets.trash.backend._visible_trash_files_directory",
-                return_value=tmp_path,
+                "docking.applets.trash.backend._visible_trash_files_directories",
+                return_value=(tmp_path,),
             ),
             patch(
                 "docking.applets.trash.backend.Gio.File.new_for_path"
             ) as new_for_path,
             patch("docking.applets.trash.backend.Gio.File.new_for_uri") as new_for_uri,
         ):
-            GioTrashBackend().monitor_file()
+            GioTrashBackend().monitor_files()
+
+        new_for_path.assert_called_once_with(str(tmp_path))
+        new_for_uri.assert_not_called()
+
+    def test_mate_monitor_uses_visible_trash_files(self, tmp_path):
+        with (
+            patch("docking.applets.trash.backend.is_flatpak", return_value=False),
+            patch(
+                "docking.applets.trash.backend._visible_trash_files_directories",
+                return_value=(tmp_path,),
+            ),
+            patch(
+                "docking.applets.trash.backend.Gio.File.new_for_path"
+            ) as new_for_path,
+            patch("docking.applets.trash.backend.Gio.File.new_for_uri") as new_for_uri,
+        ):
+            MateTrashBackend().monitor_files()
 
         new_for_path.assert_called_once_with(str(tmp_path))
         new_for_uri.assert_not_called()
@@ -530,16 +679,62 @@ class TestGioTrashBackend:
         child_b.delete.assert_called_once()
         enumerator.close.assert_called_once()
 
-    def test_delete_contents_handles_enumerate_error(self):
+    def test_delete_contents_handles_enumerate_error(self, tmp_path):
         from gi.repository import GLib
 
         trash = MagicMock()
         trash.enumerate_children.side_effect = GLib.Error("enumerate fail")
+        files_dir = tmp_path / "Trash" / "files"
+        info_dir = tmp_path / "Trash" / "info"
 
-        with patch(
-            "docking.applets.trash.backend.Gio.File.new_for_uri", return_value=trash
+        with (
+            patch(
+                "docking.applets.trash.backend._visible_trash_files_directories",
+                return_value=(files_dir,),
+            ),
+            patch(
+                "docking.applets.trash.backend._visible_trash_info_directories",
+                return_value=(info_dir,),
+            ),
+            patch(
+                "docking.applets.trash.backend.Gio.File.new_for_uri",
+                return_value=trash,
+            ),
         ):
             GioTrashBackend()._delete_contents()
+
+    def test_delete_contents_falls_back_to_visible_trash_directories(self, tmp_path):
+        from gi.repository import GLib
+
+        files_dir = tmp_path / "Trash" / "files"
+        info_dir = tmp_path / "Trash" / "info"
+        nested_dir = files_dir / "nested"
+        nested_dir.mkdir(parents=True)
+        info_dir.mkdir(parents=True)
+        (files_dir / "a.txt").write_text("a")
+        (nested_dir / "b.txt").write_text("b")
+        (info_dir / "a.txt.trashinfo").write_text("[Trash Info]")
+        trash = MagicMock()
+        trash.enumerate_children.side_effect = GLib.Error("enumerate fail")
+
+        with (
+            patch(
+                "docking.applets.trash.backend._visible_trash_files_directories",
+                return_value=(files_dir,),
+            ),
+            patch(
+                "docking.applets.trash.backend._visible_trash_info_directories",
+                return_value=(info_dir,),
+            ),
+            patch(
+                "docking.applets.trash.backend.Gio.File.new_for_uri",
+                return_value=trash,
+            ),
+        ):
+            GioTrashBackend()._delete_contents()
+
+        assert list(files_dir.iterdir()) == []
+        assert list(info_dir.iterdir()) == []
 
     def test_delete_contents_child_error(self):
         from gi.repository import GLib
@@ -565,8 +760,8 @@ class TestGioTrashBackend:
 
         monkeypatch.setattr("docking.applets.trash.backend.is_flatpak", lambda: True)
         monkeypatch.setattr(
-            "docking.applets.trash.backend._visible_trash_files_directory",
-            lambda: Path("/nonexistent/path"),
+            "docking.applets.trash.backend._visible_trash_files_directories",
+            lambda: (Path("/nonexistent/path"),),
         )
         assert GioTrashBackend().count_items() == 0
 
@@ -678,6 +873,7 @@ class TestKdeTrashBackend:
         (files_dir / "a.txt").write_text("a")
         (files_dir / "b.txt").write_text("b")
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        monkeypatch.setattr("docking.applets.trash.backend._mount_points", lambda: ())
 
         assert KdeTrashBackend().count_items() == 2
 
@@ -714,14 +910,14 @@ class TestKdeTrashBackend:
     def test_monitor_uses_kde_trash_files(self, tmp_path):
         with (
             patch(
-                "docking.applets.trash.backend._kde_trash_files_directory",
-                return_value=tmp_path,
+                "docking.applets.trash.backend._visible_trash_files_directories",
+                return_value=(tmp_path,),
             ),
             patch(
                 "docking.applets.trash.backend.Gio.File.new_for_path",
             ) as new_for_path,
         ):
-            KdeTrashBackend().monitor_file()
+            KdeTrashBackend().monitor_files()
 
         new_for_path.assert_called_once_with(str(tmp_path))
 
@@ -733,8 +929,8 @@ class TestKdeTrashBackend:
         (files_dir / "a.txt").write_text("a")
         monkeypatch.setattr("docking.applets.trash.backend.is_flatpak", lambda: True)
         monkeypatch.setattr(
-            "docking.applets.trash.backend._visible_trash_files_directory",
-            lambda: files_dir,
+            "docking.applets.trash.backend._visible_trash_files_directories",
+            lambda: (files_dir,),
         )
 
         assert KdeTrashBackend().count_items() == 1
@@ -824,6 +1020,7 @@ class TestKdeTrashBackend:
 
     def test_kde_count_items_handles_oserror(self, tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_DATA_HOME", "/nonexistent/path")
+        monkeypatch.setattr("docking.applets.trash.backend._mount_points", lambda: ())
         assert KdeTrashBackend().count_items() == 0
 
     def test_kde_open_falls_back_to_gio_on_oserror(self, monkeypatch):
@@ -896,7 +1093,7 @@ class TestKdeTrashBackend:
             result = _open_host_trash_uri(uri="trash:///")
             assert result is False
 
-    def test_monitor_file_not_flatpak_uses_uri(self):
+    def test_monitor_files_not_flatpak_uses_uri(self):
         with (
             patch("docking.applets.trash.backend.is_flatpak", return_value=False),
             patch("docking.applets.trash.backend.Gio.File.new_for_uri") as new_for_uri,
@@ -904,7 +1101,7 @@ class TestKdeTrashBackend:
                 "docking.applets.trash.backend.Gio.File.new_for_path"
             ) as new_for_path,
         ):
-            GioTrashBackend().monitor_file()
+            GioTrashBackend().monitor_files()
         new_for_uri.assert_called_once_with("trash:///")
         new_for_path.assert_not_called()
 
@@ -924,15 +1121,16 @@ class TestKdeTrashBackend:
             new_for_uri.return_value = trash
             backend.empty(lambda: False)
 
-    def test_kde_monitor_file_not_flatpak(self, tmp_path, monkeypatch):
+    def test_kde_monitor_files_not_flatpak(self, tmp_path, monkeypatch):
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        monkeypatch.setattr("docking.applets.trash.backend._mount_points", lambda: ())
         with (
             patch("docking.applets.trash.backend.is_flatpak", return_value=False),
             patch(
                 "docking.applets.trash.backend.Gio.File.new_for_path"
             ) as new_for_path,
         ):
-            KdeTrashBackend().monitor_file()
+            KdeTrashBackend().monitor_files()
         new_for_path.assert_called_once()
 
     def test_kde_delete_directory_contents_file_not_found(self, tmp_path):
@@ -998,14 +1196,15 @@ class _StubBackend:
         self.monitor = MagicMock()
         self.monitor_file_mock = MagicMock()
         self.monitor_file_mock.monitor.return_value = self.monitor
+        self.monitor_files_mock = (self.monitor_file_mock,)
         self.open_calls = 0
         self.empty_confirm: Callable[[], bool] | None = None
 
     def count_items(self) -> int:
         return self.item_count
 
-    def monitor_file(self):
-        return self.monitor_file_mock
+    def monitor_files(self):
+        return self.monitor_files_mock
 
     def open(self) -> None:
         self.open_calls += 1
@@ -1081,16 +1280,25 @@ class TestTrashAppletLifecycle:
     def test_start_sets_monitor_and_stop_cancels(self, monkeypatch):
         backend = _StubBackend()
         applet = _make_applet(monkeypatch, backend)
+        volume_monitor = MagicMock()
+        volume_monitor.connect.side_effect = [10, 11]
 
-        applet.start(lambda: None)
+        with patch(
+            "docking.applets.trash.applet.Gio.VolumeMonitor.get",
+            return_value=volume_monitor,
+        ):
+            applet.start(lambda: None)
 
-        assert applet._monitor is backend.monitor
+        assert applet._monitors == [backend.monitor]
         backend.monitor.connect.assert_called_once()
+        assert volume_monitor.connect.call_count == 2
 
         applet.stop()
 
         backend.monitor.cancel.assert_called_once()
-        assert applet._monitor is None
+        volume_monitor.disconnect.assert_any_call(10)
+        volume_monitor.disconnect.assert_any_call(11)
+        assert applet._monitors == []
 
     def test_start_handles_monitor_error(self, monkeypatch):
         from gi.repository import GLib
@@ -1098,10 +1306,72 @@ class TestTrashAppletLifecycle:
         backend = _StubBackend()
         backend.monitor_file_mock.monitor.side_effect = GLib.Error("monitor error")
         applet = _make_applet(monkeypatch, backend)
+        volume_monitor = MagicMock()
+        volume_monitor.connect.side_effect = [10, 11]
 
-        applet.start(lambda: None)
+        with patch(
+            "docking.applets.trash.applet.Gio.VolumeMonitor.get",
+            return_value=volume_monitor,
+        ):
+            applet.start(lambda: None)
 
-        assert applet._monitor is None
+        assert applet._monitors == []
+        applet.stop()
+
+    def test_start_monitors_all_backend_files_and_continues_after_error(
+        self, monkeypatch
+    ):
+        from gi.repository import GLib
+
+        backend = _StubBackend()
+        good_file = MagicMock()
+        bad_file = MagicMock()
+        good_monitor = MagicMock()
+        good_file.monitor.return_value = good_monitor
+        bad_file.monitor.side_effect = GLib.Error("monitor error")
+        backend.monitor_files_mock = (bad_file, good_file)
+        applet = _make_applet(monkeypatch, backend)
+        volume_monitor = MagicMock()
+        volume_monitor.connect.side_effect = [10, 11]
+
+        with patch(
+            "docking.applets.trash.applet.Gio.VolumeMonitor.get",
+            return_value=volume_monitor,
+        ):
+            applet.start(lambda: None)
+
+        assert applet._monitors == [good_monitor]
+        good_monitor.connect.assert_called_once()
+        applet.stop()
+
+    def test_mount_change_rebuilds_monitors_and_recounts(self, monkeypatch):
+        backend = _StubBackend(item_count=1)
+        old_monitor = MagicMock()
+        old_file = MagicMock()
+        old_file.monitor.return_value = old_monitor
+        new_monitor = MagicMock()
+        new_file = MagicMock()
+        new_file.monitor.return_value = new_monitor
+        backend.monitor_files_mock = (old_file,)
+        applet = _make_applet(monkeypatch, backend)
+        volume_monitor = MagicMock()
+        volume_monitor.connect.side_effect = [10, 11]
+
+        with patch(
+            "docking.applets.trash.applet.Gio.VolumeMonitor.get",
+            return_value=volume_monitor,
+        ):
+            applet.start(lambda: None)
+
+        backend.monitor_files_mock = (new_file,)
+        backend.item_count = 4
+
+        applet._on_mounts_changed()
+
+        old_monitor.cancel.assert_called_once()
+        assert applet._monitors == [new_monitor]
+        assert applet._item_count == 4
+        applet.stop()
 
     def test_on_clicked_delegates_to_backend(self, monkeypatch):
         backend = _StubBackend()


### PR DESCRIPTION
## Summary
- count visible trash items across home and mounted-volume freedesktop trash locations
- monitor all discovered trash file directories and rebuild monitors when mounts change
- guard trash root discovery against unstatable/stale mount paths