### PR TITLE
Keep tooltips behind open dock surfaces

### DIFF
--- a/docking/applets/alarm/applet.py
+++ b/docking/applets/alarm/applet.py
@@ -161,6 +161,7 @@ class AlarmApplet(Applet):
             modal=True,
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         add_cancel_ok_buttons(dialog=dialog, ok_label=_("OK"), cancel_label=_("Cancel"))
         if index is not None:
             dialog.add_button(_("Remove"), Gtk.ResponseType.REJECT)

--- a/docking/applets/applications/applet.py
+++ b/docking/applets/applications/applet.py
@@ -87,6 +87,7 @@ class ApplicationsApplet(Applet):
     def _build_launcher_menu(self) -> Gtk.Menu:
         """Build the categorized launcher menu lazily on each open."""
         menu = Gtk.Menu()
+        self.register_popup_surface(menu)
         categories = _build_app_categories()
         category_rows: list[tuple[Gtk.MenuItem, Gtk.Menu, list[ApplicationEntry]]] = []
 

--- a/docking/applets/base.py
+++ b/docking/applets/base.py
@@ -471,6 +471,12 @@ class Applet(ABC):
         """Update the dock icon anchor used by applet-owned popup surfaces."""
         self._popup_anchor = anchor
 
+    def register_popup_surface(self, surface: Gtk.Widget) -> None:
+        """Give an applet-owned dialog or menu priority over dock tooltips."""
+        anchor = self._popup_anchor
+        if anchor is not None and anchor.register_tooltip_blocker is not None:
+            anchor.register_tooltip_blocker(surface)
+
     def on_scroll(self, direction_up: bool) -> None:
         """Handle scroll wheel on applet icon (default: no-op)."""
         _ = direction_up

--- a/docking/applets/bookmarks/applet.py
+++ b/docking/applets/bookmarks/applet.py
@@ -112,6 +112,7 @@ class BookmarksApplet(Applet):
             modal=True,
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         add_cancel_ok_buttons(dialog=dialog)
         box = prepare_dialog_content(
             dialog=dialog,

--- a/docking/applets/certwatch/applet.py
+++ b/docking/applets/certwatch/applet.py
@@ -307,6 +307,7 @@ class CertwatchApplet(Applet):
             modal=True,
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         add_cancel_ok_buttons(dialog=dialog)
         box = prepare_dialog_content(
             dialog=dialog,

--- a/docking/applets/clock/applet.py
+++ b/docking/applets/clock/applet.py
@@ -228,6 +228,7 @@ class ClockApplet(Applet):
             modal=True,
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         add_cancel_ok_buttons(dialog=dialog, ok_label=_("OK"), cancel_label=_("Cancel"))
         content = prepare_dialog_content(
             dialog=dialog,

--- a/docking/applets/colorpicker/applet.py
+++ b/docking/applets/colorpicker/applet.py
@@ -131,6 +131,8 @@ class ColorPickerApplet(Applet):
             key_handler=self._on_overlay_key,
             cursor_type=Gdk.CursorType.CROSSHAIR,
         )
+        if self._overlay is not None:
+            self.register_popup_surface(self._overlay)
 
     @staticmethod
     def _on_overlay_draw(widget: Gtk.Window, cr) -> bool:

--- a/docking/applets/crypto/applet.py
+++ b/docking/applets/crypto/applet.py
@@ -402,6 +402,7 @@ class CryptoApplet(Applet):
             modal=True,
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         add_cancel_ok_buttons(dialog=dialog)
         box = prepare_dialog_content(
             dialog=dialog,

--- a/docking/applets/currencyfx/applet.py
+++ b/docking/applets/currencyfx/applet.py
@@ -492,6 +492,7 @@ class CurrencyFxApplet(Applet):
             modal=True,
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         add_cancel_ok_buttons(dialog=dialog)
         box = prepare_dialog_content(
             dialog=dialog,

--- a/docking/applets/lastfm/applet.py
+++ b/docking/applets/lastfm/applet.py
@@ -378,6 +378,7 @@ class LastfmApplet(Applet):
             modal=True,
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         dialog.add_button(_("Save"), Gtk.ResponseType.OK)
         dialog.set_default_response(Gtk.ResponseType.OK)

--- a/docking/applets/plantcare/applet.py
+++ b/docking/applets/plantcare/applet.py
@@ -241,6 +241,7 @@ class PlantCareApplet(Applet):
             title=_("Plant Care"),
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         dialog.add_button(_("Close"), Gtk.ResponseType.CLOSE)
         content = prepare_dialog_content(
             dialog=dialog,
@@ -468,6 +469,7 @@ class PlantCareApplet(Applet):
             modal=True,
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         add_cancel_ok_buttons(
             dialog=dialog,
             ok_label=_("Save"),

--- a/docking/applets/popup.py
+++ b/docking/applets/popup.py
@@ -52,6 +52,7 @@ class PopupAnchor:
     y: int
     position: Position
     parent: Gtk.Window | None = None
+    register_tooltip_blocker: Callable[[Gtk.Widget], None] | None = None
 
 
 def entry_completion_combo(
@@ -149,6 +150,8 @@ def show_wrapped_popup(
     anchor: PopupAnchor | None = None,
 ) -> None:
     """Replace popup content, show it, and place it near the applet anchor."""
+    if anchor is not None and anchor.register_tooltip_blocker is not None:
+        anchor.register_tooltip_blocker(window)
     child = window.get_child()
     if child:
         window.remove(child)

--- a/docking/applets/quicknote/applet.py
+++ b/docking/applets/quicknote/applet.py
@@ -84,6 +84,7 @@ class QuickNoteApplet(Applet):
             modal=True,
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         dialog.add_button(_("OK"), Gtk.ResponseType.OK)
         box = prepare_dialog_content(

--- a/docking/applets/reddit/applet.py
+++ b/docking/applets/reddit/applet.py
@@ -429,6 +429,7 @@ class RedditApplet(Applet):
             modal=True,
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         add_cancel_ok_buttons(
             dialog=dialog,
             ok_label=_("Add"),

--- a/docking/applets/runcommand/applet.py
+++ b/docking/applets/runcommand/applet.py
@@ -127,6 +127,7 @@ class RunCommandApplet(Applet):
             title=_("Run Application"),
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         dialog.add_button(_("Help"), Gtk.ResponseType.HELP)
         dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         dialog.add_button(_("Run"), Gtk.ResponseType.OK)
@@ -270,6 +271,7 @@ class RunCommandApplet(Applet):
             buttons=Gtk.ButtonsType.OK,
             text=_("Run Application"),
         )
+        self.register_popup_surface(help_dialog)
         help_dialog.format_secondary_text(
             _("Type a command or select an application to launch it."),
         )
@@ -347,6 +349,7 @@ class RunCommandApplet(Applet):
             parent=parent,
             action=Gtk.FileChooserAction.OPEN,
         )
+        self.register_popup_surface(dialog)
         dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         dialog.add_button(_("Open"), Gtk.ResponseType.OK)
         response = dialog.run()

--- a/docking/applets/sunrise/applet.py
+++ b/docking/applets/sunrise/applet.py
@@ -186,6 +186,7 @@ class SunriseApplet(Applet):
             modal=True,
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         dialog.connect("response", lambda dlg, _response: dlg.destroy())
         box = prepare_dialog_content(

--- a/docking/applets/systemtray/applet.py
+++ b/docking/applets/systemtray/applet.py
@@ -62,6 +62,7 @@ class SystemTrayApplet(Applet):
         self._legacy_host = XEmbedTrayHost(
             icon_size=min(32, max(22, icon_size)),
             on_changed=self._on_legacy_changed,
+            register_tooltip_blocker=self.register_popup_surface,
         )
         super().__init__(icon_size=icon_size, config=config)
         self.present()
@@ -290,6 +291,7 @@ class SystemTrayApplet(Applet):
             self._on_context_menu(identifier)
             return
 
+        self.register_popup_surface(menu)
         if self._popup is not None:
             self._popup.hide()
         self._item_menu = menu
@@ -354,6 +356,7 @@ class SystemTrayApplet(Applet):
             buttons=Gtk.ButtonsType.OK,
             text=_("Could not start the legacy tray"),
         )
+        self.register_popup_surface(dialog)
         dialog.format_secondary_text(message)
         dialog.run()
         dialog.destroy()
@@ -367,6 +370,7 @@ class SystemTrayApplet(Applet):
             buttons=Gtk.ButtonsType.CANCEL,
             text=_("Take over the legacy tray?"),
         )
+        self.register_popup_surface(dialog)
         dialog.add_button(_("Take Over"), Gtk.ResponseType.OK)
         dialog.format_secondary_text(
             _(

--- a/docking/applets/systemtray/xembed.py
+++ b/docking/applets/systemtray/xembed.py
@@ -126,9 +126,16 @@ class XEmbedTrayHost:
     behavior used by older docks such as Cairo-Dock.
     """
 
-    def __init__(self, *, icon_size: int, on_changed: Callable[[], None]) -> None:
+    def __init__(
+        self,
+        *,
+        icon_size: int,
+        on_changed: Callable[[], None],
+        register_tooltip_blocker: Callable[[Gtk.Widget], None] | None = None,
+    ) -> None:
         self._icon_size = max(16, icon_size)
         self._on_changed = on_changed
+        self._register_tooltip_blocker = register_tooltip_blocker
         self._xlib = _load_x11()
         self._gdk_lib = _load_gdk()
         self._display: int = 0
@@ -214,6 +221,8 @@ class XEmbedTrayHost:
             return False
 
         self._window = Gtk.Window(type=Gtk.WindowType.POPUP)
+        if self._register_tooltip_blocker is not None:
+            self._register_tooltip_blocker(self._window)
         self._window.set_decorated(False)
         self._window.set_resizable(False)
         self._window.set_skip_taskbar_hint(True)

--- a/docking/applets/trash/applet.py
+++ b/docking/applets/trash/applet.py
@@ -258,6 +258,7 @@ class TrashApplet(Applet):
             buttons=Gtk.ButtonsType.NONE,
             text=_("Empty all items from Trash?"),
         )
+        self.register_popup_surface(dialog)
         dialog.format_secondary_text(
             _("All items in the Trash will be permanently deleted."),
         )

--- a/docking/applets/unitconverter/applet.py
+++ b/docking/applets/unitconverter/applet.py
@@ -175,6 +175,7 @@ class UnitConverterApplet(Applet):
                 title=_("Unit Converter"),
                 destroy_with_parent=True,
             )
+            self.register_popup_surface(self._popup)
             self._popup.connect("delete-event", self._on_popup_delete)
 
         content = prepare_dialog_content(

--- a/docking/applets/urlshortener/applet.py
+++ b/docking/applets/urlshortener/applet.py
@@ -111,6 +111,7 @@ class UrlShortenerApplet(Applet):
             title=_("URL Shortener"),
             destroy_with_parent=True,
         )
+        self.register_popup_surface(self._dialog)
         box = prepare_dialog_content(
             dialog=self._dialog,
             width=DIALOG_WIDTH_PX,

--- a/docking/applets/weather/applet.py
+++ b/docking/applets/weather/applet.py
@@ -271,6 +271,7 @@ class WeatherApplet(Applet):
             modal=True,
             destroy_with_parent=True,
         )
+        self.register_popup_surface(dialog)
         dialog.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         dialog.connect("response", lambda dlg, _response: dlg.destroy())
         box = prepare_dialog_content(

--- a/docking/applets/windowkiller/applet.py
+++ b/docking/applets/windowkiller/applet.py
@@ -112,6 +112,8 @@ class WindowKillerApplet(Applet):
             key_handler=self._on_overlay_key,
             cursor_type=Gdk.CursorType.PIRATE,
         )
+        if self._overlay is not None:
+            self.register_popup_surface(self._overlay)
 
     @staticmethod
     def _on_overlay_draw(widget: Gtk.Window, cr) -> bool:

--- a/docking/ui/about.py
+++ b/docking/ui/about.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from pathlib import Path
@@ -43,8 +44,14 @@ log = get_logger("about")
 class AboutDialogController:
     """Owns About dialog lifecycle and single-instance behavior."""
 
-    def __init__(self, parent: Gtk.Window) -> None:
+    def __init__(
+        self,
+        parent: Gtk.Window,
+        *,
+        register_tooltip_blocker: Callable[[Gtk.Widget], None] | None = None,
+    ) -> None:
         self._parent = parent
+        self._register_tooltip_blocker = register_tooltip_blocker
         self._dialog: Gtk.AboutDialog | None = None
 
     def show(self) -> None:
@@ -58,6 +65,8 @@ class AboutDialogController:
             modal=True,
             destroy_with_parent=True,
         )
+        if self._register_tooltip_blocker is not None:
+            self._register_tooltip_blocker(dialog)
         dialog.set_program_name("Docking")
         dialog.set_version(self._project_version())
         dialog.set_comments(

--- a/docking/ui/diagnostics.py
+++ b/docking/ui/diagnostics.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import gi
@@ -48,9 +49,16 @@ log = get_logger("diagnostics")
 class DiagnosticsDialogController:
     """Owns the runtime diagnostics window lifecycle."""
 
-    def __init__(self, *, parent: Gtk.Window, backend: object) -> None:
+    def __init__(
+        self,
+        *,
+        parent: Gtk.Window,
+        backend: object,
+        register_tooltip_blocker: Callable[[Gtk.Widget], None] | None = None,
+    ) -> None:
         self._parent = parent
         self._backend = backend
+        self._register_tooltip_blocker = register_tooltip_blocker
         self._window: Gtk.Window | None = None
         self._snapshot: DiagnosticsSnapshot | None = None
 
@@ -72,6 +80,8 @@ class DiagnosticsDialogController:
             transient_for=self._parent,
             destroy_with_parent=True,
         )
+        if self._register_tooltip_blocker is not None:
+            self._register_tooltip_blocker(window)
         window.set_default_size(
             DIAGNOSTICS_WINDOW_WIDTH_PX,
             DIAGNOSTICS_WINDOW_HEIGHT_PX,
@@ -369,6 +379,8 @@ class DiagnosticsDialogController:
             buttons=Gtk.ButtonsType.CLOSE,
             text=text,
         )
+        if self._register_tooltip_blocker is not None:
+            self._register_tooltip_blocker(dialog)
         dialog.run()
         dialog.destroy()
 

--- a/docking/ui/dnd.py
+++ b/docking/ui/dnd.py
@@ -832,6 +832,7 @@ class DnDHandler:
             buttons=Gtk.ButtonsType.CANCEL,
             text="Make AppImage executable and pin it?",
         )
+        self._window.tooltip.register_blocking_surface(dialog)
         dialog.format_secondary_text(
             f"{path.name} is an AppImage, but it is not executable yet. "
             "Docking can mark it executable so it can be pinned and launched."

--- a/docking/ui/dock_window.py
+++ b/docking/ui/dock_window.py
@@ -599,6 +599,7 @@ class DockWindow(Gtk.Window):
             y=anchor_y,
             position=self.config.pos,
             parent=self,
+            register_tooltip_blocker=self.tooltip.register_blocking_surface,
         )
 
     def update_input_region(self, frame: DockGeometryFrame | None = None) -> None:

--- a/docking/ui/factory.py
+++ b/docking/ui/factory.py
@@ -119,12 +119,20 @@ def build_dock_window(
         surface_service=surface_service,
         session_backend=session_backend,
     )
-    update_checker = UpdateCheckController(window=window, config=config)
+    update_checker = UpdateCheckController(
+        window=window,
+        config=config,
+        register_tooltip_blocker=window.tooltip.register_blocking_surface,
+    )
     runtime = DockRuntime(window, update_checker=update_checker)
-    about = AboutDialogController(parent=window)
+    about = AboutDialogController(
+        parent=window,
+        register_tooltip_blocker=runtime.register_tooltip_blocker,
+    )
     diagnostics = DiagnosticsDialogController(
         parent=window,
         backend=session_backend,
+        register_tooltip_blocker=runtime.register_tooltip_blocker,
     )
     folder_stack = FolderStackController(
         config=config,
@@ -153,6 +161,7 @@ def build_dock_window(
         actions=settings_actions,
         model=model,
         config=config,
+        register_tooltip_blocker=runtime.register_tooltip_blocker,
     )
     menu = MenuHandler(
         about=about,
@@ -177,10 +186,14 @@ def build_dock_window(
         dnd=dnd,
     )
     startup_popups = StartupPopupCoordinator()
-    new_year = NewYearGreetingController(window=window)
+    new_year = NewYearGreetingController(
+        window=window,
+        register_tooltip_blocker=runtime.register_tooltip_blocker,
+    )
     startup_tips = StartupTipsController(
         window=window,
         config=config,
+        register_tooltip_blocker=runtime.register_tooltip_blocker,
     )
     startup_popups.register(new_year)
     startup_popups.register(update_checker)

--- a/docking/ui/input_controller.py
+++ b/docking/ui/input_controller.py
@@ -394,6 +394,11 @@ class DockInputController:
                 cursor_x=event.x,
                 cursor_y=event.y,
             )
+            item = None if force_background else frame.item_at_point(event.x, event.y)
+            if item is not None and is_applet(desktop_id=item.desktop_id):
+                applet = window.model.get_applet(item.desktop_id)
+                if applet is not None:
+                    applet.set_popup_anchor(window.popup_anchor_for_item(item, frame))
             self._interactions.show_context_menu(
                 event=event,
                 cursor_main=cursor_main,

--- a/docking/ui/menu.py
+++ b/docking/ui/menu.py
@@ -361,6 +361,7 @@ class MenuHandler:
 
     def _new_popup_menu(self) -> Gtk.Menu:
         menu = Gtk.Menu()
+        self._runtime.register_tooltip_blocker(menu)
         self._runtime.menu_popup_opened()
         menu.connect("hide", self._on_menu_popup_closed)
         menu.connect("deactivate", self._on_menu_popup_closed)
@@ -437,6 +438,7 @@ class MenuHandler:
             transient_for=self._dock_window,
             action=Gtk.FileChooserAction.OPEN,
         )
+        self._runtime.register_tooltip_blocker(dialog)
         dialog.add_buttons(
             _("Cancel"),
             Gtk.ResponseType.CANCEL,
@@ -471,6 +473,7 @@ class MenuHandler:
             buttons=Gtk.ButtonsType.CLOSE,
             text=_("Could not use selected icon"),
         )
+        self._runtime.register_tooltip_blocker(dialog)
         dialog.format_secondary_text(str(path))
         try:
             dialog.run()

--- a/docking/ui/new_year.py
+++ b/docking/ui/new_year.py
@@ -72,10 +72,12 @@ class NewYearGreetingController:
         window: Gtk.Window,
         state_path: Path | str | None = None,
         now_fn: Callable[[], datetime] | None = None,
+        register_tooltip_blocker: Callable[[Gtk.Widget], None] | None = None,
     ) -> None:
         self._window = window
         self._state_path = Path(state_path) if state_path else None
         self._now_fn = now_fn or datetime.now
+        self._register_tooltip_blocker = register_tooltip_blocker
         self._start_source_id: int = 0
         self._hide_source_id: int = 0
         self._popup: Gtk.Window | None = None
@@ -146,6 +148,8 @@ class NewYearGreetingController:
 
         if self._popup is None:
             popup = Gtk.Window(type=Gtk.WindowType.POPUP)
+            if self._register_tooltip_blocker is not None:
+                self._register_tooltip_blocker(popup)
             popup.set_decorated(False)
             popup.set_skip_taskbar_hint(True)
             popup.set_resizable(False)

--- a/docking/ui/runtime.py
+++ b/docking/ui/runtime.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from gi.repository import Gtk
+
     from docking.core.theme import Theme
     from docking.ui.dock_window import DockWindow
     from docking.ui.placement import MonitorChoice
@@ -90,11 +92,8 @@ class DockRuntime:
     def hide_tooltip(self) -> None:
         self._window.tooltip.hide()
 
-    def suppress_tooltip(self) -> None:
-        self._window.tooltip.set_suppressed(True)
-
-    def resume_tooltip(self) -> None:
-        self._window.tooltip.set_suppressed(False)
+    def register_tooltip_blocker(self, surface: Gtk.Widget) -> None:
+        self._window.tooltip.register_blocking_surface(surface)
 
     def hide_hover_ui(self) -> None:
         self._window.tooltip.hide()

--- a/docking/ui/settings.py
+++ b/docking/ui/settings.py
@@ -211,11 +211,13 @@ class SettingsWindowController:
         actions: SettingsActions,
         model: DockModel,
         config: Config,
+        register_tooltip_blocker: Callable[[Gtk.Widget], None] | None = None,
     ) -> None:
         self._parent = parent
         self._actions = actions
         self._model = model
         self._config = config
+        self._register_tooltip_blocker = register_tooltip_blocker
         self._window: Gtk.Window | None = None
         self._syncing_widgets = False
 
@@ -278,6 +280,8 @@ class SettingsWindowController:
             transient_for=self._parent,
             destroy_with_parent=True,
         )
+        if self._register_tooltip_blocker is not None:
+            self._register_tooltip_blocker(window)
         window.set_default_size(
             PREFERENCES_WINDOW_WIDTH_PX,
             self._preferences_default_height(),

--- a/docking/ui/stack.py
+++ b/docking/ui/stack.py
@@ -344,7 +344,6 @@ class StackPopupController:
 
         self._close_stack()
         self._runtime.hide_hover_ui()
-        self._runtime.suppress_tooltip()
         self._runtime.menu_popup_opened()
 
         window = self._ensure_stack_window()
@@ -432,7 +431,6 @@ class StackPopupController:
             revealer.set_reveal_child(False)
         window.hide()
         self._cleanup_stack()
-        self._runtime.resume_tooltip()
         self._runtime.menu_popup_closed()
 
     def _cleanup_stack(self) -> None:
@@ -461,6 +459,7 @@ class StackPopupController:
             return self._folder_stack_window
 
         window = Gtk.Window(type=Gtk.WindowType.POPUP)
+        self._runtime.register_tooltip_blocker(window)
         window.set_decorated(False)
         window.set_skip_taskbar_hint(True)
         window.set_resizable(False)

--- a/docking/ui/startup_tips.py
+++ b/docking/ui/startup_tips.py
@@ -78,11 +78,13 @@ class StartupTipsController:
         config: Config,
         state_path: Path | str | None = None,
         chooser: Callable[[Sequence[StartupTip]], StartupTip] | None = None,
+        register_tooltip_blocker: Callable[[Gtk.Widget], None] | None = None,
     ) -> None:
         self._window = window
         self._config = config
         self._state_path = Path(state_path) if state_path is not None else None
         self._chooser = chooser
+        self._register_tooltip_blocker = register_tooltip_blocker
         self._start_source_id = 0
         self._popup: Gtk.Window | None = None
         self._current_tip: StartupTip | None = None
@@ -143,6 +145,8 @@ class StartupTipsController:
         self._current_tip = tip
         if self._popup is None:
             popup = Gtk.Window(type=Gtk.WindowType.POPUP)
+            if self._register_tooltip_blocker is not None:
+                self._register_tooltip_blocker(popup)
             popup.set_decorated(False)
             popup.set_skip_taskbar_hint(True)
             popup.set_resizable(False)

--- a/docking/ui/tooltip.py
+++ b/docking/ui/tooltip.py
@@ -28,6 +28,7 @@ ordinary GTK widgets do not:
 - showing too early while the dock itself is still animating,
 - rebuilding too aggressively while the pointer churns across adjacent items,
 - staying visible after the dock has already hidden,
+- being remapped above a menu, stack, or dialog after dynamic content changes,
 - looking attached to the wrong icon because the hover changed faster than the
   popup content could be rebuilt.
 
@@ -42,7 +43,8 @@ TooltipManager owns:
 - tooltip text/widget content replacement,
 - tooltip positioning from item anchor points,
 - screen clamping,
-- hide/cancel logic.
+- hide/cancel logic,
+- the visible lifecycle of surfaces that take priority over tooltips.
 
 It does not own:
 
@@ -142,6 +144,18 @@ So the intended behavior is:
 That means this module must cooperate with hover/interaction policy rather than
 attempting to own dock visibility.
 
+Tooltip priority surfaces
+
+Menus, dialogs, stacks, and applet popups must always win over tooltips. Merely
+hiding the tooltip when one opens is insufficient: an applet such as Network
+can change its tooltip text later, causing the normal update path to map the
+tooltip again. Registered priority surfaces therefore remain in a mapped set
+from their GTK ``map`` signal through ``unmap`` or ``destroy``. Every tooltip
+update checks that set, and nested surfaces keep the tooltip blocked until the
+last one closes. Using the mapped lifecycle is important for ``Gtk.Menu``
+because ``show_all()`` prepares its widgets but ``popup_at_pointer()`` maps the
+actual menu surface.
+
 Why screen clamping belongs here
 
 The geometry frame gives the ideal anchor. But the tooltip is a real popup
@@ -164,6 +178,7 @@ from __future__ import annotations
 import datetime as dt
 import math
 from typing import TYPE_CHECKING
+from weakref import WeakSet
 
 import gi
 
@@ -309,17 +324,40 @@ class TooltipManager:
         self._last_item: DockItem | None = None
         self._last_name: str = ""
         self._pending_show_source: int = 0
-        self._suppressed = False
+        self._registered_blocking_surfaces: WeakSet[Gtk.Widget] = WeakSet()
+        self._mapped_blocking_surfaces: set[Gtk.Widget] = set()
 
     def set_theme(self, theme: Theme) -> None:
         """Update the theme used for tooltip spacing."""
         self._theme = theme
 
-    def set_suppressed(self, suppressed: bool) -> None:
-        """Prevent tooltip display while a higher-priority popup is visible."""
-        self._suppressed = suppressed
-        if suppressed:
-            self.hide()
+    def register_blocking_surface(self, surface: Gtk.Widget) -> None:
+        """Keep tooltips hidden for the mapped lifetime of ``surface``.
+
+        Dialogs, menus, stacks, and applet popups are interaction surfaces,
+        while tooltips are only decoration. Tracking the GTK lifecycle here
+        gives those surfaces priority without relying on window-manager
+        stacking hints, and the mapped-surface set makes nested popups safe.
+        """
+        if surface in self._registered_blocking_surfaces:
+            return
+        self._registered_blocking_surfaces.add(surface)
+        surface.connect("map", self._on_blocking_surface_mapped)
+        surface.connect("unmap", self._on_blocking_surface_unmapped)
+        surface.connect("destroy", self._on_blocking_surface_destroyed)
+        if surface.get_mapped() is True:
+            self._on_blocking_surface_mapped(surface)
+
+    def _on_blocking_surface_mapped(self, surface: Gtk.Widget) -> None:
+        self._mapped_blocking_surfaces.add(surface)
+        self.hide()
+
+    def _on_blocking_surface_unmapped(self, surface: Gtk.Widget) -> None:
+        self._mapped_blocking_surfaces.discard(surface)
+
+    def _on_blocking_surface_destroyed(self, surface: Gtk.Widget) -> None:
+        self._mapped_blocking_surfaces.discard(surface)
+        self._registered_blocking_surfaces.discard(surface)
 
     def update(
         self,
@@ -332,7 +370,7 @@ class TooltipManager:
         tooltip visible to avoid flicker. The dock's _on_leave hides it
         when the mouse actually exits the dock.
         """
-        if self._suppressed or not self._config.tooltips_enabled:
+        if self._mapped_blocking_surfaces or not self._config.tooltips_enabled:
             self.hide()
             return
 

--- a/docking/ui/update_popup.py
+++ b/docking/ui/update_popup.py
@@ -74,9 +74,11 @@ class UpdateCheckController:
         *,
         config: Config,
         window: Gtk.Window | None = None,
+        register_tooltip_blocker: Callable[[Gtk.Widget], None] | None = None,
     ) -> None:
         self._window = window
         self._config = config
+        self._register_tooltip_blocker = register_tooltip_blocker
         self._start_source_id: int = 0
         self._popup: Gtk.Window | None = None
         self._latest_release: ReleaseInfo | None = None
@@ -203,6 +205,8 @@ class UpdateCheckController:
         self._latest_release = release
         if self._popup is None:
             popup = Gtk.Window(type=Gtk.WindowType.POPUP)
+            if self._register_tooltip_blocker is not None:
+                self._register_tooltip_blocker(popup)
             popup.set_decorated(False)
             popup.set_skip_taskbar_hint(True)
             popup.set_resizable(False)

--- a/tests/applets/test_base.py
+++ b/tests/applets/test_base.py
@@ -293,6 +293,21 @@ class TestAppletDefaultHooks:
         applet.set_popup_anchor(anchor)
         assert applet._popup_anchor is anchor
 
+    def test_register_popup_surface_uses_anchor_callback(self):
+        applet = _DeferredInitApplet()
+        register = MagicMock()
+        applet.set_popup_anchor(SimpleNamespace(register_tooltip_blocker=register))
+        surface = MagicMock()
+
+        applet.register_popup_surface(surface)
+
+        register.assert_called_once_with(surface)
+
+    def test_register_popup_surface_without_anchor_is_noop(self):
+        applet = _DeferredInitApplet()
+
+        applet.register_popup_surface(MagicMock())
+
     def test_accepts_drop_uris_defaults_false(self):
         applet = _DeferredInitApplet()
         assert applet.accepts_drop_uris() is False

--- a/tests/applets/test_popup.py
+++ b/tests/applets/test_popup.py
@@ -318,11 +318,13 @@ def test_show_wrapped_popup_positions_from_anchor(monkeypatch):
     window = _FakePopupWindow()
     wrapped = object()
     parent = object()
+    register_tooltip_blocker = MagicMock()
     anchor = popup.PopupAnchor(
         x=40,
         y=50,
         position=Position.BOTTOM,
         parent=parent,
+        register_tooltip_blocker=register_tooltip_blocker,
     )
     position_anchor = MagicMock()
     position_pointer = MagicMock()
@@ -339,6 +341,7 @@ def test_show_wrapped_popup_positions_from_anchor(monkeypatch):
 
     assert window.transient_for is parent
     assert window.attached_to is parent
+    register_tooltip_blocker.assert_called_once_with(window)
     position_anchor.assert_called_once_with(window=window, anchor=anchor, gap_px=12)
     position_pointer.assert_not_called()
 

--- a/tests/ui/test_about.py
+++ b/tests/ui/test_about.py
@@ -131,7 +131,11 @@ class TestAboutDialogController:
             _fake_gtk(),
         )
         monkeypatch.setattr(about_mod, "pkg_version", lambda _name: "1.2.3")
-        controller = about_mod.AboutDialogController(parent=object())
+        register_tooltip_blocker = MagicMock()
+        controller = about_mod.AboutDialogController(
+            parent=object(),
+            register_tooltip_blocker=register_tooltip_blocker,
+        )
 
         # When
         controller.show()
@@ -142,6 +146,7 @@ class TestAboutDialogController:
         assert first is not None
         assert controller._dialog is first
         assert first.show_count == 2
+        register_tooltip_blocker.assert_called_once_with(first)
 
     def test_response_and_hide_destroy_dialog(self, monkeypatch):
         # Given

--- a/tests/ui/test_dnd_integration.py
+++ b/tests/ui/test_dnd_integration.py
@@ -87,6 +87,7 @@ def _make_handler(monkeypatch, lock_icons: bool = False):
         cursor_x=20.0,
         cursor_y=8.0,
         autohide=autohide,
+        tooltip=SimpleNamespace(register_blocking_surface=MagicMock()),
         is_pointer_inside_dock=MagicMock(return_value=False),
         get_display=MagicMock(return_value=display),
         get_position=MagicMock(return_value=(0, 0)),

--- a/tests/ui/test_dock_window_integration.py
+++ b/tests/ui/test_dock_window_integration.py
@@ -211,6 +211,31 @@ class TestButtonReleaseFlow:
             force_background=True,
         )
 
+    def test_right_click_sets_applet_popup_anchor_before_building_menu(self):
+        item = DockItem(desktop_id="applet://clock")
+        stub, _item = _make_stub(item=item)
+        applet = MagicMock()
+        anchor = MagicMock()
+        stub.model.get_applet.return_value = applet
+        stub.popup_anchor_for_item = MagicMock(return_value=anchor)
+        event = SimpleNamespace(
+            x=12.0,
+            y=6.0,
+            button=dock_window_mod.MOUSE_RIGHT,
+            state=0,
+        )
+
+        handled = input_controller_mod.DockInputController._on_button_release(
+            _controller(stub), MagicMock(), event
+        )
+
+        assert handled is True
+        stub.popup_anchor_for_item.assert_called_once_with(
+            item,
+            stub._test_geometry_frame,
+        )
+        applet.set_popup_anchor.assert_called_once_with(anchor)
+
     def test_left_click_on_applet_updates_tooltip_immediately(self, monkeypatch):
         # Given
         item = DockItem(desktop_id="applet://quote")

--- a/tests/ui/test_factory.py
+++ b/tests/ui/test_factory.py
@@ -159,9 +159,19 @@ class TestBuildDockWindow:
         assert kwargs["on_change"] is window.autohide.set_window_should_hide
         dodge_monitor.start.assert_called_once_with()
         assert window.dodge_monitor is dodge_monitor
+        factory_mod.AboutDialogController.assert_called_once_with(
+            parent=window,
+            register_tooltip_blocker=components.runtime.register_tooltip_blocker,
+        )
+        factory_mod.DiagnosticsDialogController.assert_called_once_with(
+            parent=window,
+            backend=session_backend,
+            register_tooltip_blocker=components.runtime.register_tooltip_blocker,
+        )
         factory_mod.UpdateCheckController.assert_called_once_with(
             window=window,
             config=config,
+            register_tooltip_blocker=window.tooltip.register_blocking_surface,
         )
         factory_mod.DockRuntime.assert_called_once_with(
             window,
@@ -194,6 +204,7 @@ class TestBuildDockWindow:
             actions=components.settings_actions,
             model=model,
             config=config,
+            register_tooltip_blocker=components.runtime.register_tooltip_blocker,
         )
         factory_mod.MenuHandler.assert_called_once_with(
             about=components.about,
@@ -218,10 +229,14 @@ class TestBuildDockWindow:
             dnd=components.dnd,
         )
         factory_mod.StartupPopupCoordinator.assert_called_once_with()
-        factory_mod.NewYearGreetingController.assert_called_once_with(window=window)
+        factory_mod.NewYearGreetingController.assert_called_once_with(
+            window=window,
+            register_tooltip_blocker=components.runtime.register_tooltip_blocker,
+        )
         factory_mod.StartupTipsController.assert_called_once_with(
             window=window,
             config=config,
+            register_tooltip_blocker=components.runtime.register_tooltip_blocker,
         )
         components.startup_popups.register.assert_any_call(components.new_year)
         components.startup_popups.register.assert_any_call(components.update_checker)

--- a/tests/ui/test_runtime.py
+++ b/tests/ui/test_runtime.py
@@ -45,7 +45,10 @@ def _make_window():
         autohide=_autohide(),
         dnd=SimpleNamespace(set_locked=MagicMock()),
         surface_service=SimpleNamespace(set_workspace_scope=MagicMock()),
-        tooltip=SimpleNamespace(hide=MagicMock(), set_suppressed=MagicMock()),
+        tooltip=SimpleNamespace(
+            hide=MagicMock(),
+            register_blocking_surface=MagicMock(),
+        ),
         preview=SimpleNamespace(hide=MagicMock()),
         theme="old-theme",
         set_theme=MagicMock(),
@@ -105,8 +108,8 @@ class TestDockRuntime:
         runtime.queue_draw()
         runtime.set_current_workspace_only(True)
         runtime.hide_tooltip()
-        runtime.suppress_tooltip()
-        runtime.resume_tooltip()
+        surface = MagicMock()
+        runtime.register_tooltip_blocker(surface)
         runtime.hide_hover_ui()
         runtime.set_theme(cast(Theme, "new-theme"))
         runtime.check_for_updates_now()
@@ -118,10 +121,7 @@ class TestDockRuntime:
             current_workspace_only=True
         )
         assert window.tooltip.hide.call_count == 2
-        assert window.tooltip.set_suppressed.call_args_list == [
-            ((True,),),
-            ((False,),),
-        ]
+        window.tooltip.register_blocking_surface.assert_called_once_with(surface)
         window.preview.hide.assert_called_once()
         update_checker.check_now.assert_called_once()
         update_checker.open_releases_page.assert_called_once()

--- a/tests/ui/test_settings.py
+++ b/tests/ui/test_settings.py
@@ -708,11 +708,13 @@ class TestSettingsWindowController:
             settings_mod, "load_catalog_icon", lambda applet_id, size: None
         )
         monkeypatch.setattr(settings_mod, "get_applet_catalog", dict)
+        register_tooltip_blocker = MagicMock()
         controller = settings_mod.SettingsWindowController(
             parent=_parent_window(),
             actions=MagicMock(),
             model=SimpleNamespace(pinned_items=[], get_applet=lambda _desktop_id: None),
             config=_config(),
+            register_tooltip_blocker=register_tooltip_blocker,
         )
 
         controller.show()
@@ -723,6 +725,7 @@ class TestSettingsWindowController:
         assert controller._window is window
         assert window.show_count == 2
         assert window.present_count == 2
+        register_tooltip_blocker.assert_called_once_with(window)
         assert window.position == FakeWindowPosition.CENTER
         switcher, stack = window.child.children
         assert isinstance(switcher, FakeStackSwitcher)

--- a/tests/ui/test_stack.py
+++ b/tests/ui/test_stack.py
@@ -149,7 +149,7 @@ def test_activation_uses_latest_callback_and_closes_popup():
     controller._close_stack.assert_called_once()
 
 
-def test_visible_stack_suppresses_tooltips_until_closed():
+def test_visible_stack_uses_popup_lifecycle_until_closed():
     controller = _controller()
     runtime = controller._runtime
     window = MagicMock()
@@ -167,10 +167,10 @@ def test_visible_stack_suppresses_tooltips_until_closed():
         anchor=SimpleNamespace(x=100, y=200, position="bottom"),
     )
 
-    runtime.suppress_tooltip.assert_called_once()
-    runtime.resume_tooltip.reset_mock()
+    runtime.menu_popup_opened.assert_called_once()
+    runtime.menu_popup_closed.reset_mock()
     controller.close()
-    runtime.resume_tooltip.assert_called_once()
+    runtime.menu_popup_closed.assert_called_once()
 
 
 def test_refresh_reloads_visible_provider_content():

--- a/tests/ui/test_tooltip.py
+++ b/tests/ui/test_tooltip.py
@@ -4,9 +4,11 @@ Covers positioning math, content caching (flicker prevention), and
 the hide/show lifecycle that prevents spurious crossing events.
 """
 
+import gc
 from collections.abc import Callable
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+from weakref import ref
 
 import docking.ui.tooltip as tooltip_mod
 from docking.core.layout import LayoutItem
@@ -17,6 +19,36 @@ from docking.ui.tooltip import (
     TooltipManager,
     compute_tooltip_position,
 )
+
+
+class _BlockingSurface:
+    def __init__(self) -> None:
+        self._mapped = False
+        self._signals: dict[str, list[Callable[[object], None]]] = {}
+        self.connect_count = 0
+
+    def connect(self, signal: str, callback: Callable[[object], None]) -> None:
+        self.connect_count += 1
+        self._signals.setdefault(signal, []).append(callback)
+
+    def get_mapped(self) -> bool:
+        return self._mapped
+
+    def show(self) -> None:
+        self._mapped = True
+        self._emit("map")
+
+    def hide(self) -> None:
+        self._mapped = False
+        self._emit("unmap")
+
+    def destroy(self) -> None:
+        self._mapped = False
+        self._emit("destroy")
+
+    def _emit(self, signal: str) -> None:
+        for callback in self._signals.get(signal, []):
+            callback(self)
 
 
 class TestTooltipManagerInit:
@@ -98,20 +130,77 @@ class TestTooltipHide:
         # Then
         tooltip._tooltip_window.hide.assert_called_once()
 
-    def test_suppressed_tooltip_ignores_updates_until_resumed(self):
+    def test_registered_surface_blocks_updates_until_hidden(self):
         tooltip = _make_tooltip()
-        tooltip._show_tooltip = MagicMock()  # type: ignore[method-assign]
+        tooltip._schedule_show = MagicMock()  # type: ignore[method-assign]
         item = _make_item("Devices")
+        surface = _BlockingSurface()
 
-        tooltip.set_suppressed(True)
+        tooltip.register_blocking_surface(surface)
+        surface.show()
+        tooltip.update(item, _frame_for_item(item))
+        item.name = "Devices (updated)"
         tooltip.update(item, _frame_for_item(item))
 
-        assert tooltip._suppressed is True
-        tooltip._show_tooltip.assert_not_called()
+        tooltip._schedule_show.assert_not_called()
 
-        tooltip.set_suppressed(False)
+        surface.hide()
+        tooltip.update(item, _frame_for_item(item))
 
-        assert tooltip._suppressed is False
+        tooltip._schedule_show.assert_called_once()
+
+    def test_nested_surfaces_keep_tooltip_blocked_until_both_close(self):
+        tooltip = _make_tooltip()
+        tooltip._schedule_show = MagicMock()  # type: ignore[method-assign]
+        item = _make_item("Devices")
+        first = _BlockingSurface()
+        second = _BlockingSurface()
+
+        tooltip.register_blocking_surface(first)
+        tooltip.register_blocking_surface(second)
+        first.show()
+        second.show()
+        first.hide()
+        tooltip.update(item, _frame_for_item(item))
+
+        tooltip._schedule_show.assert_not_called()
+
+        second.destroy()
+        tooltip.update(item, _frame_for_item(item))
+
+        tooltip._schedule_show.assert_called_once()
+
+    def test_duplicate_surface_registration_connects_lifecycle_once(self):
+        tooltip = _make_tooltip()
+        surface = _BlockingSurface()
+
+        tooltip.register_blocking_surface(surface)
+        tooltip.register_blocking_surface(surface)
+
+        assert surface.connect_count == 3
+
+    def test_mapped_surface_is_retained_until_it_unmaps(self):
+        tooltip = _make_tooltip()
+        tooltip._schedule_show = MagicMock()  # type: ignore[method-assign]
+        item = _make_item("Network")
+        surface = _BlockingSurface()
+        surface_ref = ref(surface)
+        tooltip.register_blocking_surface(surface)
+        surface.show()
+
+        del surface
+        gc.collect()
+
+        mapped_surface = surface_ref()
+        assert mapped_surface is not None
+        tooltip.update(item, _frame_for_item(item))
+        tooltip._schedule_show.assert_not_called()
+
+        mapped_surface.hide()
+        del mapped_surface
+        gc.collect()
+
+        assert surface_ref() is None
 
     def test_update_with_missing_geometry_returns_without_showing(self):
         tooltip = _make_tooltip()


### PR DESCRIPTION
## Summary

- keep tooltips hidden while menus, dialogs, stacks, and other dock surfaces are open
- prevent frequently refreshed applet tooltips from reappearing above those surfaces
- remove the older stack-specific tooltip suppression path