### PR TITLE
Show mounted network devices in the Devices applet

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,9 +532,10 @@ Shows mounted removable USB storage devices and provides safe-remove actions wit
 <details>
 <summary>Details</summary>
 
-Shows every mounted device exposed by the desktop volume monitor in a live stack.
-Selecting a device opens its mounted location. The stack updates automatically
-when devices are mounted or unmounted.
+Shows local devices and mounted network filesystems in a live stack, including
+desktop mounts such as SMB, SFTP, and WebDAV plus native CIFS, NFS, SSHFS, and
+rclone mounts. Selecting a device opens its mounted location. The stack updates
+automatically when devices are mounted or unmounted.
 
 **Click:** Open the mounted-devices stack
 **Right-click option:**

--- a/docking/applets/devices/applet.py
+++ b/docking/applets/devices/applet.py
@@ -36,6 +36,10 @@ from docking.applets.devices.state import (
     devices_tooltip,
     mounted_devices,
 )
+from docking.applets.devices.unix_mounts import (
+    get_mount_monitor,
+    read_network_mounts,
+)
 from docking.core.icons import IconSource
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -60,7 +64,7 @@ _MONITOR_SIGNALS = (
 
 
 class DevicesApplet(Applet):
-    """Show every desktop-visible mounted device in a live stack."""
+    """Show desktop-visible devices and native network mounts in a live stack."""
 
     id = meta.id
     name = _("Devices")
@@ -69,8 +73,12 @@ class DevicesApplet(Applet):
 
     def __init__(self, icon_size: int, config: Config | None = None) -> None:
         self._monitor = Gio.VolumeMonitor.get()
-        self._devices: list[MountedDevice] = mounted_devices(self._monitor)
-        self._handler_ids: list[int] = []
+        self._unix_mount_monitor = get_mount_monitor()
+        self._devices: list[MountedDevice] = mounted_devices(
+            self._monitor,
+            read_network_mounts(),
+        )
+        self._handler_ids: list[tuple[object, int]] = []
         self._stack_icons: dict[tuple[str, int], GdkPixbuf.Pixbuf | None] = {}
         super().__init__(icon_size=icon_size, config=config)
         self.present()
@@ -110,13 +118,26 @@ class DevicesApplet(Applet):
             return
         for signal_name in _MONITOR_SIGNALS:
             self._handler_ids.append(
-                self._monitor.connect(signal_name, self._on_changed)
+                (
+                    self._monitor,
+                    self._monitor.connect(signal_name, self._on_changed),
+                )
+            )
+        if self._unix_mount_monitor is not None:
+            self._handler_ids.append(
+                (
+                    self._unix_mount_monitor,
+                    self._unix_mount_monitor.connect(
+                        "mounts-changed",
+                        self._on_changed,
+                    ),
+                )
             )
 
     def stop(self) -> None:
-        """Disconnect volume-monitor signal handlers."""
-        for handler_id in self._handler_ids:
-            self._monitor.disconnect(handler_id)
+        """Disconnect volume and Unix mount-monitor signal handlers."""
+        for monitor, handler_id in self._handler_ids:
+            monitor.disconnect(handler_id)
         self._handler_ids = []
         super().stop()
 
@@ -124,7 +145,7 @@ class DevicesApplet(Applet):
         self._refresh_devices()
 
     def _refresh_devices(self) -> None:
-        devices = mounted_devices(self._monitor)
+        devices = mounted_devices(self._monitor, read_network_mounts())
         changed = _device_signature(devices) != _device_signature(self._devices)
         self._devices = devices
         if not changed:
@@ -176,15 +197,18 @@ def _load_mount_icon(
                     return icon_info.load_icon()
         except (AttributeError, GLib.Error):
             pass
-    fallback = (
-        "folder-remote"
-        if urlparse(device.uri).scheme not in {"", "file"}
-        else "drive-harddisk"
-    )
+    fallback = "folder-remote" if device.is_network else "drive-harddisk"
     return load_theme_icon(name=fallback, size=size)
 
 
 def _device_signature(devices: list[MountedDevice]) -> tuple[tuple[str, ...], ...]:
     return tuple(
-        (device.key, device.name, device.uri, device.mount_path) for device in devices
+        (
+            device.key,
+            device.name,
+            device.uri,
+            device.mount_path,
+            str(device.is_network),
+        )
+        for device in devices
     )

--- a/docking/applets/devices/state.py
+++ b/docking/applets/devices/state.py
@@ -16,10 +16,13 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from os.path import normpath
+from pathlib import Path
 from typing import Protocol
 from urllib.parse import unquote, urlparse
 
+from docking.applets.devices.unix_mounts import NativeNetworkMount
 from docking.applets.tooltip import structured_tooltip
 from docking.i18n import _
 
@@ -49,24 +52,30 @@ class MountedDevice:
     uri: str
     mount_path: str
     icon: object | None
-    mount: MountLike
+    is_network: bool = False
 
 
-def mounted_devices(monitor: VolumeMonitorLike) -> list[MountedDevice]:
-    """Return every mount exposed by the desktop volume monitor."""
+def mounted_devices(
+    monitor: VolumeMonitorLike,
+    native_mounts: Sequence[NativeNetworkMount] = (),
+) -> list[MountedDevice]:
+    """Merge desktop-visible mounts with native network filesystems."""
     devices: list[MountedDevice] = []
-    seen_uris: set[str] = set()
+    device_indexes: dict[str, int] = {}
     for mount in monitor.get_mounts():
         try:
             root = mount.get_root()
             uri = str(root.get_uri() or "").strip()
+            path = root.get_path()
         except Exception:
             continue
-        if not uri or uri in seen_uris:
+        if not uri:
             continue
-        seen_uris.add(uri)
-        path = root.get_path()
         mount_path = str(path).strip() if path else _display_uri(uri)
+        identity = _mount_identity(uri=uri, mount_path=mount_path)
+        if identity in device_indexes:
+            continue
+        device_indexes[identity] = len(devices)
         devices.append(
             MountedDevice(
                 key=_mount_key(mount=mount, uri=uri),
@@ -74,7 +83,35 @@ def mounted_devices(monitor: VolumeMonitorLike) -> list[MountedDevice]:
                 uri=uri,
                 mount_path=mount_path,
                 icon=_mount_icon(mount),
-                mount=mount,
+                is_network=urlparse(uri).scheme not in {"", "file"},
+            )
+        )
+
+    for native in native_mounts:
+        mount_path = str(native.mount_path).strip()
+        if not mount_path:
+            continue
+        try:
+            uri = Path(mount_path).as_uri()
+        except ValueError:
+            continue
+        identity = _mount_identity(uri=uri, mount_path=mount_path)
+        existing_index = device_indexes.get(identity)
+        if existing_index is not None:
+            devices[existing_index] = replace(
+                devices[existing_index],
+                is_network=True,
+            )
+            continue
+        device_indexes[identity] = len(devices)
+        devices.append(
+            MountedDevice(
+                key=f"unix:{identity}",
+                name=_native_mount_name(native),
+                uri=uri,
+                mount_path=mount_path,
+                icon=native.icon,
+                is_network=True,
             )
         )
     return sorted(devices, key=lambda device: (device.name.casefold(), device.uri))
@@ -123,6 +160,21 @@ def _mount_icon(mount: MountLike) -> object | None:
         return mount.get_icon()
     except Exception:
         return None
+
+
+def _native_mount_name(mount: NativeNetworkMount) -> str:
+    name = str(mount.name).strip()
+    if name:
+        return name
+    path_name = Path(normpath(mount.mount_path)).name
+    return path_name or mount.source or _("Mounted Device")
+
+
+def _mount_identity(*, uri: str, mount_path: str) -> str:
+    parsed = urlparse(uri)
+    if parsed.scheme in {"", "file"} and mount_path.startswith("/"):
+        return f"path:{normpath(mount_path)}"
+    return f"uri:{uri.rstrip('/')}"
 
 
 def _display_uri(uri: str) -> str:

--- a/docking/applets/devices/unix_mounts.py
+++ b/docking/applets/devices/unix_mounts.py
@@ -1,0 +1,171 @@
+# Author: Eduardo Mucelli Rezende Oliveira
+# E-mail: edumucelli@gmail.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+"""Compatibility helpers for native network mounts.
+
+GLib exposes the Unix mount table through two introspection layouts. Older
+releases publish the functions in ``Gio`` with names such as
+``unix_mounts_get``. GLib 2.84 moved the API to the ``GioUnix`` namespace and
+introduced ``mount_entries_get``. Keeping that version handling here lets the
+Devices applet consume one small, source-neutral record on every supported
+distribution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any
+
+import gi
+
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio
+
+try:
+    gi.require_version("GioUnix", "2.0")
+    _gio_unix: Any | None = import_module("gi.repository.GioUnix")
+except (ImportError, ValueError):
+    _gio_unix = None
+
+
+_NETWORK_FILESYSTEMS = frozenset(
+    {
+        "afs",
+        "ceph",
+        "cifs",
+        "coda",
+        "davfs",
+        "davfs2",
+        "fuse.ceph",
+        "fuse.curlftpfs",
+        "fuse.davfs",
+        "fuse.davfs2",
+        "fuse.glusterfs",
+        "fuse.rclone",
+        "fuse.smbnetfs",
+        "fuse.sshfs",
+        "glusterfs",
+        "nfs",
+        "nfs4",
+        "smb3",
+        "sshfs",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class NativeNetworkMount:
+    """One active network filesystem from the Unix mount table."""
+
+    mount_path: str
+    source: str
+    fs_type: str
+    name: str
+    icon: object | None
+
+
+def read_network_mounts(*, api: Any | None = None) -> list[NativeNetworkMount]:
+    """Return supported network filesystems from the active mount table."""
+    namespace = api if api is not None else _default_api()
+    try:
+        entries = _mount_entries(namespace)
+    except Exception:
+        return []
+
+    mounts: list[NativeNetworkMount] = []
+    for entry in entries:
+        try:
+            fs_type = str(_entry_value(namespace, entry, "get_fs_type") or "")
+            fs_type = fs_type.strip().casefold()
+            if fs_type not in _NETWORK_FILESYSTEMS:
+                continue
+            mount_path = str(
+                _entry_value(namespace, entry, "get_mount_path") or ""
+            ).strip()
+            if not mount_path.startswith("/"):
+                continue
+            source = str(
+                _entry_value(namespace, entry, "get_device_path") or ""
+            ).strip()
+            name = str(
+                _entry_value(namespace, entry, "guess_name", required=False) or ""
+            ).strip()
+            icon = _entry_value(namespace, entry, "guess_icon", required=False)
+        except Exception:
+            continue
+        mounts.append(
+            NativeNetworkMount(
+                mount_path=mount_path,
+                source=source,
+                fs_type=fs_type,
+                name=name,
+                icon=icon,
+            )
+        )
+    return mounts
+
+
+def get_mount_monitor(*, api: Any | None = None) -> Any | None:
+    """Return the Unix mount monitor, or ``None`` when it is unavailable."""
+    namespace = api if api is not None else _default_api()
+    monitor_type = getattr(namespace, "MountMonitor", None)
+    if monitor_type is None:
+        monitor_type = getattr(namespace, "UnixMountMonitor", None)
+    if monitor_type is None:
+        return None
+    try:
+        return monitor_type.get()
+    except Exception:
+        return None
+
+
+def _default_api() -> Any:
+    return _gio_unix if _gio_unix is not None else Gio
+
+
+def _mount_entries(api: Any) -> list[Any]:
+    getter = None
+    for name in ("mount_entries_get", "mounts_get", "unix_mounts_get"):
+        getter = getattr(api, name, None)
+        if getter is not None:
+            break
+    if getter is None:
+        return []
+    result = getter()
+    if isinstance(result, tuple):
+        result = result[0]
+    return list(result or [])
+
+
+def _entry_value(
+    api: Any,
+    entry: Any,
+    suffix: str,
+    *,
+    required: bool = True,
+) -> Any:
+    for name in (
+        f"mount_entry_{suffix}",
+        f"mount_{suffix}",
+        f"unix_mount_{suffix}",
+    ):
+        accessor = getattr(api, name, None)
+        if accessor is not None:
+            return accessor(entry)
+    accessor = getattr(entry, suffix, None)
+    if accessor is not None:
+        return accessor()
+    if required:
+        raise AttributeError(f"Unix mount accessor {suffix!r} is unavailable")
+    return None

--- a/packaging/flatpak/cc.docking.Docking.json
+++ b/packaging/flatpak/cc.docking.Docking.json
@@ -17,6 +17,8 @@
     "--socket=fallback-x11",
     "--device=dri",
     "--filesystem=host",
+    "--filesystem=xdg-run/gvfsd",
+    "--talk-name=org.gtk.vfs.*",
     "--talk-name=org.freedesktop.Notifications",
     "--talk-name=org.freedesktop.Flatpak",
     "--system-talk-name=org.freedesktop.NetworkManager",

--- a/packaging/snap/snapcraft.yaml
+++ b/packaging/snap/snapcraft.yaml
@@ -27,6 +27,7 @@ apps:
       - desktop-legacy
       - network
       - network-manager
+      - mount-observe
       - audio-playback
       - home
 

--- a/tests/applets/test_devices.py
+++ b/tests/applets/test_devices.py
@@ -10,6 +10,7 @@ from docking.applets.base import load_catalog_icon
 from docking.applets.devices.applet import DevicesApplet
 from docking.applets.devices.render import create_devices_icon
 from docking.applets.devices.state import devices_tooltip, mounted_devices
+from docking.applets.devices.unix_mounts import NativeNetworkMount
 
 
 class _FakeRoot:
@@ -93,11 +94,45 @@ def _mount(
     return _FakeMount(name=name, path=path, uri=uri, uuid=uuid, icon=icon)
 
 
-def _applet(monkeypatch, monitor: _FakeMonitor) -> DevicesApplet:
+def _native_mount(
+    *,
+    path: str = "/mnt/team",
+    source: str = "//fileserver/team",
+    fs_type: str = "cifs",
+    name: str = "Team Share",
+    icon: object | None = None,
+) -> NativeNetworkMount:
+    return NativeNetworkMount(
+        mount_path=path,
+        source=source,
+        fs_type=fs_type,
+        name=name,
+        icon=icon,
+    )
+
+
+def _applet(
+    monkeypatch,
+    monitor: _FakeMonitor,
+    *,
+    native_mounts: list[NativeNetworkMount] | None = None,
+    unix_monitor: _FakeMonitor | None = None,
+) -> DevicesApplet:
+    current_native_mounts = native_mounts if native_mounts is not None else []
     monkeypatch.setattr(
         devices_applet_mod.Gio.VolumeMonitor,
         "get",
         lambda: monitor,
+    )
+    monkeypatch.setattr(
+        devices_applet_mod,
+        "read_network_mounts",
+        lambda: list(current_native_mounts),
+    )
+    monkeypatch.setattr(
+        devices_applet_mod,
+        "get_mount_monitor",
+        lambda: unix_monitor,
     )
     return DevicesApplet(48)
 
@@ -142,6 +177,45 @@ def test_mounted_devices_deduplicates_root_uri_and_uses_name_fallback():
 
     assert len(devices) == 1
     assert devices[0].name == "Backup"
+
+
+def test_mounted_devices_merges_native_network_mounts_and_prefers_gio_entry():
+    gio_mount = _mount(
+        "Team Share",
+        path="/mnt/team",
+        uri="file:///mnt/team",
+        icon="gio-icon",
+    )
+    native_mounts = [
+        _native_mount(name="Duplicate", icon="native-icon"),
+        _native_mount(
+            path="/mnt/Cloud Team",
+            source="cloud:",
+            fs_type="fuse.rclone",
+            name="",
+        ),
+    ]
+
+    devices = mounted_devices(_FakeMonitor([gio_mount]), native_mounts)
+
+    assert [device.name for device in devices] == ["Cloud Team", "Team Share"]
+    assert devices[0].uri == "file:///mnt/Cloud%20Team"
+    assert devices[0].key == "unix:path:/mnt/Cloud Team"
+    assert devices[0].is_network is True
+    assert devices[1].icon == "gio-icon"
+    assert devices[1].is_network is True
+
+
+def test_native_network_mount_uses_remote_icon_fallback(monkeypatch):
+    device = mounted_devices(_FakeMonitor(), [_native_mount()])[0]
+    fallback = object()
+    load_theme_icon = MagicMock(return_value=fallback)
+    monkeypatch.setattr(devices_applet_mod, "load_theme_icon", load_theme_icon)
+
+    icon = devices_applet_mod._load_mount_icon(device=device, size=32)
+
+    assert icon is fallback
+    load_theme_icon.assert_called_once_with(name="folder-remote", size=32)
 
 
 def test_devices_tooltip_empty_and_populated():
@@ -248,9 +322,40 @@ class TestDevicesApplet:
         assert applet.stack_content(32).entries == ()
         notify.assert_called_once()
 
+    def test_native_network_mount_signal_refreshes_and_opens_stack_entry(
+        self, monkeypatch
+    ):
+        monitor = _FakeMonitor()
+        unix_monitor = _FakeMonitor()
+        native_mounts: list[NativeNetworkMount] = []
+        applet = _applet(
+            monkeypatch,
+            monitor,
+            native_mounts=native_mounts,
+            unix_monitor=unix_monitor,
+        )
+        notify = MagicMock()
+        open_target = MagicMock(return_value=True)
+        monkeypatch.setattr(
+            devices_applet_mod.launcher_mod,
+            "open_target",
+            open_target,
+        )
+        applet.start(notify)
+
+        native_mounts.append(_native_mount())
+        unix_monitor.emit("mounts-changed")
+
+        content = applet.stack_content(32)
+        assert [entry.label for entry in content.entries] == ["Team Share"]
+        content.entries[0].activate()
+        open_target.assert_called_once_with("file:///mnt/team")
+        notify.assert_called_once()
+
     def test_start_is_idempotent_and_stop_disconnects_handlers(self, monkeypatch):
         monitor = _FakeMonitor()
-        applet = _applet(monkeypatch, monitor)
+        unix_monitor = _FakeMonitor()
+        applet = _applet(monkeypatch, monitor, unix_monitor=unix_monitor)
 
         applet.start(MagicMock())
         applet.start(MagicMock())
@@ -260,6 +365,8 @@ class TestDevicesApplet:
         assert monitor.disconnected == list(
             range(1, len(devices_applet_mod._MONITOR_SIGNALS) + 1)
         )
+        assert list(unix_monitor.callbacks) == ["mounts-changed"]
+        assert unix_monitor.disconnected == [1]
 
     def test_unchanged_monitor_signal_does_not_notify(self, monkeypatch):
         monitor = _FakeMonitor([_mount("Data")])

--- a/tests/applets/test_devices_unix_mounts.py
+++ b/tests/applets/test_devices_unix_mounts.py
@@ -1,0 +1,121 @@
+"""Tests for native network mount compatibility helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from docking.applets.devices.unix_mounts import (
+    get_mount_monitor,
+    read_network_mounts,
+)
+
+
+class _Entry:
+    def __init__(
+        self,
+        *,
+        path: str,
+        source: str,
+        fs_type: str,
+        name: str = "",
+        icon: object | None = None,
+    ) -> None:
+        self.path = path
+        self.source = source
+        self.fs_type = fs_type
+        self.name = name
+        self.icon = icon
+
+
+class _MonitorType:
+    monitor = object()
+
+    @classmethod
+    def get(cls):
+        return cls.monitor
+
+
+def _old_api(entries: list[_Entry]):
+    return SimpleNamespace(
+        unix_mounts_get=lambda: (entries, 123),
+        unix_mount_get_mount_path=lambda entry: entry.path,
+        unix_mount_get_device_path=lambda entry: entry.source,
+        unix_mount_get_fs_type=lambda entry: entry.fs_type,
+        unix_mount_guess_name=lambda entry: entry.name,
+        unix_mount_guess_icon=lambda entry: entry.icon,
+        UnixMountMonitor=_MonitorType,
+    )
+
+
+def _new_api(entries: list[_Entry]):
+    return SimpleNamespace(
+        mount_entries_get=lambda: (entries, 456),
+        mount_entry_get_mount_path=lambda entry: entry.path,
+        mount_entry_get_device_path=lambda entry: entry.source,
+        mount_entry_get_fs_type=lambda entry: entry.fs_type,
+        mount_entry_guess_name=lambda entry: entry.name,
+        mount_entry_guess_icon=lambda entry: entry.icon,
+        MountMonitor=_MonitorType,
+    )
+
+
+def test_legacy_gio_api_returns_only_supported_network_filesystems():
+    icon = object()
+    api = _old_api(
+        [
+            _Entry(
+                path="/mnt/team",
+                source="//fileserver/team",
+                fs_type="cifs",
+                name="Team Share",
+                icon=icon,
+            ),
+            _Entry(path="/", source="/dev/sda1", fs_type="ext4"),
+            _Entry(path="/run/user/1000/doc", source="portal", fs_type="fuse.portal"),
+        ]
+    )
+
+    mounts = read_network_mounts(api=api)
+
+    assert len(mounts) == 1
+    assert mounts[0].mount_path == "/mnt/team"
+    assert mounts[0].source == "//fileserver/team"
+    assert mounts[0].fs_type == "cifs"
+    assert mounts[0].name == "Team Share"
+    assert mounts[0].icon is icon
+    assert get_mount_monitor(api=api) is _MonitorType.monitor
+
+
+def test_glib_284_api_supports_nfs_sshfs_webdav_and_rclone():
+    api = _new_api(
+        [
+            _Entry(path="/mnt/nfs", source="server:/data", fs_type="nfs4"),
+            _Entry(path="/mnt/ssh", source="user@server:/", fs_type="fuse.sshfs"),
+            _Entry(path="/mnt/dav", source="https://example.test", fs_type="davfs2"),
+            _Entry(path="/mnt/cloud", source="cloud:", fs_type="fuse.rclone"),
+        ]
+    )
+
+    mounts = read_network_mounts(api=api)
+
+    assert [mount.fs_type for mount in mounts] == [
+        "nfs4",
+        "fuse.sshfs",
+        "davfs2",
+        "fuse.rclone",
+    ]
+    assert get_mount_monitor(api=api) is _MonitorType.monitor
+
+
+def test_invalid_entries_and_unavailable_apis_are_ignored():
+    invalid_path = _Entry(path="relative/share", source="server:/", fs_type="nfs")
+    broken_api = SimpleNamespace(
+        mount_entries_get=lambda: [invalid_path],
+        mount_entry_get_mount_path=lambda entry: entry.path,
+        mount_entry_get_device_path=lambda entry: entry.source,
+        mount_entry_get_fs_type=lambda entry: entry.fs_type,
+    )
+
+    assert read_network_mounts(api=broken_api) == []
+    assert read_network_mounts(api=SimpleNamespace()) == []
+    assert get_mount_monitor(api=SimpleNamespace()) is None

--- a/tests/test_packaging_refresh.py
+++ b/tests/test_packaging_refresh.py
@@ -68,3 +68,14 @@ def test_application_desktop_entries_do_not_disable_autostart():
     for desktop_entry in desktop_entries:
         content = desktop_entry.read_text(encoding="utf-8")
         assert "X-GNOME-Autostart-enabled" not in content
+
+
+def test_sandbox_packages_allow_mounted_device_discovery():
+    flatpak = (ROOT / "packaging/flatpak/cc.docking.Docking.json").read_text(
+        encoding="utf-8"
+    )
+    snap = (ROOT / "packaging/snap/snapcraft.yaml").read_text(encoding="utf-8")
+
+    assert '"--talk-name=org.gtk.vfs.*"' in flatpak
+    assert '"--filesystem=xdg-run/gvfsd"' in flatpak
+    assert "      - mount-observe\n" in snap


### PR DESCRIPTION
## Summary

- Show mounted SMB, SFTP, WebDAV, CIFS, NFS, SSHFS, rclone, and other network filesystems in the Devices stack
- Add and remove network entries automatically as shares are mounted or unmounted
- Open native and desktop-mounted shares from the stack
- Enable mounted-share discovery in Flatpak and Snap packages