### PR TITLE
Move menu popup state to interaction coordinator

### DIFF
--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -340,7 +340,6 @@ class DockWindow(Gtk.Window):
         self.cursor_y: float = -1.0
         self.autohide: AutoHideController
         self.preview: PreviewPopup
-        self._menu_popup_visible: bool = False
         self.tooltip = TooltipManager(self, config, model, theme)
         self.geometry = DockGeometryBuilder(self)
 

--- a/docking/ui/interaction.py
+++ b/docking/ui/interaction.py
@@ -206,6 +206,7 @@ class DockInteractionCoordinator:
 
     def __init__(self, window: DockWindow) -> None:
         self._window = window
+        self._menu_popup_visible = False
 
     @property
     def dock_hovered(self) -> bool:
@@ -217,15 +218,15 @@ class DockInteractionCoordinator:
 
     def menu_popup_opened(self) -> None:
         """Track that a dock context menu popup is currently active."""
-        self._window._menu_popup_visible = True
+        self._menu_popup_visible = True
         if self._window.autohide.enabled:
             self._window.autohide.set_disabled(True, reason="menu-open")
 
     def menu_popup_closed(self) -> None:
         """Reconcile autohide state when the context menu closes."""
-        if not self._window._menu_popup_visible:
+        if not self._menu_popup_visible:
             return
-        self._window._menu_popup_visible = False
+        self._menu_popup_visible = False
 
         if not self._window.autohide.enabled:
             return

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -130,7 +130,6 @@ def _make_stub(item: DockItem | None = None):
     stub.hover.hovered_item = item
     stub.hover.cancel = MagicMock()
     stub.preview = None
-    stub._menu_popup_visible = False
     stub.autohide = _autohide(enabled=False)
     stub.cursor_x = 12.0
     stub.cursor_y = 6.0

--- a/tests/ui/test_edges.py
+++ b/tests/ui/test_edges.py
@@ -127,7 +127,6 @@ class _Harness:
         self._redraw_source_id = None
         self.preview = None
         self._interactions = MagicMock()
-        self._menu_popup_visible = False
         self._click_x = 0.0
         self._click_y = 0.0
         self._click_button = 0

--- a/tests/ui/test_interaction.py
+++ b/tests/ui/test_interaction.py
@@ -43,7 +43,6 @@ def _make_window(item: DockItem | None = None):
         tooltip=MagicMock(),
         hover=MagicMock(),
         preview=None,
-        _menu_popup_visible=False,
         autohide=_autohide(enabled=False),
         cursor_x=12.0,
         cursor_y=6.0,
@@ -141,21 +140,20 @@ class TestMenuPopupPolicy:
         coordinator.menu_popup_opened()
 
         assert coordinator.dock_hovered is True
-        assert window._menu_popup_visible is True
         window.autohide.set_disabled.assert_called_once_with(True, reason="menu-open")
 
     def test_menu_close_triggers_autohide_when_pointer_outside(self):
         window, _item = _make_window()
-        window._menu_popup_visible = True
         window.autohide = _autohide()
         window.preview = MagicMock()
         window.preview.get_visible.return_value = False
         coordinator = DockInteractionCoordinator(window)
         coordinator.pointer_inside_input_rect = MagicMock(return_value=False)
+        coordinator.menu_popup_opened()
+        window.autohide.set_disabled.reset_mock()
 
         coordinator.menu_popup_closed()
 
-        assert window._menu_popup_visible is False
         window.hover.cancel.assert_called_once()
         window.tooltip.hide.assert_called_once()
         window.preview.schedule_hide.assert_not_called()
@@ -169,16 +167,16 @@ class TestMenuPopupPolicy:
 
     def test_menu_close_with_visible_preview_defers_autohide(self):
         window, _item = _make_window()
-        window._menu_popup_visible = True
         window.autohide = _autohide()
         window.preview = MagicMock()
         window.preview.get_visible.return_value = True
         coordinator = DockInteractionCoordinator(window)
         coordinator.pointer_inside_input_rect = MagicMock(return_value=False)
+        coordinator.menu_popup_opened()
+        window.autohide.set_disabled.reset_mock()
 
         coordinator.menu_popup_closed()
 
-        assert window._menu_popup_visible is False
         window.preview.schedule_hide.assert_called_once()
         window.autohide.set_hovered.assert_called_once_with(False)
         window.autohide.set_disabled.assert_called_once_with(
@@ -188,14 +186,14 @@ class TestMenuPopupPolicy:
 
     def test_menu_close_does_not_hide_when_pointer_is_back_on_dock(self):
         window, _item = _make_window()
-        window._menu_popup_visible = True
         window.autohide = _autohide()
         coordinator = DockInteractionCoordinator(window)
         coordinator.pointer_inside_input_rect = MagicMock(return_value=True)
+        coordinator.menu_popup_opened()
+        window.autohide.set_disabled.reset_mock()
 
         coordinator.menu_popup_closed()
 
-        assert window._menu_popup_visible is False
         window.autohide.set_hovered.assert_called_once_with(True)
         window.autohide.set_disabled.assert_called_once_with(
             False, reason="menu-close-pointer-inside"
@@ -214,15 +212,30 @@ class TestMenuPopupPolicy:
 
     def test_menu_close_returns_early_when_autohide_is_disabled(self):
         window, _item = _make_window()
-        window._menu_popup_visible = True
         window.autohide = _autohide(enabled=False)
         coordinator = DockInteractionCoordinator(window)
+        coordinator.menu_popup_opened()
 
         coordinator.menu_popup_closed()
 
-        assert window._menu_popup_visible is False
         window.hover.cancel.assert_not_called()
         window.autohide.on_mouse_leave.assert_not_called()
+
+    def test_duplicate_menu_close_does_not_repeat_close_policy(self):
+        window, _item = _make_window()
+        window.autohide = _autohide()
+        coordinator = DockInteractionCoordinator(window)
+        coordinator.pointer_inside_input_rect = MagicMock(return_value=True)
+        coordinator.menu_popup_opened()
+        window.autohide.set_disabled.reset_mock()
+
+        coordinator.menu_popup_closed()
+        coordinator.menu_popup_closed()
+
+        window.autohide.set_hovered.assert_called_once_with(True)
+        window.autohide.set_disabled.assert_called_once_with(
+            False, reason="menu-close-pointer-inside"
+        )
 
 
 class TestPointerContainment:

--- a/tests/ui/test_pointer_scenarios.py
+++ b/tests/ui/test_pointer_scenarios.py
@@ -120,7 +120,6 @@ class _ScenarioHarness:
         self._cache = dock_window_mod._DockWindowCache.create()
         self._redraw_source_id = None
         self._interactions = MagicMock()
-        self._menu_popup_visible = False
         self._click_x = 0.0
         self._click_y = 0.0
         self._click_button = 0
@@ -470,14 +469,13 @@ class TestMenuLifecycleScenarios:
         handler.show(event=event, cursor_main=10.0, frame=frame)
         menu = created[0]
 
-        assert harness._menu_popup_visible is True
         harness.autohide.set_disabled.assert_called_once_with(True, reason="menu-open")
         assert menu.shown is True
         assert menu.popup_event is event
 
         menu.emit("hide")
 
-        assert harness._menu_popup_visible is False
+        assert harness.autohide.set_disabled.call_count == 2
 
 
 class TestAutohideAnimationScenarios:


### PR DESCRIPTION
## Summary
- make DockInteractionCoordinator own menu-popup lifecycle state
- remove the unused private popup flag from DockWindow and test harnesses
- cover duplicate GTK close signals without repeating autohide policy