### PR TITLE
Isolate model notification failures

### DIFF
--- a/docking/platform/model.py
+++ b/docking/platform/model.py
@@ -1286,7 +1286,13 @@ class DockModel:
         safely while notifications are in flight.
         """
         for callback in list(self._change_listeners):
-            callback()
+            try:
+                callback()
+            except Exception:
+                log.bind(
+                    action="notify_listener",
+                    listener=repr(callback),
+                ).exception("Model change listener failed")
 
     def tick_animations(self) -> bool:
         """Advance insert/remove animations. Returns True if any are active."""

--- a/tests/platform/test_model.py
+++ b/tests/platform/test_model.py
@@ -474,6 +474,42 @@ class TestCallbacks:
 
         assert calls == ["first", "second"]
 
+    def test_failing_change_listener_does_not_block_later_listener(self):
+        config = _make_config(["a.desktop"])
+        launcher = _make_launcher("a.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        good = MagicMock()
+
+        def bad() -> None:
+            raise RuntimeError("listener failed")
+
+        model.add_change_listener(bad)
+        model.add_change_listener(good)
+
+        model.notify()
+
+        good.assert_called_once()
+
+    def test_multiple_failing_change_listeners_do_not_block_later_listener(self):
+        config = _make_config(["a.desktop"])
+        launcher = _make_launcher("a.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        good = MagicMock()
+
+        def first_bad() -> None:
+            raise RuntimeError("first failed")
+
+        def second_bad() -> None:
+            raise RuntimeError("second failed")
+
+        model.add_change_listener(first_bad)
+        model.add_change_listener(second_bad)
+        model.add_change_listener(good)
+
+        model.notify()
+
+        good.assert_called_once()
+
     def test_listener_can_remove_itself_during_notify(self):
         config = _make_config(["a.desktop"])
         launcher = _make_launcher("a.desktop")


### PR DESCRIPTION
## Summary
- catch and log exceptions from individual DockModel change listeners
- continue notifying later listeners in registration order
- keep failing listeners registered so repeated failures remain visible