### PR TITLE
Reduce idle CPU usage

### DIFF
--- a/docking/applets/bluetooth/applet.py
+++ b/docking/applets/bluetooth/applet.py
@@ -446,7 +446,8 @@ class BluetoothApplet(Applet):
         return menu_item
 
     def _tick(self) -> bool:
-        self._worker.run(
+        self._worker.run_guarded(
+            key="poll",
             name="bluetooth-poll",
             fn=lambda: self._backend.get_state(
                 active_adapter_path=self._active_adapter_path
@@ -460,6 +461,9 @@ class BluetoothApplet(Applet):
         return True
 
     def _on_poll_result(self, state: BluetoothState) -> bool:
+        previous_state = self._state
+        previous_adapter_path = self._active_adapter_path
+        previous_local_discovery_active = self._local_discovery_active
         self._state = state
         self._sync_selected_adapter()
         self._record_recent_connections(state)
@@ -469,7 +473,12 @@ class BluetoothApplet(Applet):
             # still be active.
             self._local_discovery_active = False
         self._ensure_discovery()
-        self.present()
+        if (
+            state != previous_state
+            or self._active_adapter_path != previous_adapter_path
+            or self._local_discovery_active != previous_local_discovery_active
+        ):
+            self.present()
         return False
 
     def _refresh_now(self) -> None:
@@ -488,6 +497,8 @@ class BluetoothApplet(Applet):
             preferred_path=self._active_adapter_path,
         )
         if selected is not None:
+            if selected == self._active_adapter_path:
+                return
             self._active_adapter_path = selected
             if persist:
                 self._save_prefs()

--- a/docking/applets/currencyfx/applet.py
+++ b/docking/applets/currencyfx/applet.py
@@ -88,6 +88,7 @@ DIALOG_SPACING_PX = 8
 DIALOG_MARGIN_PX = 12
 _PULSE_INTERVAL_MS = 60
 _PULSE_PERIOD_MS = 1800
+_PULSE_DURATION_MS = 6000
 
 
 class CurrencyFxApplet(Applet):
@@ -113,6 +114,7 @@ class CurrencyFxApplet(Applet):
         self._startup_fetch_timer_id: int = 0
         self._pulse_timer_id: int = 0
         self._pulse_phase: float = 0.0
+        self._pulse_started_us: int = 0
         self._fetch_request_id: int = 0
         self._snapshot: FxSnapshot | None = None
         self._loading = False
@@ -544,6 +546,7 @@ class CurrencyFxApplet(Applet):
         """Run the endpoint pulse only while the chart dot is visible."""
         should_pulse = self._notify is not None and self._has_chart_dot()
         if should_pulse and not self._pulse_timer_id:
+            self._pulse_started_us = GLib.get_monotonic_time()
             self._pulse_timer_id = GLib.timeout_add(
                 _PULSE_INTERVAL_MS,
                 self._pulse_tick,
@@ -552,9 +555,21 @@ class CurrencyFxApplet(Applet):
             GLib.source_remove(self._pulse_timer_id)
             self._pulse_timer_id = 0
             self._pulse_phase = 0.0
+            self._pulse_started_us = 0
 
     def _pulse_tick(self) -> bool:
         """Advance pulse phase and repaint only the icon."""
+        now_us = GLib.get_monotonic_time()
+        if self._pulse_started_us and (
+            now_us - self._pulse_started_us >= _PULSE_DURATION_MS * 1000
+        ):
+            self._pulse_timer_id = 0
+            self._pulse_phase = 0.0
+            self._pulse_started_us = 0
+            self.item.icon = self.create_icon(size=self._icon_size)
+            if self._notify:
+                self._notify()
+            return False
         self._pulse_phase = (
             self._pulse_phase + _PULSE_INTERVAL_MS / _PULSE_PERIOD_MS
         ) % 1.0

--- a/docking/applets/weather/api.py
+++ b/docking/applets/weather/api.py
@@ -36,6 +36,7 @@ log = with_context(get_logger(name="weather.api"), applet_id=meta.id)
 REFRESH_INTERVAL = 300  # 5 minutes
 API_RETRY_COUNT = 5
 API_RETRY_BACKOFF_FACTOR = 0.2
+API_TIMEOUT_S = 5
 
 _CACHE_DIR = docking_cache_dir() / "weather"
 
@@ -163,6 +164,7 @@ def fetch_weather(lat: float, lng: float) -> WeatherData | None:
                 ],
                 "forecast_days": 5,
             },
+            timeout=API_TIMEOUT_S,
         )
         resp = responses[0]
 
@@ -247,6 +249,7 @@ def fetch_air_quality(lat: float, lng: float) -> AirQualityData | None:
                 "longitude": lng,
                 "current": ["european_aqi", "pm10", "pm2_5", "uv_index"],
             },
+            timeout=API_TIMEOUT_S,
         )
         current = responses[0].Current()
         aqi = int(current.Variables(0).Value())

--- a/docking/applets/weather/applet.py
+++ b/docking/applets/weather/applet.py
@@ -91,6 +91,7 @@ class WeatherApplet(Applet):
         self._air_quality: AirQualityData | None = None
         self._last_updated: dt.datetime | None = None
         self._loading = False
+        self._fetch_pending = False
         self._fetch_failed = False
         self._fetch_error = ""
         self._worker = BackgroundWorker(logger=log)
@@ -140,6 +141,7 @@ class WeatherApplet(Applet):
         self._air_quality = None
         self._last_updated = None
         self._loading = False
+        self._fetch_pending = False
         self._fetch_failed = False
         self._fetch_error = ""
         self._save_prefs()
@@ -342,6 +344,7 @@ class WeatherApplet(Applet):
                 self._air_quality = None
                 self._last_updated = None
                 self._loading = False
+                self._fetch_pending = False
                 self._fetch_failed = False
                 self._fetch_error = ""
                 self._save_prefs()
@@ -354,6 +357,7 @@ class WeatherApplet(Applet):
         self._air_quality = None
         self._last_updated = None
         self._loading = False
+        self._fetch_pending = False
         self._fetch_failed = False
         self._fetch_error = ""
         self._save_prefs()
@@ -369,6 +373,7 @@ class WeatherApplet(Applet):
         self._air_quality = None
         self._last_updated = None
         self._loading = False
+        self._fetch_pending = False
         self._fetch_failed = False
         self._fetch_error = ""
         self._save_prefs()
@@ -393,22 +398,29 @@ class WeatherApplet(Applet):
         if self._startup_fetch_timer_id:
             GLib.source_remove(self._startup_fetch_timer_id)
             self._startup_fetch_timer_id = 0
+        if self._loading:
+            self._fetch_pending = True
+            return
 
         self._fetch_request_id += 1
         request_id = self._fetch_request_id
         lat = active.lat
         lng = active.lng
         self._loading = True
+        self._fetch_pending = False
         self._fetch_failed = False
         self._fetch_error = ""
         self.present()
 
         def fetch() -> tuple[WeatherData | None, AirQualityData | None]:
             weather = fetch_weather(lat=lat, lng=lng)
+            if weather is None:
+                return None, None
             aqi = fetch_air_quality(lat=lat, lng=lng)
             return weather, aqi
 
-        self._worker.run(
+        started = self._worker.run_guarded(
+            key="weather-fetch",
             name="weather-fetch",
             fn=fetch,
             on_result=lambda result: self._on_fetch_result(
@@ -418,6 +430,8 @@ class WeatherApplet(Applet):
             ),
             on_error=lambda exc: self._on_fetch_error(request_id=request_id, exc=exc),
         )
+        if not started:
+            self._fetch_pending = True
 
     def _on_fetch_result(
         self,
@@ -436,7 +450,7 @@ class WeatherApplet(Applet):
             self._last_updated = dt.datetime.now(dt.timezone.utc)
         else:
             self._fetch_error = _("No weather data")
-        self.present()
+        self._present_or_run_pending_fetch()
         return False
 
     def _on_fetch_error(self, *, request_id: int, exc: Exception) -> bool:
@@ -446,8 +460,15 @@ class WeatherApplet(Applet):
         self._loading = False
         self._fetch_failed = True
         self._fetch_error = str(exc) or exc.__class__.__name__
-        self.present()
+        self._present_or_run_pending_fetch()
         return False
+
+    def _present_or_run_pending_fetch(self) -> None:
+        if self._fetch_pending and self._active_city:
+            self._fetch_pending = False
+            self._fetch_async()
+            return
+        self.present()
 
     def _build_tooltip(self) -> str:
         active = self._active_city

--- a/docking/ui/hover.py
+++ b/docking/ui/hover.py
@@ -225,6 +225,7 @@ class HoverManager:
         self.hovered_item: DockItem | None = None
         self._preview_timer_id: int = 0
         self._anim_timer_id: int = 0
+        self._last_animated_urgent_us: int = 0
 
     def set_preview(self, preview: PreviewPopup) -> None:
         self._preview = preview
@@ -327,11 +328,19 @@ class HoverManager:
 
     def on_model_changed(self) -> None:
         """Start anim pump if any item became urgent (needs bounce animation)."""
-        if any(
-            item.is_urgent and item.last_urgent > 0
-            for item in self._model.visible_items()
-        ):
+        urgent_us = max(
+            (
+                item.last_urgent
+                for item in self._model.visible_items()
+                if item.is_urgent and item.last_urgent > 0
+            ),
+            default=0,
+        )
+        if urgent_us > self._last_animated_urgent_us:
+            self._last_animated_urgent_us = urgent_us
             self.start_anim_pump(duration_ms=ANIM_PUMP_DEFAULT_DURATION_MS)
+        elif urgent_us == 0:
+            self._last_animated_urgent_us = 0
 
     def _show_preview(self, item: DockItem, _layout: object) -> bool:
         """Show the preview popup near the hovered icon.

--- a/docking/ui/input_controller.py
+++ b/docking/ui/input_controller.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import gi
@@ -162,7 +163,7 @@ class DockInputController:
             window._schedule_redraw()
 
         frame = window._current_or_build_geometry_frame(drop_insert_index=drop_insert)
-        if current_autohide_state is not None:
+        if current_autohide_state is not None and log.isEnabledFor(logging.DEBUG):
             item_positions = [
                 (
                     f"{geometry.item.desktop_id}@"

--- a/docking/ui/popup_surface.py
+++ b/docking/ui/popup_surface.py
@@ -23,6 +23,8 @@ gi.require_version("Gdk", "3.0")
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, Gtk
 
+from docking.platform.environment import compositor_active
+
 STARTUP_POPUP_WINDOW_CLASS = "dock-startup-popup-window"
 STARTUP_POPUP_SURFACE_CLASS = "dock-startup-popup-surface"
 STARTUP_POPUP_CSS = f"""
@@ -59,6 +61,9 @@ def ensure_startup_popup_css() -> Gtk.CssProvider | None:
 def configure_transparent_startup_popup_window(window: Gtk.Window) -> None:
     """Make an undecorated popup window transparent behind rounded content."""
     ensure_startup_popup_css()
+
+    if compositor_active() is False:
+        return
 
     window.set_app_paintable(True)
 

--- a/tests/applets/test_bluetooth.py
+++ b/tests/applets/test_bluetooth.py
@@ -6,6 +6,7 @@ import logging
 import subprocess
 from dataclasses import replace
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import docking.applets.bluetooth.applet as bluetooth_applet_mod
 import docking.applets.bluetooth.state as bluetooth_state_mod
@@ -1085,7 +1086,7 @@ class TestBluetoothApplet:
     def test_tick_and_discovery_tick(self, monkeypatch):
         applet, _backend = _make_applet(monkeypatch, _state())
         ticked: list[str] = []
-        applet._worker.run = lambda **kwargs: ticked.append("poll")  # type: ignore[assignment]
+        applet._worker.run_guarded = lambda **kwargs: ticked.append("poll") or True  # type: ignore[method-assign]
         applet._ensure_discovery = lambda: ticked.append("discover")  # type: ignore[assignment]
 
         assert applet._tick() is True
@@ -1114,6 +1115,18 @@ class TestBluetoothApplet:
         assert applet._on_poll_result(state) is False
         assert applet._local_discovery_active is False
 
+    def test_on_poll_result_skips_present_when_state_is_unchanged(self, monkeypatch):
+        applet, _backend = _make_applet(monkeypatch, _state())
+        state = applet._state
+        applet._local_discovery_active = False
+        applet._ensure_discovery = lambda: None  # type: ignore[assignment]
+        present = MagicMock()
+        applet.present = present  # type: ignore[method-assign]
+
+        assert applet._on_poll_result(state) is False
+
+        present.assert_not_called()
+
     def test_sync_selected_adapter_active_adapter_and_discovery_flow(self, monkeypatch):
         applet, backend = _make_applet(monkeypatch, _state())
         monkeypatch.setattr(
@@ -1127,6 +1140,10 @@ class TestBluetoothApplet:
         applet._sync_selected_adapter()
         assert applet._active_adapter_path == "/org/bluez/hci0"
         assert saved
+
+        saved.clear()
+        applet._sync_selected_adapter()
+        assert saved == []
 
         applet._state = _state(adapters=())
         assert applet._active_adapter() is None

--- a/tests/applets/test_currencyfx.py
+++ b/tests/applets/test_currencyfx.py
@@ -761,6 +761,11 @@ class TestCurrencyFxApplet:
         pulse_add = MagicMock(return_value=42)
         monkeypatch.setattr(
             currencyfx_applet_mod.GLib,
+            "get_monotonic_time",
+            lambda: 123_000,
+        )
+        monkeypatch.setattr(
+            currencyfx_applet_mod.GLib,
             "timeout_add_seconds",
             add_seconds,
         )
@@ -771,6 +776,7 @@ class TestCurrencyFxApplet:
         applet.start(lambda: None)
 
         assert applet._pulse_timer_id == 42
+        assert applet._pulse_started_us == 123_000
         pulse_add.assert_called_once()
 
     def test_pulse_timer_stops_without_chart_dot(self, monkeypatch):
@@ -787,15 +793,42 @@ class TestCurrencyFxApplet:
         remove.assert_called_once_with(42)
         assert applet._pulse_timer_id == 0
         assert applet._pulse_phase == 0.0
+        assert applet._pulse_started_us == 0
 
-    def test_pulse_tick_advances_phase_and_repaints(self):
+    def test_pulse_tick_advances_phase_and_repaints(self, monkeypatch):
+        monkeypatch.setattr(
+            currencyfx_applet_mod.GLib,
+            "get_monotonic_time",
+            lambda: 1_000_000,
+        )
         applet = _make_applet()
         applet._snapshot = _snapshot()
         applet._notify = MagicMock()
+        applet._pulse_started_us = 1_000_000
 
         assert applet._pulse_tick() is True
 
         assert applet._pulse_phase > 0.0
+        applet._notify.assert_called_once()
+
+    def test_pulse_tick_stops_after_duration(self, monkeypatch):
+        monkeypatch.setattr(
+            currencyfx_applet_mod.GLib,
+            "get_monotonic_time",
+            lambda: 7_100_000,
+        )
+        applet = _make_applet()
+        applet._snapshot = _snapshot()
+        applet._notify = MagicMock()
+        applet._pulse_timer_id = 42
+        applet._pulse_phase = 0.5
+        applet._pulse_started_us = 1_000_000
+
+        assert applet._pulse_tick() is False
+
+        assert applet._pulse_timer_id == 0
+        assert applet._pulse_phase == 0.0
+        assert applet._pulse_started_us == 0
         applet._notify.assert_called_once()
 
     def test_fetch_async_queues_worker(self, monkeypatch):

--- a/tests/applets/test_weather.py
+++ b/tests/applets/test_weather.py
@@ -61,6 +61,19 @@ class _ImmediateWorker:
         if on_result is not None:
             on_result(result)
 
+    def run_guarded(self, **kwargs) -> bool:
+        self.run(**kwargs)
+        return True
+
+
+class _PendingWorker:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def run_guarded(self, **kwargs) -> bool:
+        self.calls.append(kwargs)
+        return True
+
 
 def _make_applet(icon_size: int = 48, *, config: Config | None = None) -> WeatherApplet:
     with patch("docking.applets.weather.applet.BackgroundWorker", _ImmediateWorker):
@@ -562,6 +575,58 @@ class TestWeatherAsyncFetch:
         applet._fetch_async()
         assert captured["lat"] == _TOKYO.lat
         assert captured["lng"] == _TOKYO.lng
+
+    def test_fetch_async_skips_air_quality_when_weather_fails(self, monkeypatch):
+        applet = _make_applet()
+        applet._cities = [_BERLIN]
+        applet._active_index = 0
+        fetch_air_quality = MagicMock(return_value=_SAMPLE_AQI)
+        monkeypatch.setattr(weather_applet_mod, "fetch_weather", lambda **_kw: None)
+        monkeypatch.setattr(
+            weather_applet_mod,
+            "fetch_air_quality",
+            fetch_air_quality,
+        )
+
+        applet._fetch_async()
+
+        fetch_air_quality.assert_not_called()
+        assert applet._fetch_failed is True
+
+    def test_fetch_async_queues_refresh_while_loading(self):
+        applet = _make_applet()
+        worker = _PendingWorker()
+        applet._worker = worker
+        applet._cities = [_BERLIN]
+        applet._active_index = 0
+        applet._loading = True
+
+        applet._fetch_async()
+
+        assert worker.calls == []
+        assert applet._fetch_pending is True
+
+    def test_fetch_result_runs_pending_refresh(self):
+        applet = _make_applet()
+        worker = _PendingWorker()
+        applet._worker = worker
+        applet._cities = [_BERLIN]
+        applet._active_index = 0
+        applet._fetch_request_id = 7
+        applet._loading = True
+        applet._fetch_pending = True
+
+        result = applet._on_fetch_result(
+            request_id=7,
+            weather=_SAMPLE_WEATHER,
+            aqi=_SAMPLE_AQI,
+        )
+
+        assert result is False
+        assert applet._fetch_request_id == 8
+        assert applet._loading is True
+        assert applet._fetch_pending is False
+        assert worker.calls[0]["name"] == "weather-fetch"
 
 
 class TestWeatherLifecycleAndInteractions:

--- a/tests/applets/test_weather_api.py
+++ b/tests/applets/test_weather_api.py
@@ -4,6 +4,7 @@ import pytest
 
 import docking.applets.weather.api as weather_api_mod
 from docking.applets.weather.api import (
+    API_TIMEOUT_S,
     AirQualityData,
     DailyForecast,
     WeatherData,
@@ -134,9 +135,12 @@ class _AqiResp:
 
 class TestWeatherApiFetch:
     def test_fetch_weather_success(self, monkeypatch):
+        calls: list[dict[str, object]] = []
+
         class _Client:
-            def weather_api(self, url, params):
-                _ = (url, params)
+            def weather_api(self, url, params, **kwargs):
+                _ = url
+                calls.append({"params": params, "kwargs": kwargs})
                 return [_WeatherResp()]
 
         monkeypatch.setattr(weather_api_mod, "_get_client", lambda: _Client())
@@ -146,10 +150,12 @@ class TestWeatherApiFetch:
         assert data.weather_code == 61
         assert len(data.daily) == 2
         assert data.daily[0].description == "Clear sky"
+        assert calls[0]["kwargs"] == {"timeout": API_TIMEOUT_S}
 
     def test_fetch_weather_error_returns_none(self, monkeypatch):
         class _Client:
-            def weather_api(self, url, params):
+            def weather_api(self, url, params, **kwargs):
+                _ = (url, params, kwargs)
                 raise OSError("offline")
 
         monkeypatch.setattr(weather_api_mod, "_get_client", lambda: _Client())
@@ -167,9 +173,9 @@ class TestWeatherApiFetch:
         calls: list[dict[str, object]] = []
 
         class _Client:
-            def weather_api(self, url, params):
+            def weather_api(self, url, params, **kwargs):
                 _ = url
-                calls.append(params)
+                calls.append({"params": params, "kwargs": kwargs})
                 return [_AqiResp()]
 
         monkeypatch.setattr(weather_api_mod, "_get_client", lambda: _Client())
@@ -182,15 +188,19 @@ class TestWeatherApiFetch:
         assert data.label == "Fair"
         assert calls == [
             {
-                "latitude": 1.0,
-                "longitude": 2.0,
-                "current": ["european_aqi", "pm10", "pm2_5", "uv_index"],
+                "params": {
+                    "latitude": 1.0,
+                    "longitude": 2.0,
+                    "current": ["european_aqi", "pm10", "pm2_5", "uv_index"],
+                },
+                "kwargs": {"timeout": API_TIMEOUT_S},
             }
         ]
 
     def test_fetch_air_quality_error_returns_none(self, monkeypatch):
         class _Client:
-            def weather_api(self, url, params):
+            def weather_api(self, url, params, **kwargs):
+                _ = (url, params, kwargs)
                 raise ValueError("bad payload")
 
         monkeypatch.setattr(weather_api_mod, "_get_client", lambda: _Client())

--- a/tests/ui/test_hover_integration.py
+++ b/tests/ui/test_hover_integration.py
@@ -277,6 +277,29 @@ class TestHoverTimers:
         # Then
         hover.start_anim_pump.assert_called_once_with(duration_ms=700)
 
+    def test_on_model_changed_does_not_restart_same_urgent_pump(self):
+        hover, _window, model, _config, _tooltip, _frame = _make_hover()
+        urgent = DockItem(desktop_id="u.desktop", is_urgent=True, last_urgent=123)
+        model.visible_items.return_value = [urgent]
+        hover.start_anim_pump = MagicMock()
+
+        hover.on_model_changed()
+        hover.on_model_changed()
+
+        hover.start_anim_pump.assert_called_once_with(duration_ms=700)
+
+    def test_on_model_changed_starts_pump_for_newer_urgent_timestamp(self):
+        hover, _window, model, _config, _tooltip, _frame = _make_hover()
+        urgent = DockItem(desktop_id="u.desktop", is_urgent=True, last_urgent=123)
+        model.visible_items.return_value = [urgent]
+        hover.start_anim_pump = MagicMock()
+
+        hover.on_model_changed()
+        urgent.last_urgent = 456
+        hover.on_model_changed()
+
+        assert hover.start_anim_pump.call_count == 2
+
 
 class TestShowPreview:
     @pytest.mark.parametrize(

--- a/tests/ui/test_popup_surface.py
+++ b/tests/ui/test_popup_surface.py
@@ -144,6 +144,7 @@ def fake_gtk(monkeypatch):
     gtk_ns = _build_gtk_namespace()
     monkeypatch.setattr(ps, "Gtk", gtk_ns)
     monkeypatch.setattr(ps, "Gdk", _build_gdk_namespace())
+    monkeypatch.setattr(ps, "compositor_active", lambda: True)
     return gtk_ns
 
 
@@ -214,6 +215,19 @@ class TestConfigureTransparentStartupPopupWindow:
         assert window.app_paintable is True
         assert window.bg_override is not None
         assert STARTUP_POPUP_WINDOW_CLASS in window.get_style_context().classes
+
+    def test_keeps_window_opaque_without_compositor(self, fake_gtk, monkeypatch):
+        global _default_screen
+        _default_screen = _FakeScreen(rgba_visual=object())
+        monkeypatch.setattr(ps, "compositor_active", lambda: False)
+
+        window = _FakeWindow(screen=_default_screen)
+        configure_transparent_startup_popup_window(window)
+
+        assert window.app_paintable is False
+        assert window.visual is None
+        assert window.bg_override is None
+        assert STARTUP_POPUP_WINDOW_CLASS not in window.get_style_context().classes
 
 
 class TestWrapStartupPopupContent:


### PR DESCRIPTION
## Summary
- coalesce Bluetooth and weather background work so repeated polls/fetches do not stack up
- stop currency pulse repainting after a short duration and avoid repeated urgent animation pumps
- avoid eager debug-only input geometry work and keep startup popups opaque without a compositor