### PR TITLE
Warn when emptying trash fails

### DIFF
--- a/docking/applets/apod/render.py
+++ b/docking/applets/apod/render.py
@@ -24,6 +24,8 @@ gi.require_version("Gdk", "3.0")
 gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import Gdk, GdkPixbuf, GLib
 
+from docking.ui.overlays import draw_warning_badge
+
 
 def _rounded_rect_path(
     cr: cairo.Context,
@@ -150,7 +152,7 @@ def render_icon(
     if pixbuf is None:
         _draw_fallback(cr=cr, size=size)
         if warning:
-            _draw_warning_badge(cr=cr, size=size)
+            draw_warning_badge(cr=cr, size=size)
         return Gdk.pixbuf_get_from_surface(surface, 0, 0, size, size)
 
     # Clip to a rounded square and paint the image edge-to-edge, no backdrop.
@@ -160,20 +162,6 @@ def render_icon(
     _paint_cover(cr=cr, pixbuf=pixbuf, size=size)
     cr.restore()
     if warning:
-        _draw_warning_badge(cr=cr, size=size)
+        draw_warning_badge(cr=cr, size=size)
 
     return Gdk.pixbuf_get_from_surface(surface, 0, 0, size, size)
-
-
-def _draw_warning_badge(*, cr: cairo.Context, size: int) -> None:
-    cr.save()
-    radius = max(2.0, size * 0.08)
-    cx = size * 0.80
-    cy = size * 0.20
-    cr.arc(cx, cy, radius, 0, math.tau)
-    cr.set_source_rgba(0.95, 0.60, 0.22, 0.96)
-    cr.fill_preserve()
-    cr.set_line_width(max(0.8, size * 0.018))
-    cr.set_source_rgba(0, 0, 0, 0.44)
-    cr.stroke()
-    cr.restore()

--- a/docking/applets/crypto/render.py
+++ b/docking/applets/crypto/render.py
@@ -33,6 +33,7 @@ from docking.applets.crypto.state import (
 )
 from docking.applets.draw import rounded_rect
 from docking.core.math import clamp
+from docking.ui.overlays import draw_warning_badge
 
 _BG_TOP = (0.05, 0.07, 0.11)
 _BG_BOTTOM = (0.11, 0.12, 0.19)
@@ -70,7 +71,7 @@ def render_icon(
             pulse_phase=pulse_phase,
         )
         if fetch_failed:
-            _draw_warning_badge(cr=cr, size=size)
+            draw_warning_badge(cr=cr, size=size)
     else:
         _draw_empty_state(cr=cr, size=size, failed=fetch_failed)
 
@@ -199,13 +200,6 @@ def _draw_empty_state(*, cr: cairo.Context, size: int, failed: bool) -> None:
     cr.line_to(size * 0.73, y)
     cr.stroke()
     cr.restore()
-
-
-def _draw_warning_badge(*, cr: cairo.Context, size: int) -> None:
-    radius = max(2.0, size * 0.07)
-    cr.arc(size * 0.78, size * 0.24, radius, 0, math.tau)
-    cr.set_source_rgba(*_WARN, 0.95)
-    cr.fill()
 
 
 def _draw_symbol(*, cr: cairo.Context, size: int, text: str) -> None:

--- a/docking/applets/currencyfx/render.py
+++ b/docking/applets/currencyfx/render.py
@@ -42,6 +42,7 @@ from docking.applets.base import draw_icon_label
 from docking.applets.currencyfx.state import FxPoint, FxSnapshot, percent_change
 from docking.applets.draw import rounded_rect
 from docking.core.math import clamp
+from docking.ui.overlays import draw_warning_badge
 
 _BG_TOP = (0.08, 0.11, 0.15)
 _BG_BOTTOM = (0.12, 0.16, 0.22)
@@ -83,7 +84,7 @@ def render_icon(
             pulse_phase=pulse_phase,
         )
         if fetch_failed:
-            _draw_warning_badge(cr=cr, size=size)
+            draw_warning_badge(cr=cr, size=size)
     else:
         _draw_empty_state(cr=cr, size=size, failed=fetch_failed)
 
@@ -263,20 +264,5 @@ def _draw_empty_state(*, cr: cairo.Context, size: int, failed: bool) -> None:
     y = size * 0.48
     cr.move_to(size * 0.24, y)
     cr.line_to(size * 0.76, y)
-    cr.stroke()
-    cr.restore()
-
-
-def _draw_warning_badge(*, cr: cairo.Context, size: int) -> None:
-    """Draw a small warning marker while stale chart data is still visible."""
-    cr.save()
-    radius = max(2.0, size * 0.075)
-    cx = size * 0.79
-    cy = size * 0.22
-    cr.arc(cx, cy, radius, 0, math.tau)
-    cr.set_source_rgba(_WARN[0], _WARN[1], _WARN[2], 0.95)
-    cr.fill_preserve()
-    cr.set_line_width(max(0.8, size * 0.018))
-    cr.set_source_rgba(0, 0, 0, 0.42)
     cr.stroke()
     cr.restore()

--- a/docking/applets/trash/applet.py
+++ b/docking/applets/trash/applet.py
@@ -27,15 +27,15 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GdkPixbuf, Gio, GLib, Gtk
 
 from docking.applets.base import Applet
-from docking.applets.menu import menu_sections
+from docking.applets.menu import disabled_menu_item, menu_sections
 from docking.applets.trash import meta
 from docking.core.icons import IconSource
 from docking.i18n import _
 from docking.log import get_logger, with_context
 from docking.platform.environment import detect_desktop
 
-from .backend import TrashBackend, select_trash_backend
-from .render import create_trash_icon, trash_tooltip
+from .backend import TrashBackend, TrashEmptyResult, select_trash_backend
+from .render import add_trash_warning_badge, create_trash_icon, trash_tooltip
 
 if TYPE_CHECKING:
     from docking.core.config import Config
@@ -58,8 +58,16 @@ class TrashApplet(Applet):
         self._monitors: list[Gio.FileMonitor] = []
         self._volume_monitor: Gio.VolumeMonitor | None = None
         self._volume_monitor_handlers: list[int] = []
+        self._action_error = ""
+        self._empty_attention = False
         super().__init__(icon_size, config)
         self.present()
+
+    def create_icon(self, size: int) -> GdkPixbuf.Pixbuf | None:
+        icon = super().create_icon(size=size)
+        if icon is not None and self._empty_attention:
+            return add_trash_warning_badge(icon)
+        return icon
 
     def create_docking_icon(self, size: int) -> GdkPixbuf.Pixbuf | None:
         return create_trash_icon(size=size, item_count=self._item_count)
@@ -70,7 +78,10 @@ class TrashApplet(Applet):
         return "user-trash"
 
     def refresh_tooltip(self) -> None:
-        self.item.name = trash_tooltip(item_count=self._item_count)
+        text = trash_tooltip(item_count=self._item_count)
+        if self._action_error:
+            text = f"{text}\n{self._action_error}"
+        self.item.name = text
 
     def on_clicked(self) -> None:
         """Open trash folder in the default file manager."""
@@ -112,6 +123,10 @@ class TrashApplet(Applet):
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         """Return 'Open Trash' and 'Empty Trash' menu items."""
+        status: list[Gtk.MenuItem] = []
+        if self._action_error:
+            status.append(disabled_menu_item(self._action_error, gtk=Gtk))
+
         open_item = Gtk.MenuItem(label=_("Open Trash"))
         open_item.connect("activate", lambda _: self.on_clicked())
 
@@ -119,7 +134,12 @@ class TrashApplet(Applet):
         empty_item.set_sensitive(self._item_count > 0)
         empty_item.connect("activate", lambda _: self._empty_trash())
 
-        return menu_sections(primary=[open_item], destructive=[empty_item], gtk=Gtk)
+        return menu_sections(
+            status=status,
+            primary=[open_item],
+            destructive=[empty_item],
+            gtk=Gtk,
+        )
 
     def start(self, notify: Callable[[], None]) -> None:
         """Start trash monitoring for real-time icon updates."""
@@ -162,6 +182,8 @@ class TrashApplet(Applet):
     def _on_trash_changed(self, *_args: object) -> None:
         """File monitor callback: re-count items and update icon."""
         self._item_count = self._backend.count_items()
+        if self._item_count == 0:
+            self._clear_empty_attention()
         self.present()
 
     def _on_mounts_changed(self, *_args: object) -> None:
@@ -172,7 +194,46 @@ class TrashApplet(Applet):
 
     def _empty_trash(self) -> None:
         """Empty trash through the selected backend."""
-        self._backend.empty(self._confirm_empty_trash)
+        result = self._backend.empty(self._confirm_empty_trash)
+        self._handle_empty_result(result)
+
+    def _handle_empty_result(self, result: TrashEmptyResult | None) -> None:
+        if result is None:
+            self._item_count = self._backend.count_items()
+            if self._item_count == 0:
+                self._clear_empty_attention()
+            self.present()
+            return
+
+        self._item_count = result.remaining_count
+        if self._item_count == 0:
+            self._clear_empty_attention()
+            self.present()
+            return
+
+        if not result.attempted:
+            if result.delegated:
+                self.present()
+            return
+
+        self._action_error = self._empty_error_text(
+            permission_denied=result.permission_denied,
+        )
+        self._empty_attention = True
+        self.present()
+
+    def _clear_empty_attention(self) -> None:
+        self._action_error = ""
+        self._empty_attention = False
+
+    @staticmethod
+    def _empty_error_text(*, permission_denied: bool) -> str:
+        if permission_denied:
+            return _(
+                "Could not empty Trash. "
+                "Some items may require administrator permissions."
+            )
+        return _("Could not empty Trash.")
 
     @staticmethod
     def _file_from_drop_uri(uri: str) -> Gio.File | None:

--- a/docking/applets/trash/backend.py
+++ b/docking/applets/trash/backend.py
@@ -16,10 +16,12 @@
 from __future__ import annotations
 
 import configparser
+import errno
 import os
 import shutil
 import subprocess
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
@@ -46,6 +48,47 @@ from docking.platform.environment import (
 log = with_context(get_logger(name="trash"), applet_id=meta.id)
 
 
+@dataclass(frozen=True, slots=True)
+class TrashEmptyResult:
+    """Outcome of an Empty Trash request as far as Docking can observe it."""
+
+    attempted: bool
+    before_count: int
+    remaining_count: int
+    failures: int = 0
+    permission_denied: bool = False
+    delegated: bool = False
+
+
+@dataclass(slots=True)
+class _DeleteStats:
+    failures: int = 0
+    permission_denied: bool = False
+
+    def add_failure(self, exc: BaseException) -> None:
+        self.failures += 1
+        self.permission_denied = self.permission_denied or _is_permission_error(exc)
+
+    def merge(self, other: _DeleteStats) -> None:
+        self.failures += other.failures
+        self.permission_denied = self.permission_denied or other.permission_denied
+
+
+def _coerce_delete_stats(stats: object) -> _DeleteStats:
+    if isinstance(stats, _DeleteStats):
+        return stats
+    return _DeleteStats()
+
+
+def _is_permission_error(exc: BaseException) -> bool:
+    if isinstance(exc, PermissionError):
+        return True
+    if isinstance(exc, OSError) and exc.errno in (errno.EACCES, errno.EPERM):
+        return True
+    message = str(exc).casefold()
+    return "permission denied" in message or "operation not permitted" in message
+
+
 class TrashBackend(Protocol):
     """Desktop-specific trash behavior used by the Trash applet."""
 
@@ -58,7 +101,7 @@ class TrashBackend(Protocol):
 
     def open(self) -> None: ...
 
-    def empty(self, confirm: Callable[[], bool]) -> None: ...
+    def empty(self, confirm: Callable[[], bool]) -> TrashEmptyResult: ...
 
 
 class _CaseSensitiveConfigParser(configparser.ConfigParser):
@@ -344,18 +387,40 @@ class GioTrashBackend:
     def open(self) -> None:
         _open_trash_uri(self.uri, fallback_commands=self.open_commands)
 
-    def empty(self, confirm: Callable[[], bool]) -> None:
+    def empty(self, confirm: Callable[[], bool]) -> TrashEmptyResult:
         _ = confirm
+        before_count = self.count_items()
         if self._confirmation_preference() is False:
             if _empty_host_trash():
-                return
-            self._delete_contents()
-            return
+                return self._empty_result(before_count=before_count)
+            stats = _coerce_delete_stats(self._delete_contents())
+            return self._empty_result(before_count=before_count, stats=stats)
         if self._empty_via_dbus():
-            return
+            return TrashEmptyResult(
+                attempted=False,
+                before_count=before_count,
+                remaining_count=self.count_items(),
+                delegated=True,
+            )
         if _empty_host_trash():
-            return
-        self._delete_contents()
+            return self._empty_result(before_count=before_count)
+        stats = _coerce_delete_stats(self._delete_contents())
+        return self._empty_result(before_count=before_count, stats=stats)
+
+    def _empty_result(
+        self,
+        *,
+        before_count: int,
+        stats: _DeleteStats | None = None,
+    ) -> TrashEmptyResult:
+        stats = stats or _DeleteStats()
+        return TrashEmptyResult(
+            attempted=True,
+            before_count=before_count,
+            remaining_count=self.count_items(),
+            failures=stats.failures,
+            permission_denied=stats.permission_denied,
+        )
 
     def _confirmation_preference(self) -> bool | None:
         if self.confirmation_schema is None:
@@ -412,11 +477,11 @@ class GioTrashBackend:
                 )
         return False
 
-    def _delete_contents(self) -> None:
+    def _delete_contents(self) -> _DeleteStats:
         if self.use_visible_trash_files:
-            self._delete_visible_trash_contents()
-            return
+            return self._delete_visible_trash_contents()
 
+        stats = _DeleteStats()
         trash = Gio.File.new_for_uri(self.uri)
         try:
             enumerator = trash.enumerate_children(
@@ -427,8 +492,9 @@ class GioTrashBackend:
                 "Could not enumerate trash for deletion: %s",
                 exc,
             )
-            self._delete_visible_trash_contents()
-            return
+            stats.add_failure(exc)
+            stats.merge(self._delete_visible_trash_contents())
+            return stats
 
         while True:
             info = enumerator.next_file(None)
@@ -443,35 +509,53 @@ class GioTrashBackend:
                     info.get_name(),
                     exc,
                 )
+                stats.add_failure(exc)
         enumerator.close(None)
+        return stats
 
-    def _delete_visible_trash_contents(self) -> None:
+    def _delete_visible_trash_contents(self) -> _DeleteStats:
+        stats = _DeleteStats()
         for directory in _visible_trash_files_directories():
-            self._delete_directory_contents(directory)
+            stats.merge(self._delete_directory_contents(directory))
         for directory in _visible_trash_info_directories():
-            self._delete_directory_contents(directory)
+            stats.merge(self._delete_directory_contents(directory))
+        return stats
 
-    def _delete_directory_contents(self, directory: Path) -> None:
+    def _delete_directory_contents(self, directory: Path) -> _DeleteStats:
+        stats = _DeleteStats()
         try:
             children = list(directory.iterdir())
         except FileNotFoundError:
-            return
+            return stats
         except OSError as exc:
             log.bind(action="empty_trash_delete").debug(
                 "Could not enumerate trash directory %s: %s",
                 directory,
                 exc,
             )
-            return
+            stats.add_failure(exc)
+            return stats
 
         for child in children:
-            self._delete_path(child)
+            stats.merge(self._delete_path(child))
+        return stats
 
-    def _delete_path(self, path: Path) -> None:
+    def _delete_path(self, path: Path) -> _DeleteStats:
+        stats = _DeleteStats()
         try:
             if path.is_dir() and not path.is_symlink():
-                for child in path.iterdir():
-                    self._delete_path(child)
+                try:
+                    children = list(path.iterdir())
+                except OSError as exc:
+                    log.bind(action="empty_trash_delete").debug(
+                        "Could not enumerate trash item %s: %s",
+                        path,
+                        exc,
+                    )
+                    stats.add_failure(exc)
+                    return stats
+                for child in children:
+                    stats.merge(self._delete_path(child))
                 path.rmdir()
             else:
                 path.unlink()
@@ -481,6 +565,8 @@ class GioTrashBackend:
                 path,
                 exc,
             )
+            stats.add_failure(exc)
+        return stats
 
 
 class GnomeTrashBackend(GioTrashBackend):
@@ -555,11 +641,33 @@ class KdeTrashBackend:
 
         _open_trash_uri(self.uri)
 
-    def empty(self, confirm: Callable[[], bool]) -> None:
+    def empty(self, confirm: Callable[[], bool]) -> TrashEmptyResult:
+        before_count = self.count_items()
         if self._confirmation_preference() is False or confirm():
             if _empty_host_trash():
-                return
-            self._delete_contents()
+                return self._empty_result(before_count=before_count)
+            stats = _coerce_delete_stats(self._delete_contents())
+            return self._empty_result(before_count=before_count, stats=stats)
+        return TrashEmptyResult(
+            attempted=False,
+            before_count=before_count,
+            remaining_count=before_count,
+        )
+
+    def _empty_result(
+        self,
+        *,
+        before_count: int,
+        stats: _DeleteStats | None = None,
+    ) -> TrashEmptyResult:
+        stats = stats or _DeleteStats()
+        return TrashEmptyResult(
+            attempted=True,
+            before_count=before_count,
+            remaining_count=self.count_items(),
+            failures=stats.failures,
+            permission_denied=stats.permission_denied,
+        )
 
     def _confirmation_preference(self) -> bool:
         parser = _CaseSensitiveConfigParser()
@@ -604,33 +712,49 @@ class KdeTrashBackend:
                 return command
         return None
 
-    def _delete_contents(self) -> None:
+    def _delete_contents(self) -> _DeleteStats:
+        stats = _DeleteStats()
         for directory in _visible_trash_files_directories():
-            self._delete_directory_contents(directory)
+            stats.merge(self._delete_directory_contents(directory))
         for directory in _visible_trash_info_directories():
-            self._delete_directory_contents(directory)
+            stats.merge(self._delete_directory_contents(directory))
+        return stats
 
-    def _delete_directory_contents(self, directory: Path) -> None:
+    def _delete_directory_contents(self, directory: Path) -> _DeleteStats:
+        stats = _DeleteStats()
         try:
             children = list(directory.iterdir())
         except FileNotFoundError:
-            return
+            return stats
         except OSError as exc:
             log.bind(action="empty_kde_trash").debug(
                 "Could not enumerate KDE trash directory %s: %s",
                 directory,
                 exc,
             )
-            return
+            stats.add_failure(exc)
+            return stats
 
         for child in children:
-            self._delete_path(child)
+            stats.merge(self._delete_path(child))
+        return stats
 
-    def _delete_path(self, path: Path) -> None:
+    def _delete_path(self, path: Path) -> _DeleteStats:
+        stats = _DeleteStats()
         try:
             if path.is_dir() and not path.is_symlink():
-                for child in path.iterdir():
-                    self._delete_path(child)
+                try:
+                    children = list(path.iterdir())
+                except OSError as exc:
+                    log.bind(action="empty_kde_trash").debug(
+                        "Could not enumerate KDE trash item %s: %s",
+                        path,
+                        exc,
+                    )
+                    stats.add_failure(exc)
+                    return stats
+                for child in children:
+                    stats.merge(self._delete_path(child))
                 path.rmdir()
             else:
                 path.unlink()
@@ -640,6 +764,8 @@ class KdeTrashBackend:
                 path,
                 exc,
             )
+            stats.add_failure(exc)
+        return stats
 
 
 def select_trash_backend(*, desktop: Desktop | None = None) -> TrashBackend:

--- a/docking/applets/trash/render.py
+++ b/docking/applets/trash/render.py
@@ -20,6 +20,7 @@ import gi
 
 from docking.applets.draw import rounded_rect
 from docking.i18n import _, ngettext
+from docking.ui.overlays import draw_warning_badge
 
 gi.require_version("Gdk", "3.0")
 gi.require_version("GdkPixbuf", "2.0")
@@ -102,10 +103,26 @@ def _draw_trash_can(*, cr: cairo.Context, size: int, item_count: int) -> None:
     cr.stroke()
 
 
-def create_trash_icon(*, size: int, item_count: int) -> GdkPixbuf.Pixbuf | None:
+def create_trash_icon(
+    *,
+    size: int,
+    item_count: int,
+) -> GdkPixbuf.Pixbuf | None:
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, size, size)
     cr = cairo.Context(surface)
     cr.set_source_rgba(0, 0, 0, 0)
     cr.paint()
     _draw_trash_can(cr=cr, size=size, item_count=item_count)
     return Gdk.pixbuf_get_from_surface(surface, 0, 0, size, size)
+
+
+def add_trash_warning_badge(icon: GdkPixbuf.Pixbuf) -> GdkPixbuf.Pixbuf | None:
+    """Overlay the standard warning chip on an already-rendered Trash icon."""
+    width = icon.get_width()
+    height = icon.get_height()
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
+    cr = cairo.Context(surface)
+    Gdk.cairo_set_source_pixbuf(cr, icon, 0, 0)
+    cr.paint()
+    draw_warning_badge(cr=cr, size=min(width, height))
+    return Gdk.pixbuf_get_from_surface(surface, 0, 0, width, height)

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-07-05 14:18+0200\n"
+"POT-Creation-Date: 2026-07-09 19:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -113,8 +113,8 @@ msgstr ""
 #: docking/applets/lastfm/applet.py:380 docking/applets/quicknote/applet.py:86
 #: docking/applets/runcommand/applet.py:122
 #: docking/applets/runcommand/applet.py:340
-#: docking/applets/sunrise/applet.py:188 docking/applets/trash/applet.py:177
-#: docking/applets/weather/applet.py:271 docking/ui/diagnostics.py:342
+#: docking/applets/sunrise/applet.py:188 docking/applets/trash/applet.py:263
+#: docking/applets/weather/applet.py:273 docking/ui/diagnostics.py:342
 #: docking/ui/menu.py:439
 msgid "Cancel"
 msgstr ""
@@ -315,11 +315,11 @@ msgstr ""
 
 #: docking/applets/apod/applet.py:131 docking/applets/certwatch/applet.py:141
 #: docking/applets/crypto/applet.py:153
-#: docking/applets/currencyfx/applet.py:201
+#: docking/applets/currencyfx/applet.py:203
 #: docking/applets/hackernews/applet.py:189
 #: docking/applets/lastfm/applet.py:174 docking/applets/speedtest/applet.py:116
 #: docking/applets/thermals/applet.py:147 docking/applets/tooltip.py:46
-#: docking/applets/weather/applet.py:181 docking/applets/weather/applet.py:546
+#: docking/applets/weather/applet.py:183 docking/applets/weather/applet.py:567
 #, python-brace-format
 msgid "Error: {msg}"
 msgstr ""
@@ -336,14 +336,14 @@ msgstr ""
 #: docking/applets/camshield/applet.py:127
 #: docking/applets/capslock/applet.py:97
 #: docking/applets/certwatch/applet.py:158 docking/applets/crypto/applet.py:156
-#: docking/applets/currencyfx/applet.py:209 docking/applets/docker/applet.py:95
+#: docking/applets/currencyfx/applet.py:211 docking/applets/docker/applet.py:95
 #: docking/applets/hackernews/applet.py:206
 #: docking/applets/lastfm/applet.py:198 docking/applets/micshield/applet.py:131
 #: docking/applets/moon/applet.py:137 docking/applets/quote/applet.py:105
 #: docking/applets/systemtray/applet.py:142
 #: docking/applets/thermals/applet.py:157
 #: docking/applets/todayinhistory/applet.py:112
-#: docking/applets/trivia/applet.py:128 docking/applets/weather/applet.py:188
+#: docking/applets/trivia/applet.py:128 docking/applets/weather/applet.py:190
 msgid "Refresh Now"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Power Settings"
 msgstr ""
 
-#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:637
+#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:644
 msgid "Mouse"
 msgstr ""
 
@@ -955,23 +955,23 @@ msgid "Crypto"
 msgstr ""
 
 #: docking/applets/crypto/applet.py:161
-#: docking/applets/currencyfx/applet.py:215
+#: docking/applets/currencyfx/applet.py:217
 msgid "Chart Interval"
 msgstr ""
 
 #: docking/applets/crypto/applet.py:163
-#: docking/applets/currencyfx/applet.py:217
+#: docking/applets/currencyfx/applet.py:219
 #: docking/applets/sunrise/state.py:383
 msgid "Day"
 msgstr ""
 
 #: docking/applets/crypto/applet.py:164
-#: docking/applets/currencyfx/applet.py:218
+#: docking/applets/currencyfx/applet.py:220
 msgid "Week"
 msgstr ""
 
 #: docking/applets/crypto/applet.py:165
-#: docking/applets/currencyfx/applet.py:219
+#: docking/applets/currencyfx/applet.py:221
 msgid "Month"
 msgstr ""
 
@@ -1053,49 +1053,49 @@ msgstr ""
 msgid "{name} NFT"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:102
+#: docking/applets/currencyfx/applet.py:103
 msgid "Currency FX"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:187
+#: docking/applets/currencyfx/applet.py:189
 #: docking/applets/currencyfx/state.py:740
 msgid "Day samples"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:205
+#: docking/applets/currencyfx/applet.py:207
 msgid "Swap Pair"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:234
+#: docking/applets/currencyfx/applet.py:236
 msgid "Added Pairs"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:244
+#: docking/applets/currencyfx/applet.py:246
 msgid "Remove Current Pair"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:251
+#: docking/applets/currencyfx/applet.py:253
 msgid "Add Pair..."
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:364
+#: docking/applets/currencyfx/applet.py:366
 msgid "No rate data"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:446
+#: docking/applets/currencyfx/applet.py:448
 #, python-brace-format
 msgid "{pair}: {rate} ({change})"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:489
+#: docking/applets/currencyfx/applet.py:491
 msgid "Add FX Pair"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:503
+#: docking/applets/currencyfx/applet.py:505
 msgid "Base"
 msgstr ""
 
-#: docking/applets/currencyfx/applet.py:505 docking/applets/quote/applet.py:56
+#: docking/applets/currencyfx/applet.py:507 docking/applets/quote/applet.py:56
 #: docking/applets/quote/applet.py:96 docking/applets/quote/applet.py:221
 #: docking/applets/quote/applet.py:227
 msgid "Quote"
@@ -1350,7 +1350,7 @@ msgid "{verb} every {interval}"
 msgstr ""
 
 #: docking/applets/freshness.py:43 docking/applets/freshness.py:50
-#: docking/ui/settings.py:288
+#: docking/ui/settings.py:295
 msgid "Updates"
 msgstr ""
 
@@ -2185,16 +2185,16 @@ msgstr ""
 msgid "Label Mode"
 msgstr ""
 
-#: docking/applets/sunrise/applet.py:148 docking/applets/weather/applet.py:216
+#: docking/applets/sunrise/applet.py:148 docking/applets/weather/applet.py:218
 #, python-brace-format
 msgid "Remove {city}"
 msgstr ""
 
-#: docking/applets/sunrise/applet.py:185 docking/applets/weather/applet.py:268
+#: docking/applets/sunrise/applet.py:185 docking/applets/weather/applet.py:270
 msgid "Search for the city"
 msgstr ""
 
-#: docking/applets/sunrise/applet.py:198 docking/applets/weather/applet.py:281
+#: docking/applets/sunrise/applet.py:198 docking/applets/weather/applet.py:283
 msgid "Type city name..."
 msgstr ""
 
@@ -2313,7 +2313,7 @@ msgid "Show Disk Usage"
 msgstr ""
 
 #: docking/applets/systemmonitor/applet.py:107
-#: docking/applets/thermals/applet.py:162 docking/applets/weather/applet.py:199
+#: docking/applets/thermals/applet.py:162 docking/applets/weather/applet.py:201
 msgid "Temperature Unit"
 msgstr ""
 
@@ -2495,7 +2495,7 @@ msgstr ""
 msgid "and {n} more"
 msgstr ""
 
-#: docking/applets/systemtray/state.py:242
+#: docking/applets/systemtray/state.py:243
 msgid "session bus unavailable"
 msgstr ""
 
@@ -2581,27 +2581,36 @@ msgstr ""
 msgid "Trash"
 msgstr ""
 
-#: docking/applets/trash/applet.py:113
+#: docking/applets/trash/applet.py:130
 msgid "Open Trash"
 msgstr ""
 
-#: docking/applets/trash/applet.py:116 docking/applets/trash/applet.py:178
+#: docking/applets/trash/applet.py:133 docking/applets/trash/applet.py:264
 msgid "Empty Trash"
 msgstr ""
 
-#: docking/applets/trash/applet.py:172
+#: docking/applets/trash/applet.py:233
+msgid ""
+"Could not empty Trash. Some items may require administrator permissions."
+msgstr ""
+
+#: docking/applets/trash/applet.py:236
+msgid "Could not empty Trash."
+msgstr ""
+
+#: docking/applets/trash/applet.py:258
 msgid "Empty all items from Trash?"
 msgstr ""
 
-#: docking/applets/trash/applet.py:175
+#: docking/applets/trash/applet.py:261
 msgid "All items in the Trash will be permanently deleted."
 msgstr ""
 
-#: docking/applets/trash/render.py:31
+#: docking/applets/trash/render.py:32
 msgid "No items in Trash"
 msgstr ""
 
-#: docking/applets/trash/render.py:33 docking/applets/trash/render.py:34
+#: docking/applets/trash/render.py:34 docking/applets/trash/render.py:35
 #, python-brace-format
 msgid "{n} item in Trash"
 msgid_plural "{n} items in Trash"
@@ -2733,30 +2742,30 @@ msgstr ""
 msgid "Weather"
 msgstr ""
 
-#: docking/applets/weather/applet.py:192
+#: docking/applets/weather/applet.py:194
 msgid "Show Temperature"
 msgstr ""
 
-#: docking/applets/weather/applet.py:438
+#: docking/applets/weather/applet.py:452
 msgid "No weather data"
 msgstr ""
 
-#: docking/applets/weather/applet.py:494 docking/applets/weather/state.py:216
+#: docking/applets/weather/applet.py:515 docking/applets/weather/state.py:216
 #, python-brace-format
 msgid "{temp}, {desc}"
 msgstr ""
 
-#: docking/applets/weather/applet.py:507 docking/applets/weather/state.py:202
+#: docking/applets/weather/applet.py:528 docking/applets/weather/state.py:202
 #, python-brace-format
 msgid "Air: {label}"
 msgstr ""
 
-#: docking/applets/weather/applet.py:513 docking/applets/weather/state.py:205
+#: docking/applets/weather/applet.py:534 docking/applets/weather/state.py:205
 #, python-brace-format
 msgid "UV Index: {value}"
 msgstr ""
 
-#: docking/applets/weather/applet.py:527
+#: docking/applets/weather/applet.py:548
 #, python-brace-format
 msgid "{date}: {temp_range}"
 msgstr ""
@@ -3029,7 +3038,7 @@ msgid "Save Report..."
 msgstr ""
 
 #: docking/ui/diagnostics.py:122 docking/ui/menu.py:574
-#: docking/ui/startup_tips.py:207
+#: docking/ui/startup_tips.py:216
 msgid "Close"
 msgstr ""
 
@@ -3237,7 +3246,7 @@ msgstr ""
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:698 docking/ui/settings.py:261
+#: docking/ui/menu.py:698 docking/ui/settings.py:268
 msgid "Preferences"
 msgstr ""
 
@@ -3257,7 +3266,7 @@ msgstr ""
 msgid "Clear Recent Documents"
 msgstr ""
 
-#: docking/ui/menu.py:791 docking/ui/settings.py:739
+#: docking/ui/menu.py:791 docking/ui/settings.py:746
 msgid "Recent Documents"
 msgstr ""
 
@@ -3275,452 +3284,452 @@ msgstr ""
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-#: docking/ui/settings.py:285
+#: docking/ui/settings.py:292
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:286 docking/ui/settings.py:664
+#: docking/ui/settings.py:293 docking/ui/settings.py:671
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:287
+#: docking/ui/settings.py:294
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:311
+#: docking/ui/settings.py:318
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:312
+#: docking/ui/settings.py:319
 msgid "Always on Top"
 msgstr ""
 
-#: docking/ui/settings.py:313
+#: docking/ui/settings.py:320
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:314
+#: docking/ui/settings.py:321
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:315
+#: docking/ui/settings.py:322
 msgid "Dodge Active"
 msgstr ""
 
-#: docking/ui/settings.py:316
+#: docking/ui/settings.py:323
 msgid "Dodge Windows"
 msgstr ""
 
-#: docking/ui/settings.py:317
+#: docking/ui/settings.py:324
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:328
+#: docking/ui/settings.py:335
 msgid "Toggle Focus"
 msgstr ""
 
-#: docking/ui/settings.py:329
+#: docking/ui/settings.py:336
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:330
+#: docking/ui/settings.py:337
 msgid "Most Recent Window"
 msgstr ""
 
-#: docking/ui/settings.py:337
+#: docking/ui/settings.py:344
 msgid "New Window"
 msgstr ""
 
-#: docking/ui/settings.py:338
+#: docking/ui/settings.py:345
 msgid "Minimize Windows"
 msgstr ""
 
-#: docking/ui/settings.py:339
+#: docking/ui/settings.py:346
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:353
 msgid "Click"
 msgstr ""
 
-#: docking/ui/settings.py:347
+#: docking/ui/settings.py:354
 msgid "Hover"
 msgstr ""
 
-#: docking/ui/settings.py:354
+#: docking/ui/settings.py:361
 msgid "Default"
 msgstr ""
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:362
 msgid "Alphabetical"
 msgstr ""
 
-#: docking/ui/settings.py:373
+#: docking/ui/settings.py:380
 msgid "Daily"
 msgstr ""
 
-#: docking/ui/settings.py:374
+#: docking/ui/settings.py:381
 msgid "Weekly"
 msgstr ""
 
-#: docking/ui/settings.py:395
+#: docking/ui/settings.py:402
 msgid ""
 "When Follow Cursor is enabled, the dock follows the pointer across monitors. "
 "The selected monitor is kept as the fallback."
 msgstr ""
 
-#: docking/ui/settings.py:441
+#: docking/ui/settings.py:448
 msgid "Added on top of the theme's own distance from the edge."
 msgstr ""
 
-#: docking/ui/settings.py:481
+#: docking/ui/settings.py:488
 msgid ""
 "Pixels of cursor pressure against the edge required to reveal a hidden dock. "
 "Higher values mean the dock will not reveal as easily."
 msgstr ""
 
-#: docking/ui/settings.py:503
+#: docking/ui/settings.py:510
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:505
+#: docking/ui/settings.py:512
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:505
+#: docking/ui/settings.py:512
 msgid "Choose the dock color palette."
 msgstr ""
 
-#: docking/ui/settings.py:507
+#: docking/ui/settings.py:514
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:509
+#: docking/ui/settings.py:516
 msgid "Set the base size of dock icons before zoom is applied."
 msgstr ""
 
-#: docking/ui/settings.py:512
+#: docking/ui/settings.py:519
 msgid "Transparency"
 msgstr ""
 
-#: docking/ui/settings.py:514
+#: docking/ui/settings.py:521
 msgid "Adjust how transparent the dock background is."
 msgstr ""
 
-#: docking/ui/settings.py:517
+#: docking/ui/settings.py:524
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:519
+#: docking/ui/settings.py:526
 msgid "Enlarge icons when the pointer hovers over the dock."
 msgstr ""
 
-#: docking/ui/settings.py:522
+#: docking/ui/settings.py:529
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:524
+#: docking/ui/settings.py:531
 msgid "Set how much hovered icons grow when zoom is enabled."
 msgstr ""
 
-#: docking/ui/settings.py:527
+#: docking/ui/settings.py:534
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:529
+#: docking/ui/settings.py:536
 msgid "Show item names and details when hovering over dock items."
 msgstr ""
 
-#: docking/ui/settings.py:532
+#: docking/ui/settings.py:539
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:534
+#: docking/ui/settings.py:541
 msgid "Show window thumbnails when hovering over running apps."
 msgstr ""
 
-#: docking/ui/settings.py:537
+#: docking/ui/settings.py:544
 msgid "Show Window Counts"
 msgstr ""
 
-#: docking/ui/settings.py:540
+#: docking/ui/settings.py:547
 msgid "Show a number on running app indicators when multiple windows are open."
 msgstr ""
 
-#: docking/ui/settings.py:548
+#: docking/ui/settings.py:555
 msgid "Placement"
 msgstr ""
 
-#: docking/ui/settings.py:551
+#: docking/ui/settings.py:558
 msgid "Position"
 msgstr ""
 
-#: docking/ui/settings.py:553
+#: docking/ui/settings.py:560
 msgid "Choose which screen edge the dock uses."
 msgstr ""
 
-#: docking/ui/settings.py:555
+#: docking/ui/settings.py:562
 msgid "Extra Distance from Edge"
 msgstr ""
 
-#: docking/ui/settings.py:557
+#: docking/ui/settings.py:564
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:560
+#: docking/ui/settings.py:567
 msgid "Show running windows only from the active workspace when supported."
 msgstr ""
 
-#: docking/ui/settings.py:568 docking/ui/settings.py:578
+#: docking/ui/settings.py:575 docking/ui/settings.py:585
 msgid "Monitor"
 msgstr ""
 
-#: docking/ui/settings.py:571
+#: docking/ui/settings.py:578
 msgid "Follow Cursor"
 msgstr ""
 
-#: docking/ui/settings.py:574
+#: docking/ui/settings.py:581
 msgid "Move the dock to the monitor where the pointer is currently located."
 msgstr ""
 
-#: docking/ui/settings.py:583
+#: docking/ui/settings.py:590
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:586
+#: docking/ui/settings.py:593
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:589
+#: docking/ui/settings.py:596
 msgid "Prevent dock items from being reordered or removed by drag and drop."
 msgstr ""
 
-#: docking/ui/settings.py:594
+#: docking/ui/settings.py:601
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:596
+#: docking/ui/settings.py:603
 msgid "Keep applets grouped at the end of the dock."
 msgstr ""
 
-#: docking/ui/settings.py:599
+#: docking/ui/settings.py:606
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:601
+#: docking/ui/settings.py:608
 msgid "Keep pinned files and folders grouped at the end of the dock."
 msgstr ""
 
-#: docking/ui/settings.py:640
+#: docking/ui/settings.py:647
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:643
+#: docking/ui/settings.py:650
 msgid ""
 "Choose what happens when clicking a running app with the left mouse button."
 msgstr ""
 
-#: docking/ui/settings.py:648
+#: docking/ui/settings.py:655
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:651
+#: docking/ui/settings.py:658
 msgid "Choose what happens when clicking an app with the middle mouse button."
 msgstr ""
 
-#: docking/ui/settings.py:656
+#: docking/ui/settings.py:663
 msgid "Window List Sort"
 msgstr ""
 
-#: docking/ui/settings.py:658
+#: docking/ui/settings.py:665
 msgid "Choose how open windows are ordered in app context menus."
 msgstr ""
 
-#: docking/ui/settings.py:666
+#: docking/ui/settings.py:673
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:668
+#: docking/ui/settings.py:675
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:671
+#: docking/ui/settings.py:678
 msgid "Set how long the dock waits before hiding after the pointer leaves."
 msgstr ""
 
-#: docking/ui/settings.py:676
+#: docking/ui/settings.py:683
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:679
+#: docking/ui/settings.py:686
 msgid "Set how long the dock waits before showing after the pointer returns."
 msgstr ""
 
-#: docking/ui/settings.py:684
+#: docking/ui/settings.py:691
 msgid "Pressure Reveal"
 msgstr ""
 
-#: docking/ui/settings.py:687
+#: docking/ui/settings.py:694
 msgid ""
 "Require the pointer to push against the screen edge before revealing a "
 "hidden dock."
 msgstr ""
 
-#: docking/ui/settings.py:691
+#: docking/ui/settings.py:698
 msgid "Pressure Threshold"
 msgstr ""
 
-#: docking/ui/settings.py:693
+#: docking/ui/settings.py:700
 msgid "Show Startup Tips"
 msgstr ""
 
-#: docking/ui/settings.py:696
+#: docking/ui/settings.py:703
 msgid ""
 "Show one Docking usage tip after startup, unless a higher-priority startup "
 "notification is visible."
 msgstr ""
 
-#: docking/ui/settings.py:704
+#: docking/ui/settings.py:711
 msgid "Folder Stacks"
 msgstr ""
 
-#: docking/ui/settings.py:707
+#: docking/ui/settings.py:714
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:709
+#: docking/ui/settings.py:716
 msgid "Choose whether folder stacks open on click or while hovering."
 msgstr ""
 
-#: docking/ui/settings.py:715
+#: docking/ui/settings.py:722
 msgid "Recent Apps"
 msgstr ""
 
-#: docking/ui/settings.py:718
+#: docking/ui/settings.py:725
 msgid "Show Recently Used Apps"
 msgstr ""
 
-#: docking/ui/settings.py:721
+#: docking/ui/settings.py:728
 msgid "Show recently closed apps between pinned launchers and running apps."
 msgstr ""
 
-#: docking/ui/settings.py:726
+#: docking/ui/settings.py:733
 msgid "Number of Recent Apps"
 msgstr ""
 
-#: docking/ui/settings.py:728
+#: docking/ui/settings.py:735
 msgid "Maximum recently used app icons to display."
 msgstr ""
 
-#: docking/ui/settings.py:731
+#: docking/ui/settings.py:738
 msgid "Keep Recent Apps For"
 msgstr ""
 
-#: docking/ui/settings.py:733
+#: docking/ui/settings.py:740
 msgid "Remove recent apps after this many days of inactivity."
 msgstr ""
 
-#: docking/ui/settings.py:742
+#: docking/ui/settings.py:749
 msgid "Show Recent Documents"
 msgstr ""
 
-#: docking/ui/settings.py:745
+#: docking/ui/settings.py:752
 msgid "Show a \"Recent Documents\" submenu when right-clicking an app icon."
 msgstr ""
 
-#: docking/ui/settings.py:750
+#: docking/ui/settings.py:757
 msgid "Max Documents Per App"
 msgstr ""
 
-#: docking/ui/settings.py:752
+#: docking/ui/settings.py:759
 msgid "Maximum recent document entries shown per app."
 msgstr ""
 
-#: docking/ui/settings.py:824
+#: docking/ui/settings.py:831
 msgid "Check Now"
 msgstr ""
 
-#: docking/ui/settings.py:826
+#: docking/ui/settings.py:833
 msgid "View Releases"
 msgstr ""
 
-#: docking/ui/settings.py:838
+#: docking/ui/settings.py:845
 msgid "Update Checks"
 msgstr ""
 
-#: docking/ui/settings.py:840
+#: docking/ui/settings.py:847
 msgid "Check Automatically"
 msgstr ""
 
-#: docking/ui/settings.py:841
+#: docking/ui/settings.py:848
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:842
+#: docking/ui/settings.py:849
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:843
+#: docking/ui/settings.py:850
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:1286
+#: docking/ui/settings.py:1293
 msgid "Primary Display"
 msgstr ""
 
-#: docking/ui/settings.py:1427
+#: docking/ui/settings.py:1434
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:1431
+#: docking/ui/settings.py:1438
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:1433
+#: docking/ui/settings.py:1440
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:1514
+#: docking/ui/settings.py:1521
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1516
+#: docking/ui/settings.py:1523
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1519
+#: docking/ui/settings.py:1526
 msgid "Hides when the mouse cursor leaves the dock."
-msgstr ""
-
-#: docking/ui/settings.py:1521
-msgid ""
-"Hides when a window from the focused application overlaps the dock area."
-msgstr ""
-
-#: docking/ui/settings.py:1523
-msgid "Hides when the focused window overlaps the dock area."
-msgstr ""
-
-#: docking/ui/settings.py:1525
-msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
 #: docking/ui/settings.py:1528
 msgid ""
+"Hides when a window from the focused application overlaps the dock area."
+msgstr ""
+
+#: docking/ui/settings.py:1530
+msgid "Hides when the focused window overlaps the dock area."
+msgstr ""
+
+#: docking/ui/settings.py:1532
+msgid "Hides when any window on the current workspace overlaps the dock area."
+msgstr ""
+
+#: docking/ui/settings.py:1535
+msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""
 
-#: docking/ui/startup_tips.py:178
+#: docking/ui/startup_tips.py:187
 msgid "Tip of the day"
 msgstr ""
 
-#: docking/ui/startup_tips.py:203
+#: docking/ui/startup_tips.py:212
 msgid "Show tips on startup"
 msgstr ""
 
-#: docking/ui/startup_tips.py:206
+#: docking/ui/startup_tips.py:215
 msgid "Next Tip"
 msgstr ""
 

--- a/docking/ui/overlays.py
+++ b/docking/ui/overlays.py
@@ -113,6 +113,25 @@ def draw_count_badge(
     cr.restore()
 
 
+def draw_warning_badge(
+    *,
+    cr: cairo.Context,
+    size: int,
+) -> None:
+    """Draw the standard amber attention chip used by applet icons."""
+    cr.save()
+    draw_circle_badge(
+        cr=cr,
+        cx=size * 0.80,
+        cy=size * 0.20,
+        radius=max(2.0, size * 0.08),
+        background_rgba=(0.95, 0.60, 0.22, 0.96),
+        outline_rgba=(0.0, 0.0, 0.0, 0.42),
+        outline_width=max(0.8, size * 0.018),
+    )
+    cr.restore()
+
+
 def draw_progress_bar(
     *,
     cr: cairo.Context,

--- a/tests/applets/test_trash.py
+++ b/tests/applets/test_trash.py
@@ -15,6 +15,7 @@ from docking.applets.trash.backend import (
     GnomeTrashBackend,
     KdeTrashBackend,
     MateTrashBackend,
+    TrashEmptyResult,
     _decode_mountinfo_path,
     _empty_host_trash,
     _host_user_data_home,
@@ -550,9 +551,11 @@ class TestGioTrashBackend:
     def test_empty_trash_uses_dbus_first(self):
         bus = MagicMock()
         with patch("docking.applets.trash.backend.Gio.bus_get_sync", return_value=bus):
-            GioTrashBackend().empty(lambda: False)
+            result = GioTrashBackend().empty(lambda: False)
 
         bus.call_sync.assert_called_once()
+        assert result.delegated is True
+        assert result.attempted is False
 
     def test_empty_trash_bypasses_dbus_when_file_manager_disables_confirmation(self):
         backend = MateTrashBackend()
@@ -752,12 +755,23 @@ class TestGioTrashBackend:
         with patch(
             "docking.applets.trash.backend.Gio.File.new_for_uri", return_value=trash
         ):
-            GioTrashBackend()._delete_contents()
+            stats = GioTrashBackend()._delete_contents()
 
         enumerator.close.assert_called_once()
+        assert stats.failures == 1
+
+    def test_delete_path_reports_permission_error(self):
+        mock_path = MagicMock(spec=Path)
+        mock_path.is_dir.return_value = False
+        mock_path.is_symlink.return_value = False
+        mock_path.unlink.side_effect = PermissionError("permission denied")
+
+        stats = GioTrashBackend()._delete_path(mock_path)
+
+        assert stats.failures == 1
+        assert stats.permission_denied is True
 
     def test_count_items_handles_flatpak_oserror(self, monkeypatch):
-
         monkeypatch.setattr("docking.applets.trash.backend.is_flatpak", lambda: True)
         monkeypatch.setattr(
             "docking.applets.trash.backend._visible_trash_files_directories",
@@ -888,11 +902,14 @@ class TestKdeTrashBackend:
         (nested_dir / "b.txt").write_text("b")
         (info_dir / "a.txt.trashinfo").write_text("[Trash Info]")
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        monkeypatch.setattr("docking.applets.trash.backend._mount_points", lambda: ())
 
-        KdeTrashBackend().empty(lambda: True)
+        result = KdeTrashBackend().empty(lambda: True)
 
         assert list(files_dir.iterdir()) == []
         assert list(info_dir.iterdir()) == []
+        assert result.attempted is True
+        assert result.remaining_count == 0
 
     def test_open_uses_kde_open_command(self):
         backend = KdeTrashBackend()
@@ -984,6 +1001,18 @@ class TestKdeTrashBackend:
             backend.empty(lambda: True)
 
         delete.assert_called_once()
+
+    def test_kde_empty_returns_not_attempted_when_cancelled(
+        self, tmp_path, monkeypatch
+    ):
+        (tmp_path / "kiorc").write_text("[Confirmations]\nConfirmEmptyTrash=true\n")
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        backend = KdeTrashBackend()
+
+        result = backend.empty(lambda: False)
+
+        assert result.attempted is False
+        assert result.delegated is False
 
     def test_confirmation_preference_handles_parser_error(self, monkeypatch):
         monkeypatch.setenv("XDG_CONFIG_HOME", "/tmp/test-xdg/config")
@@ -1199,6 +1228,11 @@ class _StubBackend:
         self.monitor_files_mock = (self.monitor_file_mock,)
         self.open_calls = 0
         self.empty_confirm: Callable[[], bool] | None = None
+        self.empty_result = TrashEmptyResult(
+            attempted=True,
+            before_count=item_count,
+            remaining_count=0,
+        )
 
     def count_items(self) -> int:
         return self.item_count
@@ -1209,8 +1243,9 @@ class _StubBackend:
     def open(self) -> None:
         self.open_calls += 1
 
-    def empty(self, confirm: Callable[[], bool]) -> None:
+    def empty(self, confirm: Callable[[], bool]) -> TrashEmptyResult:
         self.empty_confirm = confirm
+        return self.empty_result
 
 
 def _make_applet(monkeypatch, backend: _StubBackend) -> TrashApplet:
@@ -1238,6 +1273,24 @@ class TestTrashAppletIcon:
 
         assert pixbuf is not None
         assert "5 items" in applet.item.name
+
+    def test_warning_attention_overlays_final_icon(self, monkeypatch):
+        applet = _make_applet(monkeypatch, _StubBackend(item_count=5))
+        applet._empty_attention = True
+        base_icon = MagicMock()
+        badged_icon = MagicMock()
+
+        with (
+            patch("docking.applets.base.Applet.create_icon", return_value=base_icon),
+            patch(
+                "docking.applets.trash.applet.add_trash_warning_badge",
+                return_value=badged_icon,
+            ) as badge,
+        ):
+            icon = applet.create_icon(48)
+
+        badge.assert_called_once_with(base_icon)
+        assert icon == badged_icon
 
     def test_single_item_singular(self, monkeypatch):
         applet = _make_applet(monkeypatch, _StubBackend(item_count=1))
@@ -1274,6 +1327,15 @@ class TestTrashAppletMenu:
         applet = _make_applet(monkeypatch, _StubBackend(item_count=3))
         items = applet.get_menu_items()
         assert items[2].get_sensitive()
+
+    def test_menu_shows_empty_trash_attention_status(self, monkeypatch):
+        applet = _make_applet(monkeypatch, _StubBackend(item_count=3))
+        applet._action_error = "Could not empty Trash."
+
+        items = applet.get_menu_items()
+
+        assert items[0].get_label() == "Could not empty Trash."
+        assert items[0].get_sensitive() is False
 
 
 class TestTrashAppletLifecycle:
@@ -1391,6 +1453,19 @@ class TestTrashAppletLifecycle:
         assert applet._item_count == 4
         assert "4 items" in applet.item.name
 
+    def test_on_trash_changed_clears_attention_when_empty(self, monkeypatch):
+        backend = _StubBackend(item_count=3)
+        applet = _make_applet(monkeypatch, backend)
+        applet._action_error = "Could not empty Trash."
+        applet._empty_attention = True
+        backend.item_count = 0
+
+        applet._on_trash_changed()
+
+        assert applet._item_count == 0
+        assert applet._action_error == ""
+        assert applet._empty_attention is False
+
     def test_empty_trash_delegates_confirmation_callback(self, monkeypatch):
         backend = _StubBackend(item_count=1)
         applet = _make_applet(monkeypatch, backend)
@@ -1398,6 +1473,65 @@ class TestTrashAppletLifecycle:
         applet._empty_trash()
 
         assert backend.empty_confirm == applet._confirm_empty_trash
+
+    def test_empty_trash_partial_failure_sets_attention(self, monkeypatch):
+        backend = _StubBackend(item_count=5)
+        backend.empty_result = TrashEmptyResult(
+            attempted=True,
+            before_count=5,
+            remaining_count=2,
+            failures=1,
+            permission_denied=True,
+        )
+        applet = _make_applet(monkeypatch, backend)
+        applet.present = MagicMock()
+
+        applet._empty_trash()
+
+        assert applet._item_count == 2
+        assert applet._empty_attention is True
+        assert "2 items remain" not in applet._action_error
+        assert "administrator permissions" in applet._action_error
+        applet.present.assert_called_once()
+        applet.refresh_tooltip()
+        assert "2 items in Trash" in applet.item.name
+        assert applet._action_error in applet.item.name
+
+    def test_empty_trash_success_clears_stale_attention(self, monkeypatch):
+        backend = _StubBackend(item_count=5)
+        backend.empty_result = TrashEmptyResult(
+            attempted=True,
+            before_count=5,
+            remaining_count=0,
+        )
+        applet = _make_applet(monkeypatch, backend)
+        applet._action_error = "Could not empty Trash."
+        applet._empty_attention = True
+        applet.present = MagicMock()
+
+        applet._empty_trash()
+
+        assert applet._item_count == 0
+        assert applet._action_error == ""
+        assert applet._empty_attention is False
+        applet.present.assert_called_once()
+
+    def test_empty_trash_delegated_result_does_not_warn(self, monkeypatch):
+        backend = _StubBackend(item_count=5)
+        backend.empty_result = TrashEmptyResult(
+            attempted=False,
+            delegated=True,
+            before_count=5,
+            remaining_count=5,
+        )
+        applet = _make_applet(monkeypatch, backend)
+        applet.present = MagicMock()
+
+        applet._empty_trash()
+
+        assert applet._action_error == ""
+        assert applet._empty_attention is False
+        applet.present.assert_called_once()
 
     def test_confirm_empty_trash_dialog(self, monkeypatch):
         applet = _make_applet(monkeypatch, _StubBackend(item_count=1))


### PR DESCRIPTION
## Summary
- return observable empty-trash results from trash backends
- show a warning badge, tooltip text, and disabled menu status when emptying Trash leaves items behind
- share the warning badge renderer with APOD, Crypto, and CurrencyFX icons