### PR TITLE
Extract reusable item stack popup

### DIFF
--- a/docking/applets/base.py
+++ b/docking/applets/base.py
@@ -86,6 +86,7 @@ from docking.log import get_logger
 if TYPE_CHECKING:
     from docking.applets.services import AppletServices
     from docking.core.config import Config
+    from docking.ui.stack import StackContent
 
 log = get_logger("applets.base")
 
@@ -455,6 +456,11 @@ class Applet(ABC):
     def on_clicked(self) -> None:
         """Handle left-click (default: no-op)."""
         return
+
+    def stack_content(self, icon_size: int) -> StackContent | None:
+        """Return reusable stack content, or None for normal click handling."""
+        _ = icon_size
+        return None
 
     @property
     def popup_anchor(self) -> PopupAnchor | None:

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-07-13 14:38+0200\n"
+"POT-Creation-Date: 2026-07-16 19:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -111,7 +111,7 @@ msgstr ""
 
 #: docking/applets/alarm/applet.py:164 docking/applets/clock/applet.py:219
 #: docking/applets/lastfm/applet.py:381 docking/applets/quicknote/applet.py:87
-#: docking/applets/reddit/applet.py:439
+#: docking/applets/reddit/applet.py:435
 #: docking/applets/runcommand/applet.py:131
 #: docking/applets/runcommand/applet.py:350
 #: docking/applets/sunrise/applet.py:189 docking/applets/trash/applet.py:264
@@ -355,11 +355,11 @@ msgstr ""
 msgid "(c) {who}"
 msgstr ""
 
-#: docking/applets/applications/applet.py:51
+#: docking/applets/applications/applet.py:55
 msgid "Applications"
 msgstr ""
 
-#: docking/applets/applications/applet.py:90
+#: docking/applets/applications/applet.py:94
 msgid "Search applications..."
 msgstr ""
 
@@ -1375,7 +1375,7 @@ msgstr ""
 #: docking/applets/hackernews/applet.py:161
 #: docking/applets/hackernews/state.py:163
 #: docking/applets/hackernews/state.py:196 docking/applets/reddit/applet.py:170
-#: docking/applets/reddit/state.py:344 docking/applets/reddit/state.py:364
+#: docking/applets/reddit/state.py:348 docking/applets/reddit/state.py:368
 msgid "Refreshes"
 msgstr ""
 
@@ -1402,21 +1402,21 @@ msgstr ""
 msgid "No Hacker News stories"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:114 docking/applets/reddit/state.py:304
+#: docking/applets/hackernews/state.py:114 docking/applets/reddit/state.py:308
 msgid "now"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:117 docking/applets/reddit/state.py:307
+#: docking/applets/hackernews/state.py:117 docking/applets/reddit/state.py:311
 #, python-brace-format
 msgid "{minutes}m ago"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:120 docking/applets/reddit/state.py:310
+#: docking/applets/hackernews/state.py:120 docking/applets/reddit/state.py:314
 #, python-brace-format
 msgid "{hours}h ago"
 msgstr ""
 
-#: docking/applets/hackernews/state.py:122 docking/applets/reddit/state.py:311
+#: docking/applets/hackernews/state.py:122 docking/applets/reddit/state.py:315
 #, python-brace-format
 msgid "{days}d ago"
 msgstr ""
@@ -1615,7 +1615,7 @@ msgid "Show Phase Name"
 msgstr ""
 
 #: docking/applets/moon/offline.py:229 docking/applets/moon/state.py:143
-#: docking/applets/reddit/state.py:155
+#: docking/applets/reddit/state.py:159
 msgid "New"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Reddit"
 msgstr ""
 
-#: docking/applets/reddit/applet.py:181 docking/applets/reddit/state.py:352
+#: docking/applets/reddit/applet.py:181 docking/applets/reddit/state.py:356
 #, python-brace-format
 msgid "Posted by u/{author}"
 msgstr ""
@@ -2008,86 +2008,86 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#: docking/applets/reddit/applet.py:244
+#: docking/applets/reddit/applet.py:242
 msgid "Top Period"
 msgstr ""
 
-#: docking/applets/reddit/applet.py:257
+#: docking/applets/reddit/applet.py:254
 msgid "Add Subreddit..."
 msgstr ""
 
-#: docking/applets/reddit/applet.py:263
+#: docking/applets/reddit/applet.py:260
 #, python-brace-format
 msgid "Remove r/{subreddit}"
 msgstr ""
 
-#: docking/applets/reddit/applet.py:381
+#: docking/applets/reddit/applet.py:376
 msgid "No Reddit posts returned"
 msgstr ""
 
-#: docking/applets/reddit/applet.py:433
+#: docking/applets/reddit/applet.py:428
 msgid "Add Subreddit"
 msgstr ""
 
-#: docking/applets/reddit/applet.py:438
+#: docking/applets/reddit/applet.py:434
 msgid "Add"
 msgstr ""
 
-#: docking/applets/reddit/applet.py:448
+#: docking/applets/reddit/applet.py:444
 msgid "Subreddit name or URL"
 msgstr ""
 
-#: docking/applets/reddit/applet.py:466
+#: docking/applets/reddit/applet.py:462
 msgid "Enter a valid subreddit name."
 msgstr ""
 
-#: docking/applets/reddit/state.py:154
+#: docking/applets/reddit/state.py:158
 msgid "Hot"
 msgstr ""
 
-#: docking/applets/reddit/state.py:156
+#: docking/applets/reddit/state.py:160
 msgid "Top"
 msgstr ""
 
-#: docking/applets/reddit/state.py:157
+#: docking/applets/reddit/state.py:161
 msgid "Rising"
 msgstr ""
 
-#: docking/applets/reddit/state.py:165
+#: docking/applets/reddit/state.py:169
 msgid "Today"
 msgstr ""
 
-#: docking/applets/reddit/state.py:166
+#: docking/applets/reddit/state.py:170
 msgid "This Week"
 msgstr ""
 
-#: docking/applets/reddit/state.py:167
+#: docking/applets/reddit/state.py:171
 msgid "This Month"
 msgstr ""
 
-#: docking/applets/reddit/state.py:168
+#: docking/applets/reddit/state.py:172
 msgid "This Year"
 msgstr ""
 
-#: docking/applets/reddit/state.py:169
+#: docking/applets/reddit/state.py:173
 msgid "All Time"
 msgstr ""
 
-#: docking/applets/reddit/state.py:183
+#: docking/applets/reddit/state.py:187
 msgid "Invalid subreddit name"
-msgstr ""
-
-#: docking/applets/reddit/state.py:199
-#, python-brace-format
-msgid "{sort}, {period}"
 msgstr ""
 
 #: docking/applets/reddit/state.py:203
 #, python-brace-format
+msgid "{sort}, {period}"
+msgstr ""
+
+#: docking/applets/reddit/state.py:207
+#, python-brace-format
 msgid "r/{subreddit} - {listing}"
 msgstr ""
 
-#: docking/applets/reddit/state.py:221
+#: docking/applets/reddit/state.py:225
 msgid "Invalid Reddit RSS response"
 msgstr ""
 
@@ -3264,29 +3264,29 @@ msgstr ""
 msgid "Modified"
 msgstr ""
 
-#: docking/ui/folder/stack.py:678
+#: docking/ui/folder/stack.py:315
 msgid "Folder not found"
 msgstr ""
 
-#: docking/ui/folder/stack.py:692
+#: docking/ui/folder/stack.py:342 docking/ui/folder/stack.py:368
 msgid "Folder is empty"
 msgstr ""
 
-#: docking/ui/folder/stack.py:1149
+#: docking/ui/folder/stack.py:380
 #, python-format
 msgid "Open in %s"
 msgstr ""
 
-#: docking/ui/folder/stack.py:1151
+#: docking/ui/folder/stack.py:382
 #, python-format
 msgid "%d More in %s"
 msgstr ""
 
-#: docking/ui/folder/stack.py:1154
+#: docking/ui/folder/stack.py:385
 msgid "Open Folder"
 msgstr ""
 
-#: docking/ui/folder/stack.py:1156
+#: docking/ui/folder/stack.py:387
 #, python-format
 msgid "%d More in Folder"
 msgstr ""
@@ -3833,6 +3833,10 @@ msgstr ""
 #: docking/ui/settings.py:1545
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
+msgstr ""
+
+#: docking/ui/stack.py:102
+msgid "No items"
 msgstr ""
 
 #: docking/ui/startup_tips.py:187

--- a/docking/platform/model.py
+++ b/docking/platform/model.py
@@ -222,6 +222,7 @@ class DockModel:
         self._applets: dict[str, Applet] = {}
         self._animating_out: list[DockItem] = []
         self._change_listeners: list[Callable[[], None]] = []
+        self._applet_change_listeners: list[Callable[[str], None]] = []
         self._launcher_entries: dict[str, LauncherEntryState] = {}
         self._launcher_item_by_sender: dict[str, str] = {}
         self._recent_apps: list[DockItem] = []
@@ -248,7 +249,18 @@ class DockModel:
             self._change_listeners.remove(callback)
         except ValueError as exc:
             log.debug("Tried to remove unknown change listener: %s", exc)
-            return
+
+    def add_applet_change_listener(self, callback: Callable[[str], None]) -> None:
+        """Register a callback receiving the applet whose presentation changed."""
+        if callback not in self._applet_change_listeners:
+            self._applet_change_listeners.append(callback)
+
+    def remove_applet_change_listener(self, callback: Callable[[str], None]) -> None:
+        """Remove a previously registered applet-change callback."""
+        try:
+            self._applet_change_listeners.remove(callback)
+        except ValueError as exc:
+            log.debug("Tried to remove unknown applet change listener: %s", exc)
 
     def _load_pinned(self) -> None:
         """Load pinned items from config and resolve their desktop info."""
@@ -804,7 +816,9 @@ class DockModel:
     def _start_applet(self, *, desktop_id: str, applet: Applet) -> bool:
         """Start one applet without letting it break the dock lifecycle."""
         try:
-            applet.start(notify=self.notify)
+            applet.start(
+                notify=lambda: self._notify_applet_changed(desktop_id=desktop_id)
+            )
         except Exception:
             log.bind(applet_id=desktop_id, action="start_applet").exception(
                 "Failed to start applet",
@@ -1293,6 +1307,19 @@ class DockModel:
                     action="notify_listener",
                     listener=repr(callback),
                 ).exception("Model change listener failed")
+
+    def _notify_applet_changed(self, *, desktop_id: str) -> None:
+        """Notify general redraw listeners and applet-specific consumers."""
+        self.notify()
+        for callback in list(self._applet_change_listeners):
+            try:
+                callback(desktop_id)
+            except Exception:
+                log.bind(
+                    action="notify_applet_listener",
+                    listener=repr(callback),
+                    applet_id=desktop_id,
+                ).exception("Applet change listener failed")
 
     def tick_animations(self) -> bool:
         """Advance insert/remove animations. Returns True if any are active."""

--- a/docking/ui/dock_interactions.py
+++ b/docking/ui/dock_interactions.py
@@ -32,6 +32,9 @@ gi.require_version("Gdk", "3.0")
 from gi.repository import Gdk
 
 if TYPE_CHECKING:
+    from gi.repository import Gtk
+
+    from docking.applets.base import Applet
     from docking.core.items import DockItem
     from docking.core.position import Position
     from docking.ui.folder.stack import FolderStackController
@@ -120,3 +123,35 @@ class DockInteractions:
     def folder_stack_item_id(self) -> str | None:
         """Return the desktop id that owns the currently visible folder stack."""
         return self._folder_stack.open_item_id()
+
+    def show_applet_stack(
+        self,
+        *,
+        applet: Applet,
+        anchor: FolderStackAnchor,
+        parent: Gtk.Window | None,
+    ) -> bool:
+        """Show declarative stack content supplied by an applet."""
+        return self._folder_stack.show_applet_stack(
+            owner_id=applet.item.desktop_id,
+            provider=applet.stack_content,
+            anchor_x=anchor.x,
+            anchor_y=anchor.y,
+            icon_w=anchor.icon_w,
+            position=anchor.position,
+            parent=parent,
+        )
+
+    def refresh_open_applet_stack(self, applet: Applet | None) -> None:
+        """Refresh or close the currently open declarative applet stack."""
+        owner_id = self._folder_stack.open_owner_id()
+        if owner_id is None or self._folder_stack.open_item_id() is not None:
+            return
+        if applet is None or applet.item.desktop_id != owner_id:
+            self._folder_stack.close()
+            return
+        self._folder_stack.refresh(owner_id=owner_id)
+
+    def open_stack_owner_id(self) -> str | None:
+        """Return the owner of any currently visible reusable stack."""
+        return self._folder_stack.open_owner_id()

--- a/docking/ui/folder/stack.py
+++ b/docking/ui/folder/stack.py
@@ -400,7 +400,7 @@ class FolderStackController(StackPopupController):
         previous_owner = self._stack_owner_id
         self._stack_owner_id = item.desktop_id
         try:
-            return self._folder_stack_cards_for_content(content)
+            return self._stack_cards_for_content(content)
         finally:
             self._stack_owner_id = previous_owner
 
@@ -409,7 +409,7 @@ class FolderStackController(StackPopupController):
             item=item,
             icon_px=max(int(self._config.icon_size), 1),
         )
-        return self._folder_stack_layout(owner_id=item.desktop_id, content=content)
+        return self._stack_layout(owner_id=item.desktop_id, content=content)
 
     def _replace_folder_stack_content(
         self,
@@ -476,8 +476,8 @@ class FolderStackController(StackPopupController):
             if window is None:
                 return False
             self._replace_folder_stack_content(item)
-            self._restart_folder_stack_animation()
-            self._position_folder_stack_window()
+            self._restart_stack_animation()
+            self._position_stack_window()
             window.show_all()
             return False
         self.refresh(owner_id=item.desktop_id)
@@ -494,11 +494,11 @@ class FolderStackController(StackPopupController):
 
     def _open_folder_stack_target(self, target: str) -> None:
         launcher_mod.open_target(target)
-        self._close_folder_stack()
+        self._close_stack()
 
     def _activate_stack_key(self, key: str) -> None:
         if self._stack_content is None:
             self._open_folder_stack_target(key)
-            self._close_folder_stack()
+            self._close_stack()
             return
         super()._activate_stack_key(key)

--- a/docking/ui/folder/stack.py
+++ b/docking/ui/folder/stack.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
 
 
 FOLDER_STACK_REFRESH_DEBOUNCE_MS = 120
-FOLDER_STACK_LAYOUT_CACHE_MAX_ENTRIES = 32
+FOLDER_STACK_CONTENT_CACHE_MAX_ENTRIES = 32
 
 FolderStackCard = StackCard
 FolderStackCardGeometry = StackCardGeometry
@@ -159,6 +159,7 @@ class FolderStackController(StackPopupController):
         toggle_if_same_item: bool = True,
     ) -> None:
         """Show the selected folder through the reusable stack controller."""
+        was_open_for_item = self.open_owner_id() == item.desktop_id
         pos = Position(position)
         centered_anchor = PopupAnchor(
             x=(
@@ -185,7 +186,8 @@ class FolderStackController(StackPopupController):
         )
         if shown and self.open_owner_id() == item.desktop_id:
             self._folder_stack_item = item
-            self._track_folder_stack(target=item.target)
+            if not was_open_for_item:
+                self._track_folder_stack(target=item.target)
 
     def show_applet_stack(
         self,
@@ -332,7 +334,10 @@ class FolderStackController(StackPopupController):
             icon_px,
             app_name,
         )
-        cached = self._folder_content_cache.get(cache_key)
+        cached = self._folder_stack_cache._get_lru(
+            self._folder_content_cache,
+            cache_key,
+        )
         if cached is not None:
             return cached
 
@@ -370,7 +375,12 @@ class FolderStackController(StackPopupController):
             ),
             empty_label=_("Folder is empty"),
         )
-        self._folder_content_cache[cache_key] = content
+        self._folder_stack_cache._put_lru(
+            self._folder_content_cache,
+            cache_key,
+            content,
+            max_entries=FOLDER_STACK_CONTENT_CACHE_MAX_ENTRIES,
+        )
         return content
 
     def _folder_stack_action_label(
@@ -442,6 +452,9 @@ class FolderStackController(StackPopupController):
         uri = launcher_mod.normalize_file_target(target)
         if uri is None:
             return
+        if self._folder_stack_monitor is not None:
+            self._folder_stack_monitor.cancel()
+            self._folder_stack_monitor = None
         try:
             folder = Gio.File.new_for_uri(uri)
             monitor = folder.monitor_directory(Gio.FileMonitorFlags.NONE, None)

--- a/docking/ui/folder/stack.py
+++ b/docking/ui/folder/stack.py
@@ -5,37 +5,27 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
 
-"""Folder stack popup, layout, drawing, and interaction."""
+"""Filesystem adapter for the reusable curved item-stack popup."""
 
 from __future__ import annotations
 
-import math
 from collections.abc import Hashable, Sequence
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeVar
 
-import cairo
 import gi
 
-gi.require_version("Gtk", "3.0")
-gi.require_version("Gdk", "3.0")
-gi.require_version("GdkPixbuf", "2.0")
 gi.require_version("Gio", "2.0")
+gi.require_version("Gtk", "3.0")
 gi.require_version("PangoCairo", "1.0")
-from gi.repository import Gdk, GdkPixbuf, Gio, GLib, Gtk, Pango, PangoCairo
+from gi.repository import Gdk, Gio, GLib, Gtk, Pango, PangoCairo
 
 import docking.platform.launcher as launcher_mod
+from docking.applets.popup import PopupAnchor
 from docking.core.items import FOLDER_KIND
 from docking.core.position import Position
 from docking.i18n import _
 from docking.log import get_logger
-from docking.ui.display import clamp_popup
 from docking.ui.folder._browser import (
     FOLDER_SMALL_ICON_PX,
     FOLDER_SORT_OPTIONS,
@@ -43,7 +33,24 @@ from docking.ui.folder._browser import (
     FolderPrefs,
     FolderRow,
 )
-from docking.ui.shelf import rounded_rect
+from docking.ui.stack import (
+    FOLDER_STACK_ACTION_ARROW_GAP_PX,
+    FOLDER_STACK_ACTION_ARROW_SIZE_PX,
+    FOLDER_STACK_ACTION_MAX_WIDTH_PX,
+    FOLDER_STACK_LABEL_MAX_WIDTH_PX,
+    FOLDER_STACK_LABEL_TEXT_MARGIN_PX,
+    FOLDER_STACK_MAX_VISIBLE_ROWS,
+    StackAction,
+    StackCard,
+    StackCardGeometry,
+    StackContent,
+    StackContentProvider,
+    StackEntry,
+    StackLayout,
+    StackLayoutCache,
+    StackPopupController,
+    _measure_stack_text_px,
+)
 
 if TYPE_CHECKING:
     from docking.core.config import Config
@@ -52,118 +59,44 @@ if TYPE_CHECKING:
     from docking.ui.runtime import DockRuntime
 
 
-FOLDER_STACK_MAX_VISIBLE_ROWS = 9
-FOLDER_STACK_GAP_PX = 8
-FOLDER_STACK_POPUP_SIDE_PADDING_PX = 14
-FOLDER_STACK_TOP_PADDING_PX = 6
+FOLDER_STACK_REFRESH_DEBOUNCE_MS = 120
+FOLDER_STACK_LAYOUT_CACHE_MAX_ENTRIES = 32
+
+FolderStackCard = StackCard
+FolderStackCardGeometry = StackCardGeometry
+FolderStackLayout = StackLayout
+
 K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
-FOLDER_STACK_ACTION_GAP_PX = 18
-FOLDER_STACK_ICON_GAP_PX = 10
-FOLDER_STACK_LABEL_HEIGHT_PX = 24
-FOLDER_STACK_LABEL_MAX_WIDTH_PX = 148
-FOLDER_STACK_ACTION_MAX_WIDTH_PX = 240
-FOLDER_STACK_ROW_STEP_PX = 54
-FOLDER_STACK_CURVE_X_PX = 40
-FOLDER_STACK_ARC_BASE_SHIFT_PX = 8
-FOLDER_STACK_ARC_RADIUS_FACTOR = 2.45
-FOLDER_STACK_ARC_LINEAR_BLEND = 0.34
-FOLDER_STACK_RIGHT_BLEED_PX = 24
-FOLDER_STACK_LABEL_RADIUS_PX = 6
-FOLDER_STACK_LABEL_TEXT_MARGIN_PX = 8
-FOLDER_STACK_ACTION_ARROW_GAP_PX = 7
-FOLDER_STACK_ACTION_ARROW_SIZE_PX = 7
-FOLDER_STACK_ROTATION_MAX_DEG = 5.5
-FOLDER_STACK_REVEAL_DURATION_MS = 160
-FOLDER_STACK_REVEAL_STAGGER_MS = 28
-FOLDER_STACK_ANIM_FRAME_MS = 16
-FOLDER_STACK_HOVER_SCALE = 1.14
-FOLDER_STACK_HOVER_EASE = 0.35
-FOLDER_STACK_LAYOUT_CACHE_MAX_ENTRIES = 32
-FOLDER_STACK_REFRESH_DEBOUNCE_MS = 120
 
 log = get_logger("folder.stack")
 
-
-@dataclass(frozen=True)
-class FolderStackCard:
-    label: str
-    target: str | None
-    icon: GdkPixbuf.Pixbuf | None
-    icon_x: int
-    icon_y: int
-    icon_size: int
-    label_x: int
-    label_y: int
-    label_w: int
-    label_h: int
-    centered: bool = False
-    stack_progress: float = 0.0
-    arc_span: float = 0.0
-
-
-@dataclass(frozen=True)
-class FolderStackCardGeometry:
-    reveal: float
-    hover_value: float
-    rotation_radians: float
-    icon_x: float
-    icon_y: float
-    icon_size: float
-    icon_center_x: float
-    icon_center_y: float
-    label_x: float
-    label_y: float
+__all__ = [
+    "FOLDER_STACK_ACTION_ARROW_GAP_PX",
+    "FOLDER_STACK_ACTION_ARROW_SIZE_PX",
+    "FOLDER_STACK_ACTION_MAX_WIDTH_PX",
+    "FOLDER_STACK_LABEL_MAX_WIDTH_PX",
+    "FOLDER_STACK_LABEL_TEXT_MARGIN_PX",
+    "FolderStackCard",
+    "FolderStackCardGeometry",
+    "FolderStackController",
+    "FolderStackLayout",
+    "Gdk",
+    "Gtk",
+    "Pango",
+    "PangoCairo",
+    "_measure_stack_text_px",
+]
 
 
-@dataclass(frozen=True)
-class FolderStackLayout:
-    cards: tuple[FolderStackCard, ...]
-    popup_w: int
-    popup_h: int
-    fold_center_x: int
-
-
-class FolderStackCache:
-    """Bounded cache state for folder stack layouts and prewarm queue."""
+class FolderStackCache(StackLayoutCache):
+    """Generic layout cache plus the folder prewarm queue."""
 
     def __init__(self) -> None:
-        self.layouts: dict[
-            tuple[str, int, str, bool, int, str | None], FolderStackLayout
-        ] = {}
+        super().__init__()
         self.prewarm_queue: list[DockItem] = []
         self.prewarm_targets: set[str] = set()
         self.prewarm_source: int = 0
-
-    @staticmethod
-    def _get_lru(cache: dict[K, V], key: K) -> V | None:
-        cached = cache.pop(key, None)
-        if cached is not None:
-            cache[key] = cached
-        return cached
-
-    @staticmethod
-    def _put_lru(cache: dict[K, V], key: K, value: V, *, max_entries: int) -> None:
-        cache[key] = value
-        while len(cache) > max_entries:
-            cache.pop(next(iter(cache)))
-
-    def get_layout(
-        self, key: tuple[str, int, str, bool, int, str | None]
-    ) -> FolderStackLayout | None:
-        return self._get_lru(self.layouts, key)
-
-    def put_layout(
-        self,
-        key: tuple[str, int, str, bool, int, str | None],
-        layout: FolderStackLayout,
-    ) -> None:
-        self._put_lru(
-            self.layouts,
-            key,
-            layout,
-            max_entries=FOLDER_STACK_LAYOUT_CACHE_MAX_ENTRIES,
-        )
 
     def queue_prewarm(self, item: DockItem, *, uri: str) -> bool:
         if uri in self.prewarm_targets:
@@ -182,8 +115,7 @@ class FolderStackCache:
         return item
 
     def invalidate_target(self, *, uri: str) -> None:
-        for key in [key for key in self.layouts if key[0] == uri]:
-            self.layouts.pop(key, None)
+        self.invalidate_owner(uri)
         self.prewarm_targets.discard(uri)
         self.prewarm_queue = [
             item
@@ -192,59 +124,8 @@ class FolderStackCache:
         ]
 
 
-def _is_folder_stack_action_card(card: FolderStackCard) -> bool:
-    return card.centered and card.target is not None and card.icon is None
-
-
-def _ease_out_cubic(value: float) -> float:
-    value = min(max(value, 0.0), 1.0)
-    return 1.0 - (1.0 - value) ** 3
-
-
-def _folder_stack_arc_offset(progress: float, span: float) -> float:
-    progress = min(max(progress, 0.0), 1.0)
-    max_offset = max(FOLDER_STACK_CURVE_X_PX, span * 0.08)
-    linear = max_offset * progress
-    if span <= 0:
-        curved = linear
-    else:
-        radius = max(span * FOLDER_STACK_ARC_RADIUS_FACTOR, span + 1.0)
-        y = progress * span
-        curved = radius - math.sqrt(max(radius * radius - y * y, 0.0))
-        max_curved = radius - math.sqrt(max(radius * radius - span * span, 0.0))
-        curved = max_offset * (curved / max_curved) if max_curved > 0 else linear
-    offset = (
-        FOLDER_STACK_ARC_LINEAR_BLEND * linear
-        + (1.0 - FOLDER_STACK_ARC_LINEAR_BLEND) * curved
-    )
-    return FOLDER_STACK_ARC_BASE_SHIFT_PX + offset
-
-
-def _folder_stack_rotation(progress: float, position: Any, span: float) -> float:
-    progress = min(max(progress, 0.0), 1.0)
-    direction = 1.0 if position in {"bottom", "left"} else -1.0
-    degrees = min(
-        (0.2 + 0.8 * progress) * FOLDER_STACK_ROTATION_MAX_DEG,
-        FOLDER_STACK_ROTATION_MAX_DEG,
-    )
-    return math.radians(degrees * direction)
-
-
-def _measure_stack_text_px(text: str) -> int:
-    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 1, 1)
-    cr = cairo.Context(surface)
-    layout = PangoCairo.create_layout(cr)
-    layout.set_text(text, -1)
-    desc = Pango.FontDescription()
-    desc.set_family("Sans")
-    desc.set_size(10 * Pango.SCALE)
-    layout.set_font_description(desc)
-    _ink, logical = layout.get_pixel_extents()
-    return max(int(logical.width), 0)
-
-
-class FolderStackController:
-    """Owns the left-click folder stack popup and visual interaction."""
+class FolderStackController(StackPopupController):
+    """Adapt folders, preferences, monitoring, and launch actions to a stack."""
 
     def __init__(
         self,
@@ -254,32 +135,101 @@ class FolderStackController:
         launcher: Launcher | None,
         dock_window: Gtk.Window | None = None,
     ) -> None:
-        self._config = config
-        self._runtime = runtime
+        super().__init__(
+            config=config,
+            runtime=runtime,
+            dock_window=dock_window,
+        )
         self._launcher = launcher
-        self._dock_window = dock_window
         self._browser = FolderBrowser(launcher=launcher)
         self._folder_stack_cache = FolderStackCache()
-        self._folder_stack_window: Gtk.Window | None = None
-        self._folder_stack_revealer: Gtk.Revealer | None = None
+        self._folder_content_cache: dict[tuple[object, ...], StackContent] = {}
         self._folder_stack_item: DockItem | None = None
-        self._folder_stack_anchor_x: int = 0
-        self._folder_stack_anchor_y: int = 0
-        self._folder_stack_icon_w: int = 0
-        self._folder_stack_fold_center_x: int = 0
-        self._folder_stack_position_value = self._config.pos
-        self._folder_stack_area: Gtk.DrawingArea | None = None
-        self._folder_stack_cards: list[FolderStackCard] = []
         self._folder_stack_monitor: Gio.FileMonitor | None = None
         self._folder_stack_refresh_source: int = 0
-        self._folder_stack_anim_source: int = 0
-        self._folder_stack_show_started_us: int = 0
-        self._folder_stack_hover_target: str | None = None
-        self._folder_stack_hover_values: dict[str, float] = {}
-        self._folder_stack_pressed_target: str | None = None
+
+    def show(
+        self,
+        *,
+        item: DockItem,
+        anchor_x: int,
+        anchor_y: int,
+        icon_w: int,
+        position: Any,
+        toggle_if_same_item: bool = True,
+    ) -> None:
+        """Show the selected folder through the reusable stack controller."""
+        pos = Position(position)
+        centered_anchor = PopupAnchor(
+            x=(
+                int(anchor_x + icon_w / 2)
+                if pos in (Position.BOTTOM, Position.TOP)
+                else int(anchor_x)
+            ),
+            y=(
+                int(anchor_y + icon_w / 2)
+                if pos in (Position.LEFT, Position.RIGHT)
+                else int(anchor_y)
+            ),
+            position=pos,
+        )
+        shown = super().show_stack(
+            owner_id=item.desktop_id,
+            provider=lambda icon_px: self._stack_content_for_item(
+                item=item,
+                icon_px=icon_px,
+            ),
+            anchor=centered_anchor,
+            toggle_if_same_owner=toggle_if_same_item,
+            on_closed=self._cleanup_folder_state,
+        )
+        if shown and self.open_owner_id() == item.desktop_id:
+            self._folder_stack_item = item
+            self._track_folder_stack(target=item.target)
+
+    def show_applet_stack(
+        self,
+        *,
+        owner_id: str,
+        provider: StackContentProvider,
+        anchor_x: int,
+        anchor_y: int,
+        icon_w: int,
+        position: Position,
+        parent: Gtk.Window | None,
+        toggle_if_same_owner: bool = True,
+    ) -> bool:
+        """Expose the generic stack surface to declarative applets."""
+        pos = Position(position)
+        centered_anchor = PopupAnchor(
+            x=(
+                int(anchor_x + icon_w / 2)
+                if pos in (Position.BOTTOM, Position.TOP)
+                else anchor_x
+            ),
+            y=(
+                int(anchor_y + icon_w / 2)
+                if pos in (Position.LEFT, Position.RIGHT)
+                else anchor_y
+            ),
+            position=pos,
+            parent=parent,
+        )
+        return super().show_stack(
+            owner_id=owner_id,
+            provider=provider,
+            anchor=centered_anchor,
+            toggle_if_same_owner=toggle_if_same_owner,
+        )
+
+    def open_item_id(self) -> str | None:
+        item = self._folder_stack_item
+        if item is None or self.open_owner_id() != item.desktop_id:
+            return None
+        return item.desktop_id
 
     def schedule_prewarm(self, item: DockItem) -> None:
-        """Queue a folder stack warm-up during idle time."""
+        """Queue a folder data and layout warm-up during idle time."""
         if item.kind != FOLDER_KIND:
             return
         uri = launcher_mod.normalize_file_target(item.target)
@@ -293,70 +243,16 @@ class FolderStackController:
             )
 
     def schedule_visible_prewarm(self, items: Sequence[DockItem]) -> None:
-        """Warm visible folder stacks so hover-open can render from cache."""
         for item in items:
             self.schedule_prewarm(item)
-
-    def show(
-        self,
-        *,
-        item: DockItem,
-        anchor_x: int,
-        anchor_y: int,
-        icon_w: int,
-        position: Any,
-        toggle_if_same_item: bool = True,
-    ) -> None:
-        """Show a folder stack popup, or optionally toggle it closed."""
-        if (
-            self._folder_stack_window is not None
-            and self._folder_stack_window.get_visible()
-            and self._folder_stack_item is not None
-            and self._folder_stack_item.desktop_id == item.desktop_id
-        ):
-            if toggle_if_same_item:
-                self._close_folder_stack()
-            return
-
-        self._close_folder_stack()
-        self._runtime.hide_hover_ui()
-        self._runtime.menu_popup_opened()
-
-        window = self._ensure_folder_stack_window()
-        revealer = self._folder_stack_revealer
-        assert revealer is not None
-
-        self._replace_folder_stack_content(item=item)
-
-        self._folder_stack_anchor_x = int(anchor_x)
-        self._folder_stack_anchor_y = int(anchor_y)
-        self._folder_stack_icon_w = max(int(icon_w), 1)
-        self._folder_stack_position_value = position
-        self._folder_stack_item = item
-        self._track_folder_stack(target=item.target)
-        self._restart_folder_stack_animation()
-        self._position_folder_stack_window()
-        revealer.set_reveal_child(True)
-        window.show_all()
-
-    def close(self) -> None:
-        self._close_folder_stack()
-
-    def open_item_id(self) -> str | None:
-        window = self._folder_stack_window
-        if (
-            window is None
-            or not window.get_visible()
-            or self._folder_stack_item is None
-        ):
-            return None
-        return self._folder_stack_item.desktop_id
 
     def invalidate_target(self, target: str) -> None:
         self._browser.invalidate_target(target)
         uri = launcher_mod.normalize_file_target(target)
         if uri is not None:
             self._folder_stack_cache.invalidate_target(uri=uri)
+            for key in [key for key in self._folder_content_cache if key[0] == uri]:
+                self._folder_content_cache.pop(key, None)
 
     def folder_prefs(self, item: DockItem) -> dict[str, Any]:
         return self._folder_prefs_for_item(item).to_dict()
@@ -381,6 +277,7 @@ class FolderStackController:
         ]
 
     def icon_px(self, folder_item: DockItem) -> int:
+        _ = folder_item
         return FOLDER_SMALL_ICON_PX
 
     def update_folder_pref(self, item: DockItem, key: str, value: Any) -> None:
@@ -411,6 +308,125 @@ class FolderStackController:
             icon_px=icon_px,
         )
 
+    def _stack_content_for_item(
+        self,
+        *,
+        item: DockItem,
+        icon_px: int,
+    ) -> StackContent:
+        if self._browser.target_state(item.target) == "missing":
+            return StackContent(empty_label=_("Folder not found"))
+
+        prefs = self._folder_prefs_for_item(item)
+        uri = launcher_mod.normalize_file_target(item.target) or item.target
+        app_name = (
+            self._launcher.default_directory_app_name()
+            if self._launcher is not None
+            else None
+        )
+        cache_key = (
+            uri,
+            self._browser.cache_stamp(item.target),
+            prefs.sort,
+            prefs.show_hidden,
+            icon_px,
+            app_name,
+        )
+        cached = self._folder_content_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        rows = self._list_directory_rows(
+            folder_item=item,
+            target=item.target,
+            icon_px=icon_px,
+        )
+        if not rows:
+            return StackContent(empty_label=_("Folder is empty"))
+
+        visible_rows = rows[:FOLDER_STACK_MAX_VISIBLE_ROWS]
+        hidden_count = max(len(rows) - len(visible_rows), 0)
+        action_label = self._folder_stack_action_label(
+            hidden_count=hidden_count,
+            app_name=app_name,
+        )
+        entries = tuple(
+            StackEntry(
+                key=str(row["target"]),
+                label=str(row["name"]),
+                icon=row["icon"],
+                activate=lambda target=str(row["target"]): (
+                    self._open_folder_stack_target(target)
+                ),
+            )
+            for row in visible_rows
+        )
+        content = StackContent(
+            entries=entries,
+            action=StackAction(
+                key=item.target,
+                label=action_label,
+                activate=lambda: self._open_folder_stack_target(item.target),
+            ),
+            empty_label=_("Folder is empty"),
+        )
+        self._folder_content_cache[cache_key] = content
+        return content
+
+    def _folder_stack_action_label(
+        self, *, hidden_count: int, app_name: str | None = None
+    ) -> str:
+        if app_name is None and self._launcher is not None:
+            app_name = self._launcher.default_directory_app_name()
+        if app_name:
+            return (
+                _("Open in %s") % app_name
+                if hidden_count == 0
+                else _("%d More in %s") % (hidden_count, app_name)
+            )
+        return (
+            _("Open Folder")
+            if hidden_count == 0
+            else _("%d More in Folder") % hidden_count
+        )
+
+    def _folder_stack_cards_for_item(
+        self, item: DockItem
+    ) -> tuple[list[FolderStackCard], int, int]:
+        content = self._stack_content_for_item(
+            item=item,
+            icon_px=max(int(self._config.icon_size), 1),
+        )
+        previous_owner = self._stack_owner_id
+        self._stack_owner_id = item.desktop_id
+        try:
+            return self._folder_stack_cards_for_content(content)
+        finally:
+            self._stack_owner_id = previous_owner
+
+    def _folder_stack_layout_for_item(self, item: DockItem) -> FolderStackLayout:
+        content = self._stack_content_for_item(
+            item=item,
+            icon_px=max(int(self._config.icon_size), 1),
+        )
+        return self._folder_stack_layout(owner_id=item.desktop_id, content=content)
+
+    def _replace_folder_stack_content(
+        self,
+        item: DockItem | None = None,
+        *,
+        content: StackContent | None = None,
+    ) -> None:
+        if content is None:
+            if item is None:
+                return
+            content = self._stack_content_for_item(
+                item=item,
+                icon_px=max(int(self._config.icon_size), 1),
+            )
+        self._stack_content = content
+        super()._replace_stack_content(content=content)
+
     def _drain_folder_stack_prewarm(self) -> bool:
         item = self._folder_stack_cache.pop_next_prewarm()
         if item is None:
@@ -421,129 +437,6 @@ class FolderStackController:
             self._folder_stack_cache.prewarm_source = 0
             return False
         return True
-
-    def _close_folder_stack(self) -> None:
-        window = self._folder_stack_window
-        if window is None or not window.get_visible():
-            return
-        revealer = self._folder_stack_revealer
-        if revealer is not None:
-            revealer.set_reveal_child(False)
-        window.hide()
-        self._cleanup_folder_stack()
-        self._runtime.menu_popup_closed()
-
-    def _cleanup_folder_stack(self) -> None:
-        if self._folder_stack_refresh_source:
-            GLib.source_remove(self._folder_stack_refresh_source)
-            self._folder_stack_refresh_source = 0
-        if self._folder_stack_anim_source:
-            GLib.source_remove(self._folder_stack_anim_source)
-            self._folder_stack_anim_source = 0
-        if self._folder_stack_monitor is not None:
-            self._folder_stack_monitor.cancel()
-            self._folder_stack_monitor = None
-        self._folder_stack_area = None
-        self._folder_stack_item = None
-        self._folder_stack_anchor_x = 0
-        self._folder_stack_anchor_y = 0
-        self._folder_stack_icon_w = 0
-        self._folder_stack_fold_center_x = 0
-        self._folder_stack_show_started_us = 0
-        self._folder_stack_hover_target = None
-        self._folder_stack_hover_values.clear()
-        self._folder_stack_pressed_target = None
-
-    def _ensure_folder_stack_window(self) -> Gtk.Window:
-        if self._folder_stack_window is not None:
-            return self._folder_stack_window
-
-        window = Gtk.Window(type=Gtk.WindowType.POPUP)
-        window.set_decorated(False)
-        window.set_skip_taskbar_hint(True)
-        window.set_resizable(False)
-        window.set_type_hint(Gdk.WindowTypeHint.TOOLTIP)
-        window.set_app_paintable(True)
-
-        # On Wayland popups need a transient parent so the compositor
-        # positions them relative to the dock rather than at (0,0).
-        if self._dock_window is not None:
-            window.set_transient_for(self._dock_window)
-
-        screen = window.get_screen()
-        visual = screen.get_rgba_visual()
-        if visual:
-            window.set_visual(visual)
-
-        revealer = Gtk.Revealer()
-        revealer.set_transition_type(self._folder_stack_transition_type())
-        revealer.set_transition_duration(140)
-        revealer.set_reveal_child(False)
-        window.add(revealer)
-
-        self._folder_stack_window = window
-        self._folder_stack_revealer = revealer
-        return window
-
-    def _folder_stack_transition_type(self):
-        # Resolved lazily so test stubs of ``Gtk`` (monkeypatched at module
-        # scope) are visible. A class-level dict would freeze the real
-        # ``Gtk`` reference at import time.
-        transitions = {
-            Position.BOTTOM: Gtk.RevealerTransitionType.SLIDE_UP,
-            Position.TOP: Gtk.RevealerTransitionType.SLIDE_DOWN,
-            Position.LEFT: Gtk.RevealerTransitionType.SLIDE_RIGHT,
-            Position.RIGHT: Gtk.RevealerTransitionType.SLIDE_LEFT,
-        }
-        return transitions[Position(self._config.pos)]
-
-    def _replace_folder_stack_content(self, item: DockItem) -> None:
-        revealer = self._folder_stack_revealer
-        if revealer is None:
-            return
-        child = revealer.get_child()
-        if child is not None:
-            revealer.remove(child)
-        content = self._build_folder_stack_content(item=item)
-        revealer.add(content)
-        content.show_all()
-
-    def _position_folder_stack_window(self) -> None:
-        window = self._folder_stack_window
-        revealer = self._folder_stack_revealer
-        if window is None or revealer is None:
-            return
-        child = revealer.get_child()
-        if child is None:
-            return
-
-        preferred = child.get_preferred_size()[1]
-        popup_w = max(int(preferred.width), 1)
-        popup_h = max(int(preferred.height), 1)
-        anchor_x = self._folder_stack_anchor_x
-        anchor_y = self._folder_stack_anchor_y
-        icon_w = max(self._folder_stack_icon_w, 1)
-        pos = self._folder_stack_position_value
-        local_icon_center_x = max(self._folder_stack_fold_center_x, 1)
-
-        pos_enum = Position(pos)
-        if pos_enum in (Position.BOTTOM, Position.TOP):
-            popup_x = int(anchor_x + icon_w / 2 - local_icon_center_x)
-            popup_y = (
-                int(anchor_y - popup_h - FOLDER_STACK_GAP_PX)
-                if pos_enum is Position.BOTTOM
-                else int(anchor_y + FOLDER_STACK_GAP_PX)
-            )
-        else:
-            popup_y = int(anchor_y + icon_w / 2 - popup_h / 2)
-            popup_x = (
-                int(anchor_x + FOLDER_STACK_GAP_PX)
-                if pos_enum is Position.LEFT
-                else int(anchor_x - popup_w - FOLDER_STACK_GAP_PX)
-            )
-
-        popup_pos = clamp_popup(window, popup_x, popup_y, popup_w, popup_h)
-        window.move(popup_pos.x, popup_pos.y)
 
     def _track_folder_stack(self, target: str) -> None:
         uri = launcher_mod.normalize_file_target(target)
@@ -575,678 +468,37 @@ class FolderStackController:
 
     def _refresh_folder_stack(self) -> bool:
         self._folder_stack_refresh_source = 0
-        window = self._folder_stack_window
         item = self._folder_stack_item
-        if window is None or item is None:
+        if item is None:
             return False
-        self._replace_folder_stack_content(item=item)
-        self._restart_folder_stack_animation()
-        self._position_folder_stack_window()
-        window.show_all()
+        if self._stack_provider is None:
+            window = self._folder_stack_window
+            if window is None:
+                return False
+            self._replace_folder_stack_content(item)
+            self._restart_folder_stack_animation()
+            self._position_folder_stack_window()
+            window.show_all()
+            return False
+        self.refresh(owner_id=item.desktop_id)
         return False
 
-    def _build_folder_stack_content(self, item: DockItem) -> Gtk.Widget:
-        cards, popup_w, popup_h = self._folder_stack_cards_for_item(item)
-        self._folder_stack_cards = cards
-
-        area = Gtk.DrawingArea()
-        area.set_size_request(popup_w, popup_h)
-        area.add_events(
-            Gdk.EventMask.BUTTON_PRESS_MASK
-            | Gdk.EventMask.BUTTON_RELEASE_MASK
-            | Gdk.EventMask.POINTER_MOTION_MASK
-            | Gdk.EventMask.LEAVE_NOTIFY_MASK
-        )
-        area.connect("draw", self._on_folder_stack_draw)
-        area.connect("button-press-event", self._on_folder_stack_button_press)
-        area.connect("button-release-event", self._on_folder_stack_button_release)
-        area.connect("motion-notify-event", self._on_folder_stack_motion_notify)
-        area.connect("leave-notify-event", self._on_folder_stack_leave_notify)
-        self._folder_stack_area = area
-        return area
-
-    def _folder_stack_cards_for_item(
-        self, item: DockItem
-    ) -> tuple[list[FolderStackCard], int, int]:
-        layout = self._folder_stack_layout_for_item(item)
-        self._folder_stack_fold_center_x = layout.fold_center_x
-        return list(layout.cards), layout.popup_w, layout.popup_h
-
-    def _folder_stack_layout_for_item(self, item: DockItem) -> FolderStackLayout:
-        prefs = self._folder_prefs_for_item(item)
-        icon_px = max(int(self._config.icon_size), 1)
-        app_name = (
-            self._launcher.default_directory_app_name()
-            if self._launcher is not None
-            else None
-        )
-        uri = launcher_mod.normalize_file_target(item.target) or item.target
-        state = self._browser.target_state(item.target)
-        if state == "missing":
-            return self._compute_folder_stack_layout(
-                item=item,
-                icon_px=icon_px,
-                app_name=app_name,
-                state=state,
-            )
-        cache_key = (
-            uri,
-            self._browser.cache_stamp(item.target),
-            str(prefs.sort),
-            bool(prefs.show_hidden),
-            icon_px,
-            app_name,
-        )
-        cached = self._folder_stack_cache.get_layout(cache_key)
-        if cached is not None:
-            return cached
-
-        layout = self._compute_folder_stack_layout(
-            item=item,
-            icon_px=icon_px,
-            app_name=app_name,
-            state=state,
-        )
-        self._folder_stack_cache.put_layout(cache_key, layout)
-        return layout
-
-    def _compute_folder_stack_layout(
-        self,
-        *,
-        item: DockItem,
-        icon_px: int,
-        app_name: str | None,
-        state: str,
-    ) -> FolderStackLayout:
-        cards: list[FolderStackCard] = []
-        label_h = FOLDER_STACK_LABEL_HEIGHT_PX
-        row_step = max(FOLDER_STACK_ROW_STEP_PX, round(icon_px * 1.08))
-        curve_extent = max(FOLDER_STACK_CURVE_X_PX, round(icon_px * 0.65))
-        right_bleed = max(
-            FOLDER_STACK_RIGHT_BLEED_PX,
-            round(curve_extent + icon_px * FOLDER_STACK_HOVER_SCALE * 0.35),
-        )
-        fold_center_x = int(
-            FOLDER_STACK_POPUP_SIDE_PADDING_PX
-            + FOLDER_STACK_LABEL_MAX_WIDTH_PX
-            + FOLDER_STACK_ICON_GAP_PX
-            + icon_px / 2
-        )
-
-        if state == "missing":
-            return self._centered_layout(
-                label=_("Folder not found"),
-                label_h=label_h,
-                fold_center_x=fold_center_x,
-                icon_px=icon_px,
-                right_bleed=right_bleed,
-            )
-
-        rows = self._list_directory_rows(
-            folder_item=item,
-            target=item.target,
-            icon_px=icon_px,
-        )
-        if not rows:
-            return self._centered_layout(
-                label=_("Folder is empty"),
-                label_h=label_h,
-                fold_center_x=fold_center_x,
-                icon_px=icon_px,
-                right_bleed=right_bleed,
-            )
-
-        visible_rows = list(rows)[:FOLDER_STACK_MAX_VISIBLE_ROWS]
-        hidden_count = max(len(rows) - len(visible_rows), 0)
-        action_label = self._folder_stack_action_label(
-            hidden_count=hidden_count,
-            app_name=app_name,
-        )
-        chip_w = self._folder_stack_action_width(label=action_label)
-        chip_h = label_h
-        total_rows = len(visible_rows)
-        top_progress = 1.0 if total_rows > 0 else 0.0
-        total_span = (total_rows - 1) * row_step
-        top_center_x = round(
-            fold_center_x + _folder_stack_arc_offset(top_progress, total_span)
-        )
-        chip_x = max(
-            FOLDER_STACK_POPUP_SIDE_PADDING_PX,
-            int(top_center_x - chip_w / 2 + curve_extent * 0.1),
-        )
-        chip_y = FOLDER_STACK_TOP_PADDING_PX
-        cards.append(
-            FolderStackCard(
-                label=action_label,
-                target=item.target,
-                icon=None,
-                icon_x=0,
-                icon_y=0,
-                icon_size=0,
-                label_x=chip_x,
-                label_y=chip_y,
-                label_w=chip_w,
-                label_h=chip_h,
-                centered=True,
-                stack_progress=1.0,
-                arc_span=float(total_span),
-            )
-        )
-
-        stack_top = chip_y + chip_h + FOLDER_STACK_ACTION_GAP_PX
-        max_right = chip_x + chip_w
-        bottom_center_y = (
-            stack_top + (total_rows - 1) * row_step + icon_px / 2 if total_rows else 0
-        )
-        for index, child in enumerate(visible_rows):
-            raw_progress = (
-                (total_rows - 1 - index) / max(total_rows - 1, 1)
-                if total_rows > 1
-                else 1.0
-            )
-            arc_progress = raw_progress
-            icon_center_x = fold_center_x + _folder_stack_arc_offset(
-                arc_progress,
-                total_span,
-            )
-            icon_center_y = bottom_center_y - total_span * raw_progress
-            icon_x = round(icon_center_x - icon_px / 2)
-            icon_y = round(icon_center_y - icon_px / 2)
-            name = str(child["name"])
-            label_w = self._folder_stack_label_width(label=name)
-            label_pull = round(arc_progress * 10)
-            label_x = max(
-                FOLDER_STACK_POPUP_SIDE_PADDING_PX,
-                icon_x - FOLDER_STACK_ICON_GAP_PX - label_w - label_pull,
-            )
-            cards.append(
-                FolderStackCard(
-                    label=name,
-                    target=str(child["target"]),
-                    icon=child["icon"],
-                    icon_x=icon_x,
-                    icon_y=icon_y,
-                    icon_size=icon_px,
-                    label_x=label_x,
-                    label_y=icon_y + max(int((icon_px - label_h) / 2), 0),
-                    label_w=label_w,
-                    label_h=label_h,
-                    centered=False,
-                    stack_progress=arc_progress,
-                    arc_span=float(total_span),
-                )
-            )
-            max_right = max(max_right, icon_x + icon_px)
-
-        popup_w = int(
-            max(
-                max_right + right_bleed,
-                fold_center_x
-                + _folder_stack_arc_offset(1.0, total_span)
-                + icon_px / 2
-                + right_bleed,
-            )
-        )
-        popup_h = (
-            stack_top
-            + (total_rows - 1) * row_step
-            + icon_px
-            + FOLDER_STACK_TOP_PADDING_PX
-        )
-        return FolderStackLayout(
-            cards=tuple(cards),
-            popup_w=popup_w,
-            popup_h=popup_h,
-            fold_center_x=fold_center_x,
-        )
-
-    def _centered_layout(
-        self,
-        *,
-        label: str,
-        label_h: int,
-        fold_center_x: int,
-        icon_px: int,
-        right_bleed: int,
-    ) -> FolderStackLayout:
-        label_w = 190
-        card = FolderStackCard(
-            label=label,
-            target=None,
-            icon=None,
-            icon_x=0,
-            icon_y=0,
-            icon_size=0,
-            label_x=max(
-                FOLDER_STACK_POPUP_SIDE_PADDING_PX,
-                int(fold_center_x - label_w / 2),
-            ),
-            label_y=FOLDER_STACK_TOP_PADDING_PX,
-            label_w=label_w,
-            label_h=label_h,
-            centered=True,
-        )
-        popup_w = int(
-            max(
-                fold_center_x + label_w / 2 + FOLDER_STACK_POPUP_SIDE_PADDING_PX,
-                fold_center_x + icon_px / 2 + right_bleed,
-            )
-        )
-        popup_h = label_h + 2 * FOLDER_STACK_TOP_PADDING_PX
-        return FolderStackLayout(
-            cards=(card,),
-            popup_w=popup_w,
-            popup_h=popup_h,
-            fold_center_x=fold_center_x,
-        )
-
-    def _on_folder_stack_draw(self, widget: Gtk.DrawingArea, cr: cairo.Context) -> bool:
-        cr.set_operator(cairo.OPERATOR_CLEAR)
-        cr.paint()
-        cr.set_operator(cairo.OPERATOR_OVER)
-        now_us = GLib.get_monotonic_time()
-        total_cards = len(self._folder_stack_cards)
-        for draw_index, card in enumerate(self._folder_stack_cards):
-            self._draw_folder_stack_card(
-                cr=cr,
-                card=card,
-                sequence_index=total_cards - 1 - draw_index,
-                now_us=now_us,
-            )
-        return False
-
-    def _folder_stack_card_geometry(
-        self,
-        *,
-        card: FolderStackCard,
-        sequence_index: int,
-        now_us: int,
-    ) -> FolderStackCardGeometry | None:
-        reveal = self._folder_stack_reveal_progress(
-            sequence_index=sequence_index,
-            now_us=now_us,
-        )
-        if reveal <= 0:
-            return None
-
-        hover_value = (
-            self._folder_stack_hover_values.get(card.target, 0.0)
-            if card.target is not None and not card.centered
-            else 0.0
-        )
-        y_offset = (1.0 - reveal) * 18.0
-        rotation_radians = (
-            _folder_stack_rotation(
-                card.stack_progress,
-                self._folder_stack_position_value,
-                card.arc_span,
-            )
-            * reveal
-        )
-        open_label_center_x = card.label_x + card.label_w / 2
-        label_center_x = (
-            self._folder_stack_fold_center_x
-            + (open_label_center_x - self._folder_stack_fold_center_x) * reveal
-        )
-        label_x = label_center_x - card.label_w / 2
-        label_y = card.label_y + y_offset
-
-        icon_size = 0.0
-        icon_x = 0.0
-        icon_y = 0.0
-        icon_center_x = 0.0
-        icon_center_y = 0.0
-        if card.icon is not None and card.icon_size > 0:
-            icon_size = max(
-                (
-                    card.icon_size
-                    * (0.82 + 0.18 * reveal)
-                    * (1.0 + hover_value * (FOLDER_STACK_HOVER_SCALE - 1.0))
-                ),
-                1.0,
-            )
-            open_icon_center_x = card.icon_x + card.icon_size / 2
-            icon_center_x = (
-                self._folder_stack_fold_center_x
-                + (open_icon_center_x - self._folder_stack_fold_center_x) * reveal
-            )
-            icon_center_y = (
-                card.icon_y + card.icon_size / 2 + y_offset - hover_value * 4.0
-            )
-            icon_x = icon_center_x - icon_size / 2
-            icon_y = icon_center_y - icon_size / 2
-
-        return FolderStackCardGeometry(
-            reveal=reveal,
-            hover_value=hover_value,
-            rotation_radians=rotation_radians,
-            icon_x=icon_x,
-            icon_y=icon_y,
-            icon_size=icon_size,
-            icon_center_x=icon_center_x,
-            icon_center_y=icon_center_y,
-            label_x=label_x,
-            label_y=label_y,
-        )
-
-    def _draw_folder_stack_card(
-        self,
-        *,
-        cr: cairo.Context,
-        card: FolderStackCard,
-        sequence_index: int,
-        now_us: int,
-    ) -> None:
-        geometry = self._folder_stack_card_geometry(
-            card=card,
-            sequence_index=sequence_index,
-            now_us=now_us,
-        )
-        if geometry is None:
-            return
-        is_action_card = _is_folder_stack_action_card(card)
-
-        if card.icon is not None and card.icon_size > 0:
-            pixbuf = card.icon
-            draw_icon_size = max(round(geometry.icon_size), 1)
-            if (
-                pixbuf.get_width() != draw_icon_size
-                or pixbuf.get_height() != draw_icon_size
-            ):
-                scaled = pixbuf.scale_simple(
-                    draw_icon_size,
-                    draw_icon_size,
-                    GdkPixbuf.InterpType.BILINEAR,
-                )
-                if scaled is not None:
-                    pixbuf = scaled
-
-            cr.save()
-            cr.translate(geometry.icon_center_x + 2, geometry.icon_center_y + 2)
-            cr.rotate(geometry.rotation_radians)
-            Gdk.cairo_set_source_pixbuf(
-                cr,
-                pixbuf,
-                -draw_icon_size / 2,
-                -draw_icon_size / 2,
-            )
-            cr.paint_with_alpha(0.16 * geometry.reveal)
-            cr.restore()
-
-            cr.save()
-            cr.translate(geometry.icon_center_x, geometry.icon_center_y)
-            cr.rotate(geometry.rotation_radians)
-            Gdk.cairo_set_source_pixbuf(
-                cr,
-                pixbuf,
-                -draw_icon_size / 2,
-                -draw_icon_size / 2,
-            )
-            cr.paint_with_alpha(0.55 + 0.45 * geometry.reveal)
-            cr.restore()
-
-        radius = FOLDER_STACK_LABEL_RADIUS_PX
-        label_center_x = geometry.label_x + card.label_w / 2
-        label_center_y = geometry.label_y + card.label_h / 2
-        cr.save()
-        cr.translate(label_center_x, label_center_y + 1)
-        cr.rotate(geometry.rotation_radians * 0.85)
-        rounded_rect(
-            cr,
-            -card.label_w / 2,
-            -card.label_h / 2,
-            card.label_w,
-            card.label_h,
-            radius,
-        )
-        cr.set_source_rgba(0, 0, 0, 0.08 * geometry.reveal)
-        cr.fill()
-        cr.restore()
-
-        cr.save()
-        cr.translate(label_center_x, label_center_y)
-        cr.rotate(geometry.rotation_radians * 0.85)
-        rounded_rect(
-            cr,
-            -card.label_w / 2,
-            -card.label_h / 2,
-            card.label_w,
-            card.label_h,
-            radius,
-        )
-        cr.set_source_rgba(0.98, 0.98, 0.98, 0.95)
-        cr.fill_preserve()
-        cr.set_source_rgba(0, 0, 0, 0.08)
-        cr.set_line_width(1.0)
-        cr.stroke()
-        cr.restore()
-
-        cr.save()
-        layout = PangoCairo.create_layout(cr)
-        layout.set_text(card.label, -1)
-        desc = Pango.FontDescription()
-        desc.set_family("Sans")
-        desc.set_size(10 * Pango.SCALE)
-        layout.set_font_description(desc)
-        layout.set_ellipsize(Pango.EllipsizeMode.END)
-        arrow_reserve = (
-            FOLDER_STACK_ACTION_ARROW_GAP_PX + FOLDER_STACK_ACTION_ARROW_SIZE_PX
-            if is_action_card
-            else 0
-        )
-        available_text_w = max(
-            int(card.label_w - 2 * FOLDER_STACK_LABEL_TEXT_MARGIN_PX - arrow_reserve),
-            1,
-        )
-        layout.set_width(available_text_w * Pango.SCALE)
-        layout.set_alignment(Pango.Alignment.CENTER)
-        _, logical = layout.get_pixel_extents()
-        text_y = int(-card.label_h / 2 + (card.label_h - logical.height) / 2)
-        text_x = -card.label_w / 2 + FOLDER_STACK_LABEL_TEXT_MARGIN_PX
-        cr.set_source_rgba(0.16, 0.2, 0.26, 1.0)
-        cr.translate(label_center_x, label_center_y)
-        cr.rotate(geometry.rotation_radians * 0.85)
-        cr.move_to(text_x, text_y)
-        PangoCairo.show_layout(cr, layout)
-        if is_action_card:
-            arrow_center_x = (
-                card.label_w / 2
-                - FOLDER_STACK_LABEL_TEXT_MARGIN_PX
-                - FOLDER_STACK_ACTION_ARROW_SIZE_PX / 2
-            )
-            half = FOLDER_STACK_ACTION_ARROW_SIZE_PX / 2
-            cr.set_line_width(1.4)
-            cr.set_line_cap(cairo.LineCap.ROUND)
-            cr.set_line_join(cairo.LineJoin.ROUND)
-            cr.move_to(arrow_center_x - half, -half)
-            cr.line_to(arrow_center_x, 0.0)
-            cr.line_to(arrow_center_x - half, half)
-            cr.stroke()
-        cr.restore()
-
-    def _folder_stack_card_at(self, x: float, y: float) -> FolderStackCard | None:
-        now_us = GLib.get_monotonic_time()
-        total_cards = len(self._folder_stack_cards)
-        for index in range(total_cards - 1, -1, -1):
-            card = self._folder_stack_cards[index]
-            geometry = self._folder_stack_card_geometry(
-                card=card,
-                sequence_index=total_cards - 1 - index,
-                now_us=now_us,
-            )
-            if geometry is None:
-                continue
-            within_label = (
-                geometry.label_x <= x <= geometry.label_x + card.label_w
-                and geometry.label_y <= y <= geometry.label_y + card.label_h
-            )
-            within_icon = (
-                geometry.icon_size > 0
-                and geometry.icon_x <= x <= geometry.icon_x + geometry.icon_size
-                and geometry.icon_y <= y <= geometry.icon_y + geometry.icon_size
-            )
-            if within_label or within_icon:
-                return card
-        return None
-
-    def _on_folder_stack_button_press(
-        self, _widget: Gtk.DrawingArea, event: Gdk.EventButton
-    ) -> bool:
-        if int(event.button) != 1:
-            self._folder_stack_pressed_target = None
-            return False
-        card = self._folder_stack_card_at(event.x, event.y)
-        self._folder_stack_pressed_target = (
-            card.target if card is not None and card.target is not None else None
-        )
-        return self._folder_stack_pressed_target is not None
-
-    def _on_folder_stack_button_release(
-        self, _widget: Gtk.DrawingArea, event: Gdk.EventButton
-    ) -> bool:
-        if int(event.button) != 1:
-            self._folder_stack_pressed_target = None
-            return False
-        card = self._folder_stack_card_at(event.x, event.y)
-        target = card.target if card is not None and card.target is not None else None
-        pressed_target = self._folder_stack_pressed_target
-        self._folder_stack_pressed_target = None
-        if target is not None and (pressed_target is None or pressed_target == target):
-            self._open_folder_stack_target(target)
-            return True
-        return False
-
-    def _on_folder_stack_motion_notify(
-        self, _widget: Gtk.DrawingArea, event: Gdk.EventMotion
-    ) -> bool:
-        card = self._folder_stack_card_at(event.x, event.y)
-        target = (
-            card.target
-            if card is not None and card.target is not None and not card.centered
-            else None
-        )
-        if target != self._folder_stack_hover_target:
-            self._folder_stack_hover_target = target
-            self._ensure_folder_stack_animating()
-        return False
-
-    def _on_folder_stack_leave_notify(
-        self, _widget: Gtk.DrawingArea, _event: Gdk.EventCrossing
-    ) -> bool:
-        if self._folder_stack_hover_target is not None:
-            self._folder_stack_hover_target = None
-            self._ensure_folder_stack_animating()
-        self._folder_stack_pressed_target = None
-        return False
-
-    def _folder_stack_action_label(
-        self, *, hidden_count: int, app_name: str | None = None
-    ) -> str:
-        if app_name is None and self._launcher is not None:
-            app_name = self._launcher.default_directory_app_name()
-        if app_name:
-            return (
-                _("Open in %s") % app_name
-                if hidden_count == 0
-                else _("%d More in %s") % (hidden_count, app_name)
-            )
-        return (
-            _("Open Folder")
-            if hidden_count == 0
-            else _("%d More in Folder") % hidden_count
-        )
-
-    def _folder_stack_action_width(self, *, label: str) -> int:
-        return min(
-            FOLDER_STACK_ACTION_MAX_WIDTH_PX,
-            _measure_stack_text_px(label)
-            + 2 * FOLDER_STACK_LABEL_TEXT_MARGIN_PX
-            + FOLDER_STACK_ACTION_ARROW_GAP_PX
-            + FOLDER_STACK_ACTION_ARROW_SIZE_PX
-            + 10,
-        )
-
-    def _folder_stack_label_width(self, *, label: str) -> int:
-        return min(
-            FOLDER_STACK_LABEL_MAX_WIDTH_PX,
-            max(
-                24,
-                _measure_stack_text_px(label)
-                + 2 * FOLDER_STACK_LABEL_TEXT_MARGIN_PX
-                + 10,
-            ),
-        )
-
-    def _restart_folder_stack_animation(self) -> None:
-        self._folder_stack_show_started_us = GLib.get_monotonic_time()
-        self._folder_stack_hover_target = None
-        self._folder_stack_hover_values.clear()
-        self._ensure_folder_stack_animating()
-
-    def _ensure_folder_stack_animating(self) -> None:
-        area = self._folder_stack_area
-        if area is None:
-            return
-        area.queue_draw()
-        if self._folder_stack_anim_source == 0:
-            self._folder_stack_anim_source = GLib.timeout_add(
-                FOLDER_STACK_ANIM_FRAME_MS,
-                self._on_folder_stack_animation_frame,
-            )
-
-    def _on_folder_stack_animation_frame(self) -> bool:
-        area = self._folder_stack_area
-        window = self._folder_stack_window
-        if area is None or window is None or not window.get_visible():
-            self._folder_stack_anim_source = 0
-            return False
-
-        active = False
-        now_us = GLib.get_monotonic_time()
-        elapsed_ms = max((now_us - self._folder_stack_show_started_us) / 1000.0, 0.0)
-        reveal_budget_ms = (
-            FOLDER_STACK_REVEAL_DURATION_MS
-            + max(
-                len(self._folder_stack_cards) - 1,
-                0,
-            )
-            * FOLDER_STACK_REVEAL_STAGGER_MS
-        )
-        if elapsed_ms < reveal_budget_ms:
-            active = True
-
-        for card in self._folder_stack_cards:
-            if card.target is None or card.centered:
-                continue
-            current = self._folder_stack_hover_values.get(card.target, 0.0)
-            target = 1.0 if self._folder_stack_hover_target == card.target else 0.0
-            updated = current + (target - current) * FOLDER_STACK_HOVER_EASE
-            if abs(updated - target) < 0.02:
-                updated = target
-            if updated <= 0.0 and target == 0.0:
-                self._folder_stack_hover_values.pop(card.target, None)
-            else:
-                self._folder_stack_hover_values[card.target] = updated
-            if updated != target:
-                active = True
-
-        area.queue_draw()
-        if not active:
-            self._folder_stack_anim_source = 0
-            return False
-        return True
-
-    def _folder_stack_reveal_progress(
-        self, *, sequence_index: int, now_us: int
-    ) -> float:
-        if self._folder_stack_show_started_us <= 0:
-            return 1.0
-        elapsed_ms = max((now_us - self._folder_stack_show_started_us) / 1000.0, 0.0)
-        elapsed_ms -= sequence_index * FOLDER_STACK_REVEAL_STAGGER_MS
-        if elapsed_ms <= 0:
-            return 0.0
-        return _ease_out_cubic(elapsed_ms / FOLDER_STACK_REVEAL_DURATION_MS)
+    def _cleanup_folder_state(self) -> None:
+        if self._folder_stack_refresh_source:
+            GLib.source_remove(self._folder_stack_refresh_source)
+            self._folder_stack_refresh_source = 0
+        if self._folder_stack_monitor is not None:
+            self._folder_stack_monitor.cancel()
+            self._folder_stack_monitor = None
+        self._folder_stack_item = None
 
     def _open_folder_stack_target(self, target: str) -> None:
         launcher_mod.open_target(target)
         self._close_folder_stack()
+
+    def _activate_stack_key(self, key: str) -> None:
+        if self._stack_content is None:
+            self._open_folder_stack_target(key)
+            self._close_folder_stack()
+            return
+        super()._activate_stack_key(key)

--- a/docking/ui/input_controller.py
+++ b/docking/ui/input_controller.py
@@ -121,9 +121,11 @@ class DockInputController:
 
     def _connect_model(self) -> None:
         self._window.model.add_change_listener(self._on_model_changed)
+        self._window.model.add_applet_change_listener(self._on_applet_changed)
 
     def _disconnect_model(self) -> None:
         self._window.model.remove_change_listener(self._on_model_changed)
+        self._window.model.remove_applet_change_listener(self._on_applet_changed)
 
     def _on_destroy(self, _window: Gtk.Window) -> None:
         self.stop()
@@ -381,20 +383,21 @@ class DockInputController:
                 if applet:
                     anchor = window.popup_anchor_for_item(item, frame)
                     applet.set_popup_anchor(anchor)
-                    stack_anchor = self._stack_anchor_for_item(
-                        item=item,
-                        frame=frame,
-                        fallback_x=event.x,
-                        fallback_y=event.y,
-                    )
-                    if self._interactions.show_applet_stack(
-                        applet=applet,
-                        anchor=stack_anchor,
-                        parent=anchor.parent if anchor is not None else window,
-                    ):
-                        window.tooltip.update(item, frame)
-                        window.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
-                        return True
+                    if event.button == MOUSE_LEFT:
+                        stack_anchor = self._stack_anchor_for_item(
+                            item=item,
+                            frame=frame,
+                            fallback_x=event.x,
+                            fallback_y=event.y,
+                        )
+                        if self._interactions.show_applet_stack(
+                            applet=applet,
+                            anchor=stack_anchor,
+                            parent=anchor.parent if anchor is not None else window,
+                        ):
+                            window.tooltip.update(item, frame)
+                            window.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
+                            return True
                     applet.on_clicked()
                     window.tooltip.update(item, frame)
                     window.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
@@ -518,10 +521,11 @@ class DockInputController:
         window.hover.on_model_changed()
         self._interactions.prewarm_visible_folder_stacks(window.model.visible_items())
         stack_owner_id = self._interactions.open_stack_owner_id()
-        if stack_owner_id is not None:
-            self._interactions.refresh_open_applet_stack(
-                window.model.get_applet(stack_owner_id)
-            )
+        if (
+            stack_owner_id is not None
+            and window.model.get_applet(stack_owner_id) is None
+        ):
+            self._interactions.refresh_open_applet_stack(None)
         if window.hover.hovered_item is not None:
             cursor_main = (
                 window.cursor_x
@@ -530,6 +534,14 @@ class DockInputController:
             )
             window.hover.update(cursor_main)
         window._schedule_redraw()
+
+    def _on_applet_changed(self, desktop_id: str) -> None:
+        """Refresh an open stack only when its owning applet changed."""
+        if self._interactions.open_stack_owner_id() != desktop_id:
+            return
+        self._interactions.refresh_open_applet_stack(
+            self._window.model.get_applet(desktop_id)
+        )
 
 
 def _scroll_direction_up(*, event: Gdk.EventScroll) -> bool | None:

--- a/docking/ui/input_controller.py
+++ b/docking/ui/input_controller.py
@@ -285,6 +285,27 @@ class DockInputController:
         fallback_y: float,
         toggle_if_same_item: bool,
     ) -> None:
+        anchor = self._stack_anchor_for_item(
+            item=item,
+            frame=frame,
+            fallback_x=fallback_x,
+            fallback_y=fallback_y,
+        )
+        self._interactions.show_folder_stack(
+            item=item,
+            anchor=anchor,
+            toggle_if_same_item=toggle_if_same_item,
+        )
+
+    def _stack_anchor_for_item(
+        self,
+        *,
+        item: DockItem,
+        frame: DockGeometryFrame,
+        fallback_x: float,
+        fallback_y: float,
+    ) -> FolderStackAnchor:
+        """Build the stack-specific edge anchor independently of PopupAnchor."""
         window = self._window
         item_geometry = frame.geometry_for_item(item)
         if item_geometry is not None:
@@ -302,15 +323,11 @@ class DockInputController:
             anchor_x = win_x + int(fallback_x)
             anchor_y = win_y + int(fallback_y)
             icon_w = int(window.config.icon_size)
-        self._interactions.show_folder_stack(
-            item=item,
-            anchor=FolderStackAnchor(
-                x=anchor_x,
-                y=anchor_y,
-                icon_w=icon_w,
-                position=window.config.pos,
-            ),
-            toggle_if_same_item=toggle_if_same_item,
+        return FolderStackAnchor(
+            x=anchor_x,
+            y=anchor_y,
+            icon_w=icon_w,
+            position=window.config.pos,
         )
 
     def _on_button_press(
@@ -362,7 +379,22 @@ class DockInputController:
             if is_applet(desktop_id=item.desktop_id):
                 applet = window.model.get_applet(item.desktop_id)
                 if applet:
-                    applet.set_popup_anchor(window.popup_anchor_for_item(item, frame))
+                    anchor = window.popup_anchor_for_item(item, frame)
+                    applet.set_popup_anchor(anchor)
+                    stack_anchor = self._stack_anchor_for_item(
+                        item=item,
+                        frame=frame,
+                        fallback_x=event.x,
+                        fallback_y=event.y,
+                    )
+                    if self._interactions.show_applet_stack(
+                        applet=applet,
+                        anchor=stack_anchor,
+                        parent=anchor.parent if anchor is not None else window,
+                    ):
+                        window.tooltip.update(item, frame)
+                        window.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
+                        return True
                     applet.on_clicked()
                     window.tooltip.update(item, frame)
                     window.hover.start_anim_pump(SHORT_ANIMATION_PUMP_MS)
@@ -485,6 +517,11 @@ class DockInputController:
         window.update_input_region()
         window.hover.on_model_changed()
         self._interactions.prewarm_visible_folder_stacks(window.model.visible_items())
+        stack_owner_id = self._interactions.open_stack_owner_id()
+        if stack_owner_id is not None:
+            self._interactions.refresh_open_applet_stack(
+                window.model.get_applet(stack_owner_id)
+            )
         if window.hover.hovered_item is not None:
             cursor_main = (
                 window.cursor_x

--- a/docking/ui/stack.py
+++ b/docking/ui/stack.py
@@ -189,7 +189,7 @@ class StackLayoutCache:
             self.layouts.pop(key, None)
 
 
-def _is_folder_stack_action_card(card: StackCard) -> bool:
+def _is_stack_action_card(card: StackCard) -> bool:
     return card.action or (
         card.centered and card.target is not None and card.icon is None
     )
@@ -200,7 +200,7 @@ def _ease_out_cubic(value: float) -> float:
     return 1.0 - (1.0 - value) ** 3
 
 
-def _folder_stack_arc_offset(progress: float, span: float) -> float:
+def _stack_arc_offset(progress: float, span: float) -> float:
     progress = min(max(progress, 0.0), 1.0)
     max_offset = max(FOLDER_STACK_CURVE_X_PX, span * 0.08)
     linear = max_offset * progress
@@ -219,7 +219,7 @@ def _folder_stack_arc_offset(progress: float, span: float) -> float:
     return FOLDER_STACK_ARC_BASE_SHIFT_PX + offset
 
 
-def _folder_stack_rotation(progress: float, position: Any, span: float) -> float:
+def _stack_rotation(progress: float, position: Any, span: float) -> float:
     progress = min(max(progress, 0.0), 1.0)
     direction = 1.0 if position in {"bottom", "left"} else -1.0
     degrees = min(
@@ -291,18 +291,18 @@ class StackPopupController:
             and self._stack_owner_id == owner_id
         ):
             if toggle_if_same_owner:
-                self._close_folder_stack()
+                self._close_stack()
             return True
 
         content = provider(max(int(self._config.icon_size), 1))
         if content is None:
             return False
 
-        self._close_folder_stack()
+        self._close_stack()
         self._runtime.hide_hover_ui()
         self._runtime.menu_popup_opened()
 
-        window = self._ensure_folder_stack_window()
+        window = self._ensure_stack_window()
         revealer = self._folder_stack_revealer
         assert revealer is not None
 
@@ -316,14 +316,14 @@ class StackPopupController:
         self._folder_stack_anchor_y = int(anchor.y)
         self._folder_stack_icon_w = 0
         self._folder_stack_position_value = anchor.position
-        self._restart_folder_stack_animation()
-        self._position_folder_stack_window()
+        self._restart_stack_animation()
+        self._position_stack_window()
         revealer.set_reveal_child(True)
         window.show_all()
         return True
 
     def close(self) -> None:
-        self._close_folder_stack()
+        self._close_stack()
 
     def open_owner_id(self) -> str | None:
         window = self._folder_stack_window
@@ -337,7 +337,7 @@ class StackPopupController:
     def prewarm(self, *, owner_id: str, provider: StackContentProvider) -> None:
         content = provider(max(int(self._config.icon_size), 1))
         if content is not None:
-            self._folder_stack_layout(owner_id=owner_id, content=content)
+            self._stack_layout(owner_id=owner_id, content=content)
 
     def refresh(self, owner_id: str | None = None) -> bool:
         if owner_id is not None and owner_id != self._stack_owner_id:
@@ -354,12 +354,12 @@ class StackPopupController:
             self.invalidate_owner(self._stack_owner_id)
         self._stack_content = content
         self._replace_stack_content(content=content)
-        self._restart_folder_stack_animation()
-        self._position_folder_stack_window()
+        self._restart_stack_animation()
+        self._position_stack_window()
         window.show_all()
         return True
 
-    def _close_folder_stack(self) -> None:
+    def _close_stack(self) -> None:
         window = self._folder_stack_window
         if window is None or not window.get_visible():
             return
@@ -367,10 +367,10 @@ class StackPopupController:
         if revealer is not None:
             revealer.set_reveal_child(False)
         window.hide()
-        self._cleanup_folder_stack()
+        self._cleanup_stack()
         self._runtime.menu_popup_closed()
 
-    def _cleanup_folder_stack(self) -> None:
+    def _cleanup_stack(self) -> None:
         if self._folder_stack_anim_source:
             GLib.source_remove(self._folder_stack_anim_source)
             self._folder_stack_anim_source = 0
@@ -391,7 +391,7 @@ class StackPopupController:
         if on_closed is not None:
             on_closed()
 
-    def _ensure_folder_stack_window(self) -> Gtk.Window:
+    def _ensure_stack_window(self) -> Gtk.Window:
         if self._folder_stack_window is not None:
             return self._folder_stack_window
 
@@ -413,7 +413,7 @@ class StackPopupController:
             window.set_visual(visual)
 
         revealer = Gtk.Revealer()
-        revealer.set_transition_type(self._folder_stack_transition_type())
+        revealer.set_transition_type(self._stack_transition_type())
         revealer.set_transition_duration(140)
         revealer.set_reveal_child(False)
         window.add(revealer)
@@ -422,7 +422,7 @@ class StackPopupController:
         self._folder_stack_revealer = revealer
         return window
 
-    def _folder_stack_transition_type(self):
+    def _stack_transition_type(self):
         # Resolved lazily so test stubs of ``Gtk`` (monkeypatched at module
         # scope) are visible. A class-level dict would freeze the real
         # ``Gtk`` reference at import time.
@@ -441,11 +441,11 @@ class StackPopupController:
         child = revealer.get_child()
         if child is not None:
             revealer.remove(child)
-        widget = self._build_folder_stack_content(content=content)
+        widget = self._build_stack_content(content=content)
         revealer.add(widget)
         widget.show_all()
 
-    def _position_folder_stack_window(self) -> None:
+    def _position_stack_window(self) -> None:
         window = self._folder_stack_window
         revealer = self._folder_stack_revealer
         if window is None or revealer is None:
@@ -482,8 +482,8 @@ class StackPopupController:
         popup_pos = clamp_popup(window, popup_x, popup_y, popup_w, popup_h)
         window.move(popup_pos.x, popup_pos.y)
 
-    def _build_folder_stack_content(self, content: StackContent) -> Gtk.Widget:
-        cards, popup_w, popup_h = self._folder_stack_cards_for_content(content)
+    def _build_stack_content(self, content: StackContent) -> Gtk.Widget:
+        cards, popup_w, popup_h = self._stack_cards_for_content(content)
         self._folder_stack_cards = cards
 
         area = Gtk.DrawingArea()
@@ -494,25 +494,23 @@ class StackPopupController:
             | Gdk.EventMask.POINTER_MOTION_MASK
             | Gdk.EventMask.LEAVE_NOTIFY_MASK
         )
-        area.connect("draw", self._on_folder_stack_draw)
-        area.connect("button-press-event", self._on_folder_stack_button_press)
-        area.connect("button-release-event", self._on_folder_stack_button_release)
-        area.connect("motion-notify-event", self._on_folder_stack_motion_notify)
-        area.connect("leave-notify-event", self._on_folder_stack_leave_notify)
+        area.connect("draw", self._on_stack_draw)
+        area.connect("button-press-event", self._on_stack_button_press)
+        area.connect("button-release-event", self._on_stack_button_release)
+        area.connect("motion-notify-event", self._on_stack_motion_notify)
+        area.connect("leave-notify-event", self._on_stack_leave_notify)
         self._folder_stack_area = area
         return area
 
-    def _folder_stack_cards_for_content(
+    def _stack_cards_for_content(
         self, content: StackContent
     ) -> tuple[list[StackCard], int, int]:
         owner_id = self._stack_owner_id or ""
-        layout = self._folder_stack_layout(owner_id=owner_id, content=content)
+        layout = self._stack_layout(owner_id=owner_id, content=content)
         self._folder_stack_fold_center_x = layout.fold_center_x
         return list(layout.cards), layout.popup_w, layout.popup_h
 
-    def _folder_stack_layout(
-        self, *, owner_id: str, content: StackContent
-    ) -> StackLayout:
+    def _stack_layout(self, *, owner_id: str, content: StackContent) -> StackLayout:
         icon_px = max(int(self._config.icon_size), 1)
         entries = tuple(content.entries[:FOLDER_STACK_MAX_VISIBLE_ROWS])
         if len(content.entries) > FOLDER_STACK_MAX_VISIBLE_ROWS:
@@ -537,7 +535,7 @@ class StackPopupController:
         if cached is not None:
             return cached
 
-        layout = self._compute_folder_stack_layout(
+        layout = self._compute_stack_layout(
             entries=entries,
             action=content.action,
             empty_label=content.empty_label,
@@ -546,7 +544,7 @@ class StackPopupController:
         self._folder_stack_cache.put_layout(cache_key, layout)
         return layout
 
-    def _compute_folder_stack_layout(
+    def _compute_stack_layout(
         self,
         *,
         entries: Sequence[StackEntry],
@@ -584,9 +582,9 @@ class StackPopupController:
         stack_top = FOLDER_STACK_TOP_PADDING_PX
         max_right = fold_center_x
         if action is not None:
-            chip_w = self._folder_stack_action_width(label=action.label)
+            chip_w = self._stack_action_width(label=action.label)
             top_center_x = round(
-                fold_center_x + _folder_stack_arc_offset(top_progress, total_span)
+                fold_center_x + _stack_arc_offset(top_progress, total_span)
             )
             chip_x = max(
                 FOLDER_STACK_POPUP_SIDE_PADDING_PX,
@@ -624,7 +622,7 @@ class StackPopupController:
                 else 1.0
             )
             arc_progress = raw_progress
-            icon_center_x = fold_center_x + _folder_stack_arc_offset(
+            icon_center_x = fold_center_x + _stack_arc_offset(
                 arc_progress,
                 total_span,
             )
@@ -632,7 +630,7 @@ class StackPopupController:
             icon_x = round(icon_center_x - icon_px / 2)
             icon_y = round(icon_center_y - icon_px / 2)
             name = entry.label
-            label_w = self._folder_stack_label_width(label=name)
+            label_w = self._stack_label_width(label=name)
             label_pull = round(arc_progress * 10)
             label_x = max(
                 FOLDER_STACK_POPUP_SIDE_PADDING_PX,
@@ -661,7 +659,7 @@ class StackPopupController:
             max(
                 max_right + right_bleed,
                 fold_center_x
-                + _folder_stack_arc_offset(1.0, total_span)
+                + _stack_arc_offset(1.0, total_span)
                 + icon_px / 2
                 + right_bleed,
             )
@@ -719,14 +717,14 @@ class StackPopupController:
             fold_center_x=fold_center_x,
         )
 
-    def _on_folder_stack_draw(self, widget: Gtk.DrawingArea, cr: cairo.Context) -> bool:
+    def _on_stack_draw(self, widget: Gtk.DrawingArea, cr: cairo.Context) -> bool:
         cr.set_operator(cairo.OPERATOR_CLEAR)
         cr.paint()
         cr.set_operator(cairo.OPERATOR_OVER)
         now_us = GLib.get_monotonic_time()
         total_cards = len(self._folder_stack_cards)
         for draw_index, card in enumerate(self._folder_stack_cards):
-            self._draw_folder_stack_card(
+            self._draw_stack_card(
                 cr=cr,
                 card=card,
                 sequence_index=total_cards - 1 - draw_index,
@@ -734,14 +732,14 @@ class StackPopupController:
             )
         return False
 
-    def _folder_stack_card_geometry(
+    def _stack_card_geometry(
         self,
         *,
         card: StackCard,
         sequence_index: int,
         now_us: int,
     ) -> StackCardGeometry | None:
-        reveal = self._folder_stack_reveal_progress(
+        reveal = self._stack_reveal_progress(
             sequence_index=sequence_index,
             now_us=now_us,
         )
@@ -755,7 +753,7 @@ class StackPopupController:
         )
         y_offset = (1.0 - reveal) * 18.0
         rotation_radians = (
-            _folder_stack_rotation(
+            _stack_rotation(
                 card.stack_progress,
                 self._folder_stack_position_value,
                 card.arc_span,
@@ -808,7 +806,7 @@ class StackPopupController:
             label_y=label_y,
         )
 
-    def _draw_folder_stack_card(
+    def _draw_stack_card(
         self,
         *,
         cr: cairo.Context,
@@ -816,14 +814,14 @@ class StackPopupController:
         sequence_index: int,
         now_us: int,
     ) -> None:
-        geometry = self._folder_stack_card_geometry(
+        geometry = self._stack_card_geometry(
             card=card,
             sequence_index=sequence_index,
             now_us=now_us,
         )
         if geometry is None:
             return
-        is_action_card = _is_folder_stack_action_card(card)
+        is_action_card = _is_stack_action_card(card)
 
         if card.icon is not None and card.icon_size > 0:
             pixbuf = card.icon
@@ -943,12 +941,12 @@ class StackPopupController:
             cr.stroke()
         cr.restore()
 
-    def _folder_stack_card_at(self, x: float, y: float) -> StackCard | None:
+    def _stack_card_at(self, x: float, y: float) -> StackCard | None:
         now_us = GLib.get_monotonic_time()
         total_cards = len(self._folder_stack_cards)
         for index in range(total_cards - 1, -1, -1):
             card = self._folder_stack_cards[index]
-            geometry = self._folder_stack_card_geometry(
+            geometry = self._stack_card_geometry(
                 card=card,
                 sequence_index=total_cards - 1 - index,
                 now_us=now_us,
@@ -968,25 +966,25 @@ class StackPopupController:
                 return card
         return None
 
-    def _on_folder_stack_button_press(
+    def _on_stack_button_press(
         self, _widget: Gtk.DrawingArea, event: Gdk.EventButton
     ) -> bool:
         if int(event.button) != 1:
             self._folder_stack_pressed_target = None
             return False
-        card = self._folder_stack_card_at(event.x, event.y)
+        card = self._stack_card_at(event.x, event.y)
         self._folder_stack_pressed_target = (
             card.key if card is not None and card.key is not None else None
         )
         return self._folder_stack_pressed_target is not None
 
-    def _on_folder_stack_button_release(
+    def _on_stack_button_release(
         self, _widget: Gtk.DrawingArea, event: Gdk.EventButton
     ) -> bool:
         if int(event.button) != 1:
             self._folder_stack_pressed_target = None
             return False
-        card = self._folder_stack_card_at(event.x, event.y)
+        card = self._stack_card_at(event.x, event.y)
         target = card.key if card is not None and card.key is not None else None
         pressed_target = self._folder_stack_pressed_target
         self._folder_stack_pressed_target = None
@@ -995,10 +993,10 @@ class StackPopupController:
             return True
         return False
 
-    def _on_folder_stack_motion_notify(
+    def _on_stack_motion_notify(
         self, _widget: Gtk.DrawingArea, event: Gdk.EventMotion
     ) -> bool:
-        card = self._folder_stack_card_at(event.x, event.y)
+        card = self._stack_card_at(event.x, event.y)
         target = (
             card.key
             if card is not None and card.key is not None and not card.centered
@@ -1006,19 +1004,19 @@ class StackPopupController:
         )
         if target != self._folder_stack_hover_target:
             self._folder_stack_hover_target = target
-            self._ensure_folder_stack_animating()
+            self._ensure_stack_animating()
         return False
 
-    def _on_folder_stack_leave_notify(
+    def _on_stack_leave_notify(
         self, _widget: Gtk.DrawingArea, _event: Gdk.EventCrossing
     ) -> bool:
         if self._folder_stack_hover_target is not None:
             self._folder_stack_hover_target = None
-            self._ensure_folder_stack_animating()
+            self._ensure_stack_animating()
         self._folder_stack_pressed_target = None
         return False
 
-    def _folder_stack_action_width(self, *, label: str) -> int:
+    def _stack_action_width(self, *, label: str) -> int:
         return min(
             FOLDER_STACK_ACTION_MAX_WIDTH_PX,
             _measure_stack_text_px(label)
@@ -1028,7 +1026,7 @@ class StackPopupController:
             + 10,
         )
 
-    def _folder_stack_label_width(self, *, label: str) -> int:
+    def _stack_label_width(self, *, label: str) -> int:
         return min(
             FOLDER_STACK_LABEL_MAX_WIDTH_PX,
             max(
@@ -1039,13 +1037,13 @@ class StackPopupController:
             ),
         )
 
-    def _restart_folder_stack_animation(self) -> None:
+    def _restart_stack_animation(self) -> None:
         self._folder_stack_show_started_us = GLib.get_monotonic_time()
         self._folder_stack_hover_target = None
         self._folder_stack_hover_values.clear()
-        self._ensure_folder_stack_animating()
+        self._ensure_stack_animating()
 
-    def _ensure_folder_stack_animating(self) -> None:
+    def _ensure_stack_animating(self) -> None:
         area = self._folder_stack_area
         if area is None:
             return
@@ -1053,10 +1051,10 @@ class StackPopupController:
         if self._folder_stack_anim_source == 0:
             self._folder_stack_anim_source = GLib.timeout_add(
                 FOLDER_STACK_ANIM_FRAME_MS,
-                self._on_folder_stack_animation_frame,
+                self._on_stack_animation_frame,
             )
 
-    def _on_folder_stack_animation_frame(self) -> bool:
+    def _on_stack_animation_frame(self) -> bool:
         area = self._folder_stack_area
         window = self._folder_stack_window
         if area is None or window is None or not window.get_visible():
@@ -1098,9 +1096,7 @@ class StackPopupController:
             return False
         return True
 
-    def _folder_stack_reveal_progress(
-        self, *, sequence_index: int, now_us: int
-    ) -> float:
+    def _stack_reveal_progress(self, *, sequence_index: int, now_us: int) -> float:
         if self._folder_stack_show_started_us <= 0:
             return 1.0
         elapsed_ms = max((now_us - self._folder_stack_show_started_us) / 1000.0, 0.0)
@@ -1127,4 +1123,4 @@ class StackPopupController:
         except Exception:
             log.exception("Failed to activate stack entry %s", key)
         finally:
-            self._close_folder_stack()
+            self._close_stack()

--- a/docking/ui/stack.py
+++ b/docking/ui/stack.py
@@ -350,6 +350,11 @@ class StackPopupController:
         if content is None:
             self.close()
             return False
+        if self._stack_content is not None and self._stack_content_signature(
+            content
+        ) == self._stack_content_signature(self._stack_content):
+            self._stack_content = content
+            return True
         if self._stack_owner_id is not None:
             self.invalidate_owner(self._stack_owner_id)
         self._stack_content = content
@@ -358,6 +363,20 @@ class StackPopupController:
         self._position_stack_window()
         window.show_all()
         return True
+
+    @staticmethod
+    def _stack_content_signature(content: StackContent) -> tuple[object, ...]:
+        """Return the visible structure while excluding replaceable callbacks."""
+        entries = content.entries[:FOLDER_STACK_MAX_VISIBLE_ROWS]
+        return (
+            tuple((entry.key, entry.label, id(entry.icon)) for entry in entries),
+            (
+                (content.action.key, content.action.label)
+                if content.action is not None
+                else None
+            ),
+            content.empty_label,
+        )
 
     def _close_stack(self) -> None:
         window = self._folder_stack_window
@@ -523,13 +542,7 @@ class StackPopupController:
         cache_key = (
             owner_id,
             icon_px,
-            tuple((entry.key, entry.label, id(entry.icon)) for entry in entries),
-            (
-                (content.action.key, content.action.label)
-                if content.action is not None
-                else None
-            ),
-            content.empty_label,
+            *self._stack_content_signature(content),
         )
         cached = self._folder_stack_cache.get_layout(cache_key)
         if cached is not None:

--- a/docking/ui/stack.py
+++ b/docking/ui/stack.py
@@ -1,0 +1,1130 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Reusable curved item-stack popup, layout, drawing, and interaction."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Hashable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, TypeVar
+
+import cairo
+import gi
+
+gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
+gi.require_version("GdkPixbuf", "2.0")
+gi.require_version("PangoCairo", "1.0")
+from gi.repository import Gdk, GdkPixbuf, GLib, Gtk, Pango, PangoCairo
+
+from docking.applets.popup import PopupAnchor
+from docking.core.position import Position
+from docking.i18n import _
+from docking.log import get_logger
+from docking.ui.display import clamp_popup
+from docking.ui.shelf import rounded_rect
+
+if TYPE_CHECKING:
+    from docking.core.config import Config
+    from docking.ui.runtime import DockRuntime
+
+
+FOLDER_STACK_MAX_VISIBLE_ROWS = 9
+FOLDER_STACK_GAP_PX = 8
+FOLDER_STACK_POPUP_SIDE_PADDING_PX = 14
+FOLDER_STACK_TOP_PADDING_PX = 6
+K = TypeVar("K", bound=Hashable)
+V = TypeVar("V")
+FOLDER_STACK_ACTION_GAP_PX = 18
+FOLDER_STACK_ICON_GAP_PX = 10
+FOLDER_STACK_LABEL_HEIGHT_PX = 24
+FOLDER_STACK_LABEL_MAX_WIDTH_PX = 148
+FOLDER_STACK_ACTION_MAX_WIDTH_PX = 240
+FOLDER_STACK_ROW_STEP_PX = 54
+FOLDER_STACK_CURVE_X_PX = 40
+FOLDER_STACK_ARC_BASE_SHIFT_PX = 8
+FOLDER_STACK_ARC_RADIUS_FACTOR = 2.45
+FOLDER_STACK_ARC_LINEAR_BLEND = 0.34
+FOLDER_STACK_RIGHT_BLEED_PX = 24
+FOLDER_STACK_LABEL_RADIUS_PX = 6
+FOLDER_STACK_LABEL_TEXT_MARGIN_PX = 8
+FOLDER_STACK_ACTION_ARROW_GAP_PX = 7
+FOLDER_STACK_ACTION_ARROW_SIZE_PX = 7
+FOLDER_STACK_ROTATION_MAX_DEG = 5.5
+FOLDER_STACK_REVEAL_DURATION_MS = 160
+FOLDER_STACK_REVEAL_STAGGER_MS = 28
+FOLDER_STACK_ANIM_FRAME_MS = 16
+FOLDER_STACK_HOVER_SCALE = 1.14
+FOLDER_STACK_HOVER_EASE = 0.35
+FOLDER_STACK_LAYOUT_CACHE_MAX_ENTRIES = 32
+FOLDER_STACK_REFRESH_DEBOUNCE_MS = 120
+
+log = get_logger("stack")
+
+
+@dataclass(frozen=True)
+class StackEntry:
+    """One presentation-ready entry in a reusable item stack."""
+
+    key: str
+    label: str
+    icon: GdkPixbuf.Pixbuf | None
+    activate: Callable[[], None]
+
+
+@dataclass(frozen=True)
+class StackAction:
+    """Optional action chip displayed above the item stack."""
+
+    key: str
+    label: str
+    activate: Callable[[], None]
+
+
+@dataclass(frozen=True)
+class StackContent:
+    """Current snapshot supplied by a folder or applet stack provider."""
+
+    entries: tuple[StackEntry, ...] = ()
+    action: StackAction | None = None
+    empty_label: str = _("No items")
+
+
+StackContentProvider = Callable[[int], StackContent | None]
+
+
+@dataclass(frozen=True)
+class StackCard:
+    target: str | None
+    label: str
+    icon: GdkPixbuf.Pixbuf | None
+    icon_x: int
+    icon_y: int
+    icon_size: int
+    label_x: int
+    label_y: int
+    label_w: int
+    label_h: int
+    centered: bool = False
+    action: bool = False
+    stack_progress: float = 0.0
+    arc_span: float = 0.0
+
+    @property
+    def key(self) -> str | None:
+        """Stable interaction key (legacy cards called this target)."""
+        return self.target
+
+
+@dataclass(frozen=True)
+class StackCardGeometry:
+    reveal: float
+    hover_value: float
+    rotation_radians: float
+    icon_x: float
+    icon_y: float
+    icon_size: float
+    icon_center_x: float
+    icon_center_y: float
+    label_x: float
+    label_y: float
+
+
+@dataclass(frozen=True)
+class StackLayout:
+    cards: tuple[StackCard, ...]
+    popup_w: int
+    popup_h: int
+    fold_center_x: int
+
+
+class StackLayoutCache:
+    """Bounded cache for reusable stack layouts."""
+
+    def __init__(self) -> None:
+        self.layouts: dict[tuple[object, ...], StackLayout] = {}
+
+    @staticmethod
+    def _get_lru(cache: dict[K, V], key: K) -> V | None:
+        cached = cache.pop(key, None)
+        if cached is not None:
+            cache[key] = cached
+        return cached
+
+    @staticmethod
+    def _put_lru(cache: dict[K, V], key: K, value: V, *, max_entries: int) -> None:
+        cache[key] = value
+        while len(cache) > max_entries:
+            cache.pop(next(iter(cache)))
+
+    def get_layout(self, key: tuple[object, ...]) -> StackLayout | None:
+        return self._get_lru(self.layouts, key)
+
+    def put_layout(
+        self,
+        key: tuple[object, ...],
+        layout: StackLayout,
+    ) -> None:
+        self._put_lru(
+            self.layouts,
+            key,
+            layout,
+            max_entries=FOLDER_STACK_LAYOUT_CACHE_MAX_ENTRIES,
+        )
+
+    def invalidate_owner(self, owner_id: str) -> None:
+        for key in [key for key in self.layouts if key[0] == owner_id]:
+            self.layouts.pop(key, None)
+
+
+def _is_folder_stack_action_card(card: StackCard) -> bool:
+    return card.action or (
+        card.centered and card.target is not None and card.icon is None
+    )
+
+
+def _ease_out_cubic(value: float) -> float:
+    value = min(max(value, 0.0), 1.0)
+    return 1.0 - (1.0 - value) ** 3
+
+
+def _folder_stack_arc_offset(progress: float, span: float) -> float:
+    progress = min(max(progress, 0.0), 1.0)
+    max_offset = max(FOLDER_STACK_CURVE_X_PX, span * 0.08)
+    linear = max_offset * progress
+    if span <= 0:
+        curved = linear
+    else:
+        radius = max(span * FOLDER_STACK_ARC_RADIUS_FACTOR, span + 1.0)
+        y = progress * span
+        curved = radius - math.sqrt(max(radius * radius - y * y, 0.0))
+        max_curved = radius - math.sqrt(max(radius * radius - span * span, 0.0))
+        curved = max_offset * (curved / max_curved) if max_curved > 0 else linear
+    offset = (
+        FOLDER_STACK_ARC_LINEAR_BLEND * linear
+        + (1.0 - FOLDER_STACK_ARC_LINEAR_BLEND) * curved
+    )
+    return FOLDER_STACK_ARC_BASE_SHIFT_PX + offset
+
+
+def _folder_stack_rotation(progress: float, position: Any, span: float) -> float:
+    progress = min(max(progress, 0.0), 1.0)
+    direction = 1.0 if position in {"bottom", "left"} else -1.0
+    degrees = min(
+        (0.2 + 0.8 * progress) * FOLDER_STACK_ROTATION_MAX_DEG,
+        FOLDER_STACK_ROTATION_MAX_DEG,
+    )
+    return math.radians(degrees * direction)
+
+
+def _measure_stack_text_px(text: str) -> int:
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 1, 1)
+    cr = cairo.Context(surface)
+    layout = PangoCairo.create_layout(cr)
+    layout.set_text(text, -1)
+    desc = Pango.FontDescription()
+    desc.set_family("Sans")
+    desc.set_size(10 * Pango.SCALE)
+    layout.set_font_description(desc)
+    _ink, logical = layout.get_pixel_extents()
+    return max(int(logical.width), 0)
+
+
+class StackPopupController:
+    """Own the reusable curved stack popup and visual interaction."""
+
+    def __init__(
+        self,
+        *,
+        config: Config,
+        runtime: DockRuntime,
+        dock_window: Gtk.Window | None = None,
+    ) -> None:
+        self._config = config
+        self._runtime = runtime
+        self._dock_window = dock_window
+        self._folder_stack_cache = StackLayoutCache()
+        self._folder_stack_window: Gtk.Window | None = None
+        self._folder_stack_revealer: Gtk.Revealer | None = None
+        self._stack_owner_id: str | None = None
+        self._stack_provider: StackContentProvider | None = None
+        self._stack_content: StackContent | None = None
+        self._stack_closed: Callable[[], None] | None = None
+        self._folder_stack_anchor_x: int = 0
+        self._folder_stack_anchor_y: int = 0
+        self._folder_stack_icon_w: int = 0
+        self._folder_stack_fold_center_x: int = 0
+        self._folder_stack_position_value = self._config.pos
+        self._folder_stack_area: Gtk.DrawingArea | None = None
+        self._folder_stack_cards: list[StackCard] = []
+        self._folder_stack_anim_source: int = 0
+        self._folder_stack_show_started_us: int = 0
+        self._folder_stack_hover_target: str | None = None
+        self._folder_stack_hover_values: dict[str, float] = {}
+        self._folder_stack_pressed_target: str | None = None
+
+    def show_stack(
+        self,
+        *,
+        owner_id: str,
+        provider: StackContentProvider,
+        anchor: PopupAnchor,
+        toggle_if_same_owner: bool = True,
+        on_closed: Callable[[], None] | None = None,
+    ) -> bool:
+        """Show a provider-backed stack, or optionally toggle it closed."""
+        if (
+            self._folder_stack_window is not None
+            and self._folder_stack_window.get_visible()
+            and self._stack_owner_id == owner_id
+        ):
+            if toggle_if_same_owner:
+                self._close_folder_stack()
+            return True
+
+        content = provider(max(int(self._config.icon_size), 1))
+        if content is None:
+            return False
+
+        self._close_folder_stack()
+        self._runtime.hide_hover_ui()
+        self._runtime.menu_popup_opened()
+
+        window = self._ensure_folder_stack_window()
+        revealer = self._folder_stack_revealer
+        assert revealer is not None
+
+        self._stack_owner_id = owner_id
+        self._stack_provider = provider
+        self._stack_content = content
+        self._stack_closed = on_closed
+        self._replace_stack_content(content=content)
+
+        self._folder_stack_anchor_x = int(anchor.x)
+        self._folder_stack_anchor_y = int(anchor.y)
+        self._folder_stack_icon_w = 0
+        self._folder_stack_position_value = anchor.position
+        self._restart_folder_stack_animation()
+        self._position_folder_stack_window()
+        revealer.set_reveal_child(True)
+        window.show_all()
+        return True
+
+    def close(self) -> None:
+        self._close_folder_stack()
+
+    def open_owner_id(self) -> str | None:
+        window = self._folder_stack_window
+        if window is None or not window.get_visible() or self._stack_owner_id is None:
+            return None
+        return self._stack_owner_id
+
+    def invalidate_owner(self, owner_id: str) -> None:
+        self._folder_stack_cache.invalidate_owner(owner_id)
+
+    def prewarm(self, *, owner_id: str, provider: StackContentProvider) -> None:
+        content = provider(max(int(self._config.icon_size), 1))
+        if content is not None:
+            self._folder_stack_layout(owner_id=owner_id, content=content)
+
+    def refresh(self, owner_id: str | None = None) -> bool:
+        if owner_id is not None and owner_id != self._stack_owner_id:
+            return False
+        provider = self._stack_provider
+        window = self._folder_stack_window
+        if provider is None or window is None or not window.get_visible():
+            return False
+        content = provider(max(int(self._config.icon_size), 1))
+        if content is None:
+            self.close()
+            return False
+        if self._stack_owner_id is not None:
+            self.invalidate_owner(self._stack_owner_id)
+        self._stack_content = content
+        self._replace_stack_content(content=content)
+        self._restart_folder_stack_animation()
+        self._position_folder_stack_window()
+        window.show_all()
+        return True
+
+    def _close_folder_stack(self) -> None:
+        window = self._folder_stack_window
+        if window is None or not window.get_visible():
+            return
+        revealer = self._folder_stack_revealer
+        if revealer is not None:
+            revealer.set_reveal_child(False)
+        window.hide()
+        self._cleanup_folder_stack()
+        self._runtime.menu_popup_closed()
+
+    def _cleanup_folder_stack(self) -> None:
+        if self._folder_stack_anim_source:
+            GLib.source_remove(self._folder_stack_anim_source)
+            self._folder_stack_anim_source = 0
+        on_closed = self._stack_closed
+        self._folder_stack_area = None
+        self._stack_owner_id = None
+        self._stack_provider = None
+        self._stack_content = None
+        self._stack_closed = None
+        self._folder_stack_anchor_x = 0
+        self._folder_stack_anchor_y = 0
+        self._folder_stack_icon_w = 0
+        self._folder_stack_fold_center_x = 0
+        self._folder_stack_show_started_us = 0
+        self._folder_stack_hover_target = None
+        self._folder_stack_hover_values.clear()
+        self._folder_stack_pressed_target = None
+        if on_closed is not None:
+            on_closed()
+
+    def _ensure_folder_stack_window(self) -> Gtk.Window:
+        if self._folder_stack_window is not None:
+            return self._folder_stack_window
+
+        window = Gtk.Window(type=Gtk.WindowType.POPUP)
+        window.set_decorated(False)
+        window.set_skip_taskbar_hint(True)
+        window.set_resizable(False)
+        window.set_type_hint(Gdk.WindowTypeHint.TOOLTIP)
+        window.set_app_paintable(True)
+
+        # On Wayland popups need a transient parent so the compositor
+        # positions them relative to the dock rather than at (0,0).
+        if self._dock_window is not None:
+            window.set_transient_for(self._dock_window)
+
+        screen = window.get_screen()
+        visual = screen.get_rgba_visual()
+        if visual:
+            window.set_visual(visual)
+
+        revealer = Gtk.Revealer()
+        revealer.set_transition_type(self._folder_stack_transition_type())
+        revealer.set_transition_duration(140)
+        revealer.set_reveal_child(False)
+        window.add(revealer)
+
+        self._folder_stack_window = window
+        self._folder_stack_revealer = revealer
+        return window
+
+    def _folder_stack_transition_type(self):
+        # Resolved lazily so test stubs of ``Gtk`` (monkeypatched at module
+        # scope) are visible. A class-level dict would freeze the real
+        # ``Gtk`` reference at import time.
+        transitions = {
+            Position.BOTTOM: Gtk.RevealerTransitionType.SLIDE_UP,
+            Position.TOP: Gtk.RevealerTransitionType.SLIDE_DOWN,
+            Position.LEFT: Gtk.RevealerTransitionType.SLIDE_RIGHT,
+            Position.RIGHT: Gtk.RevealerTransitionType.SLIDE_LEFT,
+        }
+        return transitions[Position(self._config.pos)]
+
+    def _replace_stack_content(self, content: StackContent) -> None:
+        revealer = self._folder_stack_revealer
+        if revealer is None:
+            return
+        child = revealer.get_child()
+        if child is not None:
+            revealer.remove(child)
+        widget = self._build_folder_stack_content(content=content)
+        revealer.add(widget)
+        widget.show_all()
+
+    def _position_folder_stack_window(self) -> None:
+        window = self._folder_stack_window
+        revealer = self._folder_stack_revealer
+        if window is None or revealer is None:
+            return
+        child = revealer.get_child()
+        if child is None:
+            return
+
+        preferred = child.get_preferred_size()[1]
+        popup_w = max(int(preferred.width), 1)
+        popup_h = max(int(preferred.height), 1)
+        anchor_x = self._folder_stack_anchor_x
+        anchor_y = self._folder_stack_anchor_y
+        icon_w = max(self._folder_stack_icon_w, 0)
+        pos = self._folder_stack_position_value
+        local_icon_center_x = max(self._folder_stack_fold_center_x, 1)
+
+        pos_enum = Position(pos)
+        if pos_enum in (Position.BOTTOM, Position.TOP):
+            popup_x = int(anchor_x + icon_w / 2 - local_icon_center_x)
+            popup_y = (
+                int(anchor_y - popup_h - FOLDER_STACK_GAP_PX)
+                if pos_enum is Position.BOTTOM
+                else int(anchor_y + FOLDER_STACK_GAP_PX)
+            )
+        else:
+            popup_y = int(anchor_y + icon_w / 2 - popup_h / 2)
+            popup_x = (
+                int(anchor_x + FOLDER_STACK_GAP_PX)
+                if pos_enum is Position.LEFT
+                else int(anchor_x - popup_w - FOLDER_STACK_GAP_PX)
+            )
+
+        popup_pos = clamp_popup(window, popup_x, popup_y, popup_w, popup_h)
+        window.move(popup_pos.x, popup_pos.y)
+
+    def _build_folder_stack_content(self, content: StackContent) -> Gtk.Widget:
+        cards, popup_w, popup_h = self._folder_stack_cards_for_content(content)
+        self._folder_stack_cards = cards
+
+        area = Gtk.DrawingArea()
+        area.set_size_request(popup_w, popup_h)
+        area.add_events(
+            Gdk.EventMask.BUTTON_PRESS_MASK
+            | Gdk.EventMask.BUTTON_RELEASE_MASK
+            | Gdk.EventMask.POINTER_MOTION_MASK
+            | Gdk.EventMask.LEAVE_NOTIFY_MASK
+        )
+        area.connect("draw", self._on_folder_stack_draw)
+        area.connect("button-press-event", self._on_folder_stack_button_press)
+        area.connect("button-release-event", self._on_folder_stack_button_release)
+        area.connect("motion-notify-event", self._on_folder_stack_motion_notify)
+        area.connect("leave-notify-event", self._on_folder_stack_leave_notify)
+        self._folder_stack_area = area
+        return area
+
+    def _folder_stack_cards_for_content(
+        self, content: StackContent
+    ) -> tuple[list[StackCard], int, int]:
+        owner_id = self._stack_owner_id or ""
+        layout = self._folder_stack_layout(owner_id=owner_id, content=content)
+        self._folder_stack_fold_center_x = layout.fold_center_x
+        return list(layout.cards), layout.popup_w, layout.popup_h
+
+    def _folder_stack_layout(
+        self, *, owner_id: str, content: StackContent
+    ) -> StackLayout:
+        icon_px = max(int(self._config.icon_size), 1)
+        entries = tuple(content.entries[:FOLDER_STACK_MAX_VISIBLE_ROWS])
+        if len(content.entries) > FOLDER_STACK_MAX_VISIBLE_ROWS:
+            log.warning(
+                "Stack %s supplied %d entries; displaying the first %d",
+                owner_id,
+                len(content.entries),
+                FOLDER_STACK_MAX_VISIBLE_ROWS,
+            )
+        cache_key = (
+            owner_id,
+            icon_px,
+            tuple((entry.key, entry.label, id(entry.icon)) for entry in entries),
+            (
+                (content.action.key, content.action.label)
+                if content.action is not None
+                else None
+            ),
+            content.empty_label,
+        )
+        cached = self._folder_stack_cache.get_layout(cache_key)
+        if cached is not None:
+            return cached
+
+        layout = self._compute_folder_stack_layout(
+            entries=entries,
+            action=content.action,
+            empty_label=content.empty_label,
+            icon_px=icon_px,
+        )
+        self._folder_stack_cache.put_layout(cache_key, layout)
+        return layout
+
+    def _compute_folder_stack_layout(
+        self,
+        *,
+        entries: Sequence[StackEntry],
+        action: StackAction | None,
+        empty_label: str,
+        icon_px: int,
+    ) -> StackLayout:
+        cards: list[StackCard] = []
+        label_h = FOLDER_STACK_LABEL_HEIGHT_PX
+        row_step = max(FOLDER_STACK_ROW_STEP_PX, round(icon_px * 1.08))
+        curve_extent = max(FOLDER_STACK_CURVE_X_PX, round(icon_px * 0.65))
+        right_bleed = max(
+            FOLDER_STACK_RIGHT_BLEED_PX,
+            round(curve_extent + icon_px * FOLDER_STACK_HOVER_SCALE * 0.35),
+        )
+        fold_center_x = int(
+            FOLDER_STACK_POPUP_SIDE_PADDING_PX
+            + FOLDER_STACK_LABEL_MAX_WIDTH_PX
+            + FOLDER_STACK_ICON_GAP_PX
+            + icon_px / 2
+        )
+
+        if not entries:
+            return self._centered_layout(
+                label=empty_label,
+                label_h=label_h,
+                fold_center_x=fold_center_x,
+                icon_px=icon_px,
+                right_bleed=right_bleed,
+            )
+
+        total_rows = len(entries)
+        top_progress = 1.0 if total_rows > 0 else 0.0
+        total_span = (total_rows - 1) * row_step
+        stack_top = FOLDER_STACK_TOP_PADDING_PX
+        max_right = fold_center_x
+        if action is not None:
+            chip_w = self._folder_stack_action_width(label=action.label)
+            top_center_x = round(
+                fold_center_x + _folder_stack_arc_offset(top_progress, total_span)
+            )
+            chip_x = max(
+                FOLDER_STACK_POPUP_SIDE_PADDING_PX,
+                int(top_center_x - chip_w / 2 + curve_extent * 0.1),
+            )
+            chip_y = FOLDER_STACK_TOP_PADDING_PX
+            cards.append(
+                StackCard(
+                    target=action.key,
+                    label=action.label,
+                    icon=None,
+                    icon_x=0,
+                    icon_y=0,
+                    icon_size=0,
+                    label_x=chip_x,
+                    label_y=chip_y,
+                    label_w=chip_w,
+                    label_h=label_h,
+                    centered=True,
+                    action=True,
+                    stack_progress=1.0,
+                    arc_span=float(total_span),
+                )
+            )
+            stack_top = chip_y + label_h + FOLDER_STACK_ACTION_GAP_PX
+            max_right = chip_x + chip_w
+
+        bottom_center_y = (
+            stack_top + (total_rows - 1) * row_step + icon_px / 2 if total_rows else 0
+        )
+        for index, entry in enumerate(entries):
+            raw_progress = (
+                (total_rows - 1 - index) / max(total_rows - 1, 1)
+                if total_rows > 1
+                else 1.0
+            )
+            arc_progress = raw_progress
+            icon_center_x = fold_center_x + _folder_stack_arc_offset(
+                arc_progress,
+                total_span,
+            )
+            icon_center_y = bottom_center_y - total_span * raw_progress
+            icon_x = round(icon_center_x - icon_px / 2)
+            icon_y = round(icon_center_y - icon_px / 2)
+            name = entry.label
+            label_w = self._folder_stack_label_width(label=name)
+            label_pull = round(arc_progress * 10)
+            label_x = max(
+                FOLDER_STACK_POPUP_SIDE_PADDING_PX,
+                icon_x - FOLDER_STACK_ICON_GAP_PX - label_w - label_pull,
+            )
+            cards.append(
+                StackCard(
+                    target=entry.key,
+                    label=name,
+                    icon=entry.icon,
+                    icon_x=icon_x,
+                    icon_y=icon_y,
+                    icon_size=icon_px,
+                    label_x=label_x,
+                    label_y=icon_y + max(int((icon_px - label_h) / 2), 0),
+                    label_w=label_w,
+                    label_h=label_h,
+                    centered=False,
+                    stack_progress=arc_progress,
+                    arc_span=float(total_span),
+                )
+            )
+            max_right = max(max_right, icon_x + icon_px)
+
+        popup_w = int(
+            max(
+                max_right + right_bleed,
+                fold_center_x
+                + _folder_stack_arc_offset(1.0, total_span)
+                + icon_px / 2
+                + right_bleed,
+            )
+        )
+        popup_h = (
+            stack_top
+            + (total_rows - 1) * row_step
+            + icon_px
+            + FOLDER_STACK_TOP_PADDING_PX
+        )
+        return StackLayout(
+            cards=tuple(cards),
+            popup_w=popup_w,
+            popup_h=popup_h,
+            fold_center_x=fold_center_x,
+        )
+
+    def _centered_layout(
+        self,
+        *,
+        label: str,
+        label_h: int,
+        fold_center_x: int,
+        icon_px: int,
+        right_bleed: int,
+    ) -> StackLayout:
+        label_w = 190
+        card = StackCard(
+            target=None,
+            label=label,
+            icon=None,
+            icon_x=0,
+            icon_y=0,
+            icon_size=0,
+            label_x=max(
+                FOLDER_STACK_POPUP_SIDE_PADDING_PX,
+                int(fold_center_x - label_w / 2),
+            ),
+            label_y=FOLDER_STACK_TOP_PADDING_PX,
+            label_w=label_w,
+            label_h=label_h,
+            centered=True,
+        )
+        popup_w = int(
+            max(
+                fold_center_x + label_w / 2 + FOLDER_STACK_POPUP_SIDE_PADDING_PX,
+                fold_center_x + icon_px / 2 + right_bleed,
+            )
+        )
+        popup_h = label_h + 2 * FOLDER_STACK_TOP_PADDING_PX
+        return StackLayout(
+            cards=(card,),
+            popup_w=popup_w,
+            popup_h=popup_h,
+            fold_center_x=fold_center_x,
+        )
+
+    def _on_folder_stack_draw(self, widget: Gtk.DrawingArea, cr: cairo.Context) -> bool:
+        cr.set_operator(cairo.OPERATOR_CLEAR)
+        cr.paint()
+        cr.set_operator(cairo.OPERATOR_OVER)
+        now_us = GLib.get_monotonic_time()
+        total_cards = len(self._folder_stack_cards)
+        for draw_index, card in enumerate(self._folder_stack_cards):
+            self._draw_folder_stack_card(
+                cr=cr,
+                card=card,
+                sequence_index=total_cards - 1 - draw_index,
+                now_us=now_us,
+            )
+        return False
+
+    def _folder_stack_card_geometry(
+        self,
+        *,
+        card: StackCard,
+        sequence_index: int,
+        now_us: int,
+    ) -> StackCardGeometry | None:
+        reveal = self._folder_stack_reveal_progress(
+            sequence_index=sequence_index,
+            now_us=now_us,
+        )
+        if reveal <= 0:
+            return None
+
+        hover_value = (
+            self._folder_stack_hover_values.get(card.key, 0.0)
+            if card.key is not None and not card.centered
+            else 0.0
+        )
+        y_offset = (1.0 - reveal) * 18.0
+        rotation_radians = (
+            _folder_stack_rotation(
+                card.stack_progress,
+                self._folder_stack_position_value,
+                card.arc_span,
+            )
+            * reveal
+        )
+        open_label_center_x = card.label_x + card.label_w / 2
+        label_center_x = (
+            self._folder_stack_fold_center_x
+            + (open_label_center_x - self._folder_stack_fold_center_x) * reveal
+        )
+        label_x = label_center_x - card.label_w / 2
+        label_y = card.label_y + y_offset
+
+        icon_size = 0.0
+        icon_x = 0.0
+        icon_y = 0.0
+        icon_center_x = 0.0
+        icon_center_y = 0.0
+        if card.icon is not None and card.icon_size > 0:
+            icon_size = max(
+                (
+                    card.icon_size
+                    * (0.82 + 0.18 * reveal)
+                    * (1.0 + hover_value * (FOLDER_STACK_HOVER_SCALE - 1.0))
+                ),
+                1.0,
+            )
+            open_icon_center_x = card.icon_x + card.icon_size / 2
+            icon_center_x = (
+                self._folder_stack_fold_center_x
+                + (open_icon_center_x - self._folder_stack_fold_center_x) * reveal
+            )
+            icon_center_y = (
+                card.icon_y + card.icon_size / 2 + y_offset - hover_value * 4.0
+            )
+            icon_x = icon_center_x - icon_size / 2
+            icon_y = icon_center_y - icon_size / 2
+
+        return StackCardGeometry(
+            reveal=reveal,
+            hover_value=hover_value,
+            rotation_radians=rotation_radians,
+            icon_x=icon_x,
+            icon_y=icon_y,
+            icon_size=icon_size,
+            icon_center_x=icon_center_x,
+            icon_center_y=icon_center_y,
+            label_x=label_x,
+            label_y=label_y,
+        )
+
+    def _draw_folder_stack_card(
+        self,
+        *,
+        cr: cairo.Context,
+        card: StackCard,
+        sequence_index: int,
+        now_us: int,
+    ) -> None:
+        geometry = self._folder_stack_card_geometry(
+            card=card,
+            sequence_index=sequence_index,
+            now_us=now_us,
+        )
+        if geometry is None:
+            return
+        is_action_card = _is_folder_stack_action_card(card)
+
+        if card.icon is not None and card.icon_size > 0:
+            pixbuf = card.icon
+            draw_icon_size = max(round(geometry.icon_size), 1)
+            if (
+                pixbuf.get_width() != draw_icon_size
+                or pixbuf.get_height() != draw_icon_size
+            ):
+                scaled = pixbuf.scale_simple(
+                    draw_icon_size,
+                    draw_icon_size,
+                    GdkPixbuf.InterpType.BILINEAR,
+                )
+                if scaled is not None:
+                    pixbuf = scaled
+
+            cr.save()
+            cr.translate(geometry.icon_center_x + 2, geometry.icon_center_y + 2)
+            cr.rotate(geometry.rotation_radians)
+            Gdk.cairo_set_source_pixbuf(
+                cr,
+                pixbuf,
+                -draw_icon_size / 2,
+                -draw_icon_size / 2,
+            )
+            cr.paint_with_alpha(0.16 * geometry.reveal)
+            cr.restore()
+
+            cr.save()
+            cr.translate(geometry.icon_center_x, geometry.icon_center_y)
+            cr.rotate(geometry.rotation_radians)
+            Gdk.cairo_set_source_pixbuf(
+                cr,
+                pixbuf,
+                -draw_icon_size / 2,
+                -draw_icon_size / 2,
+            )
+            cr.paint_with_alpha(0.55 + 0.45 * geometry.reveal)
+            cr.restore()
+
+        radius = FOLDER_STACK_LABEL_RADIUS_PX
+        label_center_x = geometry.label_x + card.label_w / 2
+        label_center_y = geometry.label_y + card.label_h / 2
+        cr.save()
+        cr.translate(label_center_x, label_center_y + 1)
+        cr.rotate(geometry.rotation_radians * 0.85)
+        rounded_rect(
+            cr,
+            -card.label_w / 2,
+            -card.label_h / 2,
+            card.label_w,
+            card.label_h,
+            radius,
+        )
+        cr.set_source_rgba(0, 0, 0, 0.08 * geometry.reveal)
+        cr.fill()
+        cr.restore()
+
+        cr.save()
+        cr.translate(label_center_x, label_center_y)
+        cr.rotate(geometry.rotation_radians * 0.85)
+        rounded_rect(
+            cr,
+            -card.label_w / 2,
+            -card.label_h / 2,
+            card.label_w,
+            card.label_h,
+            radius,
+        )
+        cr.set_source_rgba(0.98, 0.98, 0.98, 0.95)
+        cr.fill_preserve()
+        cr.set_source_rgba(0, 0, 0, 0.08)
+        cr.set_line_width(1.0)
+        cr.stroke()
+        cr.restore()
+
+        cr.save()
+        layout = PangoCairo.create_layout(cr)
+        layout.set_text(card.label, -1)
+        desc = Pango.FontDescription()
+        desc.set_family("Sans")
+        desc.set_size(10 * Pango.SCALE)
+        layout.set_font_description(desc)
+        layout.set_ellipsize(Pango.EllipsizeMode.END)
+        arrow_reserve = (
+            FOLDER_STACK_ACTION_ARROW_GAP_PX + FOLDER_STACK_ACTION_ARROW_SIZE_PX
+            if is_action_card
+            else 0
+        )
+        available_text_w = max(
+            int(card.label_w - 2 * FOLDER_STACK_LABEL_TEXT_MARGIN_PX - arrow_reserve),
+            1,
+        )
+        layout.set_width(available_text_w * Pango.SCALE)
+        layout.set_alignment(Pango.Alignment.CENTER)
+        _, logical = layout.get_pixel_extents()
+        text_y = int(-card.label_h / 2 + (card.label_h - logical.height) / 2)
+        text_x = -card.label_w / 2 + FOLDER_STACK_LABEL_TEXT_MARGIN_PX
+        cr.set_source_rgba(0.16, 0.2, 0.26, 1.0)
+        cr.translate(label_center_x, label_center_y)
+        cr.rotate(geometry.rotation_radians * 0.85)
+        cr.move_to(text_x, text_y)
+        PangoCairo.show_layout(cr, layout)
+        if is_action_card:
+            arrow_center_x = (
+                card.label_w / 2
+                - FOLDER_STACK_LABEL_TEXT_MARGIN_PX
+                - FOLDER_STACK_ACTION_ARROW_SIZE_PX / 2
+            )
+            half = FOLDER_STACK_ACTION_ARROW_SIZE_PX / 2
+            cr.set_line_width(1.4)
+            cr.set_line_cap(cairo.LineCap.ROUND)
+            cr.set_line_join(cairo.LineJoin.ROUND)
+            cr.move_to(arrow_center_x - half, -half)
+            cr.line_to(arrow_center_x, 0.0)
+            cr.line_to(arrow_center_x - half, half)
+            cr.stroke()
+        cr.restore()
+
+    def _folder_stack_card_at(self, x: float, y: float) -> StackCard | None:
+        now_us = GLib.get_monotonic_time()
+        total_cards = len(self._folder_stack_cards)
+        for index in range(total_cards - 1, -1, -1):
+            card = self._folder_stack_cards[index]
+            geometry = self._folder_stack_card_geometry(
+                card=card,
+                sequence_index=total_cards - 1 - index,
+                now_us=now_us,
+            )
+            if geometry is None:
+                continue
+            within_label = (
+                geometry.label_x <= x <= geometry.label_x + card.label_w
+                and geometry.label_y <= y <= geometry.label_y + card.label_h
+            )
+            within_icon = (
+                geometry.icon_size > 0
+                and geometry.icon_x <= x <= geometry.icon_x + geometry.icon_size
+                and geometry.icon_y <= y <= geometry.icon_y + geometry.icon_size
+            )
+            if within_label or within_icon:
+                return card
+        return None
+
+    def _on_folder_stack_button_press(
+        self, _widget: Gtk.DrawingArea, event: Gdk.EventButton
+    ) -> bool:
+        if int(event.button) != 1:
+            self._folder_stack_pressed_target = None
+            return False
+        card = self._folder_stack_card_at(event.x, event.y)
+        self._folder_stack_pressed_target = (
+            card.key if card is not None and card.key is not None else None
+        )
+        return self._folder_stack_pressed_target is not None
+
+    def _on_folder_stack_button_release(
+        self, _widget: Gtk.DrawingArea, event: Gdk.EventButton
+    ) -> bool:
+        if int(event.button) != 1:
+            self._folder_stack_pressed_target = None
+            return False
+        card = self._folder_stack_card_at(event.x, event.y)
+        target = card.key if card is not None and card.key is not None else None
+        pressed_target = self._folder_stack_pressed_target
+        self._folder_stack_pressed_target = None
+        if target is not None and (pressed_target is None or pressed_target == target):
+            self._activate_stack_key(target)
+            return True
+        return False
+
+    def _on_folder_stack_motion_notify(
+        self, _widget: Gtk.DrawingArea, event: Gdk.EventMotion
+    ) -> bool:
+        card = self._folder_stack_card_at(event.x, event.y)
+        target = (
+            card.key
+            if card is not None and card.key is not None and not card.centered
+            else None
+        )
+        if target != self._folder_stack_hover_target:
+            self._folder_stack_hover_target = target
+            self._ensure_folder_stack_animating()
+        return False
+
+    def _on_folder_stack_leave_notify(
+        self, _widget: Gtk.DrawingArea, _event: Gdk.EventCrossing
+    ) -> bool:
+        if self._folder_stack_hover_target is not None:
+            self._folder_stack_hover_target = None
+            self._ensure_folder_stack_animating()
+        self._folder_stack_pressed_target = None
+        return False
+
+    def _folder_stack_action_width(self, *, label: str) -> int:
+        return min(
+            FOLDER_STACK_ACTION_MAX_WIDTH_PX,
+            _measure_stack_text_px(label)
+            + 2 * FOLDER_STACK_LABEL_TEXT_MARGIN_PX
+            + FOLDER_STACK_ACTION_ARROW_GAP_PX
+            + FOLDER_STACK_ACTION_ARROW_SIZE_PX
+            + 10,
+        )
+
+    def _folder_stack_label_width(self, *, label: str) -> int:
+        return min(
+            FOLDER_STACK_LABEL_MAX_WIDTH_PX,
+            max(
+                24,
+                _measure_stack_text_px(label)
+                + 2 * FOLDER_STACK_LABEL_TEXT_MARGIN_PX
+                + 10,
+            ),
+        )
+
+    def _restart_folder_stack_animation(self) -> None:
+        self._folder_stack_show_started_us = GLib.get_monotonic_time()
+        self._folder_stack_hover_target = None
+        self._folder_stack_hover_values.clear()
+        self._ensure_folder_stack_animating()
+
+    def _ensure_folder_stack_animating(self) -> None:
+        area = self._folder_stack_area
+        if area is None:
+            return
+        area.queue_draw()
+        if self._folder_stack_anim_source == 0:
+            self._folder_stack_anim_source = GLib.timeout_add(
+                FOLDER_STACK_ANIM_FRAME_MS,
+                self._on_folder_stack_animation_frame,
+            )
+
+    def _on_folder_stack_animation_frame(self) -> bool:
+        area = self._folder_stack_area
+        window = self._folder_stack_window
+        if area is None or window is None or not window.get_visible():
+            self._folder_stack_anim_source = 0
+            return False
+
+        active = False
+        now_us = GLib.get_monotonic_time()
+        elapsed_ms = max((now_us - self._folder_stack_show_started_us) / 1000.0, 0.0)
+        reveal_budget_ms = (
+            FOLDER_STACK_REVEAL_DURATION_MS
+            + max(
+                len(self._folder_stack_cards) - 1,
+                0,
+            )
+            * FOLDER_STACK_REVEAL_STAGGER_MS
+        )
+        if elapsed_ms < reveal_budget_ms:
+            active = True
+
+        for card in self._folder_stack_cards:
+            if card.key is None or card.centered:
+                continue
+            current = self._folder_stack_hover_values.get(card.key, 0.0)
+            target = 1.0 if self._folder_stack_hover_target == card.key else 0.0
+            updated = current + (target - current) * FOLDER_STACK_HOVER_EASE
+            if abs(updated - target) < 0.02:
+                updated = target
+            if updated <= 0.0 and target == 0.0:
+                self._folder_stack_hover_values.pop(card.key, None)
+            else:
+                self._folder_stack_hover_values[card.key] = updated
+            if updated != target:
+                active = True
+
+        area.queue_draw()
+        if not active:
+            self._folder_stack_anim_source = 0
+            return False
+        return True
+
+    def _folder_stack_reveal_progress(
+        self, *, sequence_index: int, now_us: int
+    ) -> float:
+        if self._folder_stack_show_started_us <= 0:
+            return 1.0
+        elapsed_ms = max((now_us - self._folder_stack_show_started_us) / 1000.0, 0.0)
+        elapsed_ms -= sequence_index * FOLDER_STACK_REVEAL_STAGGER_MS
+        if elapsed_ms <= 0:
+            return 0.0
+        return _ease_out_cubic(elapsed_ms / FOLDER_STACK_REVEAL_DURATION_MS)
+
+    def _activate_stack_key(self, key: str) -> None:
+        content = self._stack_content
+        callback: Callable[[], None] | None = None
+        if content is not None:
+            if content.action is not None and content.action.key == key:
+                callback = content.action.activate
+            else:
+                callback = next(
+                    (entry.activate for entry in content.entries if entry.key == key),
+                    None,
+                )
+        if callback is None:
+            return
+        try:
+            callback()
+        except Exception:
+            log.exception("Failed to activate stack entry %s", key)
+        finally:
+            self._close_folder_stack()

--- a/tests/applets/test_base.py
+++ b/tests/applets/test_base.py
@@ -301,6 +301,11 @@ class TestAppletDefaultHooks:
         applet = _DeferredInitApplet()
         assert applet.on_drop_uris(["file:///test.txt"]) is False
 
+    def test_stack_content_defaults_to_none(self):
+        applet = _DeferredInitApplet()
+
+        assert applet.stack_content(48) is None
+
     def test_set_services_default_is_noop(self):
         applet = _DeferredInitApplet()
         services = MagicMock()

--- a/tests/bdd_support/harness.py
+++ b/tests/bdd_support/harness.py
@@ -152,6 +152,10 @@ def _controller(stub) -> SimpleNamespace:
         input_controller_mod.DockInputController._show_folder_stack_for_item,
         controller,
     )
+    controller._stack_anchor_for_item = MethodType(
+        input_controller_mod.DockInputController._stack_anchor_for_item,
+        controller,
+    )
     return controller
 
 

--- a/tests/platform/test_model.py
+++ b/tests/platform/test_model.py
@@ -806,6 +806,8 @@ class TestAppletLifecycleIntegration:
         model = DockModel(config, launcher, AppletServices())
         callback = MagicMock()
         model.add_change_listener(callback)
+        applet_callback = MagicMock()
+        model.add_applet_change_listener(applet_callback)
 
         class StrictApplet:
             def __init__(self):
@@ -829,6 +831,7 @@ class TestAppletLifecycleIntegration:
         # Then
         assert applet.start_calls == 1
         callback.assert_called_once()
+        applet_callback.assert_called_once_with("applet://strict")
 
     def test_find_by_desktop_id_and_unpin_applet_route(self, monkeypatch):
         # Given

--- a/tests/ui/test_dock_interactions.py
+++ b/tests/ui/test_dock_interactions.py
@@ -83,6 +83,48 @@ def test_folder_stack_stays_open_while_hovering_source_item():
     folder_stack.close.assert_not_called()
 
 
+def test_declarative_applet_stack_uses_shared_controller():
+    folder_stack = MagicMock()
+    folder_stack.show_applet_stack.return_value = True
+    interactions = DockInteractions(menu=MagicMock(), folder_stack=folder_stack)
+    applet = MagicMock()
+    applet.item.desktop_id = "applet://devices"
+    anchor = FolderStackAnchor(x=100, y=200, icon_w=48, position=Position.BOTTOM)
+    parent = MagicMock()
+
+    assert (
+        interactions.show_applet_stack(
+            applet=applet,
+            anchor=anchor,
+            parent=parent,
+        )
+        is True
+    )
+
+    folder_stack.show_applet_stack.assert_called_once_with(
+        owner_id="applet://devices",
+        provider=applet.stack_content,
+        anchor_x=100,
+        anchor_y=200,
+        icon_w=48,
+        position=Position.BOTTOM,
+        parent=parent,
+    )
+
+
+def test_open_applet_stack_refreshes_from_latest_content():
+    folder_stack = MagicMock()
+    folder_stack.open_owner_id.return_value = "applet://devices"
+    folder_stack.open_item_id.return_value = None
+    interactions = DockInteractions(menu=MagicMock(), folder_stack=folder_stack)
+    applet = MagicMock()
+    applet.item.desktop_id = "applet://devices"
+
+    interactions.refresh_open_applet_stack(applet)
+
+    folder_stack.refresh.assert_called_once_with(owner_id="applet://devices")
+
+
 def test_dock_window_does_not_import_menu_handler():
     source = inspect.getsource(dock_window_mod)
 

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -78,9 +78,11 @@ def _bind_geometry_signature(stub):
 
 
 def _controller(stub):
+    interactions = getattr(stub, "_interactions", MagicMock())
+    interactions.show_applet_stack.return_value = False
     controller = SimpleNamespace(
         _window=stub,
-        _interactions=getattr(stub, "_interactions", MagicMock()),
+        _interactions=interactions,
         _click_x=getattr(stub, "_click_x", -1.0),
         _click_y=getattr(stub, "_click_y", -1.0),
         _click_button=getattr(stub, "_click_button", 0),
@@ -96,6 +98,10 @@ def _controller(stub):
     )
     controller._show_folder_stack_for_item = MethodType(
         input_controller_mod.DockInputController._show_folder_stack_for_item,
+        controller,
+    )
+    controller._stack_anchor_for_item = MethodType(
+        input_controller_mod.DockInputController._stack_anchor_for_item,
         controller,
     )
     return controller
@@ -237,6 +243,43 @@ class TestButtonReleaseFlow:
         applet.on_clicked.assert_called_once()
         stub.tooltip.update.assert_called_once_with(item, stub._test_geometry_frame)
         stub.hover.start_anim_pump.assert_called_once_with(350)
+
+    def test_left_click_opens_declarative_applet_stack(self, monkeypatch):
+        item = DockItem(desktop_id="applet://devices")
+        stub, _ = _make_stub(item=item)
+        stub._test_geometry_frame.geometry_for_item.return_value = SimpleNamespace(
+            draw_rect=SimpleNamespace(x=4, y=5, w=48, h=48),
+            anchor_point=lambda *, win_x, win_y, position: (win_x + 4, win_y + 5),
+        )
+        applet = MagicMock()
+        stub.model.get_applet.return_value = applet
+        event = SimpleNamespace(
+            x=12.0, y=6.0, button=dock_window_mod.MOUSE_LEFT, state=0
+        )
+        monkeypatch.setattr(
+            input_controller_mod,
+            "is_applet",
+            lambda desktop_id: desktop_id.startswith("applet://"),
+        )
+        controller = _controller(stub)
+        controller._interactions.show_applet_stack.return_value = True
+
+        handled = input_controller_mod.DockInputController._on_button_release(
+            controller, MagicMock(), event
+        )
+
+        assert handled is True
+        controller._interactions.show_applet_stack.assert_called_once_with(
+            applet=applet,
+            anchor=input_controller_mod.FolderStackAnchor(
+                x=104,
+                y=205,
+                icon_w=48,
+                position=Position.BOTTOM,
+            ),
+            parent=stub,
+        )
+        applet.on_clicked.assert_not_called()
 
     def test_left_click_running_app_toggles_focus(self, monkeypatch):
         # Given

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -281,6 +281,30 @@ class TestButtonReleaseFlow:
         )
         applet.on_clicked.assert_not_called()
 
+    def test_middle_click_on_applet_skips_declarative_stack(self, monkeypatch):
+        item = DockItem(desktop_id="applet://devices")
+        stub, _ = _make_stub(item=item)
+        applet = MagicMock()
+        stub.model.get_applet.return_value = applet
+        event = SimpleNamespace(
+            x=12.0, y=6.0, button=dock_window_mod.MOUSE_MIDDLE, state=0
+        )
+        monkeypatch.setattr(
+            input_controller_mod,
+            "is_applet",
+            lambda desktop_id: desktop_id.startswith("applet://"),
+        )
+        controller = _controller(stub)
+        controller._interactions.show_applet_stack.return_value = True
+
+        handled = input_controller_mod.DockInputController._on_button_release(
+            controller, MagicMock(), event
+        )
+
+        assert handled is True
+        controller._interactions.show_applet_stack.assert_not_called()
+        applet.on_clicked.assert_called_once()
+
     def test_left_click_running_app_toggles_focus(self, monkeypatch):
         # Given
         item = DockItem(desktop_id="firefox.desktop", is_running=True)

--- a/tests/ui/test_input_controller.py
+++ b/tests/ui/test_input_controller.py
@@ -81,3 +81,33 @@ def test_stop_disconnects_signals_and_model_listener_once():
     window.model.remove_change_listener.assert_called_once_with(
         controller._on_model_changed
     )
+
+
+def test_model_change_refreshes_open_applet_stack():
+    applet = MagicMock()
+    window = SimpleNamespace(
+        model=SimpleNamespace(
+            visible_items=MagicMock(return_value=[]),
+            get_applet=MagicMock(return_value=applet),
+        ),
+        hover=SimpleNamespace(
+            hovered_item=None,
+            on_model_changed=MagicMock(),
+        ),
+        config=SimpleNamespace(pos="bottom"),
+        _invalidate_current_geometry_frame=MagicMock(),
+        update_input_region=MagicMock(),
+        _schedule_redraw=MagicMock(),
+    )
+    interactions = MagicMock()
+    interactions.open_stack_owner_id.return_value = "applet://devices"
+    controller = DockInputController(
+        window=window,
+        interactions=interactions,
+        dnd=MagicMock(),
+    )
+
+    controller._on_model_changed()
+
+    window.model.get_applet.assert_called_once_with("applet://devices")
+    interactions.refresh_open_applet_stack.assert_called_once_with(applet)

--- a/tests/ui/test_input_controller.py
+++ b/tests/ui/test_input_controller.py
@@ -32,6 +32,8 @@ def _window() -> SimpleNamespace:
         visible_items=MagicMock(return_value=["folder"]),
         add_change_listener=MagicMock(),
         remove_change_listener=MagicMock(),
+        add_applet_change_listener=MagicMock(),
+        remove_applet_change_listener=MagicMock(),
     )
     return window
 
@@ -61,6 +63,9 @@ def test_start_connects_signals_model_listener_and_prewarms_once():
     window.model.add_change_listener.assert_called_once_with(
         controller._on_model_changed
     )
+    window.model.add_applet_change_listener.assert_called_once_with(
+        controller._on_applet_changed
+    )
     interactions.prewarm_visible_folder_stacks.assert_called_once_with(["folder"])
 
 
@@ -81,9 +86,77 @@ def test_stop_disconnects_signals_and_model_listener_once():
     window.model.remove_change_listener.assert_called_once_with(
         controller._on_model_changed
     )
+    window.model.remove_applet_change_listener.assert_called_once_with(
+        controller._on_applet_changed
+    )
 
 
-def test_model_change_refreshes_open_applet_stack():
+def test_applet_change_refreshes_its_open_stack():
+    applet = MagicMock()
+    window = SimpleNamespace(
+        model=SimpleNamespace(
+            get_applet=MagicMock(return_value=applet),
+        ),
+    )
+    interactions = MagicMock()
+    interactions.open_stack_owner_id.return_value = "applet://devices"
+    controller = DockInputController(
+        window=window,
+        interactions=interactions,
+        dnd=MagicMock(),
+    )
+
+    controller._on_applet_changed("applet://devices")
+
+    window.model.get_applet.assert_called_once_with("applet://devices")
+    interactions.refresh_open_applet_stack.assert_called_once_with(applet)
+
+
+def test_unrelated_applet_change_does_not_refresh_open_stack():
+    window = SimpleNamespace(model=SimpleNamespace(get_applet=MagicMock()))
+    interactions = MagicMock()
+    interactions.open_stack_owner_id.return_value = "applet://devices"
+    controller = DockInputController(
+        window=window,
+        interactions=interactions,
+        dnd=MagicMock(),
+    )
+
+    controller._on_applet_changed("applet://clock")
+
+    window.model.get_applet.assert_not_called()
+    interactions.refresh_open_applet_stack.assert_not_called()
+
+
+def test_model_change_closes_stack_for_removed_applet():
+    window = SimpleNamespace(
+        model=SimpleNamespace(
+            visible_items=MagicMock(return_value=[]),
+            get_applet=MagicMock(return_value=None),
+        ),
+        hover=SimpleNamespace(
+            hovered_item=None,
+            on_model_changed=MagicMock(),
+        ),
+        config=SimpleNamespace(pos="bottom"),
+        _invalidate_current_geometry_frame=MagicMock(),
+        update_input_region=MagicMock(),
+        _schedule_redraw=MagicMock(),
+    )
+    interactions = MagicMock()
+    interactions.open_stack_owner_id.return_value = "applet://devices"
+    controller = DockInputController(
+        window=window,
+        interactions=interactions,
+        dnd=MagicMock(),
+    )
+
+    controller._on_model_changed()
+
+    interactions.refresh_open_applet_stack.assert_called_once_with(None)
+
+
+def test_model_change_does_not_refresh_existing_applet_stack():
     applet = MagicMock()
     window = SimpleNamespace(
         model=SimpleNamespace(
@@ -109,5 +182,4 @@ def test_model_change_refreshes_open_applet_stack():
 
     controller._on_model_changed()
 
-    window.model.get_applet.assert_called_once_with("applet://devices")
-    interactions.refresh_open_applet_stack.assert_called_once_with(applet)
+    interactions.refresh_open_applet_stack.assert_not_called()

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -1758,7 +1758,7 @@ class TestMenuCallbacks:
             + folder_stack_mod.FOLDER_STACK_ACTION_ARROW_SIZE_PX
             + 10
         )
-        assert cards[0].label_w == handler._folder_stack._folder_stack_action_width(
+        assert cards[0].label_w == handler._folder_stack._stack_action_width(
             label="5 More in Caja"
         )
         assert cards[0].label_w == expected_width
@@ -1966,13 +1966,11 @@ class TestMenuCallbacks:
             release = SimpleNamespace(x=32.0, y=60.0, button=1)
 
             assert (
-                handler._folder_stack._on_folder_stack_button_press(
-                    FakeDrawingArea(), press
-                )
+                handler._folder_stack._on_stack_button_press(FakeDrawingArea(), press)
                 is True
             )
             assert (
-                handler._folder_stack._on_folder_stack_button_release(
+                handler._folder_stack._on_stack_button_release(
                     FakeDrawingArea(), release
                 )
                 is True
@@ -1998,7 +1996,7 @@ class TestMenuCallbacks:
         )
         monkeypatch.setattr(
             handler._folder_stack,
-            "_position_folder_stack_window",
+            "_position_stack_window",
             lambda: built.append(object()) or built[-1],
         )
         handler._folder_stack._folder_stack_window = window
@@ -2032,22 +2030,22 @@ class TestMenuCallbacks:
     def test_folder_stack_transition_type_matches_position(self, handler):
         handler._config.pos = "bottom"
         assert (
-            handler._folder_stack._folder_stack_transition_type()
+            handler._folder_stack._stack_transition_type()
             == menu_mod.Gtk.RevealerTransitionType.SLIDE_UP
         )
         handler._config.pos = "top"
         assert (
-            handler._folder_stack._folder_stack_transition_type()
+            handler._folder_stack._stack_transition_type()
             == menu_mod.Gtk.RevealerTransitionType.SLIDE_DOWN
         )
         handler._config.pos = "left"
         assert (
-            handler._folder_stack._folder_stack_transition_type()
+            handler._folder_stack._stack_transition_type()
             == menu_mod.Gtk.RevealerTransitionType.SLIDE_RIGHT
         )
         handler._config.pos = "right"
         assert (
-            handler._folder_stack._folder_stack_transition_type()
+            handler._folder_stack._stack_transition_type()
             == menu_mod.Gtk.RevealerTransitionType.SLIDE_LEFT
         )
 
@@ -2080,19 +2078,19 @@ class TestMenuCallbacks:
         handler._folder_stack._folder_stack_fold_center_x = 40
 
         handler._folder_stack._folder_stack_position_value = "bottom"
-        handler._folder_stack._position_folder_stack_window()
+        handler._folder_stack._position_stack_window()
         assert window.moved_to == (104, 158)
 
         handler._folder_stack._folder_stack_position_value = "top"
-        handler._folder_stack._position_folder_stack_window()
+        handler._folder_stack._position_stack_window()
         assert window.moved_to == (104, 208)
 
         handler._folder_stack._folder_stack_position_value = "left"
-        handler._folder_stack._position_folder_stack_window()
+        handler._folder_stack._position_stack_window()
         assert window.moved_to == (128, 207)
 
         handler._folder_stack._folder_stack_position_value = "right"
-        handler._folder_stack._position_folder_stack_window()
+        handler._folder_stack._position_stack_window()
         assert window.moved_to == (0, 207)
 
     def test_track_folder_stack_handles_invalid_target_and_error(
@@ -2189,11 +2187,11 @@ class TestMenuCallbacks:
         cr = MagicMock()
         monkeypatch.setattr(
             handler._folder_stack,
-            "_folder_stack_card_geometry",
+            "_stack_card_geometry",
             lambda **_kwargs: None,
         )
 
-        handler._folder_stack._draw_folder_stack_card(
+        handler._folder_stack._draw_stack_card(
             cr=cr,
             card=folder_stack_mod.FolderStackCard(
                 label="x",
@@ -2234,7 +2232,7 @@ class TestMenuCallbacks:
         cr = MagicMock()
         monkeypatch.setattr(
             handler._folder_stack,
-            "_folder_stack_card_geometry",
+            "_stack_card_geometry",
             lambda **_kwargs: geometry,
         )
         monkeypatch.setattr(stack_mod, "rounded_rect", MagicMock())
@@ -2249,7 +2247,7 @@ class TestMenuCallbacks:
             SimpleNamespace(InterpType=SimpleNamespace(BILINEAR=1)),
         )
 
-        handler._folder_stack._draw_folder_stack_card(
+        handler._folder_stack._draw_stack_card(
             cr=cr,
             card=folder_stack_mod.FolderStackCard(
                 label="Open Folder",
@@ -2273,7 +2271,7 @@ class TestMenuCallbacks:
         assert cr.stroke.call_count >= 1
 
         cr.reset_mock()
-        handler._folder_stack._draw_folder_stack_card(
+        handler._folder_stack._draw_stack_card(
             cr=cr,
             card=folder_stack_mod.FolderStackCard(
                 label="Open Folder",
@@ -2324,7 +2322,7 @@ class TestMenuCallbacks:
         handler._folder_stack._folder_stack_cards = [bottom, top]
         monkeypatch.setattr(
             handler._folder_stack,
-            "_folder_stack_card_geometry",
+            "_stack_card_geometry",
             lambda *, card, **_kwargs: folder_stack_mod.FolderStackCardGeometry(
                 reveal=1.0,
                 hover_value=0.0,
@@ -2339,16 +2337,16 @@ class TestMenuCallbacks:
             ),
         )
 
-        assert handler._folder_stack._folder_stack_card_at(10, 10) is top
+        assert handler._folder_stack._stack_card_at(10, 10) is top
         assert (
-            handler._folder_stack._on_folder_stack_button_press(
+            handler._folder_stack._on_stack_button_press(
                 FakeDrawingArea(), SimpleNamespace(x=10.0, y=10.0, button=2)
             )
             is False
         )
         handler._folder_stack._folder_stack_pressed_target = "file:///tmp/top"
         assert (
-            handler._folder_stack._on_folder_stack_button_release(
+            handler._folder_stack._on_stack_button_release(
                 FakeDrawingArea(), SimpleNamespace(x=200.0, y=200.0, button=1)
             )
             is False
@@ -2371,7 +2369,7 @@ class TestMenuCallbacks:
             centered=False,
         )
         monkeypatch.setattr(
-            handler._folder_stack, "_folder_stack_card_at", lambda *_args: card
+            handler._folder_stack, "_stack_card_at", lambda *_args: card
         )
         handler._folder_stack._folder_stack_area = FakeDrawingArea()
         timeout_calls: list[tuple[int, object]] = []
@@ -2382,7 +2380,7 @@ class TestMenuCallbacks:
         )
 
         assert (
-            handler._folder_stack._on_folder_stack_motion_notify(
+            handler._folder_stack._on_stack_motion_notify(
                 FakeDrawingArea(), SimpleNamespace(x=1.0, y=2.0)
             )
             is False
@@ -2392,9 +2390,7 @@ class TestMenuCallbacks:
         assert handler._folder_stack._folder_stack_area.draw_queued is True
 
         assert (
-            handler._folder_stack._on_folder_stack_leave_notify(
-                FakeDrawingArea(), MagicMock()
-            )
+            handler._folder_stack._on_stack_leave_notify(FakeDrawingArea(), MagicMock())
             is False
         )
         assert handler._folder_stack._folder_stack_hover_target is None
@@ -2405,7 +2401,7 @@ class TestMenuCallbacks:
         handler._folder_stack._folder_stack_window = FakeWindow()
         handler._folder_stack._folder_stack_window.hide()
 
-        assert handler._folder_stack._on_folder_stack_animation_frame() is False
+        assert handler._folder_stack._on_stack_animation_frame() is False
         assert handler._folder_stack._folder_stack_anim_source == 0
 
         handler._folder_stack._folder_stack_window.show_all()
@@ -2429,7 +2425,7 @@ class TestMenuCallbacks:
         handler._folder_stack._folder_stack_hover_values = {"file:///tmp/doc": 0.99}
         monkeypatch.setattr(menu_mod.GLib, "get_monotonic_time", lambda: 1_000_000)
 
-        assert handler._folder_stack._on_folder_stack_animation_frame() is False
+        assert handler._folder_stack._on_stack_animation_frame() is False
         assert (
             handler._folder_stack._folder_stack_hover_values["file:///tmp/doc"] == 1.0
         )
@@ -2438,7 +2434,7 @@ class TestMenuCallbacks:
         handler._folder_stack._folder_stack_hover_target = "file:///tmp/doc"
         handler._folder_stack._folder_stack_hover_values = {"file:///tmp/doc": 0.0}
 
-        assert handler._folder_stack._on_folder_stack_animation_frame() is True
+        assert handler._folder_stack._on_stack_animation_frame() is True
         assert handler._folder_stack._folder_stack_area.draw_queued is True
 
     def test_folder_stack_reveal_open_and_target_state_helpers(
@@ -2446,22 +2442,20 @@ class TestMenuCallbacks:
     ):
         handler._folder_stack._folder_stack_show_started_us = 0
         assert (
-            handler._folder_stack._folder_stack_reveal_progress(
-                sequence_index=1, now_us=100
-            )
+            handler._folder_stack._stack_reveal_progress(sequence_index=1, now_us=100)
             == 1.0
         )
 
         handler._folder_stack._folder_stack_show_started_us = 1_000_000
         assert (
-            handler._folder_stack._folder_stack_reveal_progress(
+            handler._folder_stack._stack_reveal_progress(
                 sequence_index=10, now_us=1_000_000
             )
             == 0.0
         )
         assert (
             0.0
-            < handler._folder_stack._folder_stack_reveal_progress(
+            < handler._folder_stack._stack_reveal_progress(
                 sequence_index=0, now_us=1_100_000
             )
             <= 1.0
@@ -2471,7 +2465,7 @@ class TestMenuCallbacks:
         monkeypatch.setattr(menu_mod.launcher_mod, "open_target", opened.append)
         monkeypatch.setattr(
             handler._folder_stack,
-            "_close_folder_stack",
+            "_close_stack",
             lambda: opened.append("closed"),
         )
         handler._folder_stack._open_folder_stack_target("file:///tmp/docs")

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -19,6 +19,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for non-GI environmen
 
 import docking.ui.folder.stack as folder_stack_mod
 import docking.ui.menu as menu_mod
+import docking.ui.stack as stack_mod
 from docking.core.items import FILE_KIND, FOLDER_KIND
 from docking.platform.backends.base import (
     DisplayServer,
@@ -721,6 +722,9 @@ def handler(monkeypatch):
     monkeypatch.setattr(folder_stack_mod, "Gtk", FakeGtk)
     monkeypatch.setattr(folder_stack_mod, "Pango", FakePango)
     monkeypatch.setattr(folder_stack_mod, "PangoCairo", FakePangoCairo)
+    monkeypatch.setattr(stack_mod, "Gtk", FakeGtk)
+    monkeypatch.setattr(stack_mod, "Pango", FakePango)
+    monkeypatch.setattr(stack_mod, "PangoCairo", FakePangoCairo)
     monkeypatch.setattr(menu_mod, "load_catalog_icon", lambda applet_id, size: None)
     about = MagicMock()
     settings = MagicMock()
@@ -2233,14 +2237,14 @@ class TestMenuCallbacks:
             "_folder_stack_card_geometry",
             lambda **_kwargs: geometry,
         )
-        monkeypatch.setattr(folder_stack_mod, "rounded_rect", MagicMock())
+        monkeypatch.setattr(stack_mod, "rounded_rect", MagicMock())
         monkeypatch.setattr(
-            folder_stack_mod.Gdk,
+            stack_mod.Gdk,
             "cairo_set_source_pixbuf",
             MagicMock(),
         )
         monkeypatch.setattr(
-            folder_stack_mod,
+            stack_mod,
             "GdkPixbuf",
             SimpleNamespace(InterpType=SimpleNamespace(BILINEAR=1)),
         )

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -2140,6 +2140,90 @@ class TestMenuCallbacks:
         assert handler._folder_stack._folder_stack_monitor is monitor
         assert monitor.changed[0] == "changed"
 
+    def test_track_folder_stack_cancels_previous_monitor(self, handler, monkeypatch):
+        previous = FakeMonitor()
+        replacement = FakeMonitor()
+        handler._folder_stack._folder_stack_monitor = previous
+        monkeypatch.setattr(
+            menu_mod.launcher_mod,
+            "normalize_file_target",
+            lambda _t: "file:///tmp/docs",
+        )
+
+        class _Folder:
+            def monitor_directory(self, *_args):
+                return replacement
+
+        monkeypatch.setattr(menu_mod.Gio.File, "new_for_uri", lambda _uri: _Folder())
+
+        handler._folder_stack._track_folder_stack("file:///tmp/docs")
+
+        assert previous.cancelled is True
+        assert handler._folder_stack._folder_stack_monitor is replacement
+
+    def test_repeated_hover_show_does_not_retrack_folder(self, handler, monkeypatch):
+        item = DockItem(
+            desktop_id="file:///tmp/docs",
+            kind=FOLDER_KIND,
+            target="file:///tmp/docs",
+        )
+        window = FakeWindow()
+        window.visible = True
+        handler._folder_stack._folder_stack_window = window
+        handler._folder_stack._stack_owner_id = item.desktop_id
+        tracked = MagicMock()
+        monkeypatch.setattr(handler._folder_stack, "_track_folder_stack", tracked)
+
+        handler._folder_stack.show(
+            item=item,
+            anchor_x=100,
+            anchor_y=200,
+            icon_w=48,
+            position="bottom",
+            toggle_if_same_item=False,
+        )
+
+        tracked.assert_not_called()
+
+    def test_folder_content_cache_is_bounded(self, handler, monkeypatch):
+        item = DockItem(
+            desktop_id="file:///tmp/docs",
+            kind=FOLDER_KIND,
+            target="file:///tmp/docs",
+        )
+        monkeypatch.setattr(
+            handler._folder_stack._browser,
+            "target_state",
+            lambda _target: "ok",
+        )
+        stamps = iter(
+            range(folder_stack_mod.FOLDER_STACK_CONTENT_CACHE_MAX_ENTRIES + 1)
+        )
+        monkeypatch.setattr(
+            handler._folder_stack._browser,
+            "cache_stamp",
+            lambda _target: next(stamps),
+        )
+        monkeypatch.setattr(
+            handler._folder_stack,
+            "_list_directory_rows",
+            lambda **_kwargs: [
+                {
+                    "target": "file:///tmp/docs/file",
+                    "name": "file",
+                    "icon": None,
+                }
+            ],
+        )
+
+        for _ in range(folder_stack_mod.FOLDER_STACK_CONTENT_CACHE_MAX_ENTRIES + 1):
+            handler._folder_stack._stack_content_for_item(item=item, icon_px=48)
+
+        assert (
+            len(handler._folder_stack._folder_content_cache)
+            == folder_stack_mod.FOLDER_STACK_CONTENT_CACHE_MAX_ENTRIES
+        )
+
     def test_refresh_folder_stack_returns_false_without_window_or_item(self, handler):
         handler._folder_stack._folder_stack_window = None
         handler._folder_stack._folder_stack_item = None

--- a/tests/ui/test_stack.py
+++ b/tests/ui/test_stack.py
@@ -122,3 +122,52 @@ def test_refresh_reloads_visible_provider_content():
     controller._replace_stack_content.assert_called_once_with(content=second)
     controller._position_stack_window.assert_called_once()
     window.show_all.assert_called_once()
+
+
+def test_refresh_updates_callbacks_without_rebuilding_unchanged_content():
+    controller = _controller()
+    old_activate = MagicMock()
+    new_activate = MagicMock()
+    first = StackContent(
+        entries=(
+            StackEntry(
+                key="usb",
+                label="USB Drive",
+                icon=None,
+                activate=old_activate,
+            ),
+        )
+    )
+    second = StackContent(
+        entries=(
+            StackEntry(
+                key="usb",
+                label="USB Drive",
+                icon=None,
+                activate=new_activate,
+            ),
+        )
+    )
+    provider = MagicMock(return_value=second)
+    window = MagicMock()
+    window.get_visible.return_value = True
+    controller._folder_stack_window = window
+    controller._stack_owner_id = "applet://devices"
+    controller._stack_provider = provider
+    controller._stack_content = first
+    controller._replace_stack_content = MagicMock()
+    controller._restart_stack_animation = MagicMock()
+    controller._position_stack_window = MagicMock()
+
+    assert controller.refresh(owner_id="applet://devices") is True
+
+    assert controller._stack_content is second
+    controller._replace_stack_content.assert_not_called()
+    controller._restart_stack_animation.assert_not_called()
+    controller._position_stack_window.assert_not_called()
+    window.show_all.assert_not_called()
+
+    controller._close_stack = MagicMock()
+    controller._activate_stack_key("usb")
+    new_activate.assert_called_once()
+    old_activate.assert_not_called()

--- a/tests/ui/test_stack.py
+++ b/tests/ui/test_stack.py
@@ -33,7 +33,7 @@ def _entry(key: str, label: str | None = None) -> StackEntry:
 def test_empty_content_builds_centered_message():
     controller = _controller()
 
-    layout = controller._folder_stack_layout(
+    layout = controller._stack_layout(
         owner_id="applet://devices",
         content=StackContent(empty_label="No devices"),
     )
@@ -55,7 +55,7 @@ def test_entries_and_optional_action_build_clickable_cards():
         ),
     )
 
-    layout = controller._folder_stack_layout(
+    layout = controller._stack_layout(
         owner_id="applet://devices",
         content=content,
     )
@@ -71,7 +71,7 @@ def test_layout_limits_provider_entries(caplog):
         _entry(f"device-{index}") for index in range(FOLDER_STACK_MAX_VISIBLE_ROWS + 2)
     )
 
-    layout = controller._folder_stack_layout(
+    layout = controller._stack_layout(
         owner_id="applet://devices",
         content=StackContent(entries=entries),
     )
@@ -93,12 +93,12 @@ def test_activation_uses_latest_callback_and_closes_popup():
             ),
         )
     )
-    controller._close_folder_stack = MagicMock()
+    controller._close_stack = MagicMock()
 
     controller._activate_stack_key("usb")
 
     activate.assert_called_once()
-    controller._close_folder_stack.assert_called_once()
+    controller._close_stack.assert_called_once()
 
 
 def test_refresh_reloads_visible_provider_content():
@@ -113,12 +113,12 @@ def test_refresh_reloads_visible_provider_content():
     controller._stack_provider = provider
     controller._stack_content = first
     controller._replace_stack_content = MagicMock()
-    controller._restart_folder_stack_animation = MagicMock()
-    controller._position_folder_stack_window = MagicMock()
+    controller._restart_stack_animation = MagicMock()
+    controller._position_stack_window = MagicMock()
 
     assert controller.refresh(owner_id="applet://devices") is True
 
     assert controller._stack_content is second
     controller._replace_stack_content.assert_called_once_with(content=second)
-    controller._position_folder_stack_window.assert_called_once()
+    controller._position_stack_window.assert_called_once()
     window.show_all.assert_called_once()

--- a/tests/ui/test_stack.py
+++ b/tests/ui/test_stack.py
@@ -1,0 +1,124 @@
+"""Tests for the reusable curved item-stack popup."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from docking.ui.stack import (
+    FOLDER_STACK_MAX_VISIBLE_ROWS,
+    StackAction,
+    StackContent,
+    StackEntry,
+    StackPopupController,
+)
+
+
+def _controller() -> StackPopupController:
+    return StackPopupController(
+        config=SimpleNamespace(icon_size=48, pos="bottom"),
+        runtime=MagicMock(),
+    )
+
+
+def _entry(key: str, label: str | None = None) -> StackEntry:
+    return StackEntry(
+        key=key,
+        label=label or key,
+        icon=None,
+        activate=MagicMock(),
+    )
+
+
+def test_empty_content_builds_centered_message():
+    controller = _controller()
+
+    layout = controller._folder_stack_layout(
+        owner_id="applet://devices",
+        content=StackContent(empty_label="No devices"),
+    )
+
+    assert len(layout.cards) == 1
+    assert layout.cards[0].target is None
+    assert layout.cards[0].label == "No devices"
+    assert layout.cards[0].centered is True
+
+
+def test_entries_and_optional_action_build_clickable_cards():
+    controller = _controller()
+    content = StackContent(
+        entries=(_entry("usb", "USB Drive"), _entry("disk", "Backup Disk")),
+        action=StackAction(
+            key="settings",
+            label="Open Disks",
+            activate=MagicMock(),
+        ),
+    )
+
+    layout = controller._folder_stack_layout(
+        owner_id="applet://devices",
+        content=content,
+    )
+
+    assert [card.target for card in layout.cards] == ["settings", "usb", "disk"]
+    assert layout.cards[0].action is True
+    assert all(card.icon is None for card in layout.cards)
+
+
+def test_layout_limits_provider_entries(caplog):
+    controller = _controller()
+    entries = tuple(
+        _entry(f"device-{index}") for index in range(FOLDER_STACK_MAX_VISIBLE_ROWS + 2)
+    )
+
+    layout = controller._folder_stack_layout(
+        owner_id="applet://devices",
+        content=StackContent(entries=entries),
+    )
+
+    assert len(layout.cards) == FOLDER_STACK_MAX_VISIBLE_ROWS
+    assert "displaying the first" in caplog.text
+
+
+def test_activation_uses_latest_callback_and_closes_popup():
+    controller = _controller()
+    activate = MagicMock()
+    controller._stack_content = StackContent(
+        entries=(
+            StackEntry(
+                key="usb",
+                label="USB Drive",
+                icon=None,
+                activate=activate,
+            ),
+        )
+    )
+    controller._close_folder_stack = MagicMock()
+
+    controller._activate_stack_key("usb")
+
+    activate.assert_called_once()
+    controller._close_folder_stack.assert_called_once()
+
+
+def test_refresh_reloads_visible_provider_content():
+    controller = _controller()
+    first = StackContent(entries=(_entry("first"),))
+    second = StackContent(entries=(_entry("second"),))
+    provider = MagicMock(return_value=second)
+    window = MagicMock()
+    window.get_visible.return_value = True
+    controller._folder_stack_window = window
+    controller._stack_owner_id = "applet://devices"
+    controller._stack_provider = provider
+    controller._stack_content = first
+    controller._replace_stack_content = MagicMock()
+    controller._restart_folder_stack_animation = MagicMock()
+    controller._position_folder_stack_window = MagicMock()
+
+    assert controller.refresh(owner_id="applet://devices") is True
+
+    assert controller._stack_content is second
+    controller._replace_stack_content.assert_called_once_with(content=second)
+    controller._position_folder_stack_window.assert_called_once()
+    window.show_all.assert_called_once()

--- a/tests/visual/render_cases.py
+++ b/tests/visual/render_cases.py
@@ -306,7 +306,7 @@ def _draw_folder_stack_case(case_name: str) -> cairo.ImageSurface:
     now_us = 500_000
     total_cards = len(cards)
     for draw_index, card in enumerate(cards):
-        handler._folder_stack._draw_folder_stack_card(
+        handler._folder_stack._draw_stack_card(
             cr=cr,
             card=card,
             sequence_index=total_cards - 1 - draw_index,


### PR DESCRIPTION
## Summary

- Extract the folder stack presentation into a reusable item-stack popup.
- Preserve the existing folder stack experience and behavior.
- Allow applets to provide stack entries for future features such as devices and mount points.
- Refresh an open applet stack when its content changes.