### PR TITLE
Keep refreshed tooltips below dock popups

### DIFF
--- a/docking/ui/runtime.py
+++ b/docking/ui/runtime.py
@@ -90,12 +90,6 @@ class DockRuntime:
     def hide_tooltip(self) -> None:
         self._window.tooltip.hide()
 
-    def suppress_tooltip(self) -> None:
-        self._window.tooltip.set_suppressed(True)
-
-    def resume_tooltip(self) -> None:
-        self._window.tooltip.set_suppressed(False)
-
     def hide_hover_ui(self) -> None:
         self._window.tooltip.hide()
         self._window.preview.hide()

--- a/docking/ui/stack.py
+++ b/docking/ui/stack.py
@@ -344,7 +344,6 @@ class StackPopupController:
 
         self._close_stack()
         self._runtime.hide_hover_ui()
-        self._runtime.suppress_tooltip()
         self._runtime.menu_popup_opened()
 
         window = self._ensure_stack_window()
@@ -432,7 +431,6 @@ class StackPopupController:
             revealer.set_reveal_child(False)
         window.hide()
         self._cleanup_stack()
-        self._runtime.resume_tooltip()
         self._runtime.menu_popup_closed()
 
     def _cleanup_stack(self) -> None:

--- a/docking/ui/tooltip.py
+++ b/docking/ui/tooltip.py
@@ -533,6 +533,15 @@ class TooltipManager:
         self._tooltip_window.move(tx, ty)
         self._tooltip_window.show_all()
 
+        # Rebuilding dynamic tooltip content remaps this popup and raises it
+        # above an already-open menu. Keep it immediately below the dock: the
+        # dock remains above normal windows, while its menus and dialogs retain
+        # their higher stacking position.
+        tooltip_surface = self._tooltip_window.get_window()
+        dock_surface = self._window.get_window()
+        if tooltip_surface is not None and dock_surface is not None:
+            tooltip_surface.restack(dock_surface, False)
+
     def hide(self) -> None:
         """Hide the tooltip window and clear tracking state."""
         self._cancel_pending_show()

--- a/docking/ui/tooltip.py
+++ b/docking/ui/tooltip.py
@@ -309,17 +309,10 @@ class TooltipManager:
         self._last_item: DockItem | None = None
         self._last_name: str = ""
         self._pending_show_source: int = 0
-        self._suppressed = False
 
     def set_theme(self, theme: Theme) -> None:
         """Update the theme used for tooltip spacing."""
         self._theme = theme
-
-    def set_suppressed(self, suppressed: bool) -> None:
-        """Prevent tooltip display while a higher-priority popup is visible."""
-        self._suppressed = suppressed
-        if suppressed:
-            self.hide()
 
     def update(
         self,
@@ -332,7 +325,7 @@ class TooltipManager:
         tooltip visible to avoid flicker. The dock's _on_leave hides it
         when the mouse actually exits the dock.
         """
-        if self._suppressed or not self._config.tooltips_enabled:
+        if not self._config.tooltips_enabled:
             self.hide()
             return
 
@@ -533,10 +526,7 @@ class TooltipManager:
         self._tooltip_window.move(tx, ty)
         self._tooltip_window.show_all()
 
-        # Rebuilding dynamic tooltip content remaps this popup and raises it
-        # above an already-open menu. Keep it immediately below the dock: the
-        # dock remains above normal windows, while its menus and dialogs retain
-        # their higher stacking position.
+        # Keep tooltips behind dialogs and other dock popups.
         tooltip_surface = self._tooltip_window.get_window()
         dock_surface = self._window.get_window()
         if tooltip_surface is not None and dock_surface is not None:

--- a/tests/ui/test_runtime.py
+++ b/tests/ui/test_runtime.py
@@ -45,7 +45,7 @@ def _make_window():
         autohide=_autohide(),
         dnd=SimpleNamespace(set_locked=MagicMock()),
         surface_service=SimpleNamespace(set_workspace_scope=MagicMock()),
-        tooltip=SimpleNamespace(hide=MagicMock(), set_suppressed=MagicMock()),
+        tooltip=SimpleNamespace(hide=MagicMock()),
         preview=SimpleNamespace(hide=MagicMock()),
         theme="old-theme",
         set_theme=MagicMock(),
@@ -105,8 +105,6 @@ class TestDockRuntime:
         runtime.queue_draw()
         runtime.set_current_workspace_only(True)
         runtime.hide_tooltip()
-        runtime.suppress_tooltip()
-        runtime.resume_tooltip()
         runtime.hide_hover_ui()
         runtime.set_theme(cast(Theme, "new-theme"))
         runtime.check_for_updates_now()
@@ -118,10 +116,6 @@ class TestDockRuntime:
             current_workspace_only=True
         )
         assert window.tooltip.hide.call_count == 2
-        assert window.tooltip.set_suppressed.call_args_list == [
-            ((True,),),
-            ((False,),),
-        ]
         window.preview.hide.assert_called_once()
         update_checker.check_now.assert_called_once()
         update_checker.open_releases_page.assert_called_once()

--- a/tests/ui/test_stack.py
+++ b/tests/ui/test_stack.py
@@ -149,30 +149,6 @@ def test_activation_uses_latest_callback_and_closes_popup():
     controller._close_stack.assert_called_once()
 
 
-def test_visible_stack_suppresses_tooltips_until_closed():
-    controller = _controller()
-    runtime = controller._runtime
-    window = MagicMock()
-    window.get_visible.return_value = True
-    controller._folder_stack_window = window
-    controller._ensure_stack_window = MagicMock(return_value=window)
-    controller._folder_stack_revealer = MagicMock()
-    controller._replace_stack_content = MagicMock()
-    controller._restart_stack_animation = MagicMock()
-    controller._position_stack_window = MagicMock()
-
-    assert controller.show_stack(
-        owner_id="applet://devices",
-        provider=lambda _icon_size: StackContent(empty_label="No devices"),
-        anchor=SimpleNamespace(x=100, y=200, position="bottom"),
-    )
-
-    runtime.suppress_tooltip.assert_called_once()
-    runtime.resume_tooltip.reset_mock()
-    controller.close()
-    runtime.resume_tooltip.assert_called_once()
-
-
 def test_refresh_reloads_visible_provider_content():
     controller = _controller()
     first = StackContent(entries=(_entry("first"),))

--- a/tests/ui/test_tooltip.py
+++ b/tests/ui/test_tooltip.py
@@ -98,21 +98,6 @@ class TestTooltipHide:
         # Then
         tooltip._tooltip_window.hide.assert_called_once()
 
-    def test_suppressed_tooltip_ignores_updates_until_resumed(self):
-        tooltip = _make_tooltip()
-        tooltip._show_tooltip = MagicMock()  # type: ignore[method-assign]
-        item = _make_item("Devices")
-
-        tooltip.set_suppressed(True)
-        tooltip.update(item, _frame_for_item(item))
-
-        assert tooltip._suppressed is True
-        tooltip._show_tooltip.assert_not_called()
-
-        tooltip.set_suppressed(False)
-
-        assert tooltip._suppressed is False
-
     def test_update_with_missing_geometry_returns_without_showing(self):
         tooltip = _make_tooltip()
         tooltip._show_tooltip = MagicMock()  # type: ignore[method-assign]

--- a/tests/ui/test_tooltip.py
+++ b/tests/ui/test_tooltip.py
@@ -707,6 +707,7 @@ class _FakeTooltipScreen:
 class _FakeTooltipWindow:
     def __init__(self, **_kwargs):
         self._screen = _FakeTooltipScreen()
+        self._surface = MagicMock()
         self._visible = False
         self._child = None
         self._removed = 0
@@ -785,6 +786,9 @@ class _FakeTooltipWindow:
     def show_all(self) -> None:
         self._visible = True
 
+    def get_window(self):
+        return self._surface
+
 
 class _FakeTooltipLabel:
     def __init__(self, label: str):
@@ -827,6 +831,7 @@ class TestTooltipIntegrationBranches:
         monkeypatch.setattr(tooltip_mod, "Gtk", _FakeGtk)
         monkeypatch.setattr(tooltip_mod, "Gdk", _FakeGdk)
         window = MagicMock()
+        dock_surface = window.get_window.return_value
         window.surface_service.popups_use_parent_relative_coordinates = False
         config = SimpleNamespace(icon_size=48)
         model = MagicMock()
@@ -849,6 +854,9 @@ class TestTooltipIntegrationBranches:
         assert tooltip._tooltip_window._attached_to is window
         assert tooltip._tooltip_window._accept_focus is False
         assert tooltip._tooltip_window._focus_on_map is False
+        tooltip._tooltip_window._surface.restack.assert_called_once_with(
+            dock_surface, False
+        )
         moved = tooltip._tooltip_window._moved
         assert moved is not None
         assert moved[0] >= 0

--- a/tests/visual/render_cases.py
+++ b/tests/visual/render_cases.py
@@ -370,7 +370,10 @@ def _capture_window_surface(window: Gtk.Window) -> cairo.ImageSurface:
 
 def _draw_tooltip_case() -> cairo.ImageSurface:
     manager = TooltipManager(
-        window=SimpleNamespace(get_position=lambda: (100, 200)),
+        window=SimpleNamespace(
+            get_position=lambda: (100, 200),
+            get_window=lambda: None,
+        ),
         config=SimpleNamespace(
             tooltips_enabled=True,
             pos=Position.BOTTOM,


### PR DESCRIPTION
## Summary

- keep tooltips below dock menus and dialogs through window stacking
- prevent live applet updates from raising a tooltip over an open menu
- replace the broader lifecycle-based approach in #259 with a focused change