### PR TITLE
Open calendar from Clock applet

### DIFF
--- a/docking/applets/calendar/applet.py
+++ b/docking/applets/calendar/applet.py
@@ -28,7 +28,7 @@ from docking.applets.base import Applet
 from docking.applets.calendar import meta
 from docking.applets.calendar.render import render_icon
 from docking.applets.calendar.state import snapshot_from
-from docking.applets.popup import create_popup_window, show_wrapped_popup
+from docking.applets.popup import PopupAnchor, create_popup_window, show_wrapped_popup
 from docking.i18n import _
 
 if TYPE_CHECKING:
@@ -37,6 +37,29 @@ if TYPE_CHECKING:
 CALENDAR_TICK_INTERVAL_S = 30
 CALENDAR_POPUP_PADDING_PX = 8
 CALENDAR_POPUP_CURSOR_GAP_PX = 20
+
+
+def show_calendar_popup(
+    *,
+    popup: Gtk.Window | None,
+    anchor: PopupAnchor | None,
+) -> Gtk.Window:
+    """Show the shared calendar popup and return its window."""
+    if popup is None:
+        popup = create_popup_window()
+
+    calendar = Gtk.Calendar()
+    calendar.set_margin_start(CALENDAR_POPUP_PADDING_PX)
+    calendar.set_margin_end(CALENDAR_POPUP_PADDING_PX)
+    calendar.set_margin_top(CALENDAR_POPUP_PADDING_PX)
+    calendar.set_margin_bottom(CALENDAR_POPUP_PADDING_PX)
+    show_wrapped_popup(
+        window=popup,
+        content=calendar,
+        gap_px=CALENDAR_POPUP_CURSOR_GAP_PX,
+        anchor=anchor,
+    )
+    return popup
 
 
 class CalendarApplet(Applet):
@@ -92,17 +115,7 @@ class CalendarApplet(Applet):
         return True
 
     def _show_popup(self) -> None:
-        if self._popup is None:
-            self._popup = create_popup_window()
-
-        calendar = Gtk.Calendar()
-        calendar.set_margin_start(CALENDAR_POPUP_PADDING_PX)
-        calendar.set_margin_end(CALENDAR_POPUP_PADDING_PX)
-        calendar.set_margin_top(CALENDAR_POPUP_PADDING_PX)
-        calendar.set_margin_bottom(CALENDAR_POPUP_PADDING_PX)
-        show_wrapped_popup(
-            window=self._popup,
-            content=calendar,
-            gap_px=CALENDAR_POPUP_CURSOR_GAP_PX,
+        self._popup = show_calendar_popup(
+            popup=self._popup,
             anchor=self.popup_anchor,
         )

--- a/docking/applets/clock/applet.py
+++ b/docking/applets/clock/applet.py
@@ -26,6 +26,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GLib, Gtk
 
 from docking.applets.base import Applet
+from docking.applets.calendar.applet import show_calendar_popup
 from docking.applets.clock import meta
 from docking.applets.clock.render import render_icon
 from docking.applets.clock.state import (
@@ -55,6 +56,7 @@ class ClockApplet(Applet):
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
         self._timer = _ClockTimer()
+        self._calendar_popup: Gtk.Window | None = None
 
         prefs = config.applet_prefs.get("clock", {}) if config else None
         self._raw_alarm_target = self._prefs_alarm_target(prefs)
@@ -94,6 +96,13 @@ class ClockApplet(Applet):
     def on_clicked(self) -> None:
         if self.item.is_urgent:
             self._acknowledge_alarm()
+        if self._calendar_popup and self._calendar_popup.get_visible():
+            self._calendar_popup.hide()
+            return
+        self._calendar_popup = show_calendar_popup(
+            popup=self._calendar_popup,
+            anchor=self.popup_anchor,
+        )
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         """Clock display, seconds, and one-shot alarm controls."""
@@ -174,6 +183,9 @@ class ClockApplet(Applet):
 
     def stop(self) -> None:
         self._timer.stop()
+        if self._calendar_popup:
+            self._calendar_popup.destroy()
+            self._calendar_popup = None
         super().stop()
 
     def _on_tick(self) -> None:

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -198,6 +198,7 @@ gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk, GLib, Gtk
 
 from docking.applets.popup import PopupAnchor
+from docking.core.position import Position
 from docking.i18n import _
 from docking.platform.backends.base import (
     PreviewService,
@@ -579,7 +580,7 @@ class DockWindow(Gtk.Window):
         item: DockItem,
         frame: DockGeometryFrame,
     ) -> PopupAnchor | None:
-        """Build the current screen-space popup anchor for one dock item."""
+        """Build the current outer-center popup anchor for one dock item."""
         item_geometry = frame.geometry_for_item(item)
         if item_geometry is None:
             return None
@@ -589,6 +590,10 @@ class DockWindow(Gtk.Window):
             win_y=window_pos.y,
             position=self.config.pos,
         )
+        if self.config.pos in (Position.BOTTOM, Position.TOP):
+            anchor_x += int(item_geometry.draw_rect.w / 2)
+        else:
+            anchor_y += int(item_geometry.draw_rect.h / 2)
         return PopupAnchor(
             x=anchor_x,
             y=anchor_y,

--- a/tests/applets/test_clock.py
+++ b/tests/applets/test_clock.py
@@ -384,11 +384,38 @@ class TestClockInteractions:
         clock = ClockApplet(48)
         clock.item.is_urgent = True
         clock.present = MagicMock()
+        clock._calendar_popup = MagicMock()
+        clock._calendar_popup.get_visible.return_value = True
 
         clock.on_clicked()
 
         assert clock.item.is_urgent is False
         assert clock.present.call_count == 1
+        clock._calendar_popup.hide.assert_called_once()
+
+    def test_click_shows_shared_calendar_popup(self, monkeypatch):
+        clock = ClockApplet(48)
+        popup = MagicMock()
+        show_calendar_popup = MagicMock(return_value=popup)
+        monkeypatch.setattr(clock_mod, "show_calendar_popup", show_calendar_popup)
+
+        clock.on_clicked()
+
+        assert clock._calendar_popup is popup
+        show_calendar_popup.assert_called_once_with(
+            popup=None, anchor=clock.popup_anchor
+        )
+
+    def test_stop_destroys_calendar_popup(self):
+        clock = ClockApplet(48)
+        clock._timer = MagicMock()
+        popup = MagicMock()
+        clock._calendar_popup = popup
+
+        clock.stop()
+
+        popup.destroy.assert_called_once()
+        assert clock._calendar_popup is None
 
     def test_clear_alarm_clears_target_and_urgency(self):
         clock = ClockApplet(48)

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -230,7 +230,7 @@ class TestButtonReleaseFlow:
         # Then
         assert handled is True
         anchor = applet.set_popup_anchor.call_args.args[0]
-        assert anchor.x == 104
+        assert anchor.x == 128
         assert anchor.y == 205
         assert anchor.position == Position.BOTTOM
         assert anchor.parent is stub


### PR DESCRIPTION
## Summary

- Open the Calendar popup when the Clock applet is left-clicked.
- Center applet popups on their dock icon.