### PR TITLE
Route dock quit through runtime

### DIFF
--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -713,7 +713,7 @@ class MenuHandler:
 
         # Quit
         quit_item = Gtk.MenuItem(label=_("Quit"))
-        quit_item.connect("activate", lambda _: self._runtime._window.destroy())
+        quit_item.connect("activate", lambda _: self._runtime.quit())
         menu.append(quit_item)
 
     def _append_desktop_actions(self, menu: Gtk.Menu, desktop_id: str) -> None:

--- a/docking/ui/runtime.py
+++ b/docking/ui/runtime.py
@@ -102,3 +102,7 @@ class DockRuntime:
 
     def open_releases_page(self) -> None:
         self._update_checker.open_releases_page()
+
+    def quit(self) -> None:
+        """Close the dock window and let normal process shutdown run."""
+        self._window.destroy()

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -1353,7 +1353,7 @@ class TestDockMenu:
     ):
         # Given
         menu = FakeMenu()
-        handler._runtime._window.destroy.reset_mock()
+        handler._runtime.quit.reset_mock()
         handler._model.pinned_items = [DockItem(desktop_id="applet://clock")]
         monkeypatch.setattr(
             menu_mod,
@@ -1417,7 +1417,7 @@ class TestDockMenu:
         open_target.assert_called_once_with(menu_mod.SUPPORT_URL)
 
         next(mi for mi in menu.children if mi.get_label() == "Quit").activate()
-        handler._runtime._window.destroy.assert_called_once()
+        handler._runtime.quit.assert_called_once()
 
         applets_item = next(
             mi for mi in menu.children if mi.get_label() == menu_mod._("Add Applet")

--- a/tests/ui/test_runtime.py
+++ b/tests/ui/test_runtime.py
@@ -120,3 +120,12 @@ class TestDockRuntime:
         update_checker.check_now.assert_called_once()
         update_checker.open_releases_page.assert_called_once()
         window.set_theme.assert_called_once_with("new-theme")
+
+    def test_quit_closes_the_dock_window(self):
+        window = _make_window()
+        window.destroy = MagicMock()
+        runtime = DockRuntime(window, update_checker=_make_update_checker())
+
+        runtime.quit()
+
+        window.destroy.assert_called_once()


### PR DESCRIPTION
## Summary
- expose a DockRuntime quit command for closing the dock window
- route the menu Quit action through the runtime facade