### PR TITLE
Make ty diagnostics fail validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           . .venv/bin/activate
           python -m pip install --upgrade pip
           export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
-          python -m pip install -e ".[dev]"
+          PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3 python -m pip install -e ".[dev]"
 
       - name: Verify POT is up to date
         run: bash tools/i18n.sh --check-pot-sync
@@ -123,7 +123,7 @@ jobs:
         run: .venv/bin/python -m ruff format --check docking/ tests/
 
       - name: Type check (ty)
-        run: .venv/bin/python -m ty check docking/
+        run: .venv/bin/python -m ty check --error-on-warning docking/
 
   bdd-visual:
     name: BDD + Visual Regression
@@ -164,7 +164,7 @@ jobs:
           . .venv/bin/activate
           python -m pip install --upgrade pip
           export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
-          python -m pip install -e ".[dev]"
+          PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3 python -m pip install -e ".[dev]"
 
       - name: Screenshot regression tests
         env:
@@ -247,7 +247,7 @@ jobs:
           . .venv/bin/activate
           python -m pip install --upgrade pip
           export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
-          python -m pip install -e ".[dev]"
+          PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3 python -m pip install -e ".[dev]"
 
       - name: Install project without GI bindings
         if: matrix.python == '3.14'
@@ -257,7 +257,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python -m pip install pycairo
-          python -m pip install -e ".[dev]"
+          PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3 python -m pip install -e ".[dev]"
 
       - name: Full tests
         if: matrix.python != '3.14'
@@ -343,7 +343,7 @@ jobs:
           python -m pip install --upgrade pip
           export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python -m pip install pycairo "PyGObject==3.42.2"
-          python -m pip install -e ".[dev]"
+          PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3 python -m pip install -e ".[dev]"
 
       - name: Install project without GI bindings
         if: matrix.python == '3.14'
@@ -351,7 +351,7 @@ jobs:
           python -m pip install --upgrade pip
           export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python -m pip install pycairo
-          python -m pip install -e ".[dev]"
+          PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3 python -m pip install -e ".[dev]"
 
       - name: Full tests
         if: matrix.python != '3.14'
@@ -407,7 +407,7 @@ jobs:
           . .venv/bin/activate
           python -m pip install --upgrade pip
           export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
-          python -m pip install -e ".[dev]"
+          PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3 python -m pip install -e ".[dev]"
 
       - name: Full tests
         env:
@@ -442,7 +442,7 @@ jobs:
           . .venv/bin/activate
           python -m pip install --upgrade pip
           export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
-          python -m pip install -e ".[dev]"
+          PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3 python -m pip install -e ".[dev]"
 
       - name: Smoke tests
         env:
@@ -507,7 +507,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           export PIP_UPLOADED_PRIOR_TO="$(date -d '7 days ago' -I)"
           python -m pip install pycairo PyGObject
-          python -m pip install -e ".[dev]"
+          PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3 python -m pip install -e ".[dev]"
 
       - name: Smoke tests
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         always_run: true
       - id: ty
         name: ty
-        entry: .venv/bin/python -m ty check docking/
+        entry: .venv/bin/python -m ty check --error-on-warning docking/
         language: system
         pass_filenames: false
         always_run: true

--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ cd docking
 python3 -m venv --system-site-packages .venv
 source .venv/bin/activate
 
-# Install with dependencies
-pip install -e ".[dev]"
+# Install with development dependencies and GTK 3 type stubs
+PYGOBJECT_STUB_CONFIG=Gtk3,Gdk3 pip install -e ".[dev]"
 ```
 
 Or with [uv](https://docs.astral.sh/uv/):

--- a/docking/applets/alarm/applet.py
+++ b/docking/applets/alarm/applet.py
@@ -158,7 +158,8 @@ class AlarmApplet(Applet):
         )
         dialog = Gtk.Dialog(
             title=_("Edit Alarm") if index is not None else _("Add Alarm"),
-            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            modal=True,
+            destroy_with_parent=True,
         )
         add_cancel_ok_buttons(dialog=dialog, ok_label=_("OK"), cancel_label=_("Cancel"))
         if index is not None:

--- a/docking/applets/applications/applet.py
+++ b/docking/applets/applications/applet.py
@@ -22,11 +22,12 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("GdkPixbuf", "2.0")
-from gi.repository import GdkPixbuf, Gio, GLib, Gtk
+from gi.repository import GdkPixbuf, GLib, Gtk
 
 from docking.applets.applications import meta
 from docking.applets.applications.render import create_icon, make_menu_item_with_icon
 from docking.applets.applications.state import CATEGORY_ICONS, _build_app_categories
+from docking.applets.apps import ApplicationEntry
 from docking.applets.base import Applet
 from docking.core.icons import IconSource
 from docking.i18n import _
@@ -83,9 +84,7 @@ class ApplicationsApplet(Applet):
         """Build the categorized launcher menu lazily on each open."""
         menu = Gtk.Menu()
         categories = _build_app_categories()
-        category_rows: list[
-            tuple[Gtk.MenuItem, Gtk.Menu, list[Gio.DesktopAppInfo]]
-        ] = []
+        category_rows: list[tuple[Gtk.MenuItem, Gtk.Menu, list[ApplicationEntry]]] = []
 
         search_entry = Gtk.Entry()
         search_entry.set_placeholder_text(_("Search applications..."))
@@ -137,7 +136,7 @@ class ApplicationsApplet(Applet):
         return menu
 
 
-def _app_name(app_info: Gio.DesktopAppInfo) -> str:
+def _app_name(app_info: ApplicationEntry) -> str:
     return app_info.get_display_name() or "Unknown"
 
 
@@ -149,7 +148,7 @@ def _clear_menu(*, menu: Gtk.Menu) -> None:
 def _populate_app_submenu(
     *,
     submenu: Gtk.Menu,
-    apps: Iterable[Gio.DesktopAppInfo],
+    apps: Iterable[ApplicationEntry],
 ) -> None:
     _clear_menu(menu=submenu)
     for app_info in apps:
@@ -167,15 +166,15 @@ def _populate_app_submenu(
 
 def _filter_apps(
     *,
-    apps: Iterable[Gio.DesktopAppInfo],
+    apps: Iterable[ApplicationEntry],
     query: str,
-) -> Iterable[Gio.DesktopAppInfo]:
+) -> Iterable[ApplicationEntry]:
     if not query:
         return apps
     return [app for app in apps if query in _app_name(app).lower()]
 
 
-def _launch_app(app_info: Gio.DesktopAppInfo) -> None:
+def _launch_app(app_info: ApplicationEntry) -> None:
     """Launch an application from its DesktopAppInfo."""
     desktop_id = app_info.get_id() if app_info else None
     try:

--- a/docking/applets/apps.py
+++ b/docking/applets/apps.py
@@ -57,7 +57,7 @@ class ApplicationEntry(NamedTuple):
     def get_categories(self) -> str:
         return self.categories
 
-    def get_icon(self) -> object | None:
+    def get_icon(self) -> Gio.Icon | None:
         if self.app_info is not None:
             return self.app_info.get_icon()
         if not self.icon_name:
@@ -68,7 +68,11 @@ class ApplicationEntry(NamedTuple):
             return Gio.FileIcon.new(Gio.File.new_for_path(str(icon_path)))
         return Gio.ThemedIcon.new(self.icon_name)
 
-    def launch(self, files: list[object], context: object | None) -> None:
+    def launch(
+        self,
+        files: list[Gio.File] | None,
+        context: Gio.AppLaunchContext | None,
+    ) -> None:
         if self.desktop_id:
             launch_desktop_id(desktop_id=self.desktop_id)
             return

--- a/docking/applets/base.py
+++ b/docking/applets/base.py
@@ -306,7 +306,9 @@ def _icon_label_layout(
     font_size: int,
 ) -> Pango.Layout:
     layout = PangoCairo.create_layout(cr)
-    layout.set_font_description(Pango.FontDescription(f"Sans Bold {font_size}px"))
+    layout.set_font_description(
+        Pango.FontDescription.from_string(f"Sans Bold {font_size}px")
+    )
     layout.set_text(text, -1)
     return layout
 

--- a/docking/applets/bookmarks/applet.py
+++ b/docking/applets/bookmarks/applet.py
@@ -109,7 +109,8 @@ class BookmarksApplet(Applet):
     def _show_add_dialog(self) -> None:
         dialog = Gtk.Dialog(
             title=_("Add Bookmark"),
-            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            modal=True,
+            destroy_with_parent=True,
         )
         add_cancel_ok_buttons(dialog=dialog)
         box = prepare_dialog_content(

--- a/docking/applets/calendar/render.py
+++ b/docking/applets/calendar/render.py
@@ -67,7 +67,7 @@ def _render_calendar_icon(
     weekday_font_size = max(1, int(header_h * 0.55))
     layout = PangoCairo.create_layout(cr)
     layout.set_font_description(
-        Pango.FontDescription(f"Sans Bold {weekday_font_size}px")
+        Pango.FontDescription.from_string(f"Sans Bold {weekday_font_size}px")
     )
     layout.set_text(weekday.upper(), -1)
     _, logical = layout.get_pixel_extents()
@@ -81,7 +81,9 @@ def _render_calendar_icon(
     day_area_h = body_h - header_h
     day_font_size = max(1, int(day_area_h * 0.65))
     layout = PangoCairo.create_layout(cr)
-    layout.set_font_description(Pango.FontDescription(f"Sans Bold {day_font_size}px"))
+    layout.set_font_description(
+        Pango.FontDescription.from_string(f"Sans Bold {day_font_size}px")
+    )
     layout.set_text(str(day), -1)
     _, logical = layout.get_pixel_extents()
     tx = body_x + (body_w - logical.width) / 2 - logical.x

--- a/docking/applets/certwatch/applet.py
+++ b/docking/applets/certwatch/applet.py
@@ -304,7 +304,8 @@ class CertwatchApplet(Applet):
     def _show_add_dialog(self) -> None:
         dialog = Gtk.Dialog(
             title=_("Add Domain"),
-            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            modal=True,
+            destroy_with_parent=True,
         )
         add_cancel_ok_buttons(dialog=dialog)
         box = prepare_dialog_content(

--- a/docking/applets/clock/applet.py
+++ b/docking/applets/clock/applet.py
@@ -213,7 +213,8 @@ class ClockApplet(Applet):
     def _show_alarm_dialog(self) -> None:
         dialog = Gtk.Dialog(
             title=_("Set Alarm"),
-            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            modal=True,
+            destroy_with_parent=True,
         )
         add_cancel_ok_buttons(dialog=dialog, ok_label=_("OK"), cancel_label=_("Cancel"))
         content = prepare_dialog_content(

--- a/docking/applets/clock/render.py
+++ b/docking/applets/clock/render.py
@@ -51,6 +51,8 @@ _TOP_LAYERS = [
 def _paint_svg(cr: cairo.Context, path: Path, size: int) -> None:
     """Load an SVG at the given size and paint it onto the Cairo context."""
     pbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(str(path), size, size)
+    if pbuf is None:
+        return
     Gdk.cairo_set_source_pixbuf(cr, pbuf, 0, 0)
     cr.paint()
 
@@ -196,14 +198,14 @@ def render_digital(
             else time.strftime("%l:%M", now).strip()
         )
     time_font_size = max(1, int(size / (4.8 if show_seconds else 4)))
-    time_font = Pango.FontDescription(f"Sans Bold {time_font_size}px")
+    time_font = Pango.FontDescription.from_string(f"Sans Bold {time_font_size}px")
     rows.append((time_str, time_font, 3.0, (1, 1, 1, 1)))
 
     # Date text (digital mode only)
     if show_date:
         date_str = time.strftime("%b %-d", now)
         date_font_size = max(1, int(size / 5))
-        date_font = Pango.FontDescription(f"Sans Bold {date_font_size}px")
+        date_font = Pango.FontDescription.from_string(f"Sans Bold {date_font_size}px")
         rows.append((date_str, date_font, 2.5, (1, 1, 1, 1)))
 
     # Measure all rows to compute vertical layout
@@ -221,7 +223,7 @@ def render_digital(
     # AM/PM indicator (12h mode only, below time)
     am_pm_height = 0
     am_pm_font_size = max(1, int(size / 5))
-    am_pm_font = Pango.FontDescription(f"Sans Bold {am_pm_font_size}px")
+    am_pm_font = Pango.FontDescription.from_string(f"Sans Bold {am_pm_font_size}px")
     if not is_24h:
         tmp_layout = PangoCairo.create_layout(cr)
         tmp_layout.set_font_description(am_pm_font)

--- a/docking/applets/crypto/applet.py
+++ b/docking/applets/crypto/applet.py
@@ -399,7 +399,8 @@ class CryptoApplet(Applet):
     def _show_asset_dialog(self) -> None:
         dialog = Gtk.Dialog(
             title=_("Add Crypto Asset"),
-            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            modal=True,
+            destroy_with_parent=True,
         )
         add_cancel_ok_buttons(dialog=dialog)
         box = prepare_dialog_content(

--- a/docking/applets/currencyfx/applet.py
+++ b/docking/applets/currencyfx/applet.py
@@ -489,7 +489,8 @@ class CurrencyFxApplet(Applet):
         """Show the Add FX Pair dialog using the currently known codes."""
         dialog = Gtk.Dialog(
             title=_("Add FX Pair"),
-            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            modal=True,
+            destroy_with_parent=True,
         )
         add_cancel_ok_buttons(dialog=dialog)
         box = prepare_dialog_content(

--- a/docking/applets/hackernews/render.py
+++ b/docking/applets/hackernews/render.py
@@ -43,7 +43,7 @@ def _draw_centered_text(
     alpha: float = 1.0,
 ) -> None:
     layout = PangoCairo.create_layout(cr)
-    layout.set_font_description(Pango.FontDescription(font))
+    layout.set_font_description(Pango.FontDescription.from_string(font))
     layout.set_text(text, -1)
     _, logical = layout.get_pixel_extents()
     tx = x + (width - logical.width) / 2 - logical.x

--- a/docking/applets/lastfm/applet.py
+++ b/docking/applets/lastfm/applet.py
@@ -375,7 +375,8 @@ class LastfmApplet(Applet):
     def _show_prefs_dialog(self) -> None:
         dialog = Gtk.Dialog(
             title=_("Scrobbler Settings"),
-            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            modal=True,
+            destroy_with_parent=True,
         )
         dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         dialog.add_button(_("Save"), Gtk.ResponseType.OK)

--- a/docking/applets/lastfm/render.py
+++ b/docking/applets/lastfm/render.py
@@ -101,7 +101,7 @@ def round_pixbuf_corners(pixbuf: GdkPixbuf.Pixbuf) -> GdkPixbuf.Pixbuf:
     cr.clip()
     Gdk.cairo_set_source_pixbuf(cr, pixbuf, 0, 0)
     cr.paint()
-    return Gdk.pixbuf_get_from_surface(surface, 0, 0, width, height)
+    return Gdk.pixbuf_get_from_surface(surface, 0, 0, width, height) or pixbuf
 
 
 def _rounded_rect(

--- a/docking/applets/popup.py
+++ b/docking/applets/popup.py
@@ -278,8 +278,8 @@ def create_capture_overlay(
     click_handler: Callable[[Gtk.Window, Gdk.EventButton], bool],
     key_handler: Callable[[Gtk.Window, Gdk.EventKey], bool],
     cursor_type: Gdk.CursorType,
-) -> Gtk.Window:
-    """Create a fullscreen pointer-capture overlay with Escape handled by caller."""
+) -> Gtk.Window | None:
+    """Create a fullscreen pointer-capture overlay, or return None when unavailable."""
     overlay = Gtk.Window(type=Gtk.WindowType.POPUP)
     overlay.set_decorated(False)
     overlay.set_app_paintable(True)
@@ -299,16 +299,19 @@ def create_capture_overlay(
     display = Gdk.Display.get_default()
     if display is None:
         overlay.destroy()
-        raise RuntimeError("Could not create pointer-capture overlay")
+        return None
     cursor = Gdk.Cursor.new_for_display(display, cursor_type)
     overlay.show_all()
     window = overlay.get_window()
     if window is None:
         overlay.destroy()
-        raise RuntimeError("Could not create pointer-capture overlay")
+        return None
     window.set_cursor(cursor)
 
     seat = display.get_default_seat()
+    if seat is None:
+        overlay.destroy()
+        return None
     seat.grab(
         window,
         Gdk.SeatCapabilities.ALL_POINTING | Gdk.SeatCapabilities.KEYBOARD,

--- a/docking/applets/popup.py
+++ b/docking/applets/popup.py
@@ -297,13 +297,20 @@ def create_capture_overlay(
     overlay.connect("key-press-event", key_handler)
 
     display = Gdk.Display.get_default()
+    if display is None:
+        overlay.destroy()
+        raise RuntimeError("Could not create pointer-capture overlay")
     cursor = Gdk.Cursor.new_for_display(display, cursor_type)
     overlay.show_all()
-    overlay.get_window().set_cursor(cursor)
+    window = overlay.get_window()
+    if window is None:
+        overlay.destroy()
+        raise RuntimeError("Could not create pointer-capture overlay")
+    window.set_cursor(cursor)
 
     seat = display.get_default_seat()
     seat.grab(
-        overlay.get_window(),
+        window,
         Gdk.SeatCapabilities.ALL_POINTING | Gdk.SeatCapabilities.KEYBOARD,
         True,
         cursor,
@@ -319,7 +326,13 @@ def dismiss_capture_overlay(overlay: Gtk.Window | None) -> None:
     if overlay is None:
         return
     display = Gdk.Display.get_default()
+    if display is None:
+        overlay.destroy()
+        return
     seat = display.get_default_seat()
+    if seat is None:
+        overlay.destroy()
+        return
     seat.ungrab()
     overlay.destroy()
 

--- a/docking/applets/quicknote/applet.py
+++ b/docking/applets/quicknote/applet.py
@@ -81,7 +81,8 @@ class QuickNoteApplet(Applet):
     def _show_edit_dialog(self) -> None:
         dialog = Gtk.Dialog(
             title=_("Quick Note"),
-            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            modal=True,
+            destroy_with_parent=True,
         )
         dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         dialog.add_button(_("OK"), Gtk.ResponseType.OK)

--- a/docking/applets/runcommand/applet.py
+++ b/docking/applets/runcommand/applet.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import gi
 
@@ -167,13 +167,10 @@ class RunCommandApplet(Applet):
         self._entry_combo = Gtk.ComboBoxText.new_with_entry()
         self._entry_combo.set_entry_text_column(0)
         self._entry_combo.set_hexpand(True)
-        entry = self._entry_combo.get_child()
-        if not isinstance(entry, Gtk.Entry):
-            raise RuntimeError("Gtk.ComboBoxText did not create an entry")
-        self._entry = entry
-        entry.set_width_chars(COMMAND_WIDTH_CHARS)
-        entry.set_activates_default(True)
-        entry.connect("changed", self._on_entry_changed)
+        self._entry = cast(Gtk.Entry, self._entry_combo.get_child())
+        self._entry.set_width_chars(COMMAND_WIDTH_CHARS)
+        self._entry.set_activates_default(True)
+        self._entry.connect("changed", self._on_entry_changed)
         body.pack_start(self._entry_combo, False, False, 0)
 
         options_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
@@ -342,9 +339,12 @@ class RunCommandApplet(Applet):
         self._run_button.set_sensitive(bool(self._entry.get_text().strip()))
 
     def _on_run_with_file(self, _button: Gtk.Button) -> None:
+        parent = self._dialog
+        if parent is None:
+            return
         dialog = Gtk.FileChooserDialog(
             title=_("Run with file"),
-            transient_for=self._dialog,
+            parent=parent,
             action=Gtk.FileChooserAction.OPEN,
         )
         dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)

--- a/docking/applets/runcommand/applet.py
+++ b/docking/applets/runcommand/applet.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import gi
 
@@ -56,6 +56,14 @@ APP_LIST_HEIGHT_PX = 140
 COMMAND_WIDTH_CHARS = 48
 
 
+class _ApplicationRow(Gtk.ListBoxRow):
+    """List row that retains the application represented by its child widgets."""
+
+    def __init__(self, app: ApplicationLike) -> None:
+        super().__init__()
+        self.app = app
+
+
 class RunCommandApplet(Applet):
     """Alt+F2-style command/application launcher."""
 
@@ -75,7 +83,8 @@ class RunCommandApplet(Applet):
         self._left_icon: Gtk.Image | None = None
         self._description_label: Gtk.Label | None = None
         self._apps: list[ApplicationLike] = []
-        self._app_rows: list[Any] = []
+        self._app_list: Gtk.ListBox | None = None
+        self._app_rows: list[_ApplicationRow] = []
         self._selected_app: ApplicationLike | None = None
         self._selected_entry_text = ""
         super().__init__(icon_size=icon_size, config=config)
@@ -116,7 +125,7 @@ class RunCommandApplet(Applet):
     def _create_dialog(self) -> Gtk.Dialog:
         dialog = Gtk.Dialog(
             title=_("Run Application"),
-            flags=Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            destroy_with_parent=True,
         )
         dialog.add_button(_("Help"), Gtk.ResponseType.HELP)
         dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
@@ -158,10 +167,13 @@ class RunCommandApplet(Applet):
         self._entry_combo = Gtk.ComboBoxText.new_with_entry()
         self._entry_combo.set_entry_text_column(0)
         self._entry_combo.set_hexpand(True)
-        self._entry = self._entry_combo.get_child()
-        self._entry.set_width_chars(COMMAND_WIDTH_CHARS)
-        self._entry.set_activates_default(True)
-        self._entry.connect("changed", self._on_entry_changed)
+        entry = self._entry_combo.get_child()
+        if not isinstance(entry, Gtk.Entry):
+            raise RuntimeError("Gtk.ComboBoxText did not create an entry")
+        self._entry = entry
+        entry.set_width_chars(COMMAND_WIDTH_CHARS)
+        entry.set_activates_default(True)
+        entry.connect("changed", self._on_entry_changed)
         body.pack_start(self._entry_combo, False, False, 0)
 
         options_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
@@ -198,17 +210,16 @@ class RunCommandApplet(Applet):
         return scroll
 
     def _refresh_app_list(self) -> None:
-        if not hasattr(self, "_app_list"):
-            return
         app_list = self._app_list
+        if app_list is None:
+            return
         for child in list(app_list.get_children()):
             app_list.remove(child)
 
         self._apps = list(all_desktop_app_infos())
         self._app_rows = []
         for app in self._apps:
-            row = Gtk.ListBoxRow()
-            row.app_entry = app  # type: ignore[attr-defined]
+            row = _ApplicationRow(app)
             row.add(self._build_app_row(app))
             app_list.add(row)
             self._app_rows.append(row)
@@ -256,7 +267,8 @@ class RunCommandApplet(Applet):
         parent = self._dialog
         help_dialog = Gtk.MessageDialog(
             transient_for=parent,
-            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            modal=True,
+            destroy_with_parent=True,
             message_type=Gtk.MessageType.INFO,
             buttons=Gtk.ButtonsType.OK,
             text=_("Run Application"),
@@ -290,20 +302,18 @@ class RunCommandApplet(Applet):
     def _apply_app_filter(self, text: str) -> None:
         query = text.strip().casefold()
         for row in self._app_rows:
-            app = getattr(row, "app_entry", None)
-            visible = app is not None and _app_matches_filter(app=app, query=query)
+            visible = _app_matches_filter(app=row.app, query=query)
             if visible:
                 row.show()
             else:
                 row.hide()
 
-    def _on_app_row_selected(self, _listbox: Gtk.ListBox, row: Any) -> None:
-        if row is None:
+    def _on_app_row_selected(
+        self, _listbox: Gtk.ListBox, row: Gtk.ListBoxRow | None
+    ) -> None:
+        if not isinstance(row, _ApplicationRow):
             return
-        app = getattr(row, "app_entry", None)
-        if app is None:
-            return
-        self._select_application(app)
+        self._select_application(row.app)
 
     def _select_application(self, app: ApplicationLike) -> None:
         self._selected_app = app
@@ -334,7 +344,7 @@ class RunCommandApplet(Applet):
     def _on_run_with_file(self, _button: Gtk.Button) -> None:
         dialog = Gtk.FileChooserDialog(
             title=_("Run with file"),
-            parent=self._dialog,
+            transient_for=self._dialog,
             action=Gtk.FileChooserAction.OPEN,
         )
         dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)

--- a/docking/applets/runcommand/state.py
+++ b/docking/applets/runcommand/state.py
@@ -23,7 +23,7 @@ import subprocess
 from collections.abc import Callable, Iterable
 from enum import Enum
 from functools import cache
-from typing import Any, NamedTuple, Protocol
+from typing import NamedTuple, Protocol
 
 from gi.repository import Gio, GLib
 
@@ -82,9 +82,10 @@ DESKTOP_EXEC_FIELD_CODES_RE = re.compile(r"%[uUfFdDnNickvm]")
 
 
 class ApplicationLike(Protocol):
-    """Protocol shared by Gio app infos and the Applications applet adapter."""
+    """Application entry consumed by the Run Application dialog."""
 
-    app_info: Any
+    @property
+    def app_info(self) -> Gio.DesktopAppInfo | None: ...
 
     def get_display_name(self) -> str: ...
 
@@ -285,25 +286,39 @@ def app_display_name(app: ApplicationLike) -> str:
 
 def app_command_text(app: ApplicationLike) -> str:
     """Return command text suitable for the dialog entry."""
-    app_info = getattr(app, "app_info", None)
+    app_info = app.app_info
     commandline = ""
-    get_commandline = getattr(app_info, "get_commandline", None)
-    if callable(get_commandline):
-        commandline = clean_desktop_exec(str(get_commandline() or ""))
+    if app_info is not None:
+        commandline = clean_desktop_exec(str(app_info.get_commandline() or ""))
     return commandline or app_display_name(app)
 
 
 def app_description(app: ApplicationLike) -> str:
     """Return the best available app description/comment."""
-    app_info = getattr(app, "app_info", None)
-    for attr in ("get_description", "get_comment", "get_generic_name"):
-        getter = getattr(app_info, attr, None)
-        if not callable(getter):
-            continue
-        text = str(getter() or "").strip()
+    app_info = app.app_info
+    if app_info is None:
+        return app_display_name(app)
+    for text in (
+        str(app_info.get_description() or "").strip(),
+        _optional_app_info_text(app_info, "get_comment"),
+        _optional_app_info_text(app_info, "get_generic_name"),
+    ):
         if text:
             return text
     return app_display_name(app)
+
+
+def _optional_app_info_text(app_info: Gio.DesktopAppInfo, getter_name: str) -> str:
+    """Read metadata that is not exposed by every PyGObject runtime.
+
+    ``Gio.DesktopAppInfo`` consistently provides a description, while comment
+    and generic-name accessors vary across the available bindings. Keep those
+    two fields as best-effort metadata rather than requiring them at runtime.
+    """
+    getter = getattr(app_info, getter_name, None)
+    if not callable(getter):
+        return ""
+    return str(getter() or "").strip()
 
 
 def match_application(

--- a/docking/applets/runcommand/state.py
+++ b/docking/applets/runcommand/state.py
@@ -25,7 +25,7 @@ from enum import Enum
 from functools import cache
 from typing import Any, NamedTuple, Protocol
 
-from gi.repository import GLib
+from gi.repository import Gio, GLib
 
 from docking.applets.runcommand import meta
 from docking.log import get_logger, with_context
@@ -88,9 +88,13 @@ class ApplicationLike(Protocol):
 
     def get_display_name(self) -> str: ...
 
-    def get_icon(self) -> object | None: ...
+    def get_icon(self) -> Gio.Icon | None: ...
 
-    def launch(self, files: list[object], context: object | None) -> None: ...
+    def launch(
+        self,
+        files: list[Gio.File] | None,
+        context: Gio.AppLaunchContext | None,
+    ) -> None: ...
 
 
 def normalize_history(raw_history: object) -> list[str]:

--- a/docking/applets/sunrise/applet.py
+++ b/docking/applets/sunrise/applet.py
@@ -183,7 +183,8 @@ class SunriseApplet(Applet):
     def _show_city_dialog(self) -> None:
         dialog = Gtk.Dialog(
             title=_("Search for the city"),
-            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            modal=True,
+            destroy_with_parent=True,
         )
         dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         dialog.connect("response", lambda dlg, _response: dlg.destroy())

--- a/docking/applets/systemtray/applet.py
+++ b/docking/applets/systemtray/applet.py
@@ -349,7 +349,7 @@ class SystemTrayApplet(Applet):
         message = self._legacy_host.unavailable_reason or _("Unknown X11 tray error")
         dialog = Gtk.MessageDialog(
             transient_for=self.popup_anchor.parent if self.popup_anchor else None,
-            flags=Gtk.DialogFlags.MODAL,
+            modal=True,
             message_type=Gtk.MessageType.WARNING,
             buttons=Gtk.ButtonsType.OK,
             text=_("Could not start the legacy tray"),
@@ -362,7 +362,7 @@ class SystemTrayApplet(Applet):
         owner = self._state.legacy_tray_owner or _("another tray")
         dialog = Gtk.MessageDialog(
             transient_for=self.popup_anchor.parent if self.popup_anchor else None,
-            flags=Gtk.DialogFlags.MODAL,
+            modal=True,
             message_type=Gtk.MessageType.WARNING,
             buttons=Gtk.ButtonsType.CANCEL,
             text=_("Take over the legacy tray?"),

--- a/docking/applets/trash/applet.py
+++ b/docking/applets/trash/applet.py
@@ -252,7 +252,8 @@ class TrashApplet(Applet):
 
     def _confirm_empty_trash(self) -> bool:
         dialog = Gtk.MessageDialog(
-            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            modal=True,
+            destroy_with_parent=True,
             message_type=Gtk.MessageType.WARNING,
             buttons=Gtk.ButtonsType.NONE,
             text=_("Empty all items from Trash?"),

--- a/docking/applets/unitconverter/applet.py
+++ b/docking/applets/unitconverter/applet.py
@@ -173,7 +173,7 @@ class UnitConverterApplet(Applet):
         if self._popup is None:
             self._popup = Gtk.Dialog(
                 title=_("Unit Converter"),
-                flags=Gtk.DialogFlags.DESTROY_WITH_PARENT,
+                destroy_with_parent=True,
             )
             self._popup.connect("delete-event", self._on_popup_delete)
 

--- a/docking/applets/urlshortener/applet.py
+++ b/docking/applets/urlshortener/applet.py
@@ -109,7 +109,7 @@ class UrlShortenerApplet(Applet):
     def _show_dialog(self) -> None:
         self._dialog = Gtk.Dialog(
             title=_("URL Shortener"),
-            flags=Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            destroy_with_parent=True,
         )
         box = prepare_dialog_content(
             dialog=self._dialog,

--- a/docking/applets/usbwatch/state.py
+++ b/docking/applets/usbwatch/state.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -46,7 +47,7 @@ class MountLike(Protocol):
 
 
 class VolumeMonitorLike(Protocol):
-    def get_mounts(self) -> list[MountLike]: ...
+    def get_mounts(self) -> Sequence[MountLike]: ...
 
 
 @dataclass(frozen=True, slots=True)

--- a/docking/applets/weather/applet.py
+++ b/docking/applets/weather/applet.py
@@ -268,7 +268,8 @@ class WeatherApplet(Applet):
     def _show_city_dialog(self) -> None:
         dialog = Gtk.Dialog(
             title=_("Search for the city"),
-            flags=Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            modal=True,
+            destroy_with_parent=True,
         )
         dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         dialog.connect("response", lambda dlg, _response: dlg.destroy())

--- a/docking/core/json_types.py
+++ b/docking/core/json_types.py
@@ -1,0 +1,16 @@
+"""JSON-compatible type aliases shared by persistence and IPC boundaries."""
+
+from __future__ import annotations
+
+from typing import TypeAlias, cast
+
+JsonScalar: TypeAlias = None | bool | int | float | str
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]
+
+
+def as_json_object(value: JsonValue) -> JsonObject | None:
+    """Return *value* as a JSON object when it has string keys."""
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        return None
+    return cast(JsonObject, value)

--- a/docking/platform/backends/gnome/bridge.py
+++ b/docking/platform/backends/gnome/bridge.py
@@ -167,7 +167,7 @@ class GnomeShellBridgeClient:
         result = self._call("ActivateWorkspace", GLib.Variant("(u)", (bridge_id,)))
         return bool(result.unpack()[0]) if result is not None else False
 
-    def subscribe_changed(self, callback: Callable[[], None]) -> object | None:
+    def subscribe_changed(self, callback: Callable[[], None]) -> int | None:
         """Subscribe to extension state changes."""
         connection = self._proxy.get_connection()
         if connection is None:
@@ -195,12 +195,9 @@ class GnomeShellBridgeClient:
 
     def unsubscribe_changed(self, handle: object) -> None:
         connection = self._proxy.get_connection()
-        if connection is None:
+        if connection is None or not isinstance(handle, int):
             return
-        try:
-            connection.signal_unsubscribe(int(handle))
-        except (TypeError, ValueError):
-            return
+        connection.signal_unsubscribe(handle)
 
     def _call(
         self, method: str, parameters: GLib.Variant | None = None
@@ -521,10 +518,8 @@ class GnomeShellBridgeWorkspaceService(WorkspaceService):
         return handle
 
     def unwatch_active_workspace(self, handle: object) -> None:
-        try:
-            self._watchers.pop(int(handle), None)
-        except (TypeError, ValueError):
-            return
+        if isinstance(handle, int):
+            self._watchers.pop(handle, None)
 
     def _poll(self) -> bool:
         self.refresh()

--- a/docking/platform/backends/gnome/session.py
+++ b/docking/platform/backends/gnome/session.py
@@ -32,6 +32,7 @@ from docking.platform.backends.base import (
     WorkspaceService,
 )
 from docking.platform.backends.gnome.bridge import (
+    GnomeShellBridgeClient,
     GnomeShellBridgeDesktopActionService,
     GnomeShellBridgePreviewService,
     GnomeShellBridgeSurfaceService,
@@ -58,7 +59,7 @@ class GnomeShellBridgeRuntimeServices:
 class GnomeShellBridgeSessionBackend(SessionBackend):
     """GNOME Shell bridge backend with reduced GTK surface integration."""
 
-    def __init__(self, *, model, launcher, bridge: object) -> None:
+    def __init__(self, *, model, launcher, bridge: GnomeShellBridgeClient) -> None:
         self._services = GnomeShellBridgeRuntimeServices(
             windows=GnomeShellBridgeWindowService(
                 model=model,

--- a/docking/platform/backends/wayland/cosmic.py
+++ b/docking/platform/backends/wayland/cosmic.py
@@ -33,7 +33,7 @@ COSMIC protocol composition:
 from __future__ import annotations
 
 import struct
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
 
 from docking.log import get_logger
@@ -45,6 +45,18 @@ if TYPE_CHECKING:
     from docking.platform.backends.wayland.workspaces import WaylandWorkspaceService
 
 log = get_logger(name="cosmic_protocols")
+
+
+def _workspace_flags(value: object) -> Iterable[object] | int | None:
+    """Return a workspace flag payload accepted by the service contract."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (str, bytes, bytearray)):
+        return None
+    if isinstance(value, Iterable):
+        return value
+    return None
+
 
 # ---------------------------------------------------------------------------
 # Toplevel state constants (matching xdg-toplevel states)
@@ -439,9 +451,13 @@ class CosmicWorkspaceAdapter:
             if "name" in data:
                 service.name_changed(workspace, str(data["name"]))
             if "state" in data:
-                service.state_changed(workspace, data["state"])
+                states = _workspace_flags(data["state"])
+                if states is not None:
+                    service.state_changed(workspace, states)
             if "capabilities" in data:
-                service.capabilities_changed(workspace, data["capabilities"])
+                capabilities = _workspace_flags(data["capabilities"])
+                if capabilities is not None:
+                    service.capabilities_changed(workspace, capabilities)
         if self._pending_done:
             service.done()
 
@@ -505,12 +521,16 @@ class CosmicWorkspaceAdapter:
         if self._service is not None:
             self._service.name_changed(workspace, name)
 
-    def _on_workspace_state(self, workspace: object, states) -> None:
+    def _on_workspace_state(
+        self, workspace: object, states: Iterable[object] | int
+    ) -> None:
         self._pending_data.setdefault(workspace, {})["state"] = states
         if self._service is not None:
             self._service.state_changed(workspace, states)
 
-    def _on_workspace_capabilities(self, workspace: object, caps) -> None:
+    def _on_workspace_capabilities(
+        self, workspace: object, caps: Iterable[object] | int
+    ) -> None:
         self._pending_data.setdefault(workspace, {})["capabilities"] = caps
         if self._service is not None:
             self._service.capabilities_changed(workspace, caps)

--- a/docking/platform/backends/wayland/niri_ipc.py
+++ b/docking/platform/backends/wayland/niri_ipc.py
@@ -29,13 +29,14 @@ from collections.abc import Callable, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 import gi
 
 gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GdkPixbuf
 
+from docking.core.json_types import JsonObject, JsonValue, as_json_object
 from docking.log import get_logger
 from docking.platform.app_matcher import AppIdMatcher
 from docking.platform.backends.base import (
@@ -147,7 +148,7 @@ class NiriIpcClient:
         self._socket_factory = socket_factory
         self._timeout = timeout
 
-    def request(self, payload: object) -> dict[str, Any]:
+    def request(self, payload: JsonValue) -> JsonObject:
         """Send one JSON request and return the parsed reply dict.
 
         Returns an empty dict on any error so callers can safely chain
@@ -177,15 +178,16 @@ class NiriIpcClient:
             log.info("Niri IPC response parse error: %s", exc)
             return {}
 
-    def ok_data(self, payload: object, key: str) -> Any | None:
+    def ok_data(self, payload: JsonValue, key: str) -> JsonValue | None:
         """Send a request and return ``Ok.<key>`` from the reply, or None."""
         reply = self.request(payload)
         ok = reply.get("Ok")
-        if isinstance(ok, Mapping):
-            return ok.get(key)
+        ok_object = as_json_object(ok)
+        if ok_object is not None:
+            return ok_object.get(key)
         return None
 
-    def action(self, action_payload: Mapping[str, Any]) -> ActionResult:
+    def action(self, action_payload: Mapping[str, JsonValue]) -> ActionResult:
         """Send an ``Action`` request.  Returns OK when the server accepts it."""
         try:
             reply = self.request({"Action": action_payload})
@@ -206,7 +208,7 @@ class NiriEvent:
     """One parsed event from the Niri event stream."""
 
     name: str
-    data: dict[str, Any]
+    data: JsonObject
 
 
 class NiriEventStream:
@@ -295,7 +297,7 @@ class NiriWindowService(WindowService):
         self._event_stream_factory = event_stream_factory
         self._event_stream: NiriEventStream | None = None
         self._records: dict[int, NiriWindowRecord] = {}
-        self._workspaces: dict[int, dict[str, Any]] = {}
+        self._workspaces: dict[int, JsonObject] = {}
         self._overview_open = False
         self._on_overview_changed: Callable[[bool], None] | None = None
 
@@ -433,17 +435,14 @@ class NiriWindowService(WindowService):
             if event.name == "WorkspacesChanged":
                 workspaces_raw = event.data.get("workspaces")
                 if isinstance(workspaces_raw, list):
-                    self._workspaces = {
-                        ws["id"]: ws
-                        for ws in workspaces_raw
-                        if isinstance(ws, Mapping) and "id" in ws
-                    }
+                    self._workspaces = _workspaces_by_id(workspaces_raw)
                 return
             # Incremental updates.
             if event.name == "WindowOpenedOrChanged":
                 window_raw = event.data.get("window")
-                if isinstance(window_raw, Mapping):
-                    self._upsert_window(window_raw)
+                window = as_json_object(window_raw)
+                if window is not None:
+                    self._upsert_window(window)
             elif event.name == "WindowClosed":
                 window_id = event.data.get("id")
                 if isinstance(window_id, int):
@@ -474,24 +473,21 @@ class NiriWindowService(WindowService):
     def _refresh_workspaces(self) -> None:
         workspaces_raw = self._client.ok_data({"Workspaces": None}, "Workspaces")
         if isinstance(workspaces_raw, list):
-            self._workspaces = {
-                ws["id"]: ws
-                for ws in workspaces_raw
-                if isinstance(ws, Mapping) and "id" in ws
-            }
+            self._workspaces = _workspaces_by_id(workspaces_raw)
 
-    def _replace_windows(self, items: list[Any]) -> None:
+    def _replace_windows(self, items: list[JsonValue]) -> None:
         self._matcher.sync_visible_items(self._model.visible_items())
         records: dict[int, NiriWindowRecord] = {}
         for item in items:
-            if not isinstance(item, Mapping):
+            item_object = as_json_object(item)
+            if item_object is None:
                 continue
-            record = _record_from_window(item, matcher=self._matcher)
+            record = _record_from_window(item_object, matcher=self._matcher)
             if record is not None:
                 records[record.id] = record
         self._records = records
 
-    def _upsert_window(self, item: Mapping[str, Any]) -> None:
+    def _upsert_window(self, item: Mapping[str, JsonValue]) -> None:
         record = _record_from_window(item, matcher=self._matcher)
         if record is not None:
             self._records[record.id] = record
@@ -514,7 +510,7 @@ class NiriWindowService(WindowService):
                     geometry=record.geometry,
                 )
 
-    def _apply_urgency_change(self, data: Mapping[str, Any]) -> None:
+    def _apply_urgency_change(self, data: Mapping[str, JsonValue]) -> None:
         window_id = data.get("id")
         urgent = data.get("urgent")
         if not isinstance(window_id, int) or not isinstance(urgent, bool):
@@ -672,12 +668,13 @@ class NiriWorkspaceService(WorkspaceService):
         if isinstance(workspaces_raw, list):
             self._replace_workspaces(workspaces_raw)
 
-    def _replace_workspaces(self, items: list[Any]) -> None:
+    def _replace_workspaces(self, items: list[JsonValue]) -> None:
         records: list[NiriWorkspaceRecord] = []
         for item in items:
-            if not isinstance(item, Mapping):
+            item_object = as_json_object(item)
+            if item_object is None:
                 continue
-            record = _record_from_workspace(item, number=len(records))
+            record = _record_from_workspace(item_object, number=len(records))
             if record is not None:
                 records.append(record)
         self._records = {record.snapshot_id: record for record in records}
@@ -853,16 +850,21 @@ def niri_pick_color(
                 chunks.append(chunk)
         reply = _parse_response(b"".join(chunks))
         ok = reply.get("Ok")
-        if isinstance(ok, Mapping):
-            picked = ok.get("PickedColor")
-            if isinstance(picked, Mapping):
+        ok_object = as_json_object(ok)
+        if ok_object is not None:
+            picked = as_json_object(ok_object.get("PickedColor"))
+            if picked is not None:
                 rgb = picked.get("rgb")
                 if isinstance(rgb, list) and len(rgb) == 3:
-                    return (
-                        max(0, min(255, round(float(rgb[0]) * 255))),
-                        max(0, min(255, round(float(rgb[1]) * 255))),
-                        max(0, min(255, round(float(rgb[2]) * 255))),
-                    )
+                    red = _float_value(rgb[0])
+                    green = _float_value(rgb[1])
+                    blue = _float_value(rgb[2])
+                    if red is not None and green is not None and blue is not None:
+                        return (
+                            max(0, min(255, round(red * 255))),
+                            max(0, min(255, round(green * 255))),
+                            max(0, min(255, round(blue * 255))),
+                        )
         return None
     except OSError as exc:
         log.info("Niri PickColor failed: %s", exc)
@@ -1019,12 +1021,25 @@ def _wait_for_nonempty_file(path: str, *, timeout: float = 2.0) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _parse_response(raw: bytes) -> dict[str, Any]:
+def _workspaces_by_id(items: list[JsonValue]) -> dict[int, JsonObject]:
+    """Index valid workspace objects by their Niri numeric identifier."""
+    workspaces: dict[int, JsonObject] = {}
+    for item in items:
+        workspace = as_json_object(item)
+        if workspace is None:
+            continue
+        workspace_id = workspace.get("id")
+        if isinstance(workspace_id, int):
+            workspaces[workspace_id] = workspace
+    return workspaces
+
+
+def _parse_response(raw: bytes) -> JsonObject:
     """Parse one reply line from Niri IPC into a dict."""
     text = raw.decode("utf-8", errors="replace").strip()
     if not text:
         return {}
-    return json.loads(text)  # type: ignore[no-any-return]
+    return as_json_object(cast(JsonValue, json.loads(text))) or {}
 
 
 def _parse_event_line(line: str) -> NiriEvent | None:
@@ -1036,7 +1051,8 @@ def _parse_event_line(line: str) -> NiriEvent | None:
         obj = json.loads(stripped)
     except json.JSONDecodeError:
         return None
-    if not isinstance(obj, Mapping) or len(obj) != 1:
+    obj = as_json_object(cast(JsonValue, obj))
+    if obj is None or len(obj) != 1:
         return None
     # The first ``{"Ok":"Handled"}`` acknowledgement is not a real event.
     if "Ok" in obj:
@@ -1044,12 +1060,12 @@ def _parse_event_line(line: str) -> NiriEvent | None:
     (name, data_raw) = next(iter(obj.items()))
     if not isinstance(name, str):
         return None
-    data = dict(data_raw) if isinstance(data_raw, Mapping) else {}
+    data = as_json_object(data_raw) or {}
     return NiriEvent(name=name, data=data)
 
 
 def _record_from_window(
-    item: Mapping[str, Any],
+    item: Mapping[str, JsonValue],
     *,
     matcher: AppIdMatcher,
 ) -> NiriWindowRecord | None:
@@ -1075,7 +1091,7 @@ def _record_from_window(
 
 
 def _record_from_workspace(
-    item: Mapping[str, Any],
+    item: Mapping[str, JsonValue],
     *,
     number: int,
 ) -> NiriWorkspaceRecord | None:
@@ -1116,34 +1132,52 @@ def _focus_niri_workspace(
     return client.action({"FocusWorkspace": {"reference": {"Index": record.idx}}})
 
 
-def _geometry_from_niri_window(item: Mapping[str, Any]) -> Rect | None:
+def _geometry_from_niri_window(item: Mapping[str, JsonValue]) -> Rect | None:
     """Extract window geometry from Niri's layout fields.
 
     Niri windows don't have a single global ``(x, y, w, h)`` since they're
     tiled.  We derive an approximate geometry from the tiling layout:
     ``tile_pos_in_workspace_view`` + ``window_size`` when available.
     """
-    layout = item.get("layout")
-    if not isinstance(layout, Mapping):
+    layout = as_json_object(item.get("layout"))
+    if layout is None:
         return None
     size = layout.get("window_size")
-    if not isinstance(size, Sequence) or isinstance(size, str | bytes) or len(size) < 2:
+    if not isinstance(size, list) or len(size) < 2:
         return None
-    try:
-        w = int(size[0])
-        h = int(size[1])
-    except (TypeError, ValueError):
+    w = _int_value(size[0])
+    h = _int_value(size[1])
+    if w is None or h is None:
         return None
     pos = layout.get("tile_pos_in_workspace_view")
-    if isinstance(pos, Sequence) and not isinstance(pos, str | bytes) and len(pos) >= 2:
-        try:
-            x = int(pos[0])
-            y = int(pos[1])
-        except (TypeError, ValueError):
+    if isinstance(pos, list) and len(pos) >= 2:
+        x = _int_value(pos[0])
+        y = _int_value(pos[1])
+        if x is None or y is None:
             x, y = 0, 0
     else:
         x, y = 0, 0
     return Rect(x=x, y=y, width=w, height=h)
+
+
+def _int_value(value: JsonValue) -> int | None:
+    """Convert a scalar JSON value to an integer without accepting containers."""
+    if not isinstance(value, int | float | str):
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _float_value(value: JsonValue) -> float | None:
+    """Convert a scalar JSON value to a float without accepting containers."""
+    if not isinstance(value, int | float | str):
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
 
 
 def _niri_window_id(window_id: WindowId) -> int | None:

--- a/docking/platform/backends/wayland/previews.py
+++ b/docking/platform/backends/wayland/previews.py
@@ -497,7 +497,9 @@ class HyprlandPreviewService(PreviewService):
             os.close(request.fd)
 
 
-def _pixbuf_from_request(request: _CaptureRequest) -> PreviewImage:
+def _pixbuf_from_request(
+    request: _CaptureRequest | _HyprlandCaptureRequest,
+) -> PreviewImage:
     assert request.mmap_obj is not None
     source = request.mmap_obj[: request.stride * request.height]
     if getattr(request, "y_inverted", False):

--- a/docking/platform/backends/wayland/runtime.py
+++ b/docking/platform/backends/wayland/runtime.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -32,6 +32,20 @@ if TYPE_CHECKING:
     from docking.platform.backends.wayland.workspaces import WaylandWorkspaceService
 
 log = get_logger(name="wayland_protocol_runtime")
+
+
+def _iterable_state(value: object) -> Iterable[object] | None:
+    """Narrow raw protocol state payloads before publishing them to services."""
+    if isinstance(value, (str, bytes, bytearray)):
+        return None
+    return value if isinstance(value, Iterable) else None
+
+
+def _workspace_flags(value: object) -> Iterable[object] | int | None:
+    """Narrow raw workspace state/capability payloads to their service contract."""
+    if isinstance(value, int):
+        return value
+    return _iterable_state(value)
 
 
 @dataclass(frozen=True)
@@ -89,7 +103,9 @@ class ForeignToplevelProtocolAdapter:
             if "app_id" in data:
                 service.app_id_changed(toplevel, str(data["app_id"]))
             if "state" in data:
-                service.state_changed(toplevel, data["state"])  # type: ignore[arg-type]
+                states = _iterable_state(data["state"])
+                if states is not None:
+                    service.state_changed(toplevel, states)
             if data.get("done"):
                 service.done(toplevel)
 
@@ -183,10 +199,10 @@ class ForeignToplevelProtocolAdapter:
         if self._service is not None:
             self._service.app_id_changed(toplevel, app_id)
 
-    def _on_toplevel_state(self, toplevel: object, states: object) -> None:
+    def _on_toplevel_state(self, toplevel: object, states: Iterable[object]) -> None:
         self._pending_data.setdefault(toplevel, {})["state"] = states
         if self._service is not None:
-            self._service.state_changed(toplevel, states)  # type: ignore[arg-type]
+            self._service.state_changed(toplevel, states)
 
     def _on_toplevel_done(self, toplevel: object) -> None:
         self._pending_data.setdefault(toplevel, {})["done"] = True
@@ -241,12 +257,13 @@ class WorkspaceProtocolAdapter:
             if "name" in data:
                 service.name_changed(workspace, str(data["name"]))
             if "capabilities" in data:
-                service.capabilities_changed(
-                    workspace,
-                    data["capabilities"],  # type: ignore[arg-type]
-                )
+                capabilities = _workspace_flags(data["capabilities"])
+                if capabilities is not None:
+                    service.capabilities_changed(workspace, capabilities)
             if "state" in data:
-                service.state_changed(workspace, data["state"])  # type: ignore[arg-type]
+                states = _workspace_flags(data["state"])
+                if states is not None:
+                    service.state_changed(workspace, states)
         if self._pending_done:
             service.done()
 
@@ -313,13 +330,15 @@ class WorkspaceProtocolAdapter:
         if self._service is not None:
             self._service.name_changed(workspace, value)
 
-    def _on_workspace_state(self, workspace: object, states: object) -> None:
+    def _on_workspace_state(
+        self, workspace: object, states: Iterable[object] | int
+    ) -> None:
         self._pending_data.setdefault(workspace, {})["state"] = states
         if self._service is not None:
             self._service.state_changed(workspace, states)
 
     def _on_workspace_capabilities(
-        self, workspace: object, capabilities: object
+        self, workspace: object, capabilities: Iterable[object] | int
     ) -> None:
         self._pending_data.setdefault(workspace, {})["capabilities"] = capabilities
         if self._service is not None:

--- a/docking/platform/backends/wayland/wayfire_ipc.py
+++ b/docking/platform/backends/wayland/wayfire_ipc.py
@@ -33,7 +33,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from queue import Empty, Queue
-from typing import Any
+from typing import Any, cast
 
 from docking.log import get_logger
 from docking.platform.app_matcher import AppIdMatcher
@@ -58,7 +58,7 @@ log = get_logger(name="wayfire_ipc")
 try:
     from gi.repository import GLib
 except (ImportError, ValueError):
-    GLib = None
+    GLib = cast(Any, None)
 
 WAYFIRE_WINDOW_POLL_SECONDS = 2
 _WAYFIRE_EVENTS = (
@@ -1033,9 +1033,8 @@ def _record_from_view(
     layer = str(view.get("layer", "") or "").strip().lower()
     if view_type != "toplevel" and role != "toplevel" and layer != "workspace":
         return None
-    try:
-        view_id = int(view.get("id"))
-    except (TypeError, ValueError):
+    view_id = _optional_int(view.get("id"))
+    if view_id is None:
         return None
     app_id = str(view.get("app-id", "") or "").strip()
     desktop_id = matcher.match(app_id) if app_id else None
@@ -1058,15 +1057,13 @@ def _record_from_view(
 def _rect_from_mapping(value: object) -> Rect | None:
     if not isinstance(value, Mapping):
         return None
-    try:
-        return Rect(
-            x=int(value.get("x", 0)),
-            y=int(value.get("y", 0)),
-            width=int(value.get("width", 0)),
-            height=int(value.get("height", 0)),
-        )
-    except (TypeError, ValueError):
+    x = _optional_int(value.get("x", 0))
+    y = _optional_int(value.get("y", 0))
+    width = _optional_int(value.get("width", 0))
+    height = _optional_int(value.get("height", 0))
+    if x is None or y is None or width is None or height is None:
         return None
+    return Rect(x=x, y=y, width=width, height=height)
 
 
 def _workspace_records_from_output(
@@ -1151,6 +1148,8 @@ def _optional_bool(value: object) -> bool | None:
 
 
 def _optional_int(value: object) -> int | None:
+    if not isinstance(value, (int, float, str)):
+        return None
     try:
         return int(value)
     except (TypeError, ValueError):

--- a/docking/platform/backends/wayland/wayfire_ipc.py
+++ b/docking/platform/backends/wayland/wayfire_ipc.py
@@ -35,6 +35,7 @@ from pathlib import Path
 from queue import Empty, Queue
 from typing import Any, cast
 
+from docking.core.json_types import JsonObject, JsonValue, as_json_object
 from docking.log import get_logger
 from docking.platform.app_matcher import AppIdMatcher
 from docking.platform.backends.base import (
@@ -83,7 +84,7 @@ class WayfireEventWatcher:
         self,
         *,
         socket_path: str,
-        on_event: Callable[[str, Mapping[str, Any]], None],
+        on_event: Callable[[str, Mapping[str, JsonValue]], None],
         socket_factory: Callable[[int, int], socket.socket] = socket.socket,
     ) -> None:
         self._path = socket_path
@@ -92,7 +93,7 @@ class WayfireEventWatcher:
         self._sock: socket.socket | None = None
         self._thread: threading.Thread | None = None
         self._running = False
-        self._queue: Queue = Queue()
+        self._queue: Queue[JsonObject] = Queue()
         self._glib_source_id = 0
 
     def start(self) -> bool:
@@ -115,7 +116,8 @@ class WayfireEventWatcher:
             ).encode("utf-8")
             sock.sendall(struct.pack("I", len(payload)) + payload)
             response_len = struct.unpack("I", _read_exact(sock, 4))[0]
-            response = json.loads(_read_exact(sock, response_len).decode("utf-8"))
+            response_text = _read_exact(sock, response_len).decode("utf-8")
+            response = as_json_object(cast(JsonValue, json.loads(response_text)))
             if not isinstance(response, Mapping) or response.get("result") != "ok":
                 log.info("Wayfire event subscription rejected: %s", response)
                 sock.close()
@@ -164,8 +166,11 @@ class WayfireEventWatcher:
                     evt_len_raw += extra
                 evt_len = struct.unpack("I", evt_len_raw)[0]
                 evt = _read_exact(sock, evt_len)
-                parsed = json.loads(evt.decode("utf-8"))
-                self._queue.put(parsed)
+                parsed = as_json_object(
+                    cast(JsonValue, json.loads(evt.decode("utf-8")))
+                )
+                if parsed is not None:
+                    self._queue.put(parsed)
             except (TimeoutError, OSError):
                 if not self._running:
                     break
@@ -184,8 +189,9 @@ class WayfireEventWatcher:
                 break
             event_name = event.get("event", "")
             view_data = event.get("view")
-            if isinstance(event_name, str) and isinstance(view_data, Mapping):
-                self._on_event(event_name, view_data)
+            view = as_json_object(view_data)
+            if isinstance(event_name, str) and view is not None:
+                self._on_event(event_name, view)
             handled += 1
         return True  # keep the idle source alive
 
@@ -237,7 +243,9 @@ class WayfireIpcClient:
         self._socket_factory = socket_factory
         self._timeout = timeout
 
-    def request(self, method: str, data: Mapping[str, Any] | None = None) -> Any:
+    def request(
+        self, method: str, data: Mapping[str, JsonValue] | None = None
+    ) -> JsonValue:
         """Call one Wayfire IPC method and return the decoded JSON response."""
         payload = json.dumps(
             {
@@ -252,9 +260,9 @@ class WayfireIpcClient:
             sock.sendall(struct.pack("I", len(payload)) + payload)
             response_len = struct.unpack("I", _read_exact(sock, 4))[0]
             response = _read_exact(sock, response_len)
-        return json.loads(response.decode("utf-8"))
+        return cast(JsonValue, json.loads(response.decode("utf-8")))
 
-    def action(self, method: str, data: Mapping[str, Any]) -> ActionResult:
+    def action(self, method: str, data: Mapping[str, JsonValue]) -> ActionResult:
         """Call an action method and map Wayfire's result/error to ActionResult."""
         try:
             response = self.request(method, data)
@@ -448,7 +456,7 @@ class WayfireWindowService(WindowService):
         self._refresh()
         return True
 
-    def _on_event(self, event_name: str, view: Mapping[str, Any]) -> None:
+    def _on_event(self, event_name: str, view: Mapping[str, JsonValue]) -> None:
         """Handle one Wayfire window event by updating the local record set."""
         if event_name == "view-unmapped":
             view_id = _optional_int(view.get("id"))
@@ -1021,7 +1029,7 @@ def _read_exact(sock: socket.socket, size: int) -> bytes:
 
 
 def _record_from_view(
-    view: Mapping[str, Any],
+    view: Mapping[str, JsonValue],
     *,
     matcher: object,
     focused_id: int | None,
@@ -1067,21 +1075,25 @@ def _rect_from_mapping(value: object) -> Rect | None:
 
 
 def _workspace_records_from_output(
-    output: Mapping[str, Any],
+    output: Mapping[str, JsonValue],
     *,
     number_offset: int,
     focused_output_id: int | None,
 ) -> list[WayfireWorkspaceRecord]:
     output_id = _optional_int(output.get("id"))
-    workspace = output.get("workspace")
-    if not isinstance(workspace, Mapping):
+    workspace = as_json_object(output.get("workspace"))
+    if workspace is None:
         return []
-    try:
-        grid_width = int(workspace.get("grid_width", 1))
-        grid_height = int(workspace.get("grid_height", 1))
-        active_x = int(workspace.get("x", 0))
-        active_y = int(workspace.get("y", 0))
-    except (TypeError, ValueError):
+    grid_width = _optional_int(workspace.get("grid_width", 1))
+    grid_height = _optional_int(workspace.get("grid_height", 1))
+    active_x = _optional_int(workspace.get("x", 0))
+    active_y = _optional_int(workspace.get("y", 0))
+    if (
+        grid_width is None
+        or grid_height is None
+        or active_x is None
+        or active_y is None
+    ):
         return []
     row_output_id = output_id if output_id is not None else 0
     output_name = str(output.get("name", "") or output_id or "output")
@@ -1162,11 +1174,8 @@ def _replace_record(
     active: bool | None = None,
 ) -> WayfireWindowRecord:
     """Return a copy of *record* with the given fields replaced."""
-    kwargs: dict[str, Any] = {}
-    if active is not None:
-        kwargs["active"] = active
-    if not kwargs:
+    if active is None:
         return record
     from dataclasses import replace
 
-    return replace(record, **kwargs)
+    return replace(record, active=active)

--- a/docking/platform/backends/x11/impl/preview_capture.py
+++ b/docking/platform/backends/x11/impl/preview_capture.py
@@ -155,7 +155,9 @@ def _icon_fallback(thumb_w: int, thumb_h: int) -> GdkPixbuf.Pixbuf | None:
 
     icon_size = min(ICON_FALLBACK_SIZE, thumb_w, thumb_h)
     try:
-        icon = icon_theme.load_icon("application-x-executable", icon_size, 0)
+        icon = icon_theme.load_icon(
+            "application-x-executable", icon_size, Gtk.IconLookupFlags(0)
+        )
     except GLib.Error as exc:
         log.warning(f"Failed to load fallback preview icon: {exc}")
         icon = None
@@ -167,7 +169,7 @@ def _icon_fallback(thumb_w: int, thumb_h: int) -> GdkPixbuf.Pixbuf | None:
     else:
         scaled_icon = None
 
-    if scaled_icon is not None:
+    if scaled_icon is not None and bg is not None:
         x = (thumb_w - icon_size) // 2
         y = (thumb_h - icon_size) // 2
         scaled_icon.composite(

--- a/docking/platform/desktop_entries.py
+++ b/docking/platform/desktop_entries.py
@@ -266,13 +266,13 @@ def desktop_info_from_app_info(
 ) -> DesktopInfo:
     """Build dock metadata from resolved Gio desktop app info."""
     icon = app_info.get_icon()
-    icon_name = icon.to_string() if icon else FALLBACK_ICON
+    icon_name = icon.to_string() if icon else None
     wm_class = wm_class_for_app_info(app_info=app_info, desktop_id=desktop_id)
 
     return DesktopInfo(
         desktop_id=desktop_id,
         name=app_info.get_display_name() or desktop_id,
-        icon_name=icon_name,
+        icon_name=icon_name or FALLBACK_ICON,
         wm_class=wm_class,
         exec_line=app_info.get_commandline() or "",
     )
@@ -493,7 +493,7 @@ def desktop_listing_from_app_info(
         desktop_id=desktop_id,
         name=app_info.get_display_name() or desktop_id or "Unknown",
         categories=app_info.get_categories() or "",
-        icon_name=icon.to_string() if icon else "",
+        icon_name=(icon.to_string() if icon else None) or "",
         app_info=app_info,
     )
 

--- a/docking/platform/launcher.py
+++ b/docking/platform/launcher.py
@@ -560,7 +560,10 @@ class Launcher:
                         "Theme gicon not found (%s): %s", gicon.to_string(), exc
                     )
 
-        return self.load_icon(icon_name=gicon.to_string(), size=size)
+        icon_name = gicon.to_string()
+        if icon_name:
+            return self.load_icon(icon_name=icon_name, size=size)
+        return None
 
     def _try_load_icon(self, icon_name: str, size: int) -> GdkPixbuf.Pixbuf | None:
         """Attempt to load icon from theme or file path."""

--- a/docking/ui/dnd.py
+++ b/docking/ui/dnd.py
@@ -267,7 +267,7 @@ class DnDHandler:
             Gdk.DragAction.MOVE,
         )
         da.drag_dest_set(
-            0,
+            Gtk.DestDefaults(0),
             [_DOCK_ITEM_TARGET, _URI_TARGET],
             Gdk.DragAction.MOVE | Gdk.DragAction.COPY,
         )
@@ -827,7 +827,7 @@ class DnDHandler:
     def _confirm_make_appimage_executable(self, path: Path) -> bool:
         dialog = Gtk.MessageDialog(
             transient_for=self._window,
-            flags=Gtk.DialogFlags.MODAL,
+            modal=True,
             message_type=Gtk.MessageType.WARNING,
             buttons=Gtk.ButtonsType.CANCEL,
             text="Make AppImage executable and pin it?",

--- a/docking/ui/folder/_browser.py
+++ b/docking/ui/folder/_browser.py
@@ -15,9 +15,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Hashable, Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import gi
 
@@ -44,6 +44,9 @@ FOLDER_SORT_OPTIONS = (
 )
 
 log = get_logger("folder.browser")
+
+K = TypeVar("K", bound=Hashable)
+V = TypeVar("V")
 
 
 @dataclass(frozen=True)
@@ -109,16 +112,14 @@ class FolderBrowser:
         self._directory_rows: dict[tuple[str, int, bool, int], list[FolderRow]] = {}
 
     @staticmethod
-    def _get_lru(cache: dict[Any, Any], key: Any) -> Any | None:
+    def _get_lru(cache: dict[K, V], key: K) -> V | None:
         cached = cache.pop(key, None)
         if cached is not None:
             cache[key] = cached
         return cached
 
     @staticmethod
-    def _put_lru(
-        cache: dict[Any, Any], key: Any, value: Any, *, max_entries: int
-    ) -> None:
+    def _put_lru(cache: dict[K, V], key: K, value: V, *, max_entries: int) -> None:
         cache[key] = value
         while len(cache) > max_entries:
             cache.pop(next(iter(cache)))

--- a/docking/ui/folder/stack.py
+++ b/docking/ui/folder/stack.py
@@ -16,9 +16,9 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
+from collections.abc import Hashable, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import cairo
 import gi
@@ -56,6 +56,8 @@ FOLDER_STACK_MAX_VISIBLE_ROWS = 9
 FOLDER_STACK_GAP_PX = 8
 FOLDER_STACK_POPUP_SIDE_PADDING_PX = 14
 FOLDER_STACK_TOP_PADDING_PX = 6
+K = TypeVar("K", bound=Hashable)
+V = TypeVar("V")
 FOLDER_STACK_ACTION_GAP_PX = 18
 FOLDER_STACK_ICON_GAP_PX = 10
 FOLDER_STACK_LABEL_HEIGHT_PX = 24
@@ -134,16 +136,14 @@ class FolderStackCache:
         self.prewarm_source: int = 0
 
     @staticmethod
-    def _get_lru(cache: dict[Any, Any], key: Any) -> Any | None:
+    def _get_lru(cache: dict[K, V], key: K) -> V | None:
         cached = cache.pop(key, None)
         if cached is not None:
             cache[key] = cached
         return cached
 
     @staticmethod
-    def _put_lru(
-        cache: dict[Any, Any], key: Any, value: Any, *, max_entries: int
-    ) -> None:
+    def _put_lru(cache: dict[K, V], key: K, value: V, *, max_entries: int) -> None:
         cache[key] = value
         while len(cache) > max_entries:
             cache.pop(next(iter(cache)))

--- a/docking/ui/interaction.py
+++ b/docking/ui/interaction.py
@@ -190,6 +190,7 @@ if TYPE_CHECKING:
     from gi.repository import Gtk
 
     from docking.ui.dock_window import DockWindow
+    from docking.ui.geometry import DockGeometryFrame
 
 log = get_logger(name="interaction")
 
@@ -375,7 +376,7 @@ class DockInteractionCoordinator:
 
 def _point_inside_frame_at_window_position(
     *,
-    frame: object,
+    frame: DockGeometryFrame | None,
     screen_x: int,
     screen_y: int,
     window_x: int,

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -152,7 +152,7 @@ from __future__ import annotations
 import datetime as dt
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import gi
 
@@ -464,7 +464,7 @@ class MenuHandler:
     def _show_icon_error(self, *, path: Path) -> None:
         dialog = Gtk.MessageDialog(
             transient_for=self._dock_window,
-            flags=Gtk.DialogFlags.MODAL,
+            modal=True,
             message_type=Gtk.MessageType.ERROR,
             buttons=Gtk.ButtonsType.CLOSE,
             text=_("Could not use selected icon"),
@@ -821,7 +821,7 @@ class MenuHandler:
             height=WINDOW_MENU_THUMB_H,
         )
         image = (
-            Gtk.Image.new_from_pixbuf(thumbnail.image)
+            Gtk.Image.new_from_pixbuf(cast(GdkPixbuf.Pixbuf, thumbnail.image))
             if thumbnail is not None
             else Gtk.Image()
         )
@@ -1042,14 +1042,14 @@ class MenuHandler:
     def _clear_menu_children(self, menu: Gtk.Menu) -> None:
         for child in list(menu.get_children()):
             submenu = child.get_submenu() if isinstance(child, Gtk.MenuItem) else None
-            if submenu is not None:
+            if isinstance(submenu, Gtk.Menu):
                 self._cleanup_folder_menu_tree(submenu)
             menu.remove(child)
 
     def _cleanup_folder_menu_tree(self, menu: Gtk.Menu) -> None:
         for child in list(menu.get_children()):
             submenu = child.get_submenu() if isinstance(child, Gtk.MenuItem) else None
-            if submenu is not None:
+            if isinstance(submenu, Gtk.Menu):
                 self._cleanup_folder_menu_tree(submenu)
         self._cleanup_folder_menu(menu)
 

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -150,9 +150,9 @@ concerns in practice.
 from __future__ import annotations
 
 import datetime as dt
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import gi
 
@@ -217,6 +217,8 @@ WINDOW_MENU_CLOSE_MARGIN_END_PX = 12
 FOLDER_MENU_REFRESH_DEBOUNCE_MS = 120
 log = get_logger("menu")
 
+T = TypeVar("T")
+
 SUPPORT_URL = "https://github.com/edumucelli/docking/issues"
 
 
@@ -228,9 +230,9 @@ def _make_menu_header(label: str) -> Gtk.MenuItem:
 
 def _build_radio_submenu(
     label: str,
-    items: Sequence[tuple[str, Any]],
-    current: Any,
-    on_changed: Any,
+    items: Sequence[tuple[str, T]],
+    current: T,
+    on_changed: Callable[[Gtk.RadioMenuItem, T], None],
 ) -> Gtk.MenuItem:
     """Build a MenuItem with a radio-group submenu.
 

--- a/docking/ui/preview.py
+++ b/docking/ui/preview.py
@@ -112,13 +112,14 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import gi
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gdk", "3.0")
-from gi.repository import Gdk, GLib, Gtk
+gi.require_version("GdkPixbuf", "2.0")
+from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
 
 from docking.core.position import Position, is_horizontal
 from docking.log import get_logger
@@ -171,11 +172,13 @@ def _install_css() -> None:
     """Install CSS for preview popup (once)."""
     provider = Gtk.CssProvider()
     provider.load_from_data(_CSS)
-    Gtk.StyleContext.add_provider_for_screen(
-        Gdk.Screen.get_default(),
-        provider,
-        Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
-    )
+    screen = Gdk.Screen.get_default()
+    if screen is not None:
+        Gtk.StyleContext.add_provider_for_screen(
+            screen,
+            provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+        )
 
 
 @lru_cache(maxsize=1)
@@ -314,7 +317,7 @@ class PreviewPopup(Gtk.Window):
             window.id, width=THUMB_W, height=THUMB_H
         )
         if preview is not None:
-            image = Gtk.Image.new_from_pixbuf(preview.image)
+            image = Gtk.Image.new_from_pixbuf(cast(GdkPixbuf.Pixbuf, preview.image))
         else:
             image = Gtk.Image.new_from_icon_name(
                 fallback_icon_name, Gtk.IconSize.DIALOG

--- a/docking/ui/renderer.py
+++ b/docking/ui/renderer.py
@@ -166,13 +166,14 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import cairo
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gdk, GLib, Gtk
+gi.require_version("GdkPixbuf", "2.0")
+from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
 
 from docking.applets.separator.state import STYLE_LINE
 from docking.core.config import effective_edge_gap
@@ -1348,14 +1349,14 @@ class DockRenderer:
         cached = self._cache.cached_icon_surface_for(item=item)
         if cached is not None:
             return cached
-        surface = self._pixbuf_surface(pixbuf=item.icon)
+        surface = self._pixbuf_surface(pixbuf=cast(GdkPixbuf.Pixbuf, item.icon))
         if surface is None:
             self._cache.icon_surfaces.pop(item.desktop_id, None)
             return None
         return self._cache.store_icon_surface(item=item, surface=surface)
 
     @staticmethod
-    def _pixbuf_surface(pixbuf: object) -> cairo.ImageSurface | None:
+    def _pixbuf_surface(pixbuf: GdkPixbuf.Pixbuf | None) -> cairo.ImageSurface | None:
         if pixbuf is None:
             return None
         width = pixbuf.get_width()

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -37,8 +37,9 @@ settings a persistent, easier-to-scan home.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import gi
 
@@ -123,6 +124,7 @@ INFO_POPOVER_PADDING_PX = 8
 log = get_logger("settings")
 
 SettingsRow = tuple[str, Gtk.Widget, str | None]
+ConfigScalar = bool | int | float | str
 
 
 @dataclass
@@ -131,9 +133,9 @@ class _ScalarBinding:
 
     config_attr: str
     widget: Gtk.Widget
-    read_widget: Any
-    write_widget: Any
-    on_change: Any = None
+    read_widget: Callable[[], ConfigScalar | None]
+    write_widget: Callable[[ConfigScalar], None]
+    on_change: Callable[[], None] | None = None
 
 
 class SettingsActions:
@@ -1036,7 +1038,7 @@ class SettingsWindowController:
             self._register_switch_binding(
                 config_attr="show_window_count_numbers",
                 widget=self._window_count_numbers_switch,
-                on_change=lambda _value: self._actions.queue_draw(),
+                on_change=self._actions.queue_draw,
             ),
             self._register_switch_binding(
                 config_attr="previews_enabled",
@@ -1050,12 +1052,16 @@ class SettingsWindowController:
             self._register_switch_binding(
                 config_attr="lock_icons",
                 widget=self._lock_icons_switch,
-                on_change=self._actions.set_icons_locked,
+                on_change=lambda: self._actions.set_icons_locked(
+                    self._config.lock_icons
+                ),
             ),
             self._register_switch_binding(
                 config_attr="current_workspace_only",
                 widget=self._workspace_only_switch,
-                on_change=self._actions.set_current_workspace_only,
+                on_change=lambda: self._actions.set_current_workspace_only(
+                    self._config.current_workspace_only
+                ),
             ),
             self._register_switch_binding(
                 config_attr="active_display",
@@ -1065,17 +1071,17 @@ class SettingsWindowController:
             self._register_switch_binding(
                 config_attr="anchor_applets",
                 widget=self._anchor_applets_switch,
-                on_change=lambda _value: self._actions.queue_draw(),
+                on_change=self._actions.queue_draw,
             ),
             self._register_switch_binding(
                 config_attr="anchor_files",
                 widget=self._anchor_files_switch,
-                on_change=lambda _value: self._actions.queue_draw(),
+                on_change=self._actions.queue_draw,
             ),
             self._register_switch_binding(
                 config_attr="zoom_enabled",
                 widget=self._zoom_enabled_switch,
-                on_change=lambda _value: self._actions.queue_draw(),
+                on_change=self._actions.queue_draw,
             ),
             self._register_switch_binding(
                 config_attr="update_check_enabled",
@@ -1102,7 +1108,7 @@ class SettingsWindowController:
             self._register_choice_binding(
                 config_attr="position",
                 widget=self._position_combo,
-                on_change=lambda _value: self._actions.reposition(),
+                on_change=self._actions.reposition,
             ),
             self._register_int_binding(
                 config_attr="icon_size",
@@ -1114,7 +1120,7 @@ class SettingsWindowController:
                 widget=self._additional_distance_scale,
                 read_widget=lambda: int(self._additional_distance_scale.get_value()),
                 write_widget=lambda value: self._additional_distance_scale.set_value(
-                    float(value)
+                    cast(float, value)
                 ),
                 signal="value-changed",
                 on_change=self._after_additional_distance_changed,
@@ -1127,7 +1133,7 @@ class SettingsWindowController:
                     / TRANSPARENCY_PERCENT_SCALE
                 ),
                 write_widget=lambda value: self._transparency_scale.set_value(
-                    float(value) * TRANSPARENCY_PERCENT_SCALE
+                    cast(float, value) * TRANSPARENCY_PERCENT_SCALE
                 ),
                 signal="value-changed",
                 on_change=self._after_transparency_changed,
@@ -1139,10 +1145,10 @@ class SettingsWindowController:
                     float(self._zoom_percent_spin.get_value()) / ZOOM_PERCENT_SCALE
                 ),
                 write_widget=lambda value: self._zoom_percent_spin.set_value(
-                    float(value) * ZOOM_PERCENT_SCALE
+                    cast(float, value) * ZOOM_PERCENT_SCALE
                 ),
                 signal="value-changed",
-                on_change=lambda _value: self._actions.queue_draw(),
+                on_change=self._actions.queue_draw,
             ),
             self._register_int_binding(
                 config_attr="hide_delay_ms",
@@ -1171,7 +1177,7 @@ class SettingsWindowController:
             self._register_int_binding(
                 config_attr="recent_apps_max",
                 widget=self._recent_apps_max_spin,
-                on_change=lambda _value: self._actions.queue_draw(),
+                on_change=self._actions.queue_draw,
             ),
             self._register_numeric_binding(
                 config_attr="recent_apps_retention_days",
@@ -1183,7 +1189,7 @@ class SettingsWindowController:
                     self._recent_apps_retention_combo.set_active_id(str(value))
                 ),
                 signal="changed",
-                on_change=lambda _value: self._actions.queue_draw(),
+                on_change=self._actions.queue_draw,
             ),
             # Recent Documents
             self._register_switch_binding(
@@ -1201,7 +1207,7 @@ class SettingsWindowController:
         *,
         config_attr: str,
         widget: Gtk.Switch,
-        on_change: Any = None,
+        on_change: Callable[[], None] | None = None,
     ) -> _ScalarBinding:
         return self._register_numeric_binding(
             config_attr=config_attr,
@@ -1217,13 +1223,13 @@ class SettingsWindowController:
         *,
         config_attr: str,
         widget: Gtk.ComboBoxText,
-        on_change: Any = None,
+        on_change: Callable[[], None] | None = None,
     ) -> _ScalarBinding:
         return self._register_numeric_binding(
             config_attr=config_attr,
             widget=widget,
             read_widget=widget.get_active_id,
-            write_widget=lambda value: widget.set_active_id(str(value)),
+            write_widget=lambda value: self._set_active_id(widget, value),
             signal="changed",
             on_change=on_change,
         )
@@ -1233,13 +1239,13 @@ class SettingsWindowController:
         *,
         config_attr: str,
         widget: Gtk.SpinButton,
-        on_change: Any = None,
+        on_change: Callable[[], None] | None = None,
     ) -> _ScalarBinding:
         return self._register_numeric_binding(
             config_attr=config_attr,
             widget=widget,
             read_widget=lambda: int(widget.get_value()),
-            write_widget=lambda value: widget.set_value(float(value)),
+            write_widget=lambda value: widget.set_value(cast(float, value)),
             signal="value-changed",
             on_change=on_change,
         )
@@ -1249,10 +1255,10 @@ class SettingsWindowController:
         *,
         config_attr: str,
         widget: Gtk.Widget,
-        read_widget: Any,
-        write_widget: Any,
+        read_widget: Callable[[], ConfigScalar | None],
+        write_widget: Callable[[ConfigScalar], None],
         signal: str,
-        on_change: Any = None,
+        on_change: Callable[[], None] | None = None,
     ) -> _ScalarBinding:
         binding = _ScalarBinding(
             config_attr=config_attr,
@@ -1263,6 +1269,10 @@ class SettingsWindowController:
         )
         widget.connect(signal, lambda *_args, b=binding: self._on_binding_changed(b))
         return binding
+
+    @staticmethod
+    def _set_active_id(widget: Gtk.ComboBoxText, value: ConfigScalar) -> None:
+        widget.set_active_id(str(value))
 
     def _sync_widgets(self) -> None:
         if self._window is None:
@@ -1417,7 +1427,7 @@ class SettingsWindowController:
         setattr(self._config, binding.config_attr, value)
         self._config.save()
         if binding.on_change is not None:
-            binding.on_change(value)
+            binding.on_change()
         self._update_dependent_sensitivity()
 
     def _read_update_interval_hours(self) -> int | None:
@@ -1482,29 +1492,29 @@ class SettingsWindowController:
         )
         self._actions.set_theme(theme)
 
-    def _after_theme_changed(self, _name: str) -> None:
+    def _after_theme_changed(self) -> None:
         self._apply_runtime_theme()
         self._actions.reposition()
         self._actions.queue_draw()
 
-    def _after_icon_size_changed(self, _value: int) -> None:
+    def _after_icon_size_changed(self) -> None:
         self._apply_runtime_theme()
         self._actions.reposition()
         self._actions.queue_draw()
 
-    def _after_transparency_changed(self, _value: float) -> None:
+    def _after_transparency_changed(self) -> None:
         self._apply_runtime_theme()
         self._actions.queue_draw()
 
-    def _after_additional_distance_changed(self, _value: int) -> None:
+    def _after_additional_distance_changed(self) -> None:
         self._actions.reposition()
         self._actions.queue_draw()
 
-    def _after_pressure_reveal_changed(self, _value) -> None:
+    def _after_pressure_reveal_changed(self) -> None:
         self._actions.refresh_pressure_handler()
         self._update_dependent_sensitivity()
 
-    def _after_show_recent_apps_changed(self, _value) -> None:
+    def _after_show_recent_apps_changed(self) -> None:
         """Rebuild the recent apps section when the toggle changes."""
         if not self._config.show_recent_apps:
             self._config.recent_apps.clear()
@@ -1512,7 +1522,7 @@ class SettingsWindowController:
         self._actions.queue_draw()
         self._update_dependent_sensitivity()
 
-    def _after_hide_mode_changed(self, mode: str) -> None:
+    def _after_hide_mode_changed(self) -> None:
         self._actions.on_hide_mode_changed()
         self._update_hide_mode_description()
         self._update_dependent_sensitivity()
@@ -1546,12 +1556,12 @@ class SettingsWindowController:
         desc = self._HIDE_MODE_DESCRIPTIONS.get(mode, "")
         self._set_info_icon_text(self._hide_mode_info, desc)
 
-    def _after_tooltips_changed(self, active: bool) -> None:
-        if not active:
+    def _after_tooltips_changed(self) -> None:
+        if not self._config.tooltips_enabled:
             self._actions.hide_tooltip()
 
-    def _after_active_display_changed(self, active: bool) -> None:
-        self._actions.set_active_display(active)
+    def _after_active_display_changed(self) -> None:
+        self._actions.set_active_display(self._config.active_display)
         self._actions.reposition()
 
     def _update_dependent_sensitivity(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ wayland = [
 dev = [
     "behave>=1.2.6",
     "Pillow>=11.0",
+    "PyGObject-stubs==2.16.0",
     "pytest>=7.0",
     "pytest-cov",
     "ruff==0.15.17",
@@ -32,6 +33,9 @@ dev = [
     "ty==0.0.49",
     "vulture>=2.16",
 ]
+
+[tool.uv]
+config-settings-package = { pygobject-stubs = { config = "Gtk3,Gdk3" } }
 
 [tool.setuptools.packages.find]
 include = ["docking*"]

--- a/tests/applets/test_popup.py
+++ b/tests/applets/test_popup.py
@@ -485,6 +485,60 @@ def test_create_capture_overlay_configures_fullscreen_grab(monkeypatch):
     seat.grab.assert_called_once()
 
 
+def test_create_capture_overlay_returns_none_without_a_display(monkeypatch):
+    overlay = _FakeCaptureOverlay()
+    monkeypatch.setattr(popup.Gtk, "Window", lambda **_kwargs: overlay)
+    monkeypatch.setattr(popup.Gdk.Display, "get_default", lambda: None)
+
+    created = popup.create_capture_overlay(
+        draw_handler=MagicMock(),
+        click_handler=MagicMock(),
+        key_handler=MagicMock(),
+        cursor_type=MagicMock(),
+    )
+
+    assert created is None
+    assert overlay.destroyed is True
+
+
+def test_create_capture_overlay_returns_none_without_a_gdk_window(monkeypatch):
+    overlay = _FakeCaptureOverlay()
+    overlay.gdk_window = None
+    display = MagicMock()
+    monkeypatch.setattr(popup.Gtk, "Window", lambda **_kwargs: overlay)
+    monkeypatch.setattr(popup.Gdk.Display, "get_default", lambda: display)
+    monkeypatch.setattr(popup.Gdk.Cursor, "new_for_display", lambda *_args: "cursor")
+
+    created = popup.create_capture_overlay(
+        draw_handler=MagicMock(),
+        click_handler=MagicMock(),
+        key_handler=MagicMock(),
+        cursor_type=MagicMock(),
+    )
+
+    assert created is None
+    assert overlay.destroyed is True
+
+
+def test_create_capture_overlay_returns_none_without_an_input_seat(monkeypatch):
+    overlay = _FakeCaptureOverlay()
+    display = MagicMock()
+    display.get_default_seat.return_value = None
+    monkeypatch.setattr(popup.Gtk, "Window", lambda **_kwargs: overlay)
+    monkeypatch.setattr(popup.Gdk.Display, "get_default", lambda: display)
+    monkeypatch.setattr(popup.Gdk.Cursor, "new_for_display", lambda *_args: "cursor")
+
+    created = popup.create_capture_overlay(
+        draw_handler=MagicMock(),
+        click_handler=MagicMock(),
+        key_handler=MagicMock(),
+        cursor_type=MagicMock(),
+    )
+
+    assert created is None
+    assert overlay.destroyed is True
+
+
 def test_dismiss_capture_overlay_ungrabs_and_destroys(monkeypatch):
     overlay = _FakeCaptureOverlay()
     seat = MagicMock()

--- a/tests/applets/test_runcommand.py
+++ b/tests/applets/test_runcommand.py
@@ -13,6 +13,7 @@ from docking.applets.runcommand.state import (
     TERMINAL_CANDIDATES,
     _flatpak_host_terminal_name,
     app_command_text,
+    app_description,
     append_file_argument,
     build_shell_argv,
     build_terminal_argv,
@@ -143,6 +144,11 @@ def _make_applet() -> RunCommandApplet:
 
 
 class TestRunCommandState:
+    def test_app_description_handles_missing_optional_gio_metadata_methods(self):
+        app = _FakeApp("Fallback application")
+
+        assert app_description(app) == "Fallback application"
+
     def test_normalize_history_filters_deduplicates_and_caps(self):
         raw = [" firefox ", "", "calc", "firefox", 1, *[f"cmd{i}" for i in range(30)]]
 
@@ -311,6 +317,17 @@ class TestRunCommandApplet:
         applet = _make_applet()
         for size in [32, 48, 64]:
             assert applet.create_icon(size) is not None
+
+    def test_run_with_file_ignores_late_click_after_dialog_is_destroyed(
+        self, monkeypatch
+    ):
+        applet = _make_applet()
+        chooser = MagicMock()
+        monkeypatch.setattr(runcommand_applet_mod.Gtk, "FileChooserDialog", chooser)
+
+        applet._on_run_with_file(MagicMock())
+
+        chooser.assert_not_called()
 
     def test_select_application_updates_entry_description_and_icon(self):
         applet = _make_applet()

--- a/tests/applets/test_runcommand.py
+++ b/tests/applets/test_runcommand.py
@@ -128,7 +128,7 @@ class _FakeDialog:
 
 class _FakeRow:
     def __init__(self, app: _FakeApp) -> None:
-        self.app_entry = app
+        self.app = app
         self.visible = True
 
     def show(self) -> None:

--- a/tests/platform/test_niri_ipc.py
+++ b/tests/platform/test_niri_ipc.py
@@ -99,6 +99,11 @@ def test_parse_empty_response():
     assert _parse_response(b"   ") == {}
 
 
+def test_parse_response_ignores_non_object_json():
+    assert _parse_response(b"[]") == {}
+    assert _parse_response(b'"unexpected"') == {}
+
+
 # ---------------------------------------------------------------------------
 # Event parsing
 # ---------------------------------------------------------------------------

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -1638,7 +1638,7 @@ class TestRecentSettingsBehavior:
 
         # Disable recent apps
         config.show_recent_apps = False
-        controller._after_show_recent_apps_changed(False)
+        controller._after_show_recent_apps_changed()
 
         assert config.recent_apps == []
         config.save.assert_called()
@@ -1752,7 +1752,7 @@ class TestSettingsRuntimeCallbacks:
             config=config,
         )
 
-        controller._after_icon_size_changed(64)
+        controller._after_icon_size_changed()
 
         runtime.reposition.assert_called()
         runtime.queue_draw.assert_called()
@@ -1773,7 +1773,8 @@ class TestSettingsRuntimeCallbacks:
             config=config,
         )
 
-        controller._after_tooltips_changed(False)
+        config.tooltips_enabled = False
+        controller._after_tooltips_changed()
 
         runtime.hide_tooltip.assert_called_once()
 
@@ -1793,7 +1794,8 @@ class TestSettingsRuntimeCallbacks:
             config=config,
         )
 
-        controller._after_tooltips_changed(True)
+        config.tooltips_enabled = True
+        controller._after_tooltips_changed()
 
         runtime.hide_tooltip.assert_not_called()
 

--- a/tools/install_precommit_hook.sh
+++ b/tools/install_precommit_hook.sh
@@ -18,7 +18,7 @@ echo "Running ruff format..."
 echo "Running ruff check..."
 .venv/bin/ruff check docking/ tests/
 echo "Running ty..."
-.venv/bin/ty check docking/
+.venv/bin/ty check --error-on-warning docking/
 echo "Checking i18n template sync..."
 bash tools/i18n.sh --check-pot-sync
 echo "Checking i18n catalogs..."


### PR DESCRIPTION
## Summary
- resolve all existing ty diagnostics across GNOME and Wayland backend boundaries
- narrow raw protocol and IPC payloads before passing them to typed services
- make ty warnings fail pre-commit, the generated strict hook, and CI