### PR TITLE
Add badge and progress visibility controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ the full setting reference follows it.
 | `stack_unfold` | hover | Stack open behavior: `hover` or `click` |
 | `window_list_sort` | default | Open-window menu order: `default` or `alphabetical` |
 | `show_window_count_numbers` | false | Show numeric window counts inside running indicators |
+| `show_launcher_badges` | true | Show numeric counts reported by applications on their dock icons |
+| `show_launcher_progress` | true | Show task progress reported by applications on their dock icons |
 | `theme` | default | Theme name (loads from `~/.config/docking/themes/{name}.json` first, then built-in themes) |
 | `transparency` | 1.0 | Multiplier applied to theme alpha from `0.15` to `1.0` (`1.0` = full theme opacity) |
 | `additional_distance_from_edge` | 0 | Extra pixels added to the theme's edge gap |

--- a/docking/core/config.py
+++ b/docking/core/config.py
@@ -485,6 +485,8 @@ DEFAULT_MIDDLE_CLICK_ACTION = MiddleClickAction.NEW_WINDOW.value
 DEFAULT_STACK_UNFOLD = StackUnfold.HOVER.value
 DEFAULT_WINDOW_LIST_SORT = WindowListSort.DEFAULT.value
 DEFAULT_SHOW_WINDOW_COUNT_NUMBERS = False
+DEFAULT_SHOW_LAUNCHER_BADGES = True
+DEFAULT_SHOW_LAUNCHER_PROGRESS = True
 
 
 def _normalize_left_click_action(value: object) -> str:
@@ -804,6 +806,10 @@ class Config:
     window_list_sort: str = DEFAULT_WINDOW_LIST_SORT
     # Whether running application indicators show a numeric window count
     show_window_count_numbers: bool = DEFAULT_SHOW_WINDOW_COUNT_NUMBERS
+    # Whether numeric badges reported by applications are visible
+    show_launcher_badges: bool = DEFAULT_SHOW_LAUNCHER_BADGES
+    # Whether progress bars reported by applications are visible
+    show_launcher_progress: bool = DEFAULT_SHOW_LAUNCHER_PROGRESS
     # Theme name (loads from assets/themes/{name}.json)
     theme: str = DEFAULT_THEME
     # Multiplier applied to theme alpha values for the dock shelf
@@ -957,6 +963,14 @@ class Config:
         self.show_window_count_numbers = _normalize_bool(
             self.show_window_count_numbers,
             default=DEFAULT_SHOW_WINDOW_COUNT_NUMBERS,
+        )
+        self.show_launcher_badges = _normalize_bool(
+            self.show_launcher_badges,
+            default=DEFAULT_SHOW_LAUNCHER_BADGES,
+        )
+        self.show_launcher_progress = _normalize_bool(
+            self.show_launcher_progress,
+            default=DEFAULT_SHOW_LAUNCHER_PROGRESS,
         )
         self.theme = _normalize_theme(self.theme)
         self.transparency = _normalize_transparency(self.transparency)

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: docking\n"
 "Report-Msgid-Bugs-To: edumucelli@gmail.com\n"
-"POT-Creation-Date: 2026-07-18 10:58+0200\n"
+"POT-Creation-Date: 2026-07-18 18:10+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "Power Settings"
 msgstr ""
 
-#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:646
+#: docking/applets/battery/peripherals.py:46 docking/ui/settings.py:671
 msgid "Mouse"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "{command} (PID {pid}) using {devices}"
 msgstr ""
 
-#: docking/applets/camshield/state.py:91 docking/applets/devices/state.py:92
+#: docking/applets/camshield/state.py:91 docking/applets/devices/state.py:129
 #: docking/applets/micshield/state.py:223 docking/applets/usbwatch/state.py:99
 #, python-brace-format
 msgid "{count} more"
@@ -1206,25 +1206,25 @@ msgstr ""
 msgid "Desktop"
 msgstr ""
 
-#: docking/applets/devices/applet.py:66 docking/applets/devices/state.py:87
-#: docking/applets/devices/state.py:94
+#: docking/applets/devices/applet.py:70 docking/applets/devices/state.py:124
+#: docking/applets/devices/state.py:131
 msgid "Devices"
 msgstr ""
 
-#: docking/applets/devices/applet.py:98 docking/applets/devices/state.py:88
+#: docking/applets/devices/applet.py:106 docking/applets/devices/state.py:125
 msgid "No mounted devices"
 msgstr ""
 
-#: docking/applets/devices/applet.py:102
+#: docking/applets/devices/applet.py:110
 msgid "Refresh Devices"
 msgstr ""
 
-#: docking/applets/devices/state.py:95 docking/applets/usbwatch/state.py:102
+#: docking/applets/devices/state.py:132 docking/applets/usbwatch/state.py:102
 #, python-brace-format
 msgid "{count} mounted device(s)"
 msgstr ""
 
-#: docking/applets/devices/state.py:118
+#: docking/applets/devices/state.py:155 docking/applets/devices/state.py:170
 msgid "Mounted Device"
 msgstr ""
 
@@ -1378,7 +1378,7 @@ msgid "{verb} every {interval}"
 msgstr ""
 
 #: docking/applets/freshness.py:43 docking/applets/freshness.py:50
-#: docking/ui/settings.py:297
+#: docking/ui/settings.py:304
 msgid "Updates"
 msgstr ""
 
@@ -3394,7 +3394,7 @@ msgstr ""
 msgid "Website"
 msgstr ""
 
-#: docking/ui/diagnostics.py:71 docking/ui/menu.py:695
+#: docking/ui/diagnostics.py:71 docking/ui/menu.py:696
 msgid "Diagnostics"
 msgstr ""
 
@@ -3622,39 +3622,39 @@ msgstr ""
 msgid "Add Applet"
 msgstr ""
 
-#: docking/ui/menu.py:679
+#: docking/ui/menu.py:680
 msgid "No Applets Available"
 msgstr ""
 
-#: docking/ui/menu.py:686
+#: docking/ui/menu.py:687
 msgid "Add Separator"
 msgstr ""
 
-#: docking/ui/menu.py:700 docking/ui/settings.py:270
+#: docking/ui/menu.py:701 docking/ui/settings.py:277
 msgid "Preferences"
 msgstr ""
 
-#: docking/ui/menu.py:705
+#: docking/ui/menu.py:706
 msgid "About"
 msgstr ""
 
-#: docking/ui/menu.py:710
+#: docking/ui/menu.py:711
 msgid "Get Support"
 msgstr ""
 
-#: docking/ui/menu.py:717
+#: docking/ui/menu.py:718
 msgid "Quit"
 msgstr ""
 
-#: docking/ui/menu.py:783
+#: docking/ui/menu.py:784
 msgid "Clear Recent Documents"
 msgstr ""
 
-#: docking/ui/menu.py:793 docking/ui/settings.py:748
+#: docking/ui/menu.py:794 docking/ui/settings.py:773
 msgid "Recent Documents"
 msgstr ""
 
-#: docking/ui/menu.py:812
+#: docking/ui/menu.py:813
 msgid "Window"
 msgstr ""
 
@@ -3668,439 +3668,455 @@ msgstr ""
 msgid "Display {display}: {width}x{height}"
 msgstr ""
 
-#: docking/ui/settings.py:294
+#: docking/ui/settings.py:301
 msgid "Appearance"
 msgstr ""
 
-#: docking/ui/settings.py:295 docking/ui/settings.py:673
+#: docking/ui/settings.py:302 docking/ui/settings.py:698
 msgid "Behavior"
 msgstr ""
 
-#: docking/ui/settings.py:296
+#: docking/ui/settings.py:303
 msgid "Applets"
 msgstr ""
 
-#: docking/ui/settings.py:320
+#: docking/ui/settings.py:327
 msgid "Don't Hide"
 msgstr ""
 
-#: docking/ui/settings.py:321
+#: docking/ui/settings.py:328
 msgid "Always on Top"
 msgstr ""
 
-#: docking/ui/settings.py:322
+#: docking/ui/settings.py:329
 msgid "Auto-hide"
 msgstr ""
 
-#: docking/ui/settings.py:323
+#: docking/ui/settings.py:330
 msgid "Intelligent"
 msgstr ""
 
-#: docking/ui/settings.py:324
+#: docking/ui/settings.py:331
 msgid "Dodge Active"
 msgstr ""
 
-#: docking/ui/settings.py:325
+#: docking/ui/settings.py:332
 msgid "Dodge Windows"
 msgstr ""
 
-#: docking/ui/settings.py:326
+#: docking/ui/settings.py:333
 msgid "Dodge Maximized"
 msgstr ""
 
-#: docking/ui/settings.py:337
+#: docking/ui/settings.py:344
 msgid "Toggle Focus"
 msgstr ""
 
-#: docking/ui/settings.py:338
+#: docking/ui/settings.py:345
 msgid "Cycle Windows"
 msgstr ""
 
-#: docking/ui/settings.py:339
+#: docking/ui/settings.py:346
 msgid "Most Recent Window"
 msgstr ""
 
-#: docking/ui/settings.py:346
+#: docking/ui/settings.py:353
 msgid "New Window"
 msgstr ""
 
-#: docking/ui/settings.py:347
+#: docking/ui/settings.py:354
 msgid "Minimize Windows"
 msgstr ""
 
-#: docking/ui/settings.py:348
+#: docking/ui/settings.py:355
 msgid "Close Focused Window"
 msgstr ""
 
-#: docking/ui/settings.py:355
+#: docking/ui/settings.py:362
 msgid "Click"
 msgstr ""
 
-#: docking/ui/settings.py:356
+#: docking/ui/settings.py:363
 msgid "Hover"
 msgstr ""
 
-#: docking/ui/settings.py:363
+#: docking/ui/settings.py:370
 msgid "Default"
 msgstr ""
 
-#: docking/ui/settings.py:364
+#: docking/ui/settings.py:371
 msgid "Alphabetical"
 msgstr ""
 
-#: docking/ui/settings.py:382
+#: docking/ui/settings.py:391
 msgid "Daily"
 msgstr ""
 
-#: docking/ui/settings.py:383
+#: docking/ui/settings.py:392
 msgid "Weekly"
 msgstr ""
 
-#: docking/ui/settings.py:404
+#: docking/ui/settings.py:413
 msgid ""
 "When Follow Cursor is enabled, the dock follows the pointer across monitors. "
 "The selected monitor is kept as the fallback."
 msgstr ""
 
-#: docking/ui/settings.py:450
+#: docking/ui/settings.py:459
 msgid "Added on top of the theme's own distance from the edge."
 msgstr ""
 
-#: docking/ui/settings.py:490
+#: docking/ui/settings.py:499
 msgid ""
 "Pixels of cursor pressure against the edge required to reveal a hidden dock. "
 "Higher values mean the dock will not reveal as easily."
 msgstr ""
 
-#: docking/ui/settings.py:512
+#: docking/ui/settings.py:521
 msgid "Look"
 msgstr ""
 
-#: docking/ui/settings.py:514
+#: docking/ui/settings.py:523
 msgid "Theme"
 msgstr ""
 
-#: docking/ui/settings.py:514
+#: docking/ui/settings.py:523
 msgid "Choose the dock color palette."
 msgstr ""
 
-#: docking/ui/settings.py:516
+#: docking/ui/settings.py:525
 msgid "Icon Size"
 msgstr ""
 
-#: docking/ui/settings.py:518
+#: docking/ui/settings.py:527
 msgid "Set the base size of dock icons before zoom is applied."
 msgstr ""
 
-#: docking/ui/settings.py:521
+#: docking/ui/settings.py:530
 msgid "Transparency"
 msgstr ""
 
-#: docking/ui/settings.py:523
+#: docking/ui/settings.py:532
 msgid "Adjust how transparent the dock background is."
 msgstr ""
 
-#: docking/ui/settings.py:526
+#: docking/ui/settings.py:535
 msgid "Zoom"
 msgstr ""
 
-#: docking/ui/settings.py:528
+#: docking/ui/settings.py:537
 msgid "Enlarge icons when the pointer hovers over the dock."
 msgstr ""
 
-#: docking/ui/settings.py:531
+#: docking/ui/settings.py:540
 msgid "Zoom Percent"
 msgstr ""
 
-#: docking/ui/settings.py:533
+#: docking/ui/settings.py:542
 msgid "Set how much hovered icons grow when zoom is enabled."
 msgstr ""
 
-#: docking/ui/settings.py:536
+#: docking/ui/settings.py:545
 msgid "Show Tooltips"
 msgstr ""
 
-#: docking/ui/settings.py:538
+#: docking/ui/settings.py:547
 msgid "Show item names and details when hovering over dock items."
 msgstr ""
 
-#: docking/ui/settings.py:541
+#: docking/ui/settings.py:550
 msgid "Window Previews"
 msgstr ""
 
-#: docking/ui/settings.py:543
+#: docking/ui/settings.py:552
 msgid "Show window thumbnails when hovering over running apps."
 msgstr ""
 
-#: docking/ui/settings.py:546
+#: docking/ui/settings.py:555
 msgid "Show Window Counts"
 msgstr ""
 
-#: docking/ui/settings.py:549
+#: docking/ui/settings.py:558
 msgid "Show a number on running app indicators when multiple windows are open."
 msgstr ""
 
-#: docking/ui/settings.py:557
-msgid "Placement"
-msgstr ""
-
-#: docking/ui/settings.py:560
-msgid "Position"
-msgstr ""
-
-#: docking/ui/settings.py:562
-msgid "Choose which screen edge the dock uses."
-msgstr ""
-
-#: docking/ui/settings.py:564
-msgid "Extra Distance from Edge"
+#: docking/ui/settings.py:563
+msgid "Application Badges"
 msgstr ""
 
 #: docking/ui/settings.py:566
+msgid "Show numeric counts reported by applications on their dock icons."
+msgstr ""
+
+#: docking/ui/settings.py:571
+msgid "Application Progress"
+msgstr ""
+
+#: docking/ui/settings.py:574
+msgid "Show task progress reported by applications on their dock icons."
+msgstr ""
+
+#: docking/ui/settings.py:582
+msgid "Placement"
+msgstr ""
+
+#: docking/ui/settings.py:585
+msgid "Position"
+msgstr ""
+
+#: docking/ui/settings.py:587
+msgid "Choose which screen edge the dock uses."
+msgstr ""
+
+#: docking/ui/settings.py:589
+msgid "Extra Distance from Edge"
+msgstr ""
+
+#: docking/ui/settings.py:591
 msgid "Current Workspace Only"
 msgstr ""
 
-#: docking/ui/settings.py:569
+#: docking/ui/settings.py:594
 msgid "Show running windows only from the active workspace when supported."
 msgstr ""
 
-#: docking/ui/settings.py:577 docking/ui/settings.py:587
+#: docking/ui/settings.py:602 docking/ui/settings.py:612
 msgid "Monitor"
 msgstr ""
 
-#: docking/ui/settings.py:580
+#: docking/ui/settings.py:605
 msgid "Follow Cursor"
 msgstr ""
 
-#: docking/ui/settings.py:583
+#: docking/ui/settings.py:608
 msgid "Move the dock to the monitor where the pointer is currently located."
 msgstr ""
 
-#: docking/ui/settings.py:592
+#: docking/ui/settings.py:617
 msgid "Layout"
 msgstr ""
 
-#: docking/ui/settings.py:595
+#: docking/ui/settings.py:620
 msgid "Lock Positions"
 msgstr ""
 
-#: docking/ui/settings.py:598
+#: docking/ui/settings.py:623
 msgid "Prevent dock items from being reordered or removed by drag and drop."
 msgstr ""
 
-#: docking/ui/settings.py:603
+#: docking/ui/settings.py:628
 msgid "Anchor Applets to End"
 msgstr ""
 
-#: docking/ui/settings.py:605
+#: docking/ui/settings.py:630
 msgid "Keep applets grouped at the end of the dock."
 msgstr ""
 
-#: docking/ui/settings.py:608
+#: docking/ui/settings.py:633
 msgid "Anchor Files to End"
 msgstr ""
 
-#: docking/ui/settings.py:610
+#: docking/ui/settings.py:635
 msgid "Keep pinned files and folders grouped at the end of the dock."
 msgstr ""
 
-#: docking/ui/settings.py:649
+#: docking/ui/settings.py:674
 msgid "Left Click"
 msgstr ""
 
-#: docking/ui/settings.py:652
+#: docking/ui/settings.py:677
 msgid ""
 "Choose what happens when clicking a running app with the left mouse button."
 msgstr ""
 
-#: docking/ui/settings.py:657
+#: docking/ui/settings.py:682
 msgid "Middle Click"
 msgstr ""
 
-#: docking/ui/settings.py:660
+#: docking/ui/settings.py:685
 msgid "Choose what happens when clicking an app with the middle mouse button."
 msgstr ""
 
-#: docking/ui/settings.py:665
+#: docking/ui/settings.py:690
 msgid "Window List Sort"
 msgstr ""
 
-#: docking/ui/settings.py:667
+#: docking/ui/settings.py:692
 msgid "Choose how open windows are ordered in app context menus."
 msgstr ""
 
-#: docking/ui/settings.py:675
+#: docking/ui/settings.py:700
 msgid "Hide Mode"
 msgstr ""
 
-#: docking/ui/settings.py:677
+#: docking/ui/settings.py:702
 msgid "Hide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:680
+#: docking/ui/settings.py:705
 msgid "Set how long the dock waits before hiding after the pointer leaves."
 msgstr ""
 
-#: docking/ui/settings.py:685
+#: docking/ui/settings.py:710
 msgid "Unhide Delay"
 msgstr ""
 
-#: docking/ui/settings.py:688
+#: docking/ui/settings.py:713
 msgid "Set how long the dock waits before showing after the pointer returns."
 msgstr ""
 
-#: docking/ui/settings.py:693
+#: docking/ui/settings.py:718
 msgid "Pressure Reveal"
 msgstr ""
 
-#: docking/ui/settings.py:696
+#: docking/ui/settings.py:721
 msgid ""
 "Require the pointer to push against the screen edge before revealing a "
 "hidden dock."
 msgstr ""
 
-#: docking/ui/settings.py:700
+#: docking/ui/settings.py:725
 msgid "Pressure Threshold"
 msgstr ""
 
-#: docking/ui/settings.py:702
+#: docking/ui/settings.py:727
 msgid "Show Startup Tips"
 msgstr ""
 
-#: docking/ui/settings.py:705
+#: docking/ui/settings.py:730
 msgid ""
 "Show one Docking usage tip after startup, unless a higher-priority startup "
 "notification is visible."
 msgstr ""
 
-#: docking/ui/settings.py:713
+#: docking/ui/settings.py:738
 msgid "Stacks"
 msgstr ""
 
-#: docking/ui/settings.py:716
+#: docking/ui/settings.py:741
 msgid "Open On"
 msgstr ""
 
-#: docking/ui/settings.py:718
+#: docking/ui/settings.py:743
 msgid "Choose whether stacks open on click or while hovering."
 msgstr ""
 
-#: docking/ui/settings.py:724
+#: docking/ui/settings.py:749
 msgid "Recent Apps"
 msgstr ""
 
-#: docking/ui/settings.py:727
+#: docking/ui/settings.py:752
 msgid "Show Recently Used Apps"
 msgstr ""
 
-#: docking/ui/settings.py:730
+#: docking/ui/settings.py:755
 msgid "Show recently closed apps between pinned launchers and running apps."
 msgstr ""
 
-#: docking/ui/settings.py:735
+#: docking/ui/settings.py:760
 msgid "Number of Recent Apps"
 msgstr ""
 
-#: docking/ui/settings.py:737
+#: docking/ui/settings.py:762
 msgid "Maximum recently used app icons to display."
 msgstr ""
 
-#: docking/ui/settings.py:740
+#: docking/ui/settings.py:765
 msgid "Keep Recent Apps For"
 msgstr ""
 
-#: docking/ui/settings.py:742
+#: docking/ui/settings.py:767
 msgid "Remove recent apps after this many days of inactivity."
 msgstr ""
 
-#: docking/ui/settings.py:751
+#: docking/ui/settings.py:776
 msgid "Show Recent Documents"
 msgstr ""
 
-#: docking/ui/settings.py:754
+#: docking/ui/settings.py:779
 msgid "Show a \"Recent Documents\" submenu when right-clicking an app icon."
 msgstr ""
 
-#: docking/ui/settings.py:759
+#: docking/ui/settings.py:784
 msgid "Max Documents Per App"
 msgstr ""
 
-#: docking/ui/settings.py:761
+#: docking/ui/settings.py:786
 msgid "Maximum recent document entries shown per app."
 msgstr ""
 
-#: docking/ui/settings.py:833
+#: docking/ui/settings.py:858
 msgid "Check Now"
 msgstr ""
 
-#: docking/ui/settings.py:835
+#: docking/ui/settings.py:860
 msgid "View Releases"
 msgstr ""
 
-#: docking/ui/settings.py:847
+#: docking/ui/settings.py:872
 msgid "Update Checks"
 msgstr ""
 
-#: docking/ui/settings.py:849
+#: docking/ui/settings.py:874
 msgid "Check Automatically"
 msgstr ""
 
-#: docking/ui/settings.py:850
+#: docking/ui/settings.py:875
 msgid "Frequency"
 msgstr ""
 
-#: docking/ui/settings.py:851
+#: docking/ui/settings.py:876
 msgid "Status"
 msgstr ""
 
-#: docking/ui/settings.py:852
+#: docking/ui/settings.py:877
 msgid "Actions"
 msgstr ""
 
-#: docking/ui/settings.py:1303
+#: docking/ui/settings.py:1338
 msgid "Primary Display"
 msgstr ""
 
-#: docking/ui/settings.py:1444
+#: docking/ui/settings.py:1479
 #, python-brace-format
 msgid "Last seen version: {version}"
 msgstr ""
 
-#: docking/ui/settings.py:1448
+#: docking/ui/settings.py:1483
 msgid "No update found yet"
 msgstr ""
 
-#: docking/ui/settings.py:1450
+#: docking/ui/settings.py:1485
 msgid "Not checked yet"
 msgstr ""
 
-#: docking/ui/settings.py:1531
+#: docking/ui/settings.py:1566
 msgid "The dock is always visible and reserves screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1533
+#: docking/ui/settings.py:1568
 msgid ""
 "Always visible and floats above all windows without reserving screen space."
 msgstr ""
 
-#: docking/ui/settings.py:1536
+#: docking/ui/settings.py:1571
 msgid "Hides when the mouse cursor leaves the dock."
 msgstr ""
 
-#: docking/ui/settings.py:1538
+#: docking/ui/settings.py:1573
 msgid ""
 "Hides when a window from the focused application overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1540
+#: docking/ui/settings.py:1575
 msgid "Hides when the focused window overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1542
+#: docking/ui/settings.py:1577
 msgid "Hides when any window on the current workspace overlaps the dock area."
 msgstr ""
 
-#: docking/ui/settings.py:1545
+#: docking/ui/settings.py:1580
 msgid ""
 "Hides when the focused window is maximized or a dialog overlaps the dock."
 msgstr ""

--- a/docking/platform/model.py
+++ b/docking/platform/model.py
@@ -205,6 +205,23 @@ class LauncherEntryState:
         )
 
 
+def launcher_state_shows_effective_overlay(
+    *,
+    state: LauncherEntryState,
+    config: Config,
+) -> bool:
+    """Whether publisher state should currently create a visible dock item."""
+    return (
+        state.urgent
+        or (config.show_launcher_progress and state.progress_visible)
+        or (
+            config.show_launcher_badges
+            and state.badge_visible
+            and state.badge_count > 0
+        )
+    )
+
+
 class DockModel:
     """Ordered collection of dock items, merging pinned and running apps."""
 
@@ -578,9 +595,15 @@ class DockModel:
         self, *, item: DockItem, state: LauncherEntryState
     ) -> None:
         item.badge_count = state.badge_count
-        item.badge_visible = state.badge_visible
+        item.badge_visible = (
+            self._config.show_launcher_badges
+            and state.badge_visible
+            and state.badge_count > 0
+        )
         item.progress = clamp(state.progress, 0.0, 1.0)
-        item.progress_visible = state.progress_visible
+        item.progress_visible = (
+            self._config.show_launcher_progress and state.progress_visible
+        )
         item.launcher_entry_urgent = state.urgent
         self._recompute_urgent(item=item)
 
@@ -628,6 +651,7 @@ class DockModel:
         create_transient: bool = False,
     ) -> bool:
         """Apply LauncherEntry state to a visible item or create a transient one."""
+        self._launcher_entries.pop(sender_name, None)
         self._launcher_entries[sender_name] = state
         item = self._find_launcher_target(
             sender_name=sender_name,
@@ -637,7 +661,10 @@ class DockModel:
             item is None
             and create_transient
             and state.desktop_id
-            and state.shows_overlay
+            and launcher_state_shows_effective_overlay(
+                state=state,
+                config=self._config,
+            )
         ):
             item = self.find_by_desktop_id(desktop_id=state.desktop_id)
             if item is None:
@@ -657,10 +684,81 @@ class DockModel:
 
         self._launcher_item_by_sender[sender_name] = item.desktop_id
         self._apply_launcher_state(item=item, state=state)
-        if item in self._transient and not item.is_running and not state.shows_overlay:
+        if (
+            item in self._transient
+            and not item.is_running
+            and not launcher_state_shows_effective_overlay(
+                state=state,
+                config=self._config,
+            )
+        ):
             self._drop_transient(item=item)
         self.notify()
         return True
+
+    def refresh_launcher_overlay_visibility(self) -> None:
+        """Reapply cached publisher state after an overlay preference changes.
+
+        LauncherEntry state is retained even while hidden so re-enabling a
+        preference restores an active overlay without waiting for another
+        D-Bus signal. Rebuilding launcher-only transients here also prevents
+        hidden badge/progress state from leaving unexplained icons in the dock.
+        """
+        existing_transient = {
+            item.desktop_id: item for item in self._transient if item.kind == APP_KIND
+        }
+        self._transient = [item for item in self._transient if item.is_running]
+
+        stable_items = self.pinned_items + self._recent_apps + self._transient
+        items_by_desktop_id = {
+            item.desktop_id: item for item in stable_items if item.kind == APP_KIND
+        }
+        for item in items_by_desktop_id.values():
+            self._clear_launcher_state(item)
+            self._recompute_urgent(item=item)
+
+        for sender_name, state in self._launcher_entries.items():
+            desktop_id = state.desktop_id or self._launcher_item_by_sender.get(
+                sender_name
+            )
+            item = items_by_desktop_id.get(desktop_id) if desktop_id else None
+            if (
+                item is None
+                and desktop_id
+                and launcher_state_shows_effective_overlay(
+                    state=state,
+                    config=self._config,
+                )
+            ):
+                item = existing_transient.get(desktop_id)
+                if item is None:
+                    resolved = self._launcher.resolve(
+                        desktop_id=desktop_id,
+                        log_failures=False,
+                    )
+                    if resolved is not None:
+                        item = self._make_app_item(
+                            desktop_id=desktop_id,
+                            is_pinned=False,
+                            running_info=None,
+                        )
+                if item is not None:
+                    item.is_pinned = False
+                    item.is_running = False
+                    item.is_active = False
+                    item.instance_count = 0
+                    item.window_urgent = False
+                    self._transient.append(item)
+                    items_by_desktop_id[desktop_id] = item
+
+            if item is None:
+                if desktop_id is None:
+                    self._launcher_item_by_sender.pop(sender_name, None)
+                continue
+            self._launcher_item_by_sender[sender_name] = item.desktop_id
+            self._apply_launcher_state(item=item, state=state)
+
+        self.notify()
 
     def remove_launcher_entry(self, *, sender_name: str) -> None:
         """Clear LauncherEntry state for a vanished sender."""
@@ -1134,7 +1232,10 @@ class DockModel:
         items_by_desktop_id: dict[str, DockItem],
     ) -> DockItem | None:
         """Return or create a transient item that only has launcher overlay state."""
-        if not state.desktop_id or not state.shows_overlay:
+        if not state.desktop_id or not launcher_state_shows_effective_overlay(
+            state=state,
+            config=self._config,
+        ):
             return None
         if state.desktop_id in items_by_desktop_id:
             return items_by_desktop_id[state.desktop_id]

--- a/docking/ui/factory.py
+++ b/docking/ui/factory.py
@@ -146,6 +146,7 @@ def build_dock_window(
     settings_actions = SettingsActions(
         runtime=runtime,
         dnd=dnd,
+        model=model,
     )
     settings = SettingsWindowController(
         parent=window,

--- a/docking/ui/renderer.py
+++ b/docking/ui/renderer.py
@@ -1083,7 +1083,11 @@ class DockRenderer:
                 bounce=bounce,
             )
 
-            if item.badge_visible and item.badge_count > 0:
+            if (
+                config.show_launcher_badges
+                and item.badge_visible
+                and item.badge_count > 0
+            ):
                 self._draw_badge(
                     cr=cr,
                     x=ix,
@@ -1091,7 +1095,7 @@ class DockRenderer:
                     size=scaled_size,
                     badge_count=item.badge_count,
                 )
-            if item.progress_visible:
+            if config.show_launcher_progress and item.progress_visible:
                 self._draw_progress(
                     cr=cr,
                     x=ix,

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -152,9 +152,11 @@ class SettingsActions:
         *,
         runtime: DockRuntime,
         dnd: DnDHandler,
+        model: DockModel,
     ) -> None:
         self._runtime = runtime
         self._dnd = dnd
+        self._model = model
 
     def on_hide_mode_changed(self) -> None:
         self._runtime.on_hide_mode_changed()
@@ -179,6 +181,9 @@ class SettingsActions:
 
     def queue_draw(self) -> None:
         self._runtime.queue_draw()
+
+    def refresh_launcher_overlay_visibility(self) -> None:
+        self._model.refresh_launcher_overlay_visibility()
 
     def set_current_workspace_only(self, enabled: bool) -> None:
         self._runtime.set_current_workspace_only(enabled)
@@ -221,6 +226,8 @@ class SettingsWindowController:
         self._stack_unfold_combo: Any = None
         self._window_list_sort_combo: Any = None
         self._window_count_numbers_switch: Any = None
+        self._launcher_badges_switch: Any = None
+        self._launcher_progress_switch: Any = None
         self._previews_switch: Any = None
         self._tooltips_switch: Any = None
         self._lock_icons_switch: Any = None
@@ -368,6 +375,8 @@ class SettingsWindowController:
         self._previews_switch = self._new_switch()
         self._tooltips_switch = self._new_switch()
         self._window_count_numbers_switch = self._new_switch()
+        self._launcher_badges_switch = self._new_switch()
+        self._launcher_progress_switch = self._new_switch()
         self._lock_icons_switch = self._new_switch()
         self._workspace_only_switch = self._new_switch()
         self._active_display_switch = self._new_switch()
@@ -548,6 +557,22 @@ class SettingsWindowController:
                     _(
                         "Show a number on running app indicators when multiple "
                         "windows are open."
+                    ),
+                ),
+                (
+                    _("Application Badges"),
+                    self._launcher_badges_switch,
+                    _(
+                        "Show numeric counts reported by applications on their "
+                        "dock icons."
+                    ),
+                ),
+                (
+                    _("Application Progress"),
+                    self._launcher_progress_switch,
+                    _(
+                        "Show task progress reported by applications on their "
+                        "dock icons."
                     ),
                 ),
             ],
@@ -1039,6 +1064,16 @@ class SettingsWindowController:
                 config_attr="show_window_count_numbers",
                 widget=self._window_count_numbers_switch,
                 on_change=self._actions.queue_draw,
+            ),
+            self._register_switch_binding(
+                config_attr="show_launcher_badges",
+                widget=self._launcher_badges_switch,
+                on_change=self._actions.refresh_launcher_overlay_visibility,
+            ),
+            self._register_switch_binding(
+                config_attr="show_launcher_progress",
+                widget=self._launcher_progress_switch,
+                on_change=self._actions.refresh_launcher_overlay_visibility,
             ),
             self._register_switch_binding(
                 config_attr="previews_enabled",

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -41,6 +41,8 @@ class TestConfigDefaults:
         assert c.stack_unfold == "hover"
         assert c.window_list_sort == "default"
         assert c.show_window_count_numbers is False
+        assert c.show_launcher_badges is True
+        assert c.show_launcher_progress is True
         assert c.theme == "default"
         assert c.transparency == 1.0
         assert isinstance(c.pinned, list)
@@ -85,6 +87,8 @@ class TestConfigDefaults:
             update_check_interval_hours="bad",
             startup_tips_enabled="off",
             show_window_count_numbers="on",
+            show_launcher_badges="off",
+            show_launcher_progress=0,
             theme="",
         )
 
@@ -104,6 +108,8 @@ class TestConfigDefaults:
         assert c.update_check_interval_hours == 24
         assert c.startup_tips_enabled is False
         assert c.show_window_count_numbers is True
+        assert c.show_launcher_badges is False
+        assert c.show_launcher_progress is False
         assert c.theme == "default"
 
 
@@ -267,6 +273,8 @@ class TestConfigLoad:
                     "folder_stack_unfold": "hover",
                     "window_list_sort": "alphabetical",
                     "show_window_count_numbers": "true",
+                    "show_launcher_badges": "false",
+                    "show_launcher_progress": "no",
                 }
             )
         )
@@ -282,6 +290,8 @@ class TestConfigLoad:
         assert config.stack_unfold == "hover"
         assert config.window_list_sort == "alphabetical"
         assert config.show_window_count_numbers is True
+        assert config.show_launcher_badges is False
+        assert config.show_launcher_progress is False
 
     def test_load_clamps_transparency_to_minimum(self, tmp_path):
         path = tmp_path / "dock.json"
@@ -531,6 +541,19 @@ class TestConfigSave:
 
         saved = json.loads(path.read_text())
         assert saved["show_window_count_numbers"] is True
+
+    def test_save_persists_launcher_overlay_preferences(self, tmp_path):
+        path = tmp_path / "dock.json"
+        config = Config(
+            show_launcher_badges=False,
+            show_launcher_progress=False,
+        )
+
+        config.save(path)
+
+        saved = json.loads(path.read_text())
+        assert saved["show_launcher_badges"] is False
+        assert saved["show_launcher_progress"] is False
 
     def test_save_persists_transparency(self, tmp_path):
         path = tmp_path / "dock.json"

--- a/tests/platform/test_model.py
+++ b/tests/platform/test_model.py
@@ -51,6 +51,8 @@ def _make_config(pinned: list[str], *, show_recent_apps: bool = False):
     config.anchor_applets = False
     config.anchor_files = False
     config.item_prefs = {}
+    config.show_launcher_badges = True
+    config.show_launcher_progress = True
     config.show_recent_apps = show_recent_apps
     config.recent_apps_max = 5
     config.recent_apps_retention_days = 14
@@ -878,6 +880,212 @@ class TestLauncherEntryState:
         assert item.badge_visible is True
         assert item.progress == 0.6
         assert item.progress_visible is True
+        assert item.launcher_entry_urgent is True
+        assert item.is_urgent is True
+
+    def test_hidden_badge_retains_count_on_existing_item(self):
+        config = _make_config(["a.desktop"])
+        config.show_launcher_badges = False
+        launcher = _make_launcher("a.desktop")
+        model = DockModel(config, launcher, AppletServices())
+
+        model.apply_launcher_entry(
+            sender_name=":1.7",
+            app_uri="application://a.desktop",
+            state=LauncherEntryState(
+                sender_name=":1.7",
+                app_uri="application://a.desktop",
+                desktop_id="a.desktop",
+                badge_count=4,
+                badge_visible=True,
+            ),
+        )
+
+        item = model.visible_items()[0]
+        assert item.badge_count == 4
+        assert item.badge_visible is False
+
+    def test_hidden_progress_retains_value_on_existing_item(self):
+        config = _make_config(["a.desktop"])
+        config.show_launcher_progress = False
+        launcher = _make_launcher("a.desktop")
+        model = DockModel(config, launcher, AppletServices())
+
+        model.apply_launcher_entry(
+            sender_name=":1.7",
+            app_uri="application://a.desktop",
+            state=LauncherEntryState(
+                sender_name=":1.7",
+                app_uri="application://a.desktop",
+                desktop_id="a.desktop",
+                progress=0.6,
+                progress_visible=True,
+            ),
+        )
+
+        item = model.visible_items()[0]
+        assert item.progress == 0.6
+        assert item.progress_visible is False
+
+    def test_hidden_overlay_does_not_create_launcher_only_transient(self):
+        config = _make_config([])
+        config.show_launcher_badges = False
+        config.show_launcher_progress = False
+        launcher = _make_launcher("mail.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        state = LauncherEntryState(
+            sender_name=":1.9",
+            app_uri="application://mail.desktop",
+            desktop_id="mail.desktop",
+            badge_count=7,
+            badge_visible=True,
+            progress=0.5,
+            progress_visible=True,
+        )
+
+        applied = model.apply_launcher_entry(
+            sender_name=":1.9",
+            app_uri=state.app_uri,
+            state=state,
+            create_transient=True,
+        )
+
+        assert applied is False
+        assert model.visible_items() == []
+
+        config.show_launcher_badges = True
+        model.refresh_launcher_overlay_visibility()
+
+        items = model.visible_items()
+        assert len(items) == 1
+        assert items[0].desktop_id == "mail.desktop"
+        assert items[0].badge_count == 7
+        assert items[0].badge_visible is True
+        assert items[0].progress == 0.5
+        assert items[0].progress_visible is False
+
+    def test_zero_count_badge_does_not_create_launcher_only_transient(self):
+        config = _make_config([])
+        launcher = _make_launcher("mail.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        state = LauncherEntryState(
+            sender_name=":1.9",
+            app_uri="application://mail.desktop",
+            desktop_id="mail.desktop",
+            badge_count=0,
+            badge_visible=True,
+        )
+
+        applied = model.apply_launcher_entry(
+            sender_name=":1.9",
+            app_uri=state.app_uri,
+            state=state,
+            create_transient=True,
+        )
+
+        assert applied is False
+        assert model.visible_items() == []
+
+    def test_refresh_hides_transient_and_reenabling_restores_cached_state(self):
+        config = _make_config([])
+        launcher = _make_launcher("mail.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        state = LauncherEntryState(
+            sender_name=":1.9",
+            app_uri="application://mail.desktop",
+            desktop_id="mail.desktop",
+            badge_count=7,
+            badge_visible=True,
+        )
+        model.apply_launcher_entry(
+            sender_name=":1.9",
+            app_uri=state.app_uri,
+            state=state,
+            create_transient=True,
+        )
+
+        config.show_launcher_badges = False
+        model.refresh_launcher_overlay_visibility()
+
+        assert model.visible_items() == []
+
+        config.show_launcher_badges = True
+        model.refresh_launcher_overlay_visibility()
+
+        items = model.visible_items()
+        assert len(items) == 1
+        assert items[0].desktop_id == "mail.desktop"
+        assert items[0].badge_count == 7
+        assert items[0].badge_visible is True
+
+    def test_refresh_keeps_urgent_transient_when_visual_overlays_are_hidden(self):
+        config = _make_config([])
+        launcher = _make_launcher("mail.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        state = LauncherEntryState(
+            sender_name=":1.9",
+            app_uri="application://mail.desktop",
+            desktop_id="mail.desktop",
+            badge_count=7,
+            badge_visible=True,
+            urgent=True,
+        )
+        model.apply_launcher_entry(
+            sender_name=":1.9",
+            app_uri=state.app_uri,
+            state=state,
+            create_transient=True,
+        )
+
+        config.show_launcher_badges = False
+        config.show_launcher_progress = False
+        model.refresh_launcher_overlay_visibility()
+
+        items = model.visible_items()
+        assert len(items) == 1
+        assert items[0].badge_visible is False
+        assert items[0].launcher_entry_urgent is True
+        assert items[0].is_urgent is True
+
+    def test_refresh_preserves_latest_sender_urgency(self):
+        config = _make_config(["a.desktop"])
+        launcher = _make_launcher("a.desktop")
+        model = DockModel(config, launcher, AppletServices())
+        urgent_state = LauncherEntryState(
+            sender_name=":1.7",
+            app_uri="application://a.desktop",
+            desktop_id="a.desktop",
+            urgent=True,
+        )
+        badge_state = LauncherEntryState(
+            sender_name=":1.8",
+            app_uri="application://a.desktop",
+            desktop_id="a.desktop",
+            badge_count=4,
+            badge_visible=True,
+        )
+        model.apply_launcher_entry(
+            sender_name=urgent_state.sender_name,
+            app_uri=urgent_state.app_uri,
+            state=urgent_state,
+        )
+        model.apply_launcher_entry(
+            sender_name=badge_state.sender_name,
+            app_uri=badge_state.app_uri,
+            state=badge_state,
+        )
+        model.apply_launcher_entry(
+            sender_name=urgent_state.sender_name,
+            app_uri=urgent_state.app_uri,
+            state=urgent_state,
+        )
+        assert model.visible_items()[0].launcher_entry_urgent is True
+
+        config.show_launcher_badges = False
+        model.refresh_launcher_overlay_visibility()
+
+        item = model.visible_items()[0]
+        assert item.badge_visible is False
         assert item.launcher_entry_urgent is True
         assert item.is_urgent is True
 

--- a/tests/ui/test_active_glow.py
+++ b/tests/ui/test_active_glow.py
@@ -263,6 +263,8 @@ class TestActiveGlowTintAtCallSite:
             ).Position.BOTTOM,
             icon_size=48,
             show_window_count_numbers=False,
+            show_launcher_badges=True,
+            show_launcher_progress=True,
             additional_distance_from_edge=0,
         )
         renderer._draw_content(
@@ -320,6 +322,8 @@ class TestActiveGlowTintAtCallSite:
             ).Position.BOTTOM,
             icon_size=48,
             show_window_count_numbers=False,
+            show_launcher_badges=True,
+            show_launcher_progress=True,
             additional_distance_from_edge=0,
         )
         renderer._draw_content(
@@ -375,6 +379,8 @@ class TestActiveGlowTintAtCallSite:
             ).Position.BOTTOM,
             icon_size=48,
             show_window_count_numbers=False,
+            show_launcher_badges=True,
+            show_launcher_progress=True,
             additional_distance_from_edge=0,
         )
         renderer._draw_content(

--- a/tests/ui/test_factory.py
+++ b/tests/ui/test_factory.py
@@ -187,6 +187,7 @@ class TestBuildDockWindow:
         factory_mod.SettingsActions.assert_called_once_with(
             runtime=components.runtime,
             dnd=components.dnd,
+            model=model,
         )
         factory_mod.SettingsWindowController.assert_called_once_with(
             parent=window,

--- a/tests/ui/test_renderer_integration.py
+++ b/tests/ui/test_renderer_integration.py
@@ -169,6 +169,8 @@ class TestRendererContentFlow:
             pos=Position.BOTTOM,
             icon_size=48,
             show_window_count_numbers=False,
+            show_launcher_badges=True,
+            show_launcher_progress=True,
             additional_distance_from_edge=0,
         )
         i1 = DockItem(
@@ -235,6 +237,8 @@ class TestRendererContentFlow:
             pos=Position.BOTTOM,
             icon_size=48,
             show_window_count_numbers=False,
+            show_launcher_badges=True,
+            show_launcher_progress=True,
             additional_distance_from_edge=0,
         )
         item = DockItem(desktop_id="firefox.desktop", is_running=True)
@@ -297,6 +301,8 @@ class TestRendererContentFlow:
             pos=Position.BOTTOM,
             icon_size=48,
             show_window_count_numbers=False,
+            show_launcher_badges=True,
+            show_launcher_progress=True,
             additional_distance_from_edge=0,
         )
         item = DockItem(
@@ -334,6 +340,67 @@ class TestRendererContentFlow:
         renderer._draw_badge.assert_called_once()
         renderer._draw_progress.assert_called_once()
 
+    @pytest.mark.parametrize(
+        ("show_badges", "show_progress", "badge_calls", "progress_calls"),
+        [
+            (False, True, 0, 1),
+            (True, False, 1, 0),
+            (False, False, 0, 0),
+        ],
+    )
+    def test_draw_content_respects_launcher_overlay_preferences(
+        self,
+        monkeypatch,
+        show_badges,
+        show_progress,
+        badge_calls,
+        progress_calls,
+    ):
+        renderer = renderer_mod.DockRenderer()
+        theme = Theme.load("default", 48)
+        config = SimpleNamespace(
+            pos=Position.BOTTOM,
+            icon_size=48,
+            show_window_count_numbers=False,
+            show_launcher_badges=show_badges,
+            show_launcher_progress=show_progress,
+            additional_distance_from_edge=0,
+        )
+        item = DockItem(
+            desktop_id="firefox.desktop",
+            is_running=True,
+            badge_count=5,
+            badge_visible=True,
+            progress=0.4,
+            progress_visible=True,
+        )
+        layout = [SimpleNamespace(x=0.0, scale=1.0, width=48.0)]
+
+        monkeypatch.setattr(
+            renderer_mod, "draw_shelf_background", lambda **kwargs: None
+        )
+        monkeypatch.setattr(renderer_mod.GLib, "get_monotonic_time", lambda: 100_000)
+        renderer._draw_icon = MagicMock()
+        renderer._draw_indicator = MagicMock()
+        renderer._draw_badge = MagicMock()
+        renderer._draw_progress = MagicMock()
+
+        renderer._draw_content(
+            cr=_surface_context(),
+            frame=_frame([item], layout),
+            config=config,
+            theme=theme,
+            state=RenderState(
+                hide_offset=0.0,
+                drag_index=-1,
+                drop_insert_index=-1,
+                hovered_id="",
+            ),
+        )
+
+        assert renderer._draw_badge.call_count == badge_calls
+        assert renderer._draw_progress.call_count == progress_calls
+
     def test_draw_content_hides_shelf_when_dock_is_hidden_with_gap(self, monkeypatch):
         renderer = renderer_mod.DockRenderer()
         theme = replace(Theme.load("default", 48), distance_from_edge=6)
@@ -341,6 +408,8 @@ class TestRendererContentFlow:
             pos=Position.BOTTOM,
             icon_size=48,
             show_window_count_numbers=False,
+            show_launcher_badges=True,
+            show_launcher_progress=True,
             additional_distance_from_edge=0,
         )
         frame = build_geometry_frame(

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -667,6 +667,8 @@ def _config():
         stack_unfold="click",
         window_list_sort="default",
         show_window_count_numbers=False,
+        show_launcher_badges=True,
+        show_launcher_progress=True,
         lock_icons=False,
         current_workspace_only=False,
         active_display=False,
@@ -940,6 +942,8 @@ class TestSettingsWindowController:
             "Show Tooltips",
             "Window Previews",
             "Show Window Counts",
+            "Application Badges",
+            "Application Progress",
             "Position",
             "Follow Cursor",
             "Current Workspace Only",
@@ -1260,6 +1264,36 @@ class TestSettingsWindowController:
         assert config.show_window_count_numbers is True
         config.save.assert_called_once()
         runtime.queue_draw.assert_called_once()
+
+    def test_launcher_overlay_bindings_update_config_and_reconcile_model(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)
+        monkeypatch.setattr(
+            settings_mod,
+            "load_catalog_icon",
+            lambda applet_id, size: None,
+        )
+        monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        actions = MagicMock()
+        config = _config()
+        controller = settings_mod.SettingsWindowController(
+            parent=_parent_window(),
+            actions=actions,
+            model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
+            config=config,
+        )
+
+        controller.show()
+        controller._launcher_badges_switch.set_active(False)
+        controller._launcher_badges_switch.emit_notify_active()
+        controller._launcher_progress_switch.set_active(False)
+        controller._launcher_progress_switch.emit_notify_active()
+
+        assert config.show_launcher_badges is False
+        assert config.show_launcher_progress is False
+        assert config.save.call_count == 2
+        assert actions.refresh_launcher_overlay_visibility.call_count == 2
 
     def test_current_workspace_only_updates_surface_scope(self, monkeypatch):
         monkeypatch.setattr(settings_mod, "Gtk", FakeGtk)

--- a/tests/ui/test_settings_actions.py
+++ b/tests/ui/test_settings_actions.py
@@ -10,7 +10,7 @@ from docking.ui.settings import SettingsActions
 def test_settings_actions_delegate_dnd_locking_to_dnd_handler():
     runtime = MagicMock()
     dnd = MagicMock()
-    actions = SettingsActions(runtime=runtime, dnd=dnd)
+    actions = SettingsActions(runtime=runtime, dnd=dnd, model=MagicMock())
 
     actions.set_icons_locked(True)
 
@@ -21,7 +21,7 @@ def test_settings_actions_delegate_dnd_locking_to_dnd_handler():
 def test_settings_actions_delegate_shell_actions_to_runtime():
     runtime = MagicMock()
     dnd = MagicMock()
-    actions = SettingsActions(runtime=runtime, dnd=dnd)
+    actions = SettingsActions(runtime=runtime, dnd=dnd, model=MagicMock())
 
     actions.reposition()
     actions.queue_draw()
@@ -37,7 +37,7 @@ def test_settings_actions_delegate_shell_actions_to_runtime():
 def test_settings_actions_delegate_all_remaining_to_runtime():
     runtime = MagicMock()
     dnd = MagicMock()
-    actions = SettingsActions(runtime=runtime, dnd=dnd)
+    actions = SettingsActions(runtime=runtime, dnd=dnd, model=MagicMock())
 
     actions.on_hide_mode_changed()
     actions.set_active_display(True)
@@ -58,7 +58,7 @@ def test_settings_actions_get_monitor_choices():
     runtime = MagicMock()
     runtime.get_monitor_choices.return_value = ["mon1", "mon2"]
     dnd = MagicMock()
-    actions = SettingsActions(runtime=runtime, dnd=dnd)
+    actions = SettingsActions(runtime=runtime, dnd=dnd, model=MagicMock())
 
     result = actions.get_monitor_choices()
 
@@ -70,9 +70,20 @@ def test_settings_actions_current_monitor_choice():
     runtime = MagicMock()
     runtime.current_monitor_choice.return_value = 2
     dnd = MagicMock()
-    actions = SettingsActions(runtime=runtime, dnd=dnd)
+    actions = SettingsActions(runtime=runtime, dnd=dnd, model=MagicMock())
 
     result = actions.current_monitor_choice()
 
     assert result == 2
     runtime.current_monitor_choice.assert_called_once_with()
+
+
+def test_settings_actions_reconcile_launcher_overlay_visibility():
+    runtime = MagicMock()
+    dnd = MagicMock()
+    model = MagicMock()
+    actions = SettingsActions(runtime=runtime, dnd=dnd, model=model)
+
+    actions.refresh_launcher_overlay_visibility()
+
+    model.refresh_launcher_overlay_visibility.assert_called_once_with()

--- a/tests/visual/render_cases.py
+++ b/tests/visual/render_cases.py
@@ -91,6 +91,8 @@ def _renderer_config() -> SimpleNamespace:
         zoom_enabled=True,
         additional_distance_from_edge=0,
         show_window_count_numbers=False,
+        show_launcher_badges=True,
+        show_launcher_progress=True,
         applet_prefs={},
     )
 


### PR DESCRIPTION
## Summary

- add independent Appearance switches for application badges and progress indicators
- preserve existing behavior by default for new and existing configurations
- restore still-active overlays when re-enabled without leaving hidden-overlay icons in the dock