### PR TITLE
Allow dragging Applications applet entries to dock

### DIFF
--- a/docking/applets/applications/applet.py
+++ b/docking/applets/applications/applet.py
@@ -22,12 +22,15 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("GdkPixbuf", "2.0")
-from gi.repository import GdkPixbuf, GLib, Gtk
+from gi.repository import Gdk, GdkPixbuf, GLib, Gtk
 
 from docking.applets.applications import meta
 from docking.applets.applications.render import create_icon, make_menu_item_with_icon
-from docking.applets.applications.state import CATEGORY_ICONS, _build_app_categories
-from docking.applets.apps import ApplicationEntry
+from docking.applets.applications.state import (
+    CATEGORY_ICONS,
+    ApplicationEntry,
+    _build_app_categories,
+)
 from docking.applets.base import Applet
 from docking.core.icons import IconSource
 from docking.i18n import _
@@ -42,6 +45,7 @@ log = with_context(
 )
 
 SEARCH_ENTRY_WIDTH_CHARS = 24
+_URI_TARGET = Gtk.TargetEntry.new("text/uri-list", 0, 0)
 
 
 class ApplicationsApplet(Applet):
@@ -107,7 +111,7 @@ class ApplicationsApplet(Applet):
             )
             submenu = Gtk.Menu()
 
-            _populate_app_submenu(submenu=submenu, apps=apps)
+            _populate_app_submenu(submenu=submenu, apps=apps, config=self._config)
 
             cat_item.set_submenu(submenu)
             menu.append(cat_item)
@@ -117,7 +121,11 @@ class ApplicationsApplet(Applet):
             lowered = query.strip().lower()
             for cat_item, submenu, apps in category_rows:
                 matched = list(_filter_apps(apps=apps, query=lowered))
-                _populate_app_submenu(submenu=submenu, apps=matched)
+                _populate_app_submenu(
+                    submenu=submenu,
+                    apps=matched,
+                    config=self._config,
+                )
                 if matched:
                     cat_item.show()
                 else:
@@ -149,6 +157,7 @@ def _populate_app_submenu(
     *,
     submenu: Gtk.Menu,
     apps: Iterable[ApplicationEntry],
+    config: Config | None,
 ) -> None:
     _clear_menu(menu=submenu)
     for app_info in apps:
@@ -160,8 +169,45 @@ def _populate_app_submenu(
             "activate",
             lambda _, info=app_info: _launch_app(app_info=info),
         )
+        _configure_drag_source(
+            menu_item=menu_item,
+            app_info=app_info,
+            config=config,
+        )
         submenu.append(menu_item)
     submenu.show_all()
+
+
+def _configure_drag_source(
+    *,
+    menu_item: Gtk.MenuItem,
+    app_info: ApplicationEntry,
+    config: Config | None,
+) -> None:
+    """Make a launchable menu row draggable to the dock as a desktop URI."""
+    if config is not None and config.lock_icons:
+        return
+    uri = app_info.desktop_file_uri()
+    if uri is None:
+        return
+    menu_item.drag_source_set(
+        Gdk.ModifierType.BUTTON1_MASK,
+        [_URI_TARGET],
+        Gdk.DragAction.COPY,
+    )
+    menu_item.connect("drag-data-get", _on_drag_data_get, uri)
+
+
+def _on_drag_data_get(
+    _menu_item: Gtk.MenuItem,
+    _context: Gdk.DragContext,
+    selection: Gtk.SelectionData,
+    _info: int,
+    _time: int,
+    uri: str,
+) -> None:
+    """Provide the selected application's desktop-entry URI to the dock."""
+    selection.set_uris([uri])
 
 
 def _filter_apps(

--- a/docking/applets/applications/applet.py
+++ b/docking/applets/applications/applet.py
@@ -195,7 +195,19 @@ def _configure_drag_source(
         [_URI_TARGET],
         Gdk.DragAction.COPY,
     )
+    menu_item.connect("drag-begin", _on_drag_begin, app_info)
     menu_item.connect("drag-data-get", _on_drag_data_get, uri)
+
+
+def _on_drag_begin(
+    _menu_item: Gtk.MenuItem,
+    context: Gdk.DragContext,
+    app_info: ApplicationEntry,
+) -> None:
+    """Show the application's icon beside the pointer while it is dragged."""
+    icon = app_info.get_icon()
+    if icon is not None:
+        Gtk.drag_set_icon_gicon(context, icon, 0, 0)
 
 
 def _on_drag_data_get(

--- a/docking/applets/apps.py
+++ b/docking/applets/apps.py
@@ -68,6 +68,23 @@ class ApplicationEntry(NamedTuple):
             return Gio.FileIcon.new(Gio.File.new_for_path(str(icon_path)))
         return Gio.ThemedIcon.new(self.icon_name)
 
+    def desktop_file_uri(self) -> str | None:
+        """Return the ``.desktop`` file URI used for drag-to-pin operations."""
+        filename: str | None = None
+        if self.app_info is not None:
+            try:
+                filename = self.app_info.get_filename()
+            except (AttributeError, TypeError):
+                filename = None
+
+        if not filename:
+            path = desktop_entries.find_desktop_file(self.desktop_id)
+            if path is None:
+                return None
+            filename = str(path)
+
+        return Path(filename).expanduser().resolve().as_uri()
+
     def launch(
         self,
         files: list[Gio.File] | None,

--- a/tests/applets/test_applications.py
+++ b/tests/applets/test_applications.py
@@ -388,6 +388,43 @@ class TestApplicationsApplet:
         callback(menu_item, None, selection, 0, 0, *args)
         selection.set_uris.assert_called_once_with([desktop_file.as_uri()])
 
+    def test_application_drag_shows_entry_icon(self, tmp_path, monkeypatch):
+        self._fake_gtk(monkeypatch)
+        desktop_file = tmp_path / "org.example.Tool.desktop"
+        desktop_file.write_text("[Desktop Entry]\nType=Application\n", encoding="utf-8")
+        icon = MagicMock()
+        gio_app_info = MagicMock()
+        gio_app_info.get_filename.return_value = str(desktop_file)
+        gio_app_info.get_icon.return_value = icon
+        app = ApplicationEntry(
+            desktop_id="org.example.Tool.desktop",
+            name="Example Tool",
+            categories="Utility;",
+            icon_name="",
+            app_info=gio_app_info,
+        )
+        submenu = applications_applet_mod.Gtk.Menu()
+        set_drag_icon = MagicMock()
+        monkeypatch.setattr(
+            applications_applet_mod.Gtk,
+            "drag_set_icon_gicon",
+            set_drag_icon,
+            raising=False,
+        )
+
+        applications_applet_mod._populate_app_submenu(
+            submenu=submenu,
+            apps=[app],
+            config=None,
+        )
+
+        menu_item = submenu.get_children()[0]
+        callback, args = menu_item._signals["drag-begin"][0]
+        context = MagicMock()
+        callback(menu_item, context, *args)
+
+        set_drag_icon.assert_called_once_with(context, icon, 0, 0)
+
     def test_application_rows_are_not_draggable_when_icons_are_locked(
         self, tmp_path, monkeypatch
     ):

--- a/tests/applets/test_applications.py
+++ b/tests/applets/test_applications.py
@@ -110,6 +110,40 @@ class TestBuildAppCategories:
 
         assert launched == ["org.example.Tool.desktop"]
 
+    def test_application_entry_desktop_file_uri_uses_app_info_filename(self, tmp_path):
+        desktop_file = tmp_path / "org.example.Tool.desktop"
+        desktop_file.write_text("[Desktop Entry]\nType=Application\n", encoding="utf-8")
+        app_info = MagicMock()
+        app_info.get_filename.return_value = str(desktop_file)
+        entry = ApplicationEntry(
+            desktop_id="org.example.Tool.desktop",
+            name="Example Tool",
+            categories="Utility;",
+            icon_name="",
+            app_info=app_info,
+        )
+
+        assert entry.desktop_file_uri() == desktop_file.as_uri()
+
+    def test_application_entry_desktop_file_uri_falls_back_to_lookup(
+        self, tmp_path, monkeypatch
+    ):
+        desktop_file = tmp_path / "org.example.Tool.desktop"
+        desktop_file.write_text("[Desktop Entry]\nType=Application\n", encoding="utf-8")
+        monkeypatch.setattr(
+            apps_shared.desktop_entries,
+            "find_desktop_file",
+            lambda _desktop_id: desktop_file,
+        )
+        entry = ApplicationEntry(
+            desktop_id="org.example.Tool.desktop",
+            name="Example Tool",
+            categories="Utility;",
+            icon_name="",
+        )
+
+        assert entry.desktop_file_uri() == desktop_file.as_uri()
+
 
 class TestApplicationsApplet:
     def _fake_gtk(self, monkeypatch):
@@ -147,12 +181,16 @@ class TestApplicationsApplet:
                 self._child = None
                 self.visible = True
                 self.parent = None
+                self.drag_source_args = None
 
             def get_label(self) -> str:
                 return self._label
 
-            def connect(self, signal: str, callback) -> None:
-                self._signals.setdefault(signal, []).append(callback)
+            def connect(self, signal: str, callback, *args) -> None:
+                self._signals.setdefault(signal, []).append((callback, args))
+
+            def drag_source_set(self, *args) -> None:
+                self.drag_source_args = args
 
             def set_submenu(self, submenu) -> None:
                 self._submenu = submenu
@@ -319,6 +357,63 @@ class TestApplicationsApplet:
         assert internet_item.visible is True
         assert office_item.visible is True
         assert len(internet_item.get_submenu().get_children()) == 2
+
+    def test_application_rows_drag_desktop_uri_to_dock(self, tmp_path, monkeypatch):
+        self._fake_gtk(monkeypatch)
+        desktop_file = tmp_path / "org.example.Tool.desktop"
+        desktop_file.write_text("[Desktop Entry]\nType=Application\n", encoding="utf-8")
+        app = ApplicationEntry(
+            desktop_id="org.example.Tool.desktop",
+            name="Example Tool",
+            categories="Utility;",
+            icon_name="",
+        )
+        monkeypatch.setattr(
+            apps_shared.desktop_entries,
+            "find_desktop_file",
+            lambda _desktop_id: desktop_file,
+        )
+        submenu = applications_applet_mod.Gtk.Menu()
+
+        applications_applet_mod._populate_app_submenu(
+            submenu=submenu,
+            apps=[app],
+            config=None,
+        )
+
+        menu_item = submenu.get_children()[0]
+        assert menu_item.drag_source_args is not None
+        callback, args = menu_item._signals["drag-data-get"][0]
+        selection = MagicMock()
+        callback(menu_item, None, selection, 0, 0, *args)
+        selection.set_uris.assert_called_once_with([desktop_file.as_uri()])
+
+    def test_application_rows_are_not_draggable_when_icons_are_locked(
+        self, tmp_path, monkeypatch
+    ):
+        self._fake_gtk(monkeypatch)
+        desktop_file = tmp_path / "org.example.Tool.desktop"
+        desktop_file.write_text("[Desktop Entry]\nType=Application\n", encoding="utf-8")
+        app = ApplicationEntry(
+            desktop_id="org.example.Tool.desktop",
+            name="Example Tool",
+            categories="Utility;",
+            icon_name="",
+        )
+        monkeypatch.setattr(
+            apps_shared.desktop_entries,
+            "find_desktop_file",
+            lambda _desktop_id: desktop_file,
+        )
+        submenu = applications_applet_mod.Gtk.Menu()
+
+        applications_applet_mod._populate_app_submenu(
+            submenu=submenu,
+            apps=[app],
+            config=SimpleNamespace(lock_icons=True),
+        )
+
+        assert submenu.get_children()[0].drag_source_args is None
 
 
 class TestApplicationsRenderHelpers:


### PR DESCRIPTION
## Summary
- make Applications applet launcher rows drag sources for their desktop-entry URIs
- reuse the dock's existing URI drop flow to pin applications at the drop position
- respect the locked-icons setting and add coverage for URI resolution and drag payloads