### PR TITLE
Isolate deferred runtime startup

### DIFF
--- a/docking/app.py
+++ b/docking/app.py
@@ -52,6 +52,7 @@ import faulthandler
 import os
 import signal
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -68,6 +69,7 @@ if Path(_VENDOR_DIR).is_dir():
 
 # i18n must init before any module with translatable strings is imported.
 from docking.i18n import init as _init_i18n
+from docking.log import get_logger, with_context
 
 _init_i18n()
 
@@ -96,6 +98,9 @@ if TYPE_CHECKING:
     from docking.platform.backends.base import SessionBackend
 
 _FORCE_QUIT_SOURCE_ID = 0
+
+
+log = with_context(get_logger(name="app"), action="start_runtime")
 
 
 def main() -> None:
@@ -159,13 +164,22 @@ def main() -> None:
 
 
 def _start_runtime(
-    items_service: DockItemsService, model: DockModel, backend: SessionBackend
+    items_service: DockItemsService,
+    model: DockModel,
+    backend: SessionBackend,
 ) -> bool:
     """Start background runtime pieces after the window has been shown."""
-    backend.start()
-    items_service.start()
-    model.start_applets()
+    _start_runtime_stage(name="backend", start=backend.start)
+    _start_runtime_stage(name="items_service", start=items_service.start)
+    _start_runtime_stage(name="applets", start=model.start_applets)
     return False
+
+
+def _start_runtime_stage(*, name: str, start: Callable[[], object]) -> None:
+    try:
+        start()
+    except Exception:
+        log.exception("Failed to start runtime stage: %s", name)
 
 
 def _quit() -> bool:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 
 def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
     fake_glib = SimpleNamespace(
@@ -109,7 +111,12 @@ class TestAppImport:
 
 
 class TestAppMain:
-    def test_main_builds_runtime_graph_and_starts_loop(self, monkeypatch):
+    @pytest.mark.parametrize(
+        "failed_stage",
+        (None, "backend", "items_service", "applets"),
+        ids=("success", "backend-failure", "items-service-failure", "applets-failure"),
+    )
+    def test_main_builds_runtime_graph_and_starts_loop(self, monkeypatch, failed_stage):
         # Given
         app_mod, fake_glib, fake_gtk = _load_app_module(monkeypatch)
 
@@ -149,6 +156,12 @@ class TestAppMain:
         unity.start.side_effect = lambda: call_order.append("unity_start")
         items_service.start.side_effect = lambda: call_order.append("items_start")
         model.start_applets.side_effect = lambda: call_order.append("applets_start")
+        if failed_stage is not None:
+            {
+                "backend": backend.start,
+                "items_service": items_service.start,
+                "applets": model.start_applets,
+            }[failed_stage].side_effect = RuntimeError(f"{failed_stage} failed")
 
         def idle_add(callback, *args):
             call_order.append("idle_add")
@@ -217,21 +230,23 @@ class TestAppMain:
         unity.stop.assert_called_once()
         ui.start.assert_called_once()
         ui.stop.assert_called_once()
-        fake_glib.idle_add.assert_called_once_with(
+        fake_glib.idle_add.assert_called_once()
+        assert fake_glib.idle_add.call_args.args == (
             app_mod._start_runtime,
             items_service,
             model,
             backend,
         )
         fake_gtk.main.assert_called_once()
-        assert call_order == [
-            "unity_start",
-            "show_all",
-            "ui_start",
-            "idle_add",
-            "items_start",
-            "applets_start",
-        ]
+        if failed_stage is None:
+            assert call_order == [
+                "unity_start",
+                "show_all",
+                "ui_start",
+                "idle_add",
+                "items_start",
+                "applets_start",
+            ]
 
         assert fake_glib.unix_signal_add.call_count == 2
         sig_calls = [c.args[1] for c in fake_glib.unix_signal_add.call_args_list]


### PR DESCRIPTION
## Summary
- isolate backend, IPC, and applet startup failures in the deferred runtime callback
- keep teardown unconditional so partially initialized services are cleaned up
- cover successful startup and each deferred-stage failure through the main lifecycle