### PR TITLE
Require non-null constructor dependencies

### DIFF
--- a/docking/applets/aiusage/applet.py
+++ b/docking/applets/aiusage/applet.py
@@ -75,12 +75,10 @@ class AiUsageApplet(Applet):
     name = _("AI Usage")
     icon_name = "utilities-terminal"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        prefs = None
-        if config:
-            prefs = config.applet_prefs.get(PREFS_KEY)
-            if not prefs:
-                prefs = config.applet_prefs.get(PREFS_KEY_LEGACY)
+    def __init__(self, icon_size: int, config: Config) -> None:
+        prefs = config.applet_prefs.get(PREFS_KEY)
+        if not prefs:
+            prefs = config.applet_prefs.get(PREFS_KEY_LEGACY)
         self._state = state_from_prefs(prefs=prefs)
         self._timer_id: int = 0
         self._selected_provider: Provider | None = None

--- a/docking/applets/alarm/applet.py
+++ b/docking/applets/alarm/applet.py
@@ -67,8 +67,8 @@ class AlarmApplet(Applet):
     name = _("Alarm")
     icon_name = "alarm"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        prefs = config.applet_prefs.get("alarm", {}) if config else None
+    def __init__(self, icon_size: int, config: Config) -> None:
+        prefs = config.applet_prefs.get("alarm", {})
         self._state: AlarmState = state_from_prefs(prefs=prefs)
         self._timer_id: int = 0
         super().__init__(icon_size=icon_size, config=config)

--- a/docking/applets/ambient/applet.py
+++ b/docking/applets/ambient/applet.py
@@ -80,8 +80,8 @@ class AmbientApplet(Applet):
     name = _("Ambient")
     icon_name = "audio-speakers"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        prefs = config.applet_prefs.get("ambient", {}) if config else None
+    def __init__(self, icon_size: int, config: Config) -> None:
+        prefs = config.applet_prefs.get("ambient", {})
         self._state = state_from_prefs(prefs=prefs)
         self._pipeline: Gst.Element | None = None
         self._bus_watching = False

--- a/docking/applets/apod/applet.py
+++ b/docking/applets/apod/applet.py
@@ -68,7 +68,7 @@ class ApodApplet(Applet):
     name = _("Astronomy Picture of the Day")
     icon_name = "image-x-generic"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._refresh_timer_id: int = 0
         self._retry_timer_id: int = 0
         self._startup_fetch_timer_id: int = 0
@@ -77,9 +77,7 @@ class ApodApplet(Applet):
         self._error: str | None = None
         self._worker = BackgroundWorker(logger=log)
 
-        prefs = prefs_from_mapping(
-            config.applet_prefs.get(meta.id, {}) if config else None
-        )
+        prefs = prefs_from_mapping(config.applet_prefs.get(meta.id, {}))
         self._result: ApodResult | None = prefs.last_result
 
         super().__init__(icon_size=icon_size, config=config)

--- a/docking/applets/applications/applet.py
+++ b/docking/applets/applications/applet.py
@@ -56,7 +56,7 @@ class ApplicationsApplet(Applet):
     icon_name = "view-app-grid"
     icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         super().__init__(icon_size=icon_size, config=config)
         self._popup_menu: Gtk.Menu | None = None
         self.present()

--- a/docking/applets/base.py
+++ b/docking/applets/base.py
@@ -349,7 +349,7 @@ class Applet(ABC):
     icon_name: str
     icon_source_options: tuple[IconSource, ...] = (IconSource.DOCKING,)
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._config = config
         self._icon_size = icon_size
         self._notify: Callable[[], None] | None = None
@@ -371,15 +371,12 @@ class Applet(ABC):
 
     def load_prefs(self) -> dict[str, Any]:
         """Load this applet's preferences from config."""
-        if self._config:
-            return dict(self._config.applet_prefs.get(self.id, {}))
-        return {}
+        return dict(self._config.applet_prefs.get(self.id, {}))
 
     def save_prefs(self, prefs: dict[str, Any]) -> None:
         """Save this applet's preferences to config."""
-        if self._config:
-            self._config.applet_prefs[self.id] = prefs
-            self._config.save()
+        self._config.applet_prefs[self.id] = prefs
+        self._config.save()
 
     def create_icon(self, size: int) -> GdkPixbuf.Pixbuf | None:
         """Render the active icon source at the given size."""

--- a/docking/applets/battery/applet.py
+++ b/docking/applets/battery/applet.py
@@ -63,13 +63,12 @@ class BatteryApplet(Applet):
     name = _("Battery")
     icon_name = "battery-good"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._timer_id: int = 0
         self._power_timer_id: int = 0
         self._overlay = OVERLAY_NONE
-        if config:
-            prefs = config.applet_prefs.get(meta.id, {})
-            self._overlay = overlay_from_prefs(prefs)
+        prefs = config.applet_prefs.get(meta.id, {})
+        self._overlay = overlay_from_prefs(prefs)
         self._state: BatteryState | None = read_battery()
         self._peripherals: list[PeripheralBattery] = read_peripheral_batteries()
         super().__init__(icon_size=icon_size, config=config)

--- a/docking/applets/bluetooth/applet.py
+++ b/docking/applets/bluetooth/applet.py
@@ -81,7 +81,7 @@ class BluetoothApplet(Applet):
     name = _("Bluetooth")
     icon_name = "bluetooth-active-symbolic"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._backend = BluezBackend()
         self._state: BluetoothState = unavailable_state()
         self._poll_id: int = 0
@@ -100,22 +100,21 @@ class BluetoothApplet(Applet):
         self._recent_connections: dict[str, float] = {}
         self._prefs_dirty = False
 
-        if config:
-            prefs = config.applet_prefs.get(meta.id, {})
-            self._active_adapter_path = str(prefs.get("active_adapter_path", "") or "")
-            self._continuous_discovery = _as_pref_bool(
-                prefs.get("continuous_discovery", True),
-                default=True,
-            )
-            raw_recent = prefs.get("recent_connections", {})
-            if isinstance(raw_recent, dict):
-                for address, value in raw_recent.items():
-                    try:
-                        timestamp = float(value)
-                    except (TypeError, ValueError):
-                        continue
-                    if address:
-                        self._recent_connections[str(address)] = timestamp
+        prefs = config.applet_prefs.get(meta.id, {})
+        self._active_adapter_path = str(prefs.get("active_adapter_path", "") or "")
+        self._continuous_discovery = _as_pref_bool(
+            prefs.get("continuous_discovery", True),
+            default=True,
+        )
+        raw_recent = prefs.get("recent_connections", {})
+        if isinstance(raw_recent, dict):
+            for address, value in raw_recent.items():
+                try:
+                    timestamp = float(value)
+                except (TypeError, ValueError):
+                    continue
+                if address:
+                    self._recent_connections[str(address)] = timestamp
 
         self._known_connected_addresses: set[str] = set()
         super().__init__(icon_size=icon_size, config=config)

--- a/docking/applets/bookmarks/applet.py
+++ b/docking/applets/bookmarks/applet.py
@@ -55,9 +55,9 @@ class BookmarksApplet(Applet):
     name = _("Bookmarks")
     icon_name = "user-bookmarks"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._bookmarks: list[Bookmark] = bookmarks_from_prefs(
-            config.applet_prefs.get("bookmarks", {}) if config else None
+            config.applet_prefs.get("bookmarks", {})
         )
         super().__init__(icon_size=icon_size, config=config)
         self.present()

--- a/docking/applets/brightness/applet.py
+++ b/docking/applets/brightness/applet.py
@@ -56,7 +56,7 @@ class BrightnessApplet(Applet):
     name = _("Brightness")
     icon_name = "display-brightness-symbolic"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._backend = detect_output()
         if not self._backend:
             log.warning("No xrandr output detected")
@@ -65,9 +65,8 @@ class BrightnessApplet(Applet):
         self._timer_id: int = 0
         self._worker = BackgroundWorker(logger=log)
 
-        if config:
-            prefs = config.applet_prefs.get(meta.id, {})
-            self._show_level = prefs.get("show_level", False)
+        prefs = config.applet_prefs.get(meta.id, {})
+        self._show_level = prefs.get("show_level", False)
 
         self._poll()
         super().__init__(icon_size=icon_size, config=config)

--- a/docking/applets/caffeine/applet.py
+++ b/docking/applets/caffeine/applet.py
@@ -59,10 +59,10 @@ class CaffeineApplet(Applet):
     def __init__(
         self,
         icon_size: int,
-        config: Config | None = None,
+        config: Config,
         inhibitor: Inhibitor | None = None,
     ) -> None:
-        prefs = config.applet_prefs.get(meta.id, {}) if config else None
+        prefs = config.applet_prefs.get(meta.id, {})
         self._data = state_from_prefs(prefs=prefs)
         self._inhibitor = inhibitor if inhibitor is not None else default_inhibitor()
         self._timer_id: int = 0

--- a/docking/applets/calculator/applet.py
+++ b/docking/applets/calculator/applet.py
@@ -79,11 +79,11 @@ class CalculatorApplet(Applet):
     icon_name = "accessories-calculator"
     icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._popup: Gtk.Window | None = None
         self._entry: Gtk.Entry | None = None
 
-        prefs = config.applet_prefs.get("calculator", {}) if config else {}
+        prefs = config.applet_prefs.get("calculator", {})
         self._last_expr = str(prefs.get("last_expression", ""))
 
         super().__init__(icon_size=icon_size, config=config)

--- a/docking/applets/calendar/applet.py
+++ b/docking/applets/calendar/applet.py
@@ -69,7 +69,7 @@ class CalendarApplet(Applet):
     name = _("Calendar")
     icon_name = "office-calendar"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._timer_id: int = 0
         self._last_day: int = -1
         self._tooltip_text: str = _("Calendar")

--- a/docking/applets/camshield/applet.py
+++ b/docking/applets/camshield/applet.py
@@ -62,7 +62,7 @@ class CamshieldApplet(Applet):
     name = _("Cam Shield")
     icon_name = "camera-web"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._state: CamshieldState = probe_camera_state()
         self._timer_id: int = 0
         self._pulse_timer_id: int = 0

--- a/docking/applets/capslock/applet.py
+++ b/docking/applets/capslock/applet.py
@@ -51,7 +51,7 @@ class CapslockApplet(Applet):
     name = _("Caps Lock")
     icon_name = "input-keyboard"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._state: LockKeyState = query_lock_state()
         self._timer_id: int = 0
         super().__init__(icon_size=icon_size, config=config)

--- a/docking/applets/certwatch/applet.py
+++ b/docking/applets/certwatch/applet.py
@@ -76,7 +76,7 @@ class CertwatchApplet(Applet):
     name = _("Cert Watch")
     icon_name = "application-certificate"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._timer_id: int = 0
         self._startup_fetch_timer_id: int = 0
         self._retry_timer_id: int = 0
@@ -86,9 +86,7 @@ class CertwatchApplet(Applet):
         self._fetch_error = ""
         self._worker = BackgroundWorker(logger=log)
 
-        prefs = prefs_from_mapping(
-            config.applet_prefs.get(meta.id, {}) if config else None
-        )
+        prefs = prefs_from_mapping(config.applet_prefs.get(meta.id, {}))
         self._domains: list[DomainPref] = list(prefs.domains)
         self._certs: dict[tuple[str, int], CertInfo] = {}
 

--- a/docking/applets/clippy/applet.py
+++ b/docking/applets/clippy/applet.py
@@ -48,7 +48,7 @@ class ClippyApplet(Applet):
     name = _("Clippy")
     icon_name = "edit-paste"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._clips: list[str] = []
         self._cur_position: int = 0
         self._handler_id: int = 0
@@ -56,9 +56,8 @@ class ClippyApplet(Applet):
 
         # Load prefs
         self._max_entries = 15
-        if config:
-            prefs = config.applet_prefs.get("clippy", {})
-            self._max_entries = prefs.get("max_entries", 15)
+        prefs = config.applet_prefs.get("clippy", {})
+        self._max_entries = prefs.get("max_entries", 15)
 
         super().__init__(icon_size=icon_size, config=config)
         self.present()

--- a/docking/applets/clock/applet.py
+++ b/docking/applets/clock/applet.py
@@ -54,11 +54,11 @@ class ClockApplet(Applet):
     name = _("Clock")
     icon_name = "clock"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._timer = _ClockTimer()
         self._calendar_popup: Gtk.Window | None = None
 
-        prefs = config.applet_prefs.get("clock", {}) if config else None
+        prefs = config.applet_prefs.get("clock", {})
         self._raw_alarm_target = self._prefs_alarm_target(prefs)
         (
             self._show_digital,

--- a/docking/applets/colorpicker/applet.py
+++ b/docking/applets/colorpicker/applet.py
@@ -59,21 +59,20 @@ class ColorPickerApplet(Applet):
     name = _("Color Picker")
     icon_name = "color-select"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._r, self._g, self._b = _DEFAULT_RGB
         self._hex = ""
         self._show_hex = True
         self._overlay: Gtk.Window | None = None
         self._screen_capture: ScreenCaptureService | None = None
 
-        if config:
-            prefs = config.applet_prefs.get(meta.id, {})
-            self._show_hex = prefs.get("show_hex", True)
-            # Restore last picked color
-            self._r = prefs.get("r", _DEFAULT_RGB[0])
-            self._g = prefs.get("g", _DEFAULT_RGB[1])
-            self._b = prefs.get("b", _DEFAULT_RGB[2])
-            self._hex = prefs.get("hex", "")
+        prefs = config.applet_prefs.get(meta.id, {})
+        self._show_hex = prefs.get("show_hex", True)
+        # Restore last picked color
+        self._r = prefs.get("r", _DEFAULT_RGB[0])
+        self._g = prefs.get("g", _DEFAULT_RGB[1])
+        self._b = prefs.get("b", _DEFAULT_RGB[2])
+        self._hex = prefs.get("hex", "")
 
         super().__init__(icon_size=icon_size, config=config)
         self.present()

--- a/docking/applets/crypto/applet.py
+++ b/docking/applets/crypto/applet.py
@@ -79,7 +79,7 @@ class CryptoApplet(Applet):
     name = _("Crypto")
     icon_name = "emblem-money-symbolic"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._timer_id: int = 0
         self._startup_fetch_timer_id: int = 0
         self._pulse_timer_id: int = 0
@@ -91,7 +91,7 @@ class CryptoApplet(Applet):
         self._fetch_error = ""
         self._worker = BackgroundWorker(logger=log)
 
-        raw_prefs = config.applet_prefs.get(meta.id, {}) if config else None
+        raw_prefs = config.applet_prefs.get(meta.id, {})
         prefs = prefs_from_mapping(raw_prefs)
         self._assets = list(prefs.assets)
         self._active_index = prefs.active_index

--- a/docking/applets/currencyfx/applet.py
+++ b/docking/applets/currencyfx/applet.py
@@ -103,7 +103,7 @@ class CurrencyFxApplet(Applet):
     name = _("Currency FX")
     icon_name = "emblem-synchronizing-symbolic"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         """Load preferences and render the first icon state.
 
         A day interval can render immediately from the local cache before the
@@ -122,7 +122,7 @@ class CurrencyFxApplet(Applet):
         self._fetch_error = ""
         self._worker = BackgroundWorker(logger=log)
 
-        raw_prefs = config.applet_prefs.get(meta.id, {}) if config else None
+        raw_prefs = config.applet_prefs.get(meta.id, {})
         prefs = prefs_from_mapping(raw_prefs)
         self._pairs = list(prefs.pairs)
         self._active_index = prefs.active_index

--- a/docking/applets/deskpresence/applet.py
+++ b/docking/applets/deskpresence/applet.py
@@ -67,15 +67,13 @@ class DeskpresenceApplet(Applet):
     name = _("Desk Presence")
     icon_name = "user-available"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._timer_id: int = 0
         self._pulse_timer_id: int = 0
         self._pulse_phase: float = 0.0
         self._idle_service: IdleService | None = None
 
-        prefs = prefs_from_mapping(
-            config.applet_prefs.get(meta.id, {}) if config else None
-        )
+        prefs = prefs_from_mapping(config.applet_prefs.get(meta.id, {}))
         self._state: PresenceState = state_from_prefs(prefs=prefs)
 
         super().__init__(icon_size=icon_size, config=config)

--- a/docking/applets/desktop/applet.py
+++ b/docking/applets/desktop/applet.py
@@ -42,7 +42,7 @@ class DesktopApplet(Applet):
     icon_name = "user-desktop"
     icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._desktop_actions: DesktopActionService | None = None
         super().__init__(icon_size=icon_size, config=config)
         self.present()

--- a/docking/applets/devices/applet.py
+++ b/docking/applets/devices/applet.py
@@ -71,7 +71,7 @@ class DevicesApplet(Applet):
     icon_name = "drive-harddisk"
     icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._monitor = Gio.VolumeMonitor.get()
         self._unix_mount_monitor = get_mount_monitor()
         self._devices: list[MountedDevice] = mounted_devices(

--- a/docking/applets/docker/applet.py
+++ b/docking/applets/docker/applet.py
@@ -54,7 +54,7 @@ class DockerApplet(Applet):
     name = _("Docker")
     icon_name = "docker"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._state: DockerState = query_docker_state()
         self._timer_id: int = 0
         self._worker = BackgroundWorker(logger=log)

--- a/docking/applets/dragshare/applet.py
+++ b/docking/applets/dragshare/applet.py
@@ -53,8 +53,8 @@ class DragshareApplet(Applet):
     name = _("Drag Share")
     icon_name = "folder-publicshare"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        prefs = config.applet_prefs.get(meta.id, {}) if config else {}
+    def __init__(self, icon_size: int, config: Config) -> None:
+        prefs = config.applet_prefs.get(meta.id, {})
         self._status = DragshareStatus.IDLE
         self._last_url = str(prefs.get("last_url", ""))
         self._file_name = ""

--- a/docking/applets/hackernews/applet.py
+++ b/docking/applets/hackernews/applet.py
@@ -69,10 +69,8 @@ class HackerNewsApplet(Applet):
     name = _("Hacker News")
     icon_name = "internet-news-reader"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        prefs = prefs_from_mapping(
-            config.applet_prefs.get(meta.id, {}) if config else None
-        )
+    def __init__(self, icon_size: int, config: Config) -> None:
+        prefs = prefs_from_mapping(config.applet_prefs.get(meta.id, {}))
         self._stories: list[HackerNewsStory] = list(prefs.stories)
         self._active_index = prefs.active_index
         self._next_story_offset = prefs.next_offset

--- a/docking/applets/hydration/applet.py
+++ b/docking/applets/hydration/applet.py
@@ -53,8 +53,8 @@ class HydrationApplet(Applet):
     name = _("Hydration")
     icon_name = "weather-showers"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        prefs = config.applet_prefs.get("hydration", {}) if config else None
+    def __init__(self, icon_size: int, config: Config) -> None:
+        prefs = config.applet_prefs.get("hydration", {})
         self._state = state_from_prefs(prefs=prefs)
         self._timer_id: int = 0
 

--- a/docking/applets/keyboardlayout/applet.py
+++ b/docking/applets/keyboardlayout/applet.py
@@ -60,7 +60,7 @@ class KeyboardLayoutApplet(Applet):
     name = _("Keyboard Layout")
     icon_name = "input-keyboard"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._backend = detect_backend()
         self._layout = LayoutState(active="", available=[])
         self._timer_id: int = 0

--- a/docking/applets/lastfm/applet.py
+++ b/docking/applets/lastfm/applet.py
@@ -80,10 +80,8 @@ class LastfmApplet(Applet):
     name = _("Last.fm")
     icon_name = "lastfm"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        prefs = prefs_from_mapping(
-            config.applet_prefs.get(meta.id, {}) if config else None
-        )
+    def __init__(self, icon_size: int, config: Config) -> None:
+        prefs = prefs_from_mapping(config.applet_prefs.get(meta.id, {}))
         self._prefs = prefs
         self._tracks: list[PlayedTrack] = []
         self._image_cache = ImageCache(max_entries=prefs.max_entries)

--- a/docking/applets/micshield/applet.py
+++ b/docking/applets/micshield/applet.py
@@ -57,7 +57,7 @@ class MicShieldApplet(Applet):
     name = _("Mic Shield")
     icon_name = "audio-input-microphone"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._state: MicShieldState = probe_mic_state()
         self._timer_id: int = 0
         self._pulse_timer_id: int = 0

--- a/docking/applets/moon/applet.py
+++ b/docking/applets/moon/applet.py
@@ -62,15 +62,14 @@ class MoonApplet(Applet):
     name = _("Moon")
     icon_name = "weather-clear-night"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._moon: MoonData | None = None
         self._show_phase = True
         self._timer_id: int = 0
         self._worker = BackgroundWorker(logger=log)
 
-        if config:
-            prefs = config.applet_prefs.get(meta.id, {})
-            self._show_phase = prefs.get("show_phase", True)
+        prefs = config.applet_prefs.get(meta.id, {})
+        self._show_phase = prefs.get("show_phase", True)
 
         super().__init__(icon_size=icon_size, config=config)
         self.present()

--- a/docking/applets/music/applet.py
+++ b/docking/applets/music/applet.py
@@ -58,7 +58,7 @@ class MusicApplet(Applet):
     name = _("Music")
     icon_name = "audio-x-generic"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._backend = HybridBackend()
         self._cover_art = CoverArtResolver()
         self._state = unavailable_state()

--- a/docking/applets/network/applet.py
+++ b/docking/applets/network/applet.py
@@ -79,7 +79,7 @@ class NetworkApplet(Applet):
     name = _("Network")
     icon_name = "network-wireless-symbolic"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._timer_id: int = 0
         self._nm_client: NM.Client | None = None
         self._nm_handler_id: int = 0
@@ -95,9 +95,8 @@ class NetworkApplet(Applet):
         self._prev_time: float = 0.0
         self._last_wifi_scan_request_time: float = 0.0
 
-        if config:
-            prefs = config.applet_prefs.get(meta.id, {})
-            self._speed_overlay = prefs.get("speed_overlay", "download")
+        prefs = config.applet_prefs.get(meta.id, {})
+        self._speed_overlay = prefs.get("speed_overlay", "download")
 
         super().__init__(icon_size=icon_size, config=config)
         self.present()

--- a/docking/applets/news/applet.py
+++ b/docking/applets/news/applet.py
@@ -110,10 +110,8 @@ class NewsApplet(Applet):
     name = _("News")
     icon_name = "internet-news-reader"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        prefs = prefs_from_mapping(
-            config.applet_prefs.get(meta.id, {}) if config else None
-        )
+    def __init__(self, icon_size: int, config: Config) -> None:
+        prefs = prefs_from_mapping(config.applet_prefs.get(meta.id, {}))
         self._sources = list(prefs.sources)
         self._active_source_index = prefs.active_source_index
         self._articles = list(prefs.articles)

--- a/docking/applets/notifications/applet.py
+++ b/docking/applets/notifications/applet.py
@@ -78,7 +78,7 @@ class NotificationsApplet(Applet):
     name = _("Notifications")
     icon_name = "preferences-system-notifications"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._backend: NotificationsBackend = detect_backend()
         self._state: NotificationsState = self._backend.get_state()
         self._timer_id: int = 0

--- a/docking/applets/pet/applet.py
+++ b/docking/applets/pet/applet.py
@@ -54,7 +54,7 @@ class PetApplet(Applet):
     name = _("Pet")
     icon_name = "face-smile"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._state = PetState()
         self._prev_sample: CpuSample | None = None
         self._timer_id: int = 0

--- a/docking/applets/plantcare/applet.py
+++ b/docking/applets/plantcare/applet.py
@@ -62,9 +62,9 @@ class PlantCareApplet(Applet):
     name = _("Plant Care")
     icon_name = "emblem-default"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         today = self._today()
-        prefs = config.applet_prefs.get(meta.id, {}) if config else None
+        prefs = config.applet_prefs.get(meta.id, {})
         self._state: PlantCareState = state_from_prefs(
             prefs=prefs,
             today=today,

--- a/docking/applets/pomodoro/applet.py
+++ b/docking/applets/pomodoro/applet.py
@@ -61,8 +61,8 @@ class PomodoroApplet(Applet):
     name = _("Pomodoro")
     icon_name = "alarm"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        prefs = config.applet_prefs.get("pomodoro", {}) if config else None
+    def __init__(self, icon_size: int, config: Config) -> None:
+        prefs = config.applet_prefs.get("pomodoro", {})
         self._data = state_from_prefs(prefs=prefs)
         self._timer_id: int = 0
 

--- a/docking/applets/powerprofiles/applet.py
+++ b/docking/applets/powerprofiles/applet.py
@@ -71,7 +71,7 @@ class PowerProfilesApplet(Applet):
     name = _("Power Profiles")
     icon_name = "battery-good-symbolic"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         # Backend is auto-detected once during applet initialization.
         # Polling then queries the same backend instance repeatedly.
         self._backend: PowerProfilesControlBackend = detect_backend()

--- a/docking/applets/quicknote/applet.py
+++ b/docking/applets/quicknote/applet.py
@@ -54,8 +54,8 @@ class QuickNoteApplet(Applet):
     name = _("Quick Note")
     icon_name = "text-editor"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        prefs = config.applet_prefs.get("quicknote", {}) if config else None
+    def __init__(self, icon_size: int, config: Config) -> None:
+        prefs = config.applet_prefs.get("quicknote", {})
         self._note = note_from_prefs(prefs)
         super().__init__(icon_size=icon_size, config=config)
         self.present()

--- a/docking/applets/quote/applet.py
+++ b/docking/applets/quote/applet.py
@@ -56,7 +56,7 @@ class QuoteApplet(Applet):
     name = _("Quote")
     icon_name = "idea"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._source = DEFAULT_SOURCE
         self._quotes: list[QuoteEntry] = []
         self._index = -1
@@ -64,11 +64,10 @@ class QuoteApplet(Applet):
         self._loading = False
         self._clipboard: Gtk.Clipboard | None = None
 
-        if config:
-            prefs = config.applet_prefs.get("quote", {})
-            source = prefs.get("source", DEFAULT_SOURCE)
-            if source in SOURCE_LABELS:
-                self._source = source
+        prefs = config.applet_prefs.get("quote", {})
+        source = prefs.get("source", DEFAULT_SOURCE)
+        if source in SOURCE_LABELS:
+            self._source = source
 
         super().__init__(icon_size, config)
         self._quotes = source_fallback(source=self._source)

--- a/docking/applets/recentfiles/applet.py
+++ b/docking/applets/recentfiles/applet.py
@@ -48,7 +48,7 @@ class RecentFilesApplet(Applet):
     name = _("Recent Files")
     icon_name = "document-open-recent"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._entries: list[RecentEntry] = []
         self._signal_id: int | None = None
         self._refresh_entries()

--- a/docking/applets/reddit/applet.py
+++ b/docking/applets/reddit/applet.py
@@ -67,10 +67,8 @@ class RedditApplet(Applet):
     name = _("Reddit")
     icon_name = "internet-news-reader"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        prefs = prefs_from_mapping(
-            config.applet_prefs.get(meta.id, {}) if config else None
-        )
+    def __init__(self, icon_size: int, config: Config) -> None:
+        prefs = prefs_from_mapping(config.applet_prefs.get(meta.id, {}))
         self._subreddits = list(prefs.subreddits)
         self._active_subreddit_index = prefs.active_subreddit_index
         self._sort = prefs.sort

--- a/docking/applets/runcommand/applet.py
+++ b/docking/applets/runcommand/applet.py
@@ -72,8 +72,8 @@ class RunCommandApplet(Applet):
     icon_name = "system-run"
     icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        prefs = config.applet_prefs.get(meta.id, {}) if config else {}
+    def __init__(self, icon_size: int, config: Config) -> None:
+        prefs = config.applet_prefs.get(meta.id, {})
         self._history = normalize_history(prefs.get("history"))
         self._dialog: Gtk.Dialog | None = None
         self._entry_combo: Gtk.ComboBoxText | None = None

--- a/docking/applets/screenshot/applet.py
+++ b/docking/applets/screenshot/applet.py
@@ -55,7 +55,7 @@ class ScreenshotApplet(Applet):
     icon_name = "applets-screenshooter"
     icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._tool = _detect_tool()
         if not self._tool:
             log.bind(action="detect_tool").warning(

--- a/docking/applets/separator/applet.py
+++ b/docking/applets/separator/applet.py
@@ -51,7 +51,7 @@ class SeparatorApplet(Applet):
     name = _("Separator")
     icon_name = "list-remove"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._gap = DEFAULT_SIZE
         self._style = STYLE_SPACE
         self._invert_color = False
@@ -65,14 +65,11 @@ class SeparatorApplet(Applet):
         return self.item.desktop_id.removeprefix("applet://")
 
     def load_instance_prefs(self) -> dict[str, Any]:
-        if self._config:
-            return dict(self._config.applet_prefs.get(self._prefs_key(), {}))
-        return {}
+        return dict(self._config.applet_prefs.get(self._prefs_key(), {}))
 
     def save_instance_prefs(self, prefs: dict[str, Any]) -> None:
-        if self._config:
-            self._config.applet_prefs[self._prefs_key()] = prefs
-            self._config.save()
+        self._config.applet_prefs[self._prefs_key()] = prefs
+        self._config.save()
 
     def apply_prefs(self) -> None:
         """Load persisted gap size after desktop_id is finalized."""

--- a/docking/applets/session/applet.py
+++ b/docking/applets/session/applet.py
@@ -43,7 +43,7 @@ class SessionApplet(Applet):
     icon_name = "system-log-out"
     icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         super().__init__(icon_size, config)
         self.present()
 

--- a/docking/applets/speedtest/applet.py
+++ b/docking/applets/speedtest/applet.py
@@ -55,15 +55,13 @@ class SpeedtestApplet(Applet):
     name = _("Speedtest")
     icon_name = "network-wired"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._running: bool = False
         self._error: str | None = None
         self._run_request_id: int = 0
         self._worker = BackgroundWorker(logger=log)
 
-        prefs = prefs_from_mapping(
-            config.applet_prefs.get(meta.id, {}) if config else None
-        )
+        prefs = prefs_from_mapping(config.applet_prefs.get(meta.id, {}))
         self._result: SpeedtestResult | None = prefs.last_result
 
         super().__init__(icon_size=icon_size, config=config)

--- a/docking/applets/stretchcoach/applet.py
+++ b/docking/applets/stretchcoach/applet.py
@@ -54,8 +54,8 @@ class StretchCoachApplet(Applet):
     name = _("Stretch Coach")
     icon_name = "alarm"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
-        prefs = config.applet_prefs.get("stretchcoach", {}) if config else None
+    def __init__(self, icon_size: int, config: Config) -> None:
+        prefs = config.applet_prefs.get("stretchcoach", {})
         self._state = state_from_prefs(prefs=prefs)
         self._cards = load_cards()
         self._timer_id: int = 0

--- a/docking/applets/sunrise/applet.py
+++ b/docking/applets/sunrise/applet.py
@@ -64,11 +64,9 @@ class SunriseApplet(Applet):
     name = _("Sunrise")
     icon_name = "weather-clear"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._timer_id: int = 0
-        prefs = prefs_from_mapping(
-            config.applet_prefs.get("sunrise", {}) if config else None
-        )
+        prefs = prefs_from_mapping(config.applet_prefs.get("sunrise", {}))
         self._cities: list[CityPref] = list(prefs.cities)
         self._active_index: int = prefs.active_index
         self._label_mode: LabelMode = prefs.label_mode

--- a/docking/applets/systemmonitor/applet.py
+++ b/docking/applets/systemmonitor/applet.py
@@ -65,7 +65,7 @@ class SystemMonitorApplet(Applet):
     name = _("System Monitor")
     icon_name = "utilities-system-monitor"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._timer_id: int = 0
         self._prev_sample: CpuSample | None = None
         self._cpu: float = 0.0
@@ -76,9 +76,7 @@ class SystemMonitorApplet(Applet):
         self._gpu_reader = GpuReader()
         self._last_drawn_cpu: float = -1.0
         self._last_drawn_mem: float = -1.0
-        prefs = prefs_from_mapping(
-            config.applet_prefs.get(meta.id, {}) if config else None
-        )
+        prefs = prefs_from_mapping(config.applet_prefs.get(meta.id, {}))
         self._show_disk = prefs.show_disk
         self._temperature_unit = prefs.temperature_unit
         super().__init__(icon_size=icon_size, config=config)

--- a/docking/applets/systemtray/applet.py
+++ b/docking/applets/systemtray/applet.py
@@ -57,7 +57,7 @@ class SystemTrayApplet(Applet):
     name = _("System Tray")
     icon_name = "application-x-executable"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._backend = StatusNotifierBackend()
         self._state = self._backend.get_state()
         self._timer_id: int = 0

--- a/docking/applets/thermals/applet.py
+++ b/docking/applets/thermals/applet.py
@@ -66,7 +66,7 @@ class ThermalsApplet(Applet):
     name = _("Thermals")
     icon_name = "utilities-system-monitor"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._snapshot: ThermalSnapshot | None = None
         self._last_updated: dt.datetime | None = None
         self._loading = False
@@ -75,9 +75,7 @@ class ThermalsApplet(Applet):
         self._startup_fetch_timer_id = 0
         self._request_id = 0
         self._worker = BackgroundWorker(logger=log)
-        prefs = prefs_from_mapping(
-            config.applet_prefs.get(meta.id, {}) if config else None
-        )
+        prefs = prefs_from_mapping(config.applet_prefs.get(meta.id, {}))
         self._temperature_unit = prefs.temperature_unit
         super().__init__(icon_size=icon_size, config=config)
         self.present()

--- a/docking/applets/todayinhistory/applet.py
+++ b/docking/applets/todayinhistory/applet.py
@@ -60,7 +60,7 @@ class TodayInHistoryApplet(Applet):
     name = _("Today in History")
     icon_name = "office-calendar"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._events: list[HistoryEvent] = []
         self._index = -1
         self._current: HistoryEvent | None = None

--- a/docking/applets/trash/applet.py
+++ b/docking/applets/trash/applet.py
@@ -51,7 +51,7 @@ class TrashApplet(Applet):
     icon_name = "user-trash"
     icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._desktop = detect_desktop()
         self._backend: TrashBackend = select_trash_backend(desktop=self._desktop)
         self._item_count = self._backend.count_items()

--- a/docking/applets/trivia/applet.py
+++ b/docking/applets/trivia/applet.py
@@ -55,7 +55,7 @@ class TriviaApplet(Applet):
     name = _("Random Trivia")
     icon_name = "dialog-question"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._entries: list[TriviaEntry] = []
         self._index = -1
         self._current: TriviaEntry | None = None

--- a/docking/applets/unitconverter/applet.py
+++ b/docking/applets/unitconverter/applet.py
@@ -116,7 +116,7 @@ class UnitConverterApplet(Applet):
     name = _("Unit Converter")
     icon_name = "emblem-synchronizing-symbolic"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._popup: Gtk.Dialog | None = None
         self._result_label: Gtk.Label | None = None
         self._from_combo: Gtk.ComboBoxText | None = None
@@ -125,7 +125,7 @@ class UnitConverterApplet(Applet):
         self._cat_combo: Gtk.ComboBoxText | None = None
         self._worker = BackgroundWorker(logger=log)
 
-        prefs = config.applet_prefs.get("unitconverter", {}) if config else {}
+        prefs = config.applet_prefs.get("unitconverter", {})
         self._cat_idx = int(prefs.get("category_index", 0))
         self._from_idx = int(prefs.get("from_index", 0))
         self._to_idx = int(prefs.get("to_index", 1))

--- a/docking/applets/urlshortener/applet.py
+++ b/docking/applets/urlshortener/applet.py
@@ -72,7 +72,7 @@ class UrlShortenerApplet(Applet):
     name = _("URL Shortener")
     icon_name = "chain"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._dialog: Gtk.Dialog | None = None
         self._url_entry: Gtk.Entry | None = None
         self._result_label: Gtk.Label | None = None
@@ -80,7 +80,7 @@ class UrlShortenerApplet(Applet):
         self._copy_btn: Gtk.Button | None = None
         self._last_result: str = ""
 
-        prefs = config.applet_prefs.get("urlshortener", {}) if config else {}
+        prefs = config.applet_prefs.get("urlshortener", {})
         self._last_url = str(prefs.get("last_url", ""))
 
         super().__init__(icon_size=icon_size, config=config)

--- a/docking/applets/usbwatch/applet.py
+++ b/docking/applets/usbwatch/applet.py
@@ -52,7 +52,7 @@ class UsbWatchApplet(Applet):
     icon_name = "drive-removable-media-usb"
     icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._monitor = Gio.VolumeMonitor.get()
         self._devices: list[MountedUsbDevice] = mounted_usb_devices(self._monitor)
         self._handler_ids: list[int] = []

--- a/docking/applets/volume/applet.py
+++ b/docking/applets/volume/applet.py
@@ -55,7 +55,7 @@ class VolumeApplet(Applet):
     name = _("Volume")
     icon_name = "audio-volume-medium"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._backend = _detect_backend()
         if not self._backend:
             log.bind(action="detect_backend").warning(
@@ -67,9 +67,8 @@ class VolumeApplet(Applet):
         self._show_level = False
         self._timer_id: int = 0
         self._worker = BackgroundWorker(logger=log)
-        if config:
-            prefs = config.applet_prefs.get(meta.id, {})
-            self._show_level = bool(prefs.get("show_level", False))
+        prefs = config.applet_prefs.get(meta.id, {})
+        self._show_level = bool(prefs.get("show_level", False))
         self._poll()
         super().__init__(icon_size, config)
         self.present()

--- a/docking/applets/weather/applet.py
+++ b/docking/applets/weather/applet.py
@@ -83,7 +83,7 @@ class WeatherApplet(Applet):
     name = _("Weather")
     icon_name = "weather-few-clouds"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._timer_id: int = 0
         self._startup_fetch_timer_id: int = 0
         self._fetch_request_id: int = 0
@@ -96,9 +96,7 @@ class WeatherApplet(Applet):
         self._fetch_error = ""
         self._worker = BackgroundWorker(logger=log)
 
-        prefs = prefs_from_mapping(
-            config.applet_prefs.get("weather", {}) if config else None
-        )
+        prefs = prefs_from_mapping(config.applet_prefs.get("weather", {}))
         self._cities: list[CityPref] = list(prefs.cities)
         self._active_index: int = prefs.active_index
         self._show_temperature = prefs.show_temperature

--- a/docking/applets/whatsapp/applet.py
+++ b/docking/applets/whatsapp/applet.py
@@ -44,7 +44,7 @@ class WhatsAppApplet(Applet):
     icon_name = "phone-symbolic"
     browser_factory = WhatsAppBrowser
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._state = WhatsAppState()
         self._startup_source_id = 0
         self._browser = self.browser_factory(

--- a/docking/applets/whatsapp/notifications.py
+++ b/docking/applets/whatsapp/notifications.py
@@ -30,10 +30,10 @@ class DesktopNotifier:
         self,
         *,
         on_activate: Callable[[], None],
-        on_shown: Callable[[], None] | None = None,
+        on_shown: Callable[[], None],
     ) -> None:
         self._on_activate = on_activate
-        self._on_shown = on_shown or (lambda: None)
+        self._on_shown = on_shown
         self._bus: Gio.DBusConnection | None = None
         self._action_subscription = 0
         self._closed_subscription = 0

--- a/docking/applets/windowkiller/applet.py
+++ b/docking/applets/windowkiller/applet.py
@@ -78,7 +78,7 @@ class WindowKillerApplet(Applet):
     name = _("Window Killer")
     icon_name = "process-stop"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._overlay: Gtk.Window | None = None
         self._window_picker: WindowPickService | None = None
         super().__init__(icon_size=icon_size, config=config)

--- a/docking/applets/workspaces/applet.py
+++ b/docking/applets/workspaces/applet.py
@@ -54,7 +54,7 @@ class WorkspacesApplet(Applet):
     name = _("Workspaces")
     icon_name = "preferences-desktop-workspaces"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         self._workspace_service: WorkspaceService | None = None
         self._watch_handle: object | None = None
         self._last_logged_state: tuple[int, int, str, str] | None = None

--- a/docking/platform/backends/kwin/atspi_window.py
+++ b/docking/platform/backends/kwin/atspi_window.py
@@ -49,6 +49,7 @@ from docking.platform.running import RunningAppInfo, RunningWindowInfo
 
 if TYPE_CHECKING:
     from docking.platform.launcher import Launcher
+    from docking.platform.model import DockModel
 
 log = get_logger(name="atspi_window")
 
@@ -137,17 +138,15 @@ class AtspiWindowService(WindowService):
     def __init__(
         self,
         *,
-        launcher: Launcher | None = None,
-        model: object | None = None,
+        launcher: Launcher,
+        model: DockModel,
     ) -> None:
         self._connection: Gio.DBusConnection | None = None
         self._windows: dict[str, _AtspiWindow] = {}
         self._lock = Lock()
         self._refresh_running = False
         self._model = model
-        self._matcher: AppIdMatcher | None = None
-        if launcher is not None:
-            self._matcher = AppIdMatcher(launcher=launcher)
+        self._matcher = AppIdMatcher(launcher=launcher)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -327,21 +326,18 @@ class AtspiWindowService(WindowService):
     def _publish_running(self) -> None:
         """Build RunningAppInfo per desktop_id and push to the model."""
         model = self._model
-        if model is None:
-            return
         matcher = self._matcher
 
         # Sync visible items into the matcher
-        if matcher is not None:
-            with contextlib.suppress(Exception):
-                matcher.sync_visible_items(model.visible_items())
+        with contextlib.suppress(Exception):
+            matcher.sync_visible_items(model.visible_items())
 
         # Group windows by resolved desktop_id
         by_desktop: dict[str, list[_AtspiWindow]] = {}
         with self._lock:
             for w in self._windows.values():
                 desktop_id = None
-                if matcher is not None and w.app_name:
+                if w.app_name:
                     desktop_id = matcher.match(w.app_name)
                 if not desktop_id:
                     desktop_id = f"kwin:{w.app_name or w.window_id.value}"
@@ -622,7 +618,7 @@ class AtspiWindowService(WindowService):
         # Resolve to a proper .desktop ID via the matcher, falling back to
         # app_name with a kwin: prefix so the UI can still show something.
         desktop_id = None
-        if self._matcher is not None and w.app_name:
+        if w.app_name:
             desktop_id = self._matcher.match(w.app_name)
         if not desktop_id:
             desktop_id = f"kwin:{w.app_name or w.window_id.value}"

--- a/docking/platform/backends/wayland/hyprland_ipc.py
+++ b/docking/platform/backends/wayland/hyprland_ipc.py
@@ -217,8 +217,7 @@ class HyprlandWindowService(WindowService):
         client: HyprlandIpcClient,
         event_stream_factory: Callable[
             [Callable[[HyprlandEvent], None]], HyprlandEventStream | None
-        ]
-        | None = None,
+        ],
         preview_handle_source: object | None = None,
     ) -> None:
         self._model = model
@@ -237,10 +236,9 @@ class HyprlandWindowService(WindowService):
         """Load initial clients and subscribe to taskbar-relevant changes."""
         self._start_preview_handle_source()
         self._refresh()
-        if self._event_stream_factory is not None:
-            self._event_stream = self._event_stream_factory(self._on_event)
-            if self._event_stream is not None:
-                self._event_stream.start()
+        self._event_stream = self._event_stream_factory(self._on_event)
+        if self._event_stream is not None:
+            self._event_stream.start()
 
     def stop(self) -> None:
         """Stop event delivery and clear published running state."""

--- a/docking/platform/backends/wayland/niri_ipc.py
+++ b/docking/platform/backends/wayland/niri_ipc.py
@@ -288,8 +288,7 @@ class NiriWindowService(WindowService):
         client: NiriIpcClient,
         event_stream_factory: Callable[
             [Callable[[NiriEvent], None]], NiriEventStream | None
-        ]
-        | None = None,
+        ],
     ) -> None:
         self._model = model
         self._matcher = AppIdMatcher(launcher=launcher)
@@ -307,10 +306,9 @@ class NiriWindowService(WindowService):
         """Load initial windows and subscribe to events."""
         self._refresh_windows()
         self._refresh_workspaces()
-        if self._event_stream_factory is not None:
-            self._event_stream = self._event_stream_factory(self._on_event)
-            if self._event_stream is not None:
-                self._event_stream.start()
+        self._event_stream = self._event_stream_factory(self._on_event)
+        if self._event_stream is not None:
+            self._event_stream.start()
 
     def stop(self) -> None:
         """Stop event delivery and clear published running state."""
@@ -594,8 +592,7 @@ class NiriWorkspaceService(WorkspaceService):
         client: NiriIpcClient,
         event_stream_factory: Callable[
             [Callable[[NiriEvent], None]], NiriEventStream | None
-        ]
-        | None = None,
+        ],
     ) -> None:
         self._client = client
         self._event_stream_factory = event_stream_factory
@@ -607,10 +604,9 @@ class NiriWorkspaceService(WorkspaceService):
 
     def start(self) -> None:
         self._refresh_workspaces()
-        if self._event_stream_factory is not None:
-            self._event_stream = self._event_stream_factory(self._on_event)
-            if self._event_stream is not None:
-                self._event_stream.start()
+        self._event_stream = self._event_stream_factory(self._on_event)
+        if self._event_stream is not None:
+            self._event_stream.start()
 
     def stop(self) -> None:
         if self._event_stream is not None:

--- a/docking/platform/backends/wayland/wayfire_session.py
+++ b/docking/platform/backends/wayland/wayfire_session.py
@@ -51,6 +51,7 @@ from docking.platform.backends.wayland.wayfire_ipc import (
 )
 
 if TYPE_CHECKING:
+    from docking.core.config import Config
     from docking.platform.launcher import Launcher
     from docking.platform.model import DockModel
 
@@ -79,7 +80,7 @@ class WayfireSessionBackend(SessionBackend):
         layer_shell: object,
         model: DockModel,
         launcher: Launcher,
-        config: object | None = None,
+        config: Config,
         protocol_runtime: WaylandProtocolRuntime | None = None,
         screen_capture: ScreenCaptureService | None = None,
         window_service: WindowService | None = None,
@@ -109,7 +110,7 @@ class WayfireSessionBackend(SessionBackend):
         )
 
         visibility = visibility_service
-        if visibility is None and config is not None:
+        if visibility is None:
             visibility = load_wayfire_visibility_service(config=config)
         if visibility is None:
             visibility = ReducedVisibilityService()

--- a/docking/platform/backends/x11/impl/window_tracker.py
+++ b/docking/platform/backends/x11/impl/window_tracker.py
@@ -245,9 +245,7 @@ class WindowMatcher:
 class WindowTracker:
     """Tracks running applications and maps them to dock items via WM_CLASS."""
 
-    def __init__(
-        self, model: DockModel, launcher: Launcher, config: Config | None = None
-    ) -> None:
+    def __init__(self, model: DockModel, launcher: Launcher, config: Config) -> None:
         self._model = model
         self._config = config
         self._launcher = launcher
@@ -322,7 +320,7 @@ class WindowTracker:
         active_xid = self._active_xid()
         active_workspace = (
             self._screen.get_active_workspace()
-            if self._config and self._config.current_workspace_only
+            if self._config.current_workspace_only
             else None
         )
         snapshots_by_desktop: dict[str, list[RunningWindowInfo]] = {}
@@ -950,7 +948,7 @@ class WindowTracker:
         result: list[Wnck.Window] = []
         active_ws = (
             self._screen.get_active_workspace()
-            if self._config and self._config.current_workspace_only
+            if self._config.current_workspace_only
             else None
         )
         for xid in self._running_xids_by_desktop.get(desktop_id, []):

--- a/docking/scaffold.py
+++ b/docking/scaffold.py
@@ -130,7 +130,7 @@ class {class_name}(Applet):
     name = _("{display}")
     icon_name = "{icon_name}"
 
-    def __init__(self, icon_size: int, config: Config | None = None) -> None:
+    def __init__(self, icon_size: int, config: Config) -> None:
         super().__init__(icon_size, config)
         self.present()
 
@@ -147,16 +147,17 @@ _TEST_PY = '''\
 from __future__ import annotations
 
 from docking.applets.{aid}.applet import {class_name}
+from docking.core.config import Config
 
 
 class Test{class_name}:
     def test_creates_with_icon(self):
-        applet = {class_name}(48)
+        applet = {class_name}(48, Config())
         assert applet.item.icon is not None
 
     def test_icon_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            applet = {class_name}(size)
+            applet = {class_name}(size, Config())
             pixbuf = applet.create_icon(size=size)
             assert pixbuf is not None
             assert pixbuf.get_width() == size

--- a/docking/ui/folder/_browser.py
+++ b/docking/ui/folder/_browser.py
@@ -107,7 +107,7 @@ class FolderRow:
 class FolderBrowser:
     """List folder children with bounded caching and stable sort behavior."""
 
-    def __init__(self, launcher: Launcher | None = None) -> None:
+    def __init__(self, launcher: Launcher) -> None:
         self._launcher = launcher
         self._directory_rows: dict[tuple[str, int, bool, int], list[FolderRow]] = {}
 
@@ -230,17 +230,13 @@ class FolderBrowser:
                     size=int(info.get_size()),
                     created=int(info.get_attribute_uint64("time::created")),
                     modified=int(info.get_attribute_uint64("time::modified")),
-                    icon=(
-                        self._launcher.resolve_file_icon(
-                            target=child_uri,
-                            gicon=icon,
-                            content_type=info.get_content_type() or "",
-                            size=resolved_icon_px,
-                            is_dir=is_dir,
-                        )
-                    )
-                    if self._launcher
-                    else None,
+                    icon=self._launcher.resolve_file_icon(
+                        target=child_uri,
+                        gicon=icon,
+                        content_type=info.get_content_type() or "",
+                        size=resolved_icon_px,
+                        is_dir=is_dir,
+                    ),
                 )
             )
         self._put_lru(

--- a/docking/ui/folder/stack.py
+++ b/docking/ui/folder/stack.py
@@ -132,8 +132,8 @@ class FolderStackController(StackPopupController):
         *,
         config: Config,
         runtime: DockRuntime,
-        launcher: Launcher | None,
-        dock_window: Gtk.Window | None = None,
+        launcher: Launcher,
+        dock_window: Gtk.Window,
     ) -> None:
         super().__init__(
             config=config,
@@ -321,11 +321,7 @@ class FolderStackController(StackPopupController):
 
         prefs = self._folder_prefs_for_item(item)
         uri = launcher_mod.normalize_file_target(item.target) or item.target
-        app_name = (
-            self._launcher.default_directory_app_name()
-            if self._launcher is not None
-            else None
-        )
+        app_name = self._launcher.default_directory_app_name()
         cache_key = (
             uri,
             self._browser.cache_stamp(item.target),
@@ -386,7 +382,7 @@ class FolderStackController(StackPopupController):
     def _folder_stack_action_label(
         self, *, hidden_count: int, app_name: str | None = None
     ) -> str:
-        if app_name is None and self._launcher is not None:
+        if app_name is None:
             app_name = self._launcher.default_directory_app_name()
         if app_name:
             return (

--- a/docking/ui/stack.py
+++ b/docking/ui/stack.py
@@ -294,7 +294,7 @@ class StackPopupController:
         *,
         config: Config,
         runtime: DockRuntime,
-        dock_window: Gtk.Window | None = None,
+        dock_window: Gtk.Window,
     ) -> None:
         self._config = config
         self._runtime = runtime
@@ -467,8 +467,7 @@ class StackPopupController:
 
         # On Wayland popups need a transient parent so the compositor
         # positions them relative to the dock rather than at (0,0).
-        if self._dock_window is not None:
-            window.set_transient_for(self._dock_window)
+        window.set_transient_for(self._dock_window)
 
         screen = window.get_screen()
         visual = screen.get_rgba_visual()

--- a/docking/ui/update_popup.py
+++ b/docking/ui/update_popup.py
@@ -73,7 +73,7 @@ class UpdateCheckController:
         self,
         *,
         config: Config,
-        window: Gtk.Window | None = None,
+        window: Gtk.Window,
     ) -> None:
         self._window = window
         self._config = config
@@ -194,9 +194,6 @@ class UpdateCheckController:
         return self._show_popup(release=release)
 
     def _show_popup(self, *, release: ReleaseInfo) -> bool:
-        if self._window is None:
-            log.debug("Skipping update popup because dock window is unavailable")
-            return False
         if not self._window.get_realized():
             log.debug("Skipping update popup because dock window is not realized")
             return False
@@ -258,7 +255,7 @@ class UpdateCheckController:
         return wrap_startup_popup_content(box)
 
     def _position_popup(self) -> None:
-        if self._popup is None or self._window is None:
+        if self._popup is None:
             return
         window_pos = window_screen_position(self._window)
         win_x, win_y = window_pos.x, window_pos.y

--- a/tests/applets/test_aiusage.py
+++ b/tests/applets/test_aiusage.py
@@ -887,22 +887,22 @@ class TestAiUsageApplet:
         assert applet._state.days[0].sessions == 1
 
     def test_creates_with_icon(self):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         assert applet.item.icon is not None
 
     def test_icon_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            applet = AiUsageApplet(size)
+            applet = AiUsageApplet(size, config=Config())
             pixbuf = applet.create_icon(size=size)
             assert pixbuf is not None
             assert pixbuf.get_width() == size
 
     def test_tooltip_no_usage(self):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         assert "no usage" in applet.item.name
 
     def test_create_icon_forwards_selected_provider_and_display_mode(self, monkeypatch):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         applet._selected_provider = Provider.CODEX
         applet._display_mode = DisplayMode.TOKENS
         render_icon = MagicMock(return_value="pixbuf")
@@ -917,7 +917,7 @@ class TestAiUsageApplet:
         )
 
     def test_start_and_stop_manage_timer(self, monkeypatch):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         monkeypatch.setattr(
             aiusage_mod.GLib, "timeout_add_seconds", lambda _s, _cb: 999
         )
@@ -947,12 +947,12 @@ class TestAiUsageApplet:
         assert applet._timer_id == 0
 
     def test_menu_has_reset(self):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         labels = [mi.get_label() for mi in applet.get_menu_items()]
         assert "Reset Today" in labels
 
     def test_tooltip_widget_builds_headless_box(self, monkeypatch):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         _patch_tooltip_widgets(monkeypatch)
 
         box = applet._build_tooltip_widget()
@@ -962,7 +962,7 @@ class TestAiUsageApplet:
         assert box.children[0].label == "AI Usage: no usage today"
 
     def test_tooltip_widget_renders_token_breakdown_and_week_total(self, monkeypatch):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         _patch_tooltip_widgets(monkeypatch)
         today = set_session(
             session_id="today",
@@ -987,7 +987,7 @@ class TestAiUsageApplet:
         assert "This week: 3.9K" in labels[2]
 
     def test_tooltip_widget_filters_selected_provider_costs(self, monkeypatch):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         _patch_tooltip_widgets(monkeypatch)
         applet._selected_provider = Provider.CODEX
         applet._state = set_session(
@@ -1006,7 +1006,7 @@ class TestAiUsageApplet:
         assert "Gpt-5.4: $2.50" in labels[1]
 
     def test_on_scroll_cycles_providers_and_presents(self, monkeypatch):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         applet.present = MagicMock()
 
         applet.on_scroll(direction_up=True)
@@ -1017,7 +1017,7 @@ class TestAiUsageApplet:
         assert applet.present.call_count == 3
 
     def test_set_provider_and_display_mode_present(self):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         applet.present = MagicMock()
 
         applet._set_provider(provider=Provider.OPENCODE)
@@ -1028,7 +1028,7 @@ class TestAiUsageApplet:
         assert applet.present.call_count == 2
 
     def test_tick_merges_opencode_sessions_and_updates_state(self, monkeypatch):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         applet.present = MagicMock()
         monkeypatch.setattr(aiusage_mod, "_read_prefs_from_disk", lambda: None)
         monkeypatch.setattr(
@@ -1057,7 +1057,7 @@ class TestAiUsageApplet:
         assert applet.present.call_count == 1
 
     def test_tick_merges_codex_sessions_and_updates_state(self, monkeypatch):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         applet.present = MagicMock()
         monkeypatch.setattr(aiusage_mod, "_read_prefs_from_disk", lambda: None)
         monkeypatch.setattr(
@@ -1087,7 +1087,7 @@ class TestAiUsageApplet:
         assert applet.present.call_count == 1
 
     def test_reset_today_saves_prefs_and_presents(self):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         applet._state = set_session(
             session_id="test",
             state=AiUsageState(),
@@ -1103,7 +1103,7 @@ class TestAiUsageApplet:
         applet.present.assert_called_once()
 
     def test_tick_warns_once_when_opencode_poll_fails(self, monkeypatch, caplog):
-        applet = AiUsageApplet(48)
+        applet = AiUsageApplet(48, config=Config())
         monkeypatch.setattr(aiusage_mod, "_read_prefs_from_disk", lambda: None)
 
         def fail_query():

--- a/tests/applets/test_alarm.py
+++ b/tests/applets/test_alarm.py
@@ -162,12 +162,12 @@ class TestAlarmState:
 
 class TestAlarmApplet:
     def test_creates_with_icon(self):
-        applet = AlarmApplet(48)
+        applet = AlarmApplet(48, config=Config())
 
         assert applet.item.icon is not None
 
     def test_icon_renders_at_various_sizes(self):
-        applet = AlarmApplet(48)
+        applet = AlarmApplet(48, config=Config())
         applet._state = AlarmState(presets=(AlarmPreset(hour=7, minute=30),))
 
         for size in [32, 48, 64]:

--- a/tests/applets/test_ambient.py
+++ b/tests/applets/test_ambient.py
@@ -12,6 +12,7 @@ from docking.applets.ambient.state import (
     DEFAULT_VOLUME,
     VOLUME_STEP,
 )
+from docking.core.config import Config
 
 
 class _FakeMenuItem:
@@ -41,7 +42,7 @@ class _FakeCheckMenuItem(_FakeMenuItem):
 def _make_applet() -> AmbientApplet:
     """Create applet with mocked GStreamer."""
     with patch("docking.applets.ambient.applet.Gst"):
-        return AmbientApplet(48)
+        return AmbientApplet(48, config=Config())
 
 
 class TestAmbientApplet:

--- a/tests/applets/test_apod.py
+++ b/tests/applets/test_apod.py
@@ -47,7 +47,7 @@ class _ImmediateWorker:
 
 def _make_applet(icon_size: int = 48, *, config: Config | None = None) -> ApodApplet:
     with patch("docking.applets.apod.applet.BackgroundWorker", _ImmediateWorker):
-        return ApodApplet(icon_size, config=config)
+        return ApodApplet(icon_size, config=config or Config())
 
 
 def _sample_result(**overrides: object) -> ApodResult:

--- a/tests/applets/test_applications.py
+++ b/tests/applets/test_applications.py
@@ -9,6 +9,7 @@ import docking.applets.apps as apps_shared
 from docking.applets.applications.applet import ApplicationsApplet
 from docking.applets.applications.state import _build_app_categories
 from docking.applets.apps import ApplicationEntry, all_desktop_app_infos
+from docking.core.config import Config
 
 
 class TestBuildAppCategories:
@@ -270,12 +271,12 @@ class TestApplicationsApplet:
         )
 
     def test_creates_with_icon(self):
-        d = ApplicationsApplet(48)
+        d = ApplicationsApplet(48, config=Config())
         assert d.item.icon is not None
 
     def test_left_click_opens_launcher_menu(self, monkeypatch):
         self._fake_gtk(monkeypatch)
-        d = ApplicationsApplet(48)
+        d = ApplicationsApplet(48, config=Config())
         d.on_clicked()
 
         assert d._popup_menu is not None
@@ -284,7 +285,7 @@ class TestApplicationsApplet:
 
     def test_launcher_menu_contains_search_entry(self, monkeypatch):
         self._fake_gtk(monkeypatch)
-        d = ApplicationsApplet(48)
+        d = ApplicationsApplet(48, config=Config())
         menu = d._build_launcher_menu()
         items = menu.get_children()
         assert items[0]._child.children[0].placeholder == "Search applications..."
@@ -292,12 +293,12 @@ class TestApplicationsApplet:
         assert isinstance(menu, applications_applet_mod.Gtk.Menu)
 
     def test_right_click_menu_items_are_empty(self):
-        d = ApplicationsApplet(48)
+        d = ApplicationsApplet(48, config=Config())
         assert d.get_menu_items() == []
 
     def test_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            d = ApplicationsApplet(size)
+            d = ApplicationsApplet(size, config=Config())
             pixbuf = d.create_icon(size)
             assert pixbuf is not None
 
@@ -322,7 +323,7 @@ class TestApplicationsApplet:
             },
         )
 
-        applet = ApplicationsApplet(48)
+        applet = ApplicationsApplet(48, config=Config())
         items = applet._build_launcher_menu().get_children()
         search_entry = items[0]._child.children[0]
         internet_item = items[2]

--- a/tests/applets/test_base.py
+++ b/tests/applets/test_base.py
@@ -17,6 +17,7 @@ from docking.applets.base import (
     _icon_label_outline_width,
     draw_icon_label,
 )
+from docking.core.config import Config
 from docking.core.icons import IconSource
 
 
@@ -25,10 +26,10 @@ class _DeferredInitApplet(Applet):
     name = "Deferred Init"
     icon_name = "system-log-out"
 
-    def __init__(self) -> None:
+    def __init__(self, config: Config) -> None:
         self._label = ""
         self.render_calls = 0
-        super().__init__(icon_size=48)
+        super().__init__(icon_size=48, config=config)
         self._label = "Ready"
         self.present()
 
@@ -43,7 +44,7 @@ class _DeferredInitApplet(Applet):
 
 class TestAppletBaseLifecycle:
     def test_initial_presentation_waits_for_subclass_init(self):
-        applet = _DeferredInitApplet()
+        applet = _DeferredInitApplet(Config())
 
         assert applet.render_calls == 1
         assert applet.item.name == "Ready"
@@ -55,7 +56,7 @@ class _BasicApplet(Applet):
     name = "Basic"
     icon_name = "system-log-out"
 
-    def __init__(self, config=None) -> None:
+    def __init__(self, config: Config) -> None:
         self.render_count = 0
         super().__init__(icon_size=32, config=config)
 
@@ -74,7 +75,7 @@ class _SystemIconApplet(Applet):
     icon_name = "system-log-out"
     icon_source_options = (IconSource.DOCKING, IconSource.SYSTEM)
 
-    def __init__(self, config=None) -> None:
+    def __init__(self, config: Config) -> None:
         self.docking_icon = object()
         self.render_count = 0
         super().__init__(icon_size=32, config=config)
@@ -96,8 +97,8 @@ class TestAppletBaseHelpers:
 
         assert applet.load_prefs() == {"enabled": True}
 
-    def test_load_prefs_without_config_returns_empty(self):
-        applet = _BasicApplet()
+    def test_load_prefs_from_empty_config_returns_empty(self):
+        applet = _BasicApplet(Config())
 
         assert applet.load_prefs() == {}
 
@@ -112,7 +113,7 @@ class TestAppletBaseHelpers:
         config.save.assert_called_once_with()
 
     def test_default_hooks_are_safe_and_present_notifies(self):
-        applet = _BasicApplet()
+        applet = _BasicApplet(Config())
         notify = MagicMock()
 
         applet.start(notify)
@@ -128,7 +129,7 @@ class TestAppletBaseHelpers:
         notify.assert_called_once_with()
 
     def test_system_icon_applet_defaults_to_docking_icon(self):
-        applet = _SystemIconApplet()
+        applet = _SystemIconApplet(Config())
 
         assert applet.icon_source() == ICON_SOURCE_DOCKING
         assert applet.create_icon(32) is applet.docking_icon
@@ -262,25 +263,25 @@ class TestDrawIconLabel:
 
 class TestAppletDefaultHooks:
     def test_create_docking_icon_raises_not_implemented(self):
-        applet = _DeferredInitApplet()
+        applet = _DeferredInitApplet(Config())
         with pytest.raises(NotImplementedError):
             applet.create_docking_icon(48)
 
     def test_system_icon_name_defaults_to_icon_name(self):
-        applet = _DeferredInitApplet()
+        applet = _DeferredInitApplet(Config())
         assert applet.system_icon_name() == applet.icon_name
 
     def test_icon_source_no_system_support_returns_docking(self):
-        applet = _DeferredInitApplet()
+        applet = _DeferredInitApplet(Config())
         assert applet.icon_source() == ICON_SOURCE_DOCKING
 
     def test_set_icon_source_no_system_support_returns_early(self):
-        applet = _DeferredInitApplet()
+        applet = _DeferredInitApplet(Config())
         # Should not raise or save
         applet.set_icon_source(ICON_SOURCE_SYSTEM)
 
     def test_set_icon_source_same_value_returns_early(self, monkeypatch):
-        applet = _SystemIconApplet()
+        applet = _SystemIconApplet(Config())
         monkeypatch.setattr(
             applet, "load_prefs", lambda: {ICON_SOURCE_PREF_KEY: ICON_SOURCE_DOCKING}
         )
@@ -288,36 +289,36 @@ class TestAppletDefaultHooks:
         applet.set_icon_source(ICON_SOURCE_DOCKING)
 
     def test_set_popup_anchor(self):
-        applet = _DeferredInitApplet()
+        applet = _DeferredInitApplet(Config())
         anchor = MagicMock()
         applet.set_popup_anchor(anchor)
         assert applet._popup_anchor is anchor
 
     def test_accepts_drop_uris_defaults_false(self):
-        applet = _DeferredInitApplet()
+        applet = _DeferredInitApplet(Config())
         assert applet.accepts_drop_uris() is False
 
     def test_on_drop_uris_default_returns_false(self):
-        applet = _DeferredInitApplet()
+        applet = _DeferredInitApplet(Config())
         assert applet.on_drop_uris(["file:///test.txt"]) is False
 
     def test_stack_content_defaults_to_none(self):
-        applet = _DeferredInitApplet()
+        applet = _DeferredInitApplet(Config())
 
         assert applet.stack_content(48) is None
 
     def test_set_services_default_is_noop(self):
-        applet = _DeferredInitApplet()
+        applet = _DeferredInitApplet(Config())
         services = MagicMock()
         # Should not raise
         applet.set_services(services)
 
     def test_on_scroll_default_is_noop(self):
-        applet = _DeferredInitApplet()
+        applet = _DeferredInitApplet(Config())
         # Should not raise
         applet.on_scroll(direction_up=True)
 
     def test_refresh_tooltip_default_is_noop(self):
-        applet = _DeferredInitApplet()
+        applet = _DeferredInitApplet(Config())
         # Should not raise
         applet.refresh_tooltip()

--- a/tests/applets/test_battery.py
+++ b/tests/applets/test_battery.py
@@ -480,7 +480,7 @@ class TestPeripheralLabel:
 
 class TestPeripheralTooltip:
     def test_tooltip_lists_peripherals_under_battery(self):
-        applet = BatteryApplet(48)
+        applet = BatteryApplet(48, config=Config())
         applet._state = BatteryState(
             icon_name="battery-good",
             capacity=80,
@@ -499,7 +499,7 @@ class TestPeripheralTooltip:
         )
 
     def test_tooltip_battery_only_when_no_peripherals(self):
-        applet = BatteryApplet(48)
+        applet = BatteryApplet(48, config=Config())
         applet._state = BatteryState(
             icon_name="battery-good",
             capacity=80,
@@ -567,7 +567,7 @@ class TestPowerSettingsLauncher:
 
 class TestBatteryAppletRendering:
     def test_renders_valid_pixbuf(self):
-        applet = BatteryApplet(48)
+        applet = BatteryApplet(48, config=Config())
         pixbuf = applet.create_icon(48)
         assert pixbuf is not None
 
@@ -600,7 +600,7 @@ class TestBatteryAppletRendering:
             lambda: opened.append("opened") or True,
         )
 
-        applet = BatteryApplet(48)
+        applet = BatteryApplet(48, config=Config())
         items = applet.get_menu_items()
 
         assert [item.get_label() for item in items] == [
@@ -617,7 +617,7 @@ class TestBatteryAppletRendering:
     def test_menu_overlay_only_without_power_settings_tool(self, monkeypatch):
         monkeypatch.setattr(battery_applet_mod, "power_settings_command", lambda: None)
 
-        applet = BatteryApplet(48)
+        applet = BatteryApplet(48, config=Config())
         assert [item.get_label() for item in applet.get_menu_items()] == [
             "No overlay",
             "Percentage",
@@ -659,13 +659,13 @@ class TestBatteryAppletRendering:
             "docking.applets.battery.applet.read_battery",
             return_value=read_battery("BAT0", base=tmp_path),
         ):
-            applet = BatteryApplet(48)
+            applet = BatteryApplet(48, config=Config())
         assert applet.item.name == "Battery: 72%"
 
     def test_tooltip_no_battery(self, monkeypatch):
         monkeypatch.setattr(battery_applet_mod, "read_peripheral_batteries", list)
         with patch("docking.applets.battery.applet.read_battery", return_value=None):
-            applet = BatteryApplet(48)
+            applet = BatteryApplet(48, config=Config())
         assert applet.item.name == "No battery"
 
     def test_full_charging_icon(self, tmp_path, monkeypatch):
@@ -702,7 +702,7 @@ class TestBatteryAppletRendering:
             battery_applet_mod, "render_icon", lambda **_kwargs: object()
         )
 
-        applet = BatteryApplet(48)
+        applet = BatteryApplet(48, config=Config())
         applet.start(lambda: None)
         assert applet._timer_id == 77
         assert timer_ids == [60]

--- a/tests/applets/test_bluetooth.py
+++ b/tests/applets/test_bluetooth.py
@@ -23,6 +23,7 @@ from docking.applets.bluetooth.state import (
     device_menu_label,
     unavailable_state,
 )
+from docking.core.config import Config
 
 
 class _ImmediateThread:
@@ -787,7 +788,7 @@ def _make_applet(
     backend = _StubBackend(initial_state=state)
     monkeypatch.setattr(bluetooth_applet_mod, "BluezBackend", lambda: backend)
     monkeypatch.setattr(bluetooth_applet_mod, "BackgroundWorker", _ImmediateWorker)
-    applet = BluetoothApplet(48)
+    applet = BluetoothApplet(48, config=Config())
     applet._on_poll_result(
         backend.get_state(active_adapter_path=applet._active_adapter_path)
     )
@@ -868,7 +869,7 @@ class TestBluetoothApplet:
         monkeypatch.setattr(bluetooth_applet_mod, "BluezBackend", lambda: backend)
         monkeypatch.setattr(bluetooth_applet_mod, "BackgroundWorker", _ImmediateWorker)
 
-        applet = BluetoothApplet(48)
+        applet = BluetoothApplet(48, config=Config())
 
         assert backend.get_state_calls == 0
         assert applet._state.available is False

--- a/tests/applets/test_bookmarks.py
+++ b/tests/applets/test_bookmarks.py
@@ -13,6 +13,7 @@ from docking.applets.bookmarks.state import (
     tooltip_text,
     truncate_label,
 )
+from docking.core.config import Config
 
 
 class TestState:
@@ -88,7 +89,7 @@ class TestApplet:
         """Given no config, when created, then empty bookmarks."""
         from docking.applets.bookmarks.applet import BookmarksApplet
 
-        applet = BookmarksApplet(icon_size=48)
+        applet = BookmarksApplet(icon_size=48, config=Config())
         assert applet.item.icon is not None
         assert "No bookmarks" in applet.item.name
 
@@ -109,7 +110,7 @@ class TestApplet:
         """Given bookmarks, when clicked, then opens first URL."""
         from docking.applets.bookmarks.applet import BookmarksApplet
 
-        applet = BookmarksApplet(icon_size=48)
+        applet = BookmarksApplet(icon_size=48, config=Config())
         applet._bookmarks = [Bookmark(name="Ex", url="https://example.com")]
 
         with patch("docking.applets.bookmarks.applet.Gio") as mock_gio:
@@ -122,7 +123,7 @@ class TestApplet:
         """Given no bookmarks, when clicked, then no-op."""
         from docking.applets.bookmarks.applet import BookmarksApplet
 
-        applet = BookmarksApplet(icon_size=48)
+        applet = BookmarksApplet(icon_size=48, config=Config())
         with patch("docking.applets.bookmarks.applet.Gio") as mock_gio:
             applet.on_clicked()
             mock_gio.AppInfo.launch_default_for_uri.assert_not_called()
@@ -148,7 +149,7 @@ class TestApplet:
             bookmarks_applet_mod.Gtk, "SeparatorMenuItem", _FakeMenuItem
         )
 
-        applet = BookmarksApplet(icon_size=48)
+        applet = BookmarksApplet(icon_size=48, config=Config())
         applet._bookmarks = [Bookmark(name="Ex", url="https://example.com")]
         open_url = []
         add_calls = []
@@ -170,7 +171,7 @@ class TestApplet:
     def test_open_url_logs_glib_error(self, monkeypatch):
         from docking.applets.bookmarks.applet import BookmarksApplet
 
-        applet = BookmarksApplet(icon_size=48)
+        applet = BookmarksApplet(icon_size=48, config=Config())
         logger = SimpleNamespace(warning=lambda *_args, **_kwargs: None)
 
         def bind(**_kwargs):
@@ -268,7 +269,7 @@ class TestApplet:
         )
         monkeypatch.setattr(bookmarks_applet_mod.Gtk, "Entry", lambda: next(entries))
 
-        applet = BookmarksApplet(icon_size=48)
+        applet = BookmarksApplet(icon_size=48, config=Config())
         applet.save_prefs = lambda prefs: saved.append(prefs)  # type: ignore[method-assign]
         applet.present = lambda: presented.append(True)  # type: ignore[method-assign]
         saved: list[dict[str, object]] = []
@@ -360,7 +361,7 @@ class TestApplet:
         )
         monkeypatch.setattr(bookmarks_applet_mod.Gtk, "Entry", lambda: next(entries))
 
-        applet = BookmarksApplet(icon_size=48)
+        applet = BookmarksApplet(icon_size=48, config=Config())
         applet.save_prefs = lambda prefs: (_ for _ in ()).throw(AssertionError(prefs))  # type: ignore[method-assign]
 
         applet._show_add_dialog()
@@ -370,7 +371,7 @@ class TestApplet:
     def test_remove_all_clears_state_and_presents(self):
         from docking.applets.bookmarks.applet import BookmarksApplet
 
-        applet = BookmarksApplet(icon_size=48)
+        applet = BookmarksApplet(icon_size=48, config=Config())
         applet._bookmarks = [Bookmark(name="Ex", url="https://example.com")]
         saved: list[dict[str, object]] = []
         applet.save_prefs = lambda prefs: saved.append(prefs)  # type: ignore[method-assign]

--- a/tests/applets/test_brightness.py
+++ b/tests/applets/test_brightness.py
@@ -15,6 +15,7 @@ from docking.applets.brightness.state import (
     detect_output,
     get_brightness,
 )
+from docking.core.config import Config
 
 
 class _ImmediateWorker:
@@ -275,7 +276,7 @@ def _make_applet(brightness: float = 0.8) -> BrightnessApplet:
             return_value=brightness,
         ),
     ):
-        return BrightnessApplet(48)
+        return BrightnessApplet(48, config=Config())
 
 
 class TestBrightnessApplet:
@@ -352,7 +353,7 @@ class TestBrightnessApplet:
         with patch(
             "docking.applets.brightness.applet.detect_output", return_value=None
         ):
-            applet = BrightnessApplet(48)
+            applet = BrightnessApplet(48, config=Config())
         applet.on_scroll(direction_up=True)
         applet.on_clicked()
 

--- a/tests/applets/test_caffeine.py
+++ b/tests/applets/test_caffeine.py
@@ -23,6 +23,7 @@ from docking.applets.caffeine.state import (
     toggle,
     tooltip_text,
 )
+from docking.core.config import Config
 
 
 class FakeInhibitor:
@@ -205,24 +206,24 @@ class TestCompositeInhibitor:
 
 class TestApplet:
     def test_creates_with_icon(self):
-        applet = CaffeineApplet(48, inhibitor=FakeInhibitor())
+        applet = CaffeineApplet(48, inhibitor=FakeInhibitor(), config=Config())
         assert applet.item.icon is not None
 
     def test_icon_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            applet = CaffeineApplet(size, inhibitor=FakeInhibitor())
+            applet = CaffeineApplet(size, inhibitor=FakeInhibitor(), config=Config())
             pixbuf = applet.create_icon(size=size)
             assert pixbuf is not None
             assert pixbuf.get_width() == size
 
     def test_starts_off(self):
-        applet = CaffeineApplet(48, inhibitor=FakeInhibitor())
+        applet = CaffeineApplet(48, inhibitor=FakeInhibitor(), config=Config())
         assert applet._data.active is False
         assert applet.item.name == "Caffeine: off"
 
     def test_click_toggles_and_acquires(self):
         inhibitor = FakeInhibitor()
-        applet = CaffeineApplet(48, inhibitor=inhibitor)
+        applet = CaffeineApplet(48, inhibitor=inhibitor, config=Config())
 
         applet.on_clicked()
 
@@ -232,7 +233,7 @@ class TestApplet:
 
     def test_second_click_releases(self):
         inhibitor = FakeInhibitor()
-        applet = CaffeineApplet(48, inhibitor=inhibitor)
+        applet = CaffeineApplet(48, inhibitor=inhibitor, config=Config())
 
         applet.on_clicked()
         applet.on_clicked()
@@ -243,7 +244,7 @@ class TestApplet:
 
     def test_timed_tick_to_zero_releases(self):
         inhibitor = FakeInhibitor()
-        applet = CaffeineApplet(48, inhibitor=inhibitor)
+        applet = CaffeineApplet(48, inhibitor=inhibitor, config=Config())
         applet._data = CaffeineState(active=True, duration_min=1, remaining=1)
         inhibitor.acquire()
 
@@ -255,7 +256,7 @@ class TestApplet:
 
     def test_stop_releases(self):
         inhibitor = FakeInhibitor()
-        applet = CaffeineApplet(48, inhibitor=inhibitor)
+        applet = CaffeineApplet(48, inhibitor=inhibitor, config=Config())
         applet.on_clicked()
 
         applet.stop()
@@ -263,7 +264,7 @@ class TestApplet:
         assert inhibitor.active is False
 
     def test_menu_lists_duration_choices(self):
-        applet = CaffeineApplet(48, inhibitor=FakeInhibitor())
+        applet = CaffeineApplet(48, inhibitor=FakeInhibitor(), config=Config())
         labels = [
             item.get_label() for item in applet.get_menu_items() if item.get_label()
         ]
@@ -271,7 +272,7 @@ class TestApplet:
         assert "30 min" in labels
 
     def test_menu_shows_status_header(self):
-        applet = CaffeineApplet(48, inhibitor=FakeInhibitor())
+        applet = CaffeineApplet(48, inhibitor=FakeInhibitor(), config=Config())
         labels = [item.get_label() for item in applet.get_menu_items()]
         assert "Off" in labels
 

--- a/tests/applets/test_calculator.py
+++ b/tests/applets/test_calculator.py
@@ -12,7 +12,7 @@ from docking.core.config import Config
 
 
 def _make_applet(config: Config | None = None) -> CalculatorApplet:
-    return CalculatorApplet(48, config=config)
+    return CalculatorApplet(48, config=config or Config())
 
 
 class _FakePopupWindow:
@@ -218,7 +218,7 @@ class TestAppletCreation:
 
     def test_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            applet = CalculatorApplet(size)
+            applet = CalculatorApplet(size, config=Config())
             pixbuf = applet.create_icon(size)
             assert pixbuf is not None
 

--- a/tests/applets/test_calendar.py
+++ b/tests/applets/test_calendar.py
@@ -12,6 +12,7 @@ import pytest
 import docking.applets.calendar.applet as calendar_applet_mod
 from docking.applets.calendar.applet import CalendarApplet
 from docking.applets.calendar.render import _render_calendar_icon
+from docking.core.config import Config
 
 
 class TestRenderCalendarIcon:
@@ -39,11 +40,11 @@ class TestRenderCalendarIcon:
 
 class TestCalendarApplet:
     def test_creates_with_icon(self):
-        applet = CalendarApplet(48)
+        applet = CalendarApplet(48, config=Config())
         assert applet.item.icon is not None
 
     def test_tooltip_is_full_date(self):
-        applet = CalendarApplet(48)
+        applet = CalendarApplet(48, config=Config())
         # Given a second create_icon call (item exists after __init__)
         applet.create_icon(48)
         # Then tooltip contains current day number
@@ -52,18 +53,18 @@ class TestCalendarApplet:
 
     def test_icon_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            applet = CalendarApplet(size)
+            applet = CalendarApplet(size, config=Config())
             pixbuf = applet.create_icon(size)
             assert pixbuf is not None
             assert pixbuf.get_width() == size
 
     def test_no_menu_items(self):
-        applet = CalendarApplet(48)
+        applet = CalendarApplet(48, config=Config())
         assert applet.get_menu_items() == []
 
     def test_start_and_stop_manage_timer(self, monkeypatch):
         # Given
-        applet = CalendarApplet(48)
+        applet = CalendarApplet(48, config=Config())
         remove = MagicMock()
         monkeypatch.setattr(
             calendar_applet_mod.GLib, "timeout_add_seconds", lambda *_a: 77
@@ -80,7 +81,7 @@ class TestCalendarApplet:
 
     def test_tick_refreshes_presentation_when_day_changes(self, monkeypatch):
         # Given
-        applet = CalendarApplet(48)
+        applet = CalendarApplet(48, config=Config())
         applet._last_day = 10
         applet.present = MagicMock()
         monkeypatch.setattr(
@@ -99,7 +100,7 @@ class TestCalendarApplet:
 
     def test_tick_updates_tooltip_only_when_same_day(self, monkeypatch):
         # Given
-        applet = CalendarApplet(48)
+        applet = CalendarApplet(48, config=Config())
         applet._last_day = 10
         applet.present = MagicMock()
         monkeypatch.setattr(
@@ -118,7 +119,7 @@ class TestCalendarApplet:
 
     def test_on_clicked_hides_existing_popup(self):
         # Given
-        applet = CalendarApplet(48)
+        applet = CalendarApplet(48, config=Config())
         applet._popup = MagicMock()
         applet._popup.get_visible.return_value = True
         applet._show_popup = MagicMock()
@@ -229,7 +230,7 @@ class _FakePopupWindow:
 class TestCalendarPopup:
     def test_show_popup_creates_window_and_uses_shared_surface(self, monkeypatch):
         # Given
-        applet = CalendarApplet(48)
+        applet = CalendarApplet(48, config=Config())
         fake_popup = _FakePopupWindow()
         shown: dict[str, object] = {}
 
@@ -269,7 +270,7 @@ class TestCalendarPopup:
 
     def test_stop_destroys_popup(self):
         # Given
-        applet = CalendarApplet(48)
+        applet = CalendarApplet(48, config=Config())
         popup = MagicMock()
         applet._popup = popup
 

--- a/tests/applets/test_camshield.py
+++ b/tests/applets/test_camshield.py
@@ -17,6 +17,7 @@ from docking.applets.camshield.state import (
     holder_label,
     probe_camera_state,
 )
+from docking.core.config import Config
 
 
 def _proc_holder(
@@ -225,7 +226,7 @@ class TestApplet:
         )
         monkeypatch.setattr(camshield_applet_mod, "probe_camera_state", lambda: state)
 
-        applet = CamshieldApplet(icon_size=48)
+        applet = CamshieldApplet(icon_size=48, config=Config())
 
         assert applet.item.desktop_id == "applet://camshield"
         assert "Camera active" in applet.item.name
@@ -234,7 +235,7 @@ class TestApplet:
     def test_menu_contains_refresh(self, monkeypatch):
         state = CamshieldState(available=True, active=False, devices=("video0",))
         monkeypatch.setattr(camshield_applet_mod, "probe_camera_state", lambda: state)
-        applet = CamshieldApplet(icon_size=48)
+        applet = CamshieldApplet(icon_size=48, config=Config())
 
         labels = [item.get_label() for item in applet.get_menu_items()]
 
@@ -249,7 +250,7 @@ class TestApplet:
             "_helper_available",
             lambda _self: False,
         )
-        applet = CamshieldApplet(icon_size=48)
+        applet = CamshieldApplet(icon_size=48, config=Config())
 
         items = applet.get_menu_items()
         labels = [item.get_label() for item in items]
@@ -277,7 +278,7 @@ class TestApplet:
             "source_remove",
             lambda timer_id: removed.append(timer_id),
         )
-        applet = CamshieldApplet(icon_size=48)
+        applet = CamshieldApplet(icon_size=48, config=Config())
 
         applet.start(lambda: None)
         assert applet._timer_id == 11
@@ -301,7 +302,7 @@ class TestApplet:
             holders=(CameraHolder(pid=7, command="camera-app", devices=("video0",)),),
         )
         monkeypatch.setattr(camshield_applet_mod, "probe_camera_state", lambda: state)
-        applet = CamshieldApplet(icon_size=48)
+        applet = CamshieldApplet(icon_size=48, config=Config())
         notifications = 0
 
         def notify():
@@ -332,7 +333,7 @@ class TestApplet:
             "source_remove",
             lambda timer_id: removed.append(timer_id),
         )
-        applet = CamshieldApplet(icon_size=48)
+        applet = CamshieldApplet(icon_size=48, config=Config())
         applet._pulse_timer_id = 42
         applet._pulse_phase = 0.5
 
@@ -350,7 +351,7 @@ class TestApplet:
             "which",
             lambda command: "/usr/bin/pkexec" if command == "pkexec" else None,
         )
-        applet = CamshieldApplet(icon_size=48)
+        applet = CamshieldApplet(icon_size=48, config=Config())
 
         assert applet._helper_available() is False
 
@@ -358,7 +359,7 @@ class TestApplet:
         assert applet._helper_available() is True
 
     def test_run_helper_action_and_command_paths(self, monkeypatch):
-        applet = CamshieldApplet(icon_size=48)
+        applet = CamshieldApplet(icon_size=48, config=Config())
         applet._run_helper_command = MagicMock()
 
         class _Thread:
@@ -382,7 +383,7 @@ class TestApplet:
         applet._run_helper_action("lock")
 
     def test_run_helper_command_refreshes_and_logs_failures(self, monkeypatch):
-        applet = CamshieldApplet(icon_size=48)
+        applet = CamshieldApplet(icon_size=48, config=Config())
         idle: list[object] = []
         monkeypatch.setattr(
             camshield_applet_mod.GLib, "idle_add", lambda cb: idle.append(cb)

--- a/tests/applets/test_capslock.py
+++ b/tests/applets/test_capslock.py
@@ -15,6 +15,7 @@ from docking.applets.capslock.state import (
     query_lock_state,
     tooltip_text,
 )
+from docking.core.config import Config
 
 XSET_OUTPUT = """Keyboard Control:
   auto repeat:  on    key click percent:  0    LED mask:  00000002
@@ -109,7 +110,7 @@ class TestApplet:
         state = LockKeyState(available=True, caps_lock=True, num_lock=True)
         monkeypatch.setattr(capslock_applet_mod, "query_lock_state", lambda: state)
 
-        applet = CapslockApplet(icon_size=48)
+        applet = CapslockApplet(icon_size=48, config=Config())
 
         assert applet.item.desktop_id == "applet://capslock"
         assert "Caps Lock: On" in applet.item.name
@@ -119,7 +120,7 @@ class TestApplet:
     def test_menu_contains_refresh(self, monkeypatch):
         state = LockKeyState(available=True, caps_lock=False, num_lock=True)
         monkeypatch.setattr(capslock_applet_mod, "query_lock_state", lambda: state)
-        applet = CapslockApplet(icon_size=48)
+        applet = CapslockApplet(icon_size=48, config=Config())
 
         labels = [item.get_label() for item in applet.get_menu_items()]
 
@@ -139,7 +140,7 @@ class TestApplet:
             "query_lock_state",
             lambda: next(states),
         )
-        applet = CapslockApplet(icon_size=48)
+        applet = CapslockApplet(icon_size=48, config=Config())
         labels = [item.get_label() for item in applet.get_menu_items()]
         assert "Keyboard lock state unavailable" in labels
 
@@ -161,7 +162,7 @@ class TestApplet:
             "source_remove",
             lambda timer_id: removed.append(timer_id),
         )
-        applet = CapslockApplet(icon_size=48)
+        applet = CapslockApplet(icon_size=48, config=Config())
 
         applet.start(lambda: None)
         applet.stop()
@@ -179,7 +180,7 @@ class TestApplet:
         monkeypatch.setattr(
             capslock_applet_mod, "query_lock_state", lambda: next(states)
         )
-        applet = CapslockApplet(icon_size=48)
+        applet = CapslockApplet(icon_size=48, config=Config())
         calls = 0
 
         def present():
@@ -194,7 +195,7 @@ class TestApplet:
     def test_tick_does_not_present_when_state_is_same(self, monkeypatch):
         state = LockKeyState(available=True, caps_lock=False, num_lock=False)
         monkeypatch.setattr(capslock_applet_mod, "query_lock_state", lambda: state)
-        applet = CapslockApplet(icon_size=48)
+        applet = CapslockApplet(icon_size=48, config=Config())
         applet.present = lambda: (_ for _ in ()).throw(AssertionError("no present"))
 
         assert applet._tick() is True

--- a/tests/applets/test_certwatch.py
+++ b/tests/applets/test_certwatch.py
@@ -73,7 +73,7 @@ def _make_applet(
     icon_size: int = 48, *, config: Config | None = None
 ) -> CertwatchApplet:
     with patch("docking.applets.certwatch.applet.BackgroundWorker", _ImmediateWorker):
-        return CertwatchApplet(icon_size, config=config)
+        return CertwatchApplet(icon_size, config=config or Config())
 
 
 class TestParseHostPort:

--- a/tests/applets/test_clippy.py
+++ b/tests/applets/test_clippy.py
@@ -27,20 +27,20 @@ class TestTruncate:
 
 class TestClipHistory:
     def test_add_clip(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d.add_clip("first")
         d.add_clip("second")
         assert d._clips == ["first", "second"]
 
     def test_dedup_moves_to_end(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d.add_clip("a")
         d.add_clip("b")
         d.add_clip("a")
         assert d._clips == ["b", "a"]
 
     def test_cap_at_max_entries(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d._max_entries = 3
         for i in range(5):
             d.add_clip(str(i))
@@ -48,7 +48,7 @@ class TestClipHistory:
         assert d._clips == ["2", "3", "4"]
 
     def test_position_tracks_newest(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d.add_clip("a")
         assert d._cur_position == 1
         d.add_clip("b")
@@ -57,7 +57,7 @@ class TestClipHistory:
 
 class TestClipScroll:
     def test_scroll_up_decrements(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d.add_clip("a")
         d.add_clip("b")
         d.add_clip("c")
@@ -66,7 +66,7 @@ class TestClipScroll:
         assert d._cur_position == 2
 
     def test_scroll_wraps_around(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d.add_clip("a")
         d.add_clip("b")
         d._cur_position = 1
@@ -74,7 +74,7 @@ class TestClipScroll:
         assert d._cur_position == 2  # wraps to end
 
     def test_scroll_down_increments(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d.add_clip("a")
         d.add_clip("b")
         d._cur_position = 1
@@ -82,7 +82,7 @@ class TestClipScroll:
         assert d._cur_position == 2
 
     def test_scroll_empty_noop(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d.on_scroll(direction_up=True)  # no crash
         assert d._cur_position == 0
 
@@ -121,12 +121,12 @@ class TestClipMenu:
         )
 
     def test_empty_returns_empty(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         assert d.get_menu_items() == []
 
     def test_returns_clips_newest_first(self, monkeypatch):
         self._fake_gtk(monkeypatch)
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d.add_clip("old")
         d.add_clip("new")
         items = d.get_menu_items()
@@ -136,7 +136,7 @@ class TestClipMenu:
         assert items[1].get_label() == "old"
 
     def test_clear_empties_list(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d.add_clip("text")
         d._clear()
         assert d._clips == []
@@ -145,23 +145,23 @@ class TestClipMenu:
 
 class TestClipRendering:
     def test_creates_with_icon(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         assert d.item.icon is not None
 
     def test_tooltip_empty(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d.create_icon(48)
         assert "empty" in d.item.name.lower()
 
     def test_tooltip_shows_current_clip(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d.add_clip("hello world")
         d.refresh_tooltip()
         assert "hello world" in d.item.name
 
     def test_tooltip_updates_on_scroll(self):
         # Given two clips
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d.add_clip("first")
         d.add_clip("second")
         d.refresh_tooltip()
@@ -174,7 +174,7 @@ class TestClipRendering:
         assert "first" in d.item.name
 
     def test_scroll_down_wraps_and_updates_tooltip(self):
-        d = ClippyApplet(48)
+        d = ClippyApplet(48, config=Config())
         d.add_clip("a")
         d.add_clip("b")
         d._cur_position = 2  # at "b"
@@ -193,7 +193,7 @@ class TestClipLifecycle:
         assert applet._max_entries == 7
 
     def test_on_clicked_copies_current_clip_when_available(self):
-        applet = ClippyApplet(48)
+        applet = ClippyApplet(48, config=Config())
         applet._clips = ["a", "b"]
         applet._cur_position = 2
         applet._clipboard = MagicMock()
@@ -204,7 +204,7 @@ class TestClipLifecycle:
         applet._clipboard.store.assert_called_once()
 
     def test_start_connects_clipboard_and_stop_disconnects(self, monkeypatch):
-        applet = ClippyApplet(48)
+        applet = ClippyApplet(48, config=Config())
         clipboard = MagicMock()
         clipboard.connect.return_value = 99
         monkeypatch.setattr(
@@ -221,7 +221,7 @@ class TestClipLifecycle:
         assert applet._handler_id == 0
 
     def test_owner_change_adds_clip_and_refreshes(self):
-        applet = ClippyApplet(48)
+        applet = ClippyApplet(48, config=Config())
         clipboard = MagicMock()
         clipboard.wait_for_text.return_value = "new text"
         applet.add_clip = MagicMock()
@@ -233,7 +233,7 @@ class TestClipLifecycle:
         applet.present.assert_called_once()
 
     def test_copy_to_clipboard_helper_uses_clipboard(self):
-        applet = ClippyApplet(48)
+        applet = ClippyApplet(48, config=Config())
         applet._clipboard = MagicMock()
 
         applet._copy_to_clipboard("hello")

--- a/tests/applets/test_clock.py
+++ b/tests/applets/test_clock.py
@@ -123,7 +123,7 @@ class TestClockState:
 
 class TestClockPrefs:
     def test_defaults_when_no_config(self):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         assert clock._show_digital is False
         assert clock._show_military is False
         assert clock._show_date is False
@@ -184,7 +184,7 @@ class TestClockPrefs:
 class TestClockRendering:
     @pytest.mark.parametrize("size", [32, 48, 64, 96])
     def test_analog_12h_renders(self, size):
-        clock = ClockApplet(size)
+        clock = ClockApplet(size, config=Config())
         pixbuf = clock.create_icon(size)
         assert pixbuf is not None
         assert pixbuf.get_width() == size
@@ -226,7 +226,7 @@ class TestClockRendering:
 
 class TestClockTooltip:
     def test_tooltip_updates_on_render(self):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         clock.create_icon(48)
         assert clock.item.name != "Clock"
         assert time.strftime("%b") in clock.item.name
@@ -242,12 +242,12 @@ class TestClockTooltip:
 
 class TestClockMenuItems:
     def test_returns_six_items_without_alarm(self):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         items = clock.get_menu_items()
         assert len(items) == 6
 
     def test_date_insensitive_in_analog_mode(self):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         items = clock.get_menu_items()
         assert not items[2].get_sensitive()
 
@@ -270,7 +270,7 @@ class TestClockMenuItems:
         assert "Clear Alarm" in labels
 
     def test_acknowledge_item_is_visible_when_alarm_is_urgent(self):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         clock.item.is_urgent = True
         labels = [
             item.get_label()
@@ -282,7 +282,7 @@ class TestClockMenuItems:
 
 class TestClockInteractions:
     def test_toggle_handlers_update_state_and_refresh(self):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         clock._save_prefs = MagicMock()
         clock.present = MagicMock()
 
@@ -304,7 +304,7 @@ class TestClockInteractions:
         assert clock.present.call_count == 4
 
     def test_start_and_stop_delegate_to_clock_timer(self):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         clock._timer = MagicMock()
         clock.start(lambda: None)
         clock.stop()
@@ -326,7 +326,7 @@ class TestClockInteractions:
     def test_tick_only_redraws_on_minute_change_when_seconds_disabled(
         self, monkeypatch
     ):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         clock.present = MagicMock()
         clock._last_minute = 10
         monkeypatch.setattr(
@@ -344,7 +344,7 @@ class TestClockInteractions:
         assert clock._last_minute == 11
 
     def test_tick_triggers_alarm_and_clears_target(self, monkeypatch):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         clock.present = MagicMock()
         clock._save_prefs = MagicMock()
         clock._alarm_target = 100
@@ -363,7 +363,7 @@ class TestClockInteractions:
         assert clock.present.call_count == 1
 
     def test_set_alarm_persists_future_target(self, monkeypatch):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         clock.present = MagicMock()
         clock._save_prefs = MagicMock()
         fake_now = 1_700_000_000
@@ -381,7 +381,7 @@ class TestClockInteractions:
         assert clock.present.call_count == 1
 
     def test_click_acknowledges_urgent_alarm(self):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         clock.item.is_urgent = True
         clock.present = MagicMock()
         clock._calendar_popup = MagicMock()
@@ -394,7 +394,7 @@ class TestClockInteractions:
         clock._calendar_popup.hide.assert_called_once()
 
     def test_click_shows_shared_calendar_popup(self, monkeypatch):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         popup = MagicMock()
         show_calendar_popup = MagicMock(return_value=popup)
         monkeypatch.setattr(clock_mod, "show_calendar_popup", show_calendar_popup)
@@ -407,7 +407,7 @@ class TestClockInteractions:
         )
 
     def test_stop_destroys_calendar_popup(self):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         clock._timer = MagicMock()
         popup = MagicMock()
         clock._calendar_popup = popup
@@ -418,7 +418,7 @@ class TestClockInteractions:
         assert clock._calendar_popup is None
 
     def test_clear_alarm_clears_target_and_urgency(self):
-        clock = ClockApplet(48)
+        clock = ClockApplet(48, config=Config())
         clock._alarm_target = int(time.time()) + 60
         clock.item.is_urgent = True
         clock._save_prefs = MagicMock()

--- a/tests/applets/test_colorpicker.py
+++ b/tests/applets/test_colorpicker.py
@@ -7,6 +7,7 @@ from docking.applets.colorpicker.applet import ColorPickerApplet
 from docking.applets.colorpicker.render import create_icon
 from docking.applets.colorpicker.state import rgb_to_hex
 from docking.applets.services import AppletServices
+from docking.core.config import Config
 
 
 class TestRgbToHex:
@@ -41,52 +42,52 @@ class TestRenderIcon:
 
 class TestColorPickerApplet:
     def test_creates_with_icon(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         assert applet.item.icon is not None
 
     def test_default_tooltip(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         assert applet.item.name == "Color Picker"
 
     def test_tooltip_after_pick(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         applet._hex = "#FF0000"
         applet.refresh_tooltip()
         assert applet.item.name == "#FF0000"
 
     def test_menu_has_show_hex_toggle(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         labels = [mi.get_label() for mi in applet.get_menu_items()]
         assert "Show Hex" in labels
 
     def test_menu_has_copy_when_color_picked(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         applet._hex = "#ABCDEF"
         labels = [mi.get_label() for mi in applet.get_menu_items()]
         assert "Copy #ABCDEF" in labels
 
     def test_menu_no_copy_when_no_color(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         applet._hex = ""
         labels = [mi.get_label() for mi in applet.get_menu_items()]
         assert not any("Copy" in label for label in labels)
 
     def test_icon_renders_at_various_sizes(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         for size in [32, 48, 64]:
             pixbuf = applet.create_icon(size=size)
             assert pixbuf is not None
             assert pixbuf.get_width() == size
 
     def test_on_clicked_starts_pick_mode(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         calls: list[str] = []
         applet._start_pick = lambda: calls.append("pick")  # type: ignore[method-assign]
         applet.on_clicked()
         assert calls == ["pick"]
 
     def test_toggle_hex_saves_and_refreshes(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         calls: list[str] = []
         applet._save = lambda: calls.append("save")  # type: ignore[method-assign]
         applet.present = lambda: calls.append("refresh")  # type: ignore[method-assign]
@@ -113,7 +114,7 @@ class TestColorPickerApplet:
         assert calls == ["rgba", "paint"]
 
     def test_overlay_click_updates_state_when_pixel_found(self, monkeypatch):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         calls: list[str] = []
         applet._dismiss_overlay = lambda: calls.append("dismiss")  # type: ignore[method-assign]
         applet._copy_to_clipboard = lambda: calls.append("copy")  # type: ignore[method-assign]
@@ -141,7 +142,7 @@ class TestColorPickerApplet:
         assert calls == ["dismiss", "copy", "save", "refresh"]
 
     def test_overlay_click_no_pixel_only_dismisses(self, monkeypatch):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         calls: list[str] = []
         applet._dismiss_overlay = lambda: calls.append("dismiss")  # type: ignore[method-assign]
         applet._copy_to_clipboard = lambda: calls.append("copy")  # type: ignore[method-assign]
@@ -160,7 +161,7 @@ class TestColorPickerApplet:
         assert calls == ["dismiss"]
 
     def test_overlay_key_escape_dismisses(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         calls: list[str] = []
         applet._dismiss_overlay = lambda: calls.append("dismiss")  # type: ignore[method-assign]
 
@@ -171,7 +172,7 @@ class TestColorPickerApplet:
         assert calls == ["dismiss"]
 
     def test_overlay_key_other_key_is_noop(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         calls: list[str] = []
         applet._dismiss_overlay = lambda: calls.append("dismiss")  # type: ignore[method-assign]
 
@@ -182,7 +183,7 @@ class TestColorPickerApplet:
         assert calls == []
 
     def test_dismiss_overlay_ungrabs_and_destroys(self, monkeypatch):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         calls: list[str] = []
 
         class _Seat:
@@ -206,7 +207,7 @@ class TestColorPickerApplet:
         assert calls == ["ungrab", "destroy"]
 
     def test_copy_to_clipboard_noop_without_hex(self, monkeypatch):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         applet._hex = ""
         monkeypatch.setattr(
             colorpicker_applet_mod.Gtk.Clipboard,
@@ -218,7 +219,7 @@ class TestColorPickerApplet:
         applet._copy_to_clipboard()
 
     def test_copy_to_clipboard_sets_text(self, monkeypatch):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         applet._hex = "#FF00AA"
         calls: list[tuple[str, object]] = []
 
@@ -238,7 +239,7 @@ class TestColorPickerApplet:
         assert calls == [("set_text", "#FF00AA"), ("store", None)]
 
     def test_save_persists_preferences_payload(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         applet._show_hex = False
         applet._r = 0.1
         applet._g = 0.2
@@ -277,7 +278,7 @@ class TestColorPickerApplet:
         assert applet._b == 0.3
 
     def test_start_pick_noop_when_overlay_exists(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         marker = object()
         applet._overlay = marker
         applet.set_services(AppletServices(screen_capture=object()))
@@ -285,12 +286,12 @@ class TestColorPickerApplet:
         assert applet._overlay is marker
 
     def test_start_pick_noop_without_screen_capture_service(self):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         applet._start_pick()
         assert applet._overlay is None
 
     def test_start_pick_creates_overlay_and_grabs_pointer(self, monkeypatch):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         applet.set_services(AppletServices(screen_capture=object()))
         calls: list[str] = []
 
@@ -366,7 +367,7 @@ class TestColorPickerApplet:
         assert "set_cursor" in calls
 
     def test_stop_dismisses_active_overlay(self, monkeypatch):
-        applet = ColorPickerApplet(48)
+        applet = ColorPickerApplet(48, config=Config())
         calls: list[str] = []
 
         class _Seat:

--- a/tests/applets/test_crypto.py
+++ b/tests/applets/test_crypto.py
@@ -25,6 +25,7 @@ from docking.applets.crypto.state import (
     prefs_from_mapping,
     prefs_payload,
 )
+from docking.core.config import Config
 
 BTC = CryptoAsset(AssetType.COIN, "bitcoin", "BTC", "Bitcoin")
 PUNK = CryptoAsset(AssetType.NFT, "cryptopunks", "PUNK", "CryptoPunks")
@@ -200,7 +201,7 @@ class TestCryptoApplet:
         )
 
         with patch("docking.applets.crypto.applet.BackgroundWorker", _InlineWorker):
-            applet = CryptoApplet(icon_size=48)
+            applet = CryptoApplet(icon_size=48, config=Config())
             applet._snapshot = _snapshot()
             applet.present()
 
@@ -214,7 +215,7 @@ class TestCryptoApplet:
             lambda **_kwargs: object(),
         )
         with patch("docking.applets.crypto.applet.BackgroundWorker", _InlineWorker):
-            applet = CryptoApplet(icon_size=48)
+            applet = CryptoApplet(icon_size=48, config=Config())
         nft_snapshot = CryptoSnapshot(
             asset=PUNK,
             vs_currency="usd",

--- a/tests/applets/test_currencyfx.py
+++ b/tests/applets/test_currencyfx.py
@@ -62,7 +62,7 @@ class _ImmediateWorker:
 
 def _make_applet(config: Config | None = None) -> CurrencyFxApplet:
     with patch("docking.applets.currencyfx.applet.BackgroundWorker", _ImmediateWorker):
-        return CurrencyFxApplet(48, config=config)
+        return CurrencyFxApplet(48, config=config or Config())
 
 
 def _units() -> tuple[Unit, ...]:

--- a/tests/applets/test_deskpresence.py
+++ b/tests/applets/test_deskpresence.py
@@ -31,7 +31,7 @@ from docking.core.config import Config
 def _make_applet(
     icon_size: int = 48, *, config: Config | None = None
 ) -> DeskpresenceApplet:
-    return DeskpresenceApplet(icon_size, config=config)
+    return DeskpresenceApplet(icon_size, config=config or Config())
 
 
 class TestFormatDuration:

--- a/tests/applets/test_desktop.py
+++ b/tests/applets/test_desktop.py
@@ -4,28 +4,29 @@ from unittest.mock import MagicMock
 
 from docking.applets.desktop.applet import DesktopApplet
 from docking.applets.services import AppletServices
+from docking.core.config import Config
 
 
 class TestDesktopApplet:
     def test_creates_with_icon(self):
-        applet = DesktopApplet(48)
+        applet = DesktopApplet(48, config=Config())
         assert applet.item.icon is not None
         assert applet.item.name == "Desktop"
 
     def test_no_menu_items(self):
-        applet = DesktopApplet(48)
+        applet = DesktopApplet(48, config=Config())
         assert applet.get_menu_items() == []
 
     def test_icon_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            applet = DesktopApplet(size)
+            applet = DesktopApplet(size, config=Config())
             pixbuf = applet.create_icon(size)
             assert pixbuf is not None
             assert pixbuf.get_width() == size
 
     def test_click_uses_desktop_action_service(self):
         service = MagicMock()
-        applet = DesktopApplet(48)
+        applet = DesktopApplet(48, config=Config())
         applet.set_services(AppletServices(desktop_actions=service))
 
         applet.on_clicked()
@@ -33,6 +34,6 @@ class TestDesktopApplet:
         service.show_desktop.assert_called_once_with()
 
     def test_click_without_desktop_action_service_is_safe(self):
-        applet = DesktopApplet(48)
+        applet = DesktopApplet(48, config=Config())
 
         applet.on_clicked()

--- a/tests/applets/test_devices.py
+++ b/tests/applets/test_devices.py
@@ -11,6 +11,7 @@ from docking.applets.devices.applet import DevicesApplet
 from docking.applets.devices.render import create_devices_icon
 from docking.applets.devices.state import devices_tooltip, mounted_devices
 from docking.applets.devices.unix_mounts import NativeNetworkMount
+from docking.core.config import Config
 
 
 class _FakeRoot:
@@ -134,7 +135,7 @@ def _applet(
         "get_mount_monitor",
         lambda: unix_monitor,
     )
-    return DevicesApplet(48)
+    return DevicesApplet(48, config=Config())
 
 
 def test_mounted_devices_includes_local_network_and_unbacked_mounts():

--- a/tests/applets/test_docker.py
+++ b/tests/applets/test_docker.py
@@ -18,6 +18,7 @@ from docking.applets.docker.state import (
     restart_container,
     stop_container,
 )
+from docking.core.config import Config
 
 
 class _InlineWorker:
@@ -185,7 +186,7 @@ class TestDockerApplet:
             docker_applet_mod, "render_icon", lambda **_kwargs: object()
         )
 
-        applet = DockerApplet(icon_size=48)
+        applet = DockerApplet(icon_size=48, config=Config())
 
         assert applet.item.name == "Docker: 1 running container"
         assert applet.item.icon is not None
@@ -201,7 +202,7 @@ class TestDockerApplet:
         )
         monkeypatch.setattr(docker_applet_mod, "BackgroundWorker", _InlineWorker)
 
-        applet = DockerApplet(icon_size=48)
+        applet = DockerApplet(icon_size=48, config=Config())
         items = applet.get_menu_items()
 
         labels = [item.get_label() for item in items]
@@ -217,7 +218,7 @@ class TestDockerApplet:
         )
         monkeypatch.setattr(docker_applet_mod, "BackgroundWorker", _InlineWorker)
 
-        applet = DockerApplet(icon_size=48)
+        applet = DockerApplet(icon_size=48, config=Config())
         items = applet.get_menu_items()
         container_item = next(
             item for item in items if item.get_label() == "web (nginx:latest)"
@@ -250,7 +251,7 @@ class TestDockerApplet:
         )
         monkeypatch.setattr(docker_applet_mod, "BackgroundWorker", _InlineWorker)
 
-        applet = DockerApplet(icon_size=48)
+        applet = DockerApplet(icon_size=48, config=Config())
         container_item = next(
             item
             for item in applet.get_menu_items()
@@ -275,7 +276,7 @@ class TestDockerApplet:
         )
         monkeypatch.setattr(docker_applet_mod, "BackgroundWorker", _InlineWorker)
 
-        applet = DockerApplet(icon_size=48)
+        applet = DockerApplet(icon_size=48, config=Config())
         applet.on_clicked()
 
         assert applet.item.name == "Docker: 1 running container"

--- a/tests/applets/test_dragshare.py
+++ b/tests/applets/test_dragshare.py
@@ -19,6 +19,7 @@ from docking.applets.dragshare.state import (
     first_uploadable_file,
     upload_file,
 )
+from docking.core.config import Config
 
 
 class _Response:
@@ -188,7 +189,7 @@ class TestApplet:
         assert saved == [True]
 
     def test_drop_without_local_file_sets_error(self, tmp_path):
-        applet = DragshareApplet(icon_size=48)
+        applet = DragshareApplet(icon_size=48, config=Config())
 
         consumed = applet.on_drop_uris(["https://example.test/file.txt"])
 

--- a/tests/applets/test_hackernews.py
+++ b/tests/applets/test_hackernews.py
@@ -82,7 +82,7 @@ def _make_applet(config: Config | None = None) -> HackerNewsApplet:
         "docking.applets.hackernews.applet.BackgroundWorker",
         _ImmediateWorker,
     ):
-        return HackerNewsApplet(48, config=config)
+        return HackerNewsApplet(48, config=config or Config())
 
 
 class TestHackerNewsState:

--- a/tests/applets/test_hydration.py
+++ b/tests/applets/test_hydration.py
@@ -11,6 +11,7 @@ from docking.applets.hydration.state import (
     tooltip_text,
     water_color,
 )
+from docking.core.config import Config
 
 
 class TestWaterColor:
@@ -34,54 +35,54 @@ class TestTooltipText:
 
 class TestHydrationApplet:
     def test_creates_with_icon(self):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         assert applet.item.icon is not None
         assert "45:00" in applet.item.name
 
     def test_icon_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            applet = HydrationApplet(size)
+            applet = HydrationApplet(size, config=Config())
             pixbuf = applet.create_icon(size=size)
             assert pixbuf is not None
             assert pixbuf.get_width() == size
 
     def test_starts_full(self):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         assert applet._fill == 1.0
 
     def test_tick_decreases_fill(self):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         applet._tick()
         assert applet._fill < 1.0
 
     def test_click_refills(self):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         applet._fill = 0.5
         applet.on_clicked()
         assert applet._fill == 1.0
 
     def test_empty_triggers_urgent(self):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         applet._fill = 1.0 / (DEFAULT_INTERVAL * 60)  # one tick from empty
         applet._tick()
         assert applet._fill <= 0
         assert applet.item.is_urgent is True
 
     def test_click_clears_urgent(self):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         applet._fill = 0.0
         applet.item.is_urgent = True
         applet.on_clicked()
         assert applet.item.is_urgent is False
 
     def test_tick_noop_when_empty(self):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         applet._fill = 0.0
         applet._tick()
         assert applet._fill == 0.0
 
     def test_menu_has_interval_presets(self):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         labels = [mi.get_label() for mi in applet.get_menu_items()]
         assert "30 min" in labels
         assert "45 min" in labels
@@ -89,13 +90,13 @@ class TestHydrationApplet:
         assert "90 min" in labels
 
     def test_renders_when_empty(self):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         applet._fill = 0.0
         pixbuf = applet.create_icon(size=48)
         assert pixbuf is not None
 
     def test_renders_at_half(self):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         applet._fill = 0.5
         pixbuf = applet.create_icon(size=48)
         assert pixbuf is not None
@@ -120,7 +121,7 @@ class TestMouthCurvature:
 
 class TestHydrationLifecycle:
     def test_property_accessors_cover_interval_show_timer_and_tick_count(self):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         applet._interval_min = 30
         applet._show_timer = False
         applet._tick_count = 12
@@ -129,7 +130,7 @@ class TestHydrationLifecycle:
         assert applet._tick_count == 12
 
     def test_start_and_stop_manage_timer(self, monkeypatch):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         monkeypatch.setattr(
             hydration_mod.GLib, "timeout_add_seconds", lambda _s, _cb: 444
         )
@@ -148,7 +149,7 @@ class TestHydrationLifecycle:
         assert applet._timer_id == 0
 
     def test_toggle_timer_updates_state_and_saves(self):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         widget = MagicMock()
         widget.get_active.return_value = False
         applet._save = MagicMock()
@@ -161,7 +162,7 @@ class TestHydrationLifecycle:
         applet.present.assert_called_once()
 
     def test_tick_should_refresh_branch_updates_tooltip(self, monkeypatch):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         refreshed = []
         monkeypatch.setattr(applet, "present", lambda: refreshed.append(True))
         monkeypatch.setattr(
@@ -176,7 +177,7 @@ class TestHydrationLifecycle:
         assert refreshed == [True]
 
     def test_set_interval_saves_preferences(self):
-        applet = HydrationApplet(48)
+        applet = HydrationApplet(48, config=Config())
         applet._save = MagicMock()
         applet._set_interval(minutes=90)
         assert applet._interval_min == 90

--- a/tests/applets/test_keyboardlayout.py
+++ b/tests/applets/test_keyboardlayout.py
@@ -42,6 +42,7 @@ from docking.applets.keyboardlayout.state import (
     show_current_layout,
     tooltip_text,
 )
+from docking.core.config import Config
 from docking.platform.environment import Desktop
 
 
@@ -1048,7 +1049,7 @@ class TestKeyboardLayoutApplet:
         self._mock_ibus(monkeypatch)
         from docking.applets.keyboardlayout.applet import KeyboardLayoutApplet
 
-        applet = KeyboardLayoutApplet(icon_size=48)
+        applet = KeyboardLayoutApplet(icon_size=48, config=Config())
         assert applet._active == "us"
         assert applet._available == ["us", "br"]
 
@@ -1056,7 +1057,7 @@ class TestKeyboardLayoutApplet:
         self._mock_ibus(monkeypatch)
         from docking.applets.keyboardlayout.applet import KeyboardLayoutApplet
 
-        applet = KeyboardLayoutApplet(icon_size=48)
+        applet = KeyboardLayoutApplet(icon_size=48, config=Config())
         applet.refresh_tooltip()
         assert applet.item.name == "English (US)"
 
@@ -1074,7 +1075,7 @@ class TestKeyboardLayoutApplet:
         monkeypatch.setattr(kbl_state, "_run", mock_run)
         from docking.applets.keyboardlayout.applet import KeyboardLayoutApplet
 
-        applet = KeyboardLayoutApplet(icon_size=48)
+        applet = KeyboardLayoutApplet(icon_size=48, config=Config())
         applet.on_clicked()
         assert applet._active == "br"
         assert ["ibus", "engine", "xkb:br::por"] in commands
@@ -1083,7 +1084,7 @@ class TestKeyboardLayoutApplet:
         self._mock_ibus(monkeypatch)
         from docking.applets.keyboardlayout.applet import KeyboardLayoutApplet
 
-        applet = KeyboardLayoutApplet(icon_size=48)
+        applet = KeyboardLayoutApplet(icon_size=48, config=Config())
         applet.on_scroll(direction_up=True)
         assert applet._active == "br"
         applet.on_scroll(direction_up=False)
@@ -1101,7 +1102,7 @@ class TestKeyboardLayoutApplet:
             "docking.applets.keyboardlayout.applet.current_layout_command",
             lambda layout_code: ["gkbd-keyboard-display", "-l", layout_code],
         )
-        applet = KeyboardLayoutApplet(icon_size=48)
+        applet = KeyboardLayoutApplet(icon_size=48, config=Config())
         labels = [item.get_label() for item in applet.get_menu_items()]
         assert labels[0] == "Show Current Layout"
         assert labels[-1] == "Keyboard Settings"
@@ -1118,6 +1119,6 @@ class TestKeyboardLayoutApplet:
         monkeypatch.setattr(kbl_state, "_run", lambda cmd: None)
         from docking.applets.keyboardlayout.applet import KeyboardLayoutApplet
 
-        applet = KeyboardLayoutApplet(icon_size=48)
+        applet = KeyboardLayoutApplet(icon_size=48, config=Config())
         applet.refresh_tooltip()
         assert "No keyboard" in applet.item.name

--- a/tests/applets/test_micshield.py
+++ b/tests/applets/test_micshield.py
@@ -22,6 +22,7 @@ from docking.applets.micshield.state import (
     stream_label,
     toggle_mic_mute,
 )
+from docking.core.config import Config
 
 
 class _ImmediateWorker:
@@ -63,7 +64,7 @@ def _make_applet(state: MicShieldState | None = None) -> MicShieldApplet:
             lambda: state or MicShieldState(False, False, False),
         ),
     ):
-        return MicShieldApplet(48)
+        return MicShieldApplet(48, config=Config())
 
 
 SOURCE_OUTPUTS = """

--- a/tests/applets/test_moon.py
+++ b/tests/applets/test_moon.py
@@ -15,6 +15,7 @@ from docking.applets.moon.offline import (
 )
 from docking.applets.moon.render import create_icon
 from docking.applets.moon.state import MoonData, _parse_moon_html, phase_name
+from docking.core.config import Config
 
 _SAMPLE_HTML = """
 <html><head><title>The Moon's Phase</title></head>
@@ -225,27 +226,27 @@ class TestRenderIcon:
 
 class TestMoonApplet:
     def test_creates_with_icon(self):
-        applet = MoonApplet(48)
+        applet = MoonApplet(48, config=Config())
         assert applet.item.icon is not None
 
     def test_tooltip_loading(self):
-        applet = MoonApplet(48)
+        applet = MoonApplet(48, config=Config())
         assert "loading" in applet.item.name.lower()
 
     def test_tooltip_after_data(self):
-        applet = MoonApplet(48)
+        applet = MoonApplet(48, config=Config())
         applet._moon = _SAMPLE_MOON
         applet.refresh_tooltip()
         assert "96%" in applet.item.name
 
     def test_menu_has_entries(self):
-        applet = MoonApplet(48)
+        applet = MoonApplet(48, config=Config())
         labels = [mi.get_label() for mi in applet.get_menu_items()]
         assert "Show Phase Name" in labels
         assert "Refresh Now" in labels
 
     def test_icon_renders_with_data(self):
-        applet = MoonApplet(48)
+        applet = MoonApplet(48, config=Config())
         applet._moon = _SAMPLE_MOON
         assert applet.create_icon(size=48) is not None
 
@@ -272,7 +273,7 @@ class TestMoonApplet:
         applet.present.assert_called_once()
 
     def test_start_stop_tick_clicked_and_fetch_async(self, monkeypatch):
-        applet = MoonApplet(48)
+        applet = MoonApplet(48, config=Config())
         calls: list[str] = []
         removed: list[int] = []
         applet._fetch_async = lambda: calls.append("fetch")  # type: ignore[assignment]
@@ -299,7 +300,7 @@ class TestMoonApplet:
         assert removed == [55]
 
     def test_fetch_async_and_on_result_branches(self, monkeypatch):
-        applet = MoonApplet(48)
+        applet = MoonApplet(48, config=Config())
         calls: list[tuple[str, object]] = []
         monkeypatch.setattr(moon_applet_mod, "fetch_moon", lambda: _SAMPLE_MOON)
 

--- a/tests/applets/test_music.py
+++ b/tests/applets/test_music.py
@@ -22,6 +22,7 @@ from docking.applets.music.state import (
     tooltip_text,
     unavailable_state,
 )
+from docking.core.config import Config
 
 
 def _state(**overrides: object) -> MusicState:
@@ -629,7 +630,7 @@ def _make_applet(monkeypatch, state: MusicState):
 
     monkeypatch.setattr(music_applet_mod, "HybridBackend", lambda: backend)
     monkeypatch.setattr(music_applet_mod, "CoverArtResolver", lambda: resolver)
-    return MusicApplet(48), backend, resolver
+    return MusicApplet(48, config=Config()), backend, resolver
 
 
 class TestMusicApplet:

--- a/tests/applets/test_network.py
+++ b/tests/applets/test_network.py
@@ -243,23 +243,23 @@ class TestNetworkApplet:
         monkeypatch.setattr(network_applet_mod, "Gtk", fake_gtk)
 
     def test_creates_with_icon(self):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         assert applet.item.icon is not None
 
     def test_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            applet = NetworkApplet(size)
+            applet = NetworkApplet(size, config=Config())
             pixbuf = applet.create_icon(size)
             assert pixbuf is not None
 
     def test_tooltip_disconnected(self):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet.refresh_tooltip()
         assert "not connected" in applet.item.name.lower()
 
     def test_menu_returns_items(self, monkeypatch):
         self._fake_gtk(monkeypatch)
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         items = applet.get_menu_items()
         assert len(items) >= 1
 
@@ -273,7 +273,7 @@ class TestNetworkApplet:
 
     def test_menu_status_rows_for_wifi_and_ethernet(self, monkeypatch):
         self._fake_gtk(monkeypatch)
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._state = NetworkState(
             is_connected=True,
             is_wifi=True,
@@ -319,7 +319,7 @@ class TestNetworkApplet:
         wifi_device = MagicMock()
         wifi_device.get_device_type.return_value = 2
 
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._nm_client = MagicMock()
         applet._nm_client.get_devices.return_value = [wifi_device]
         applet._nm_client.networking_get_enabled.return_value = True
@@ -364,7 +364,7 @@ class TestNetworkApplet:
         wifi_device.get_active_access_point.return_value = active
         wifi_device.get_access_points.return_value = [active, duplicate_weaker, guest]
 
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._nm_client = MagicMock()
         applet._nm_client.get_devices.return_value = [wifi_device]
         applet._nm_client.get_connections.return_value = []
@@ -400,7 +400,7 @@ class TestNetworkApplet:
         wifi_device.get_active_access_point.return_value = None
         wifi_device.request_scan.return_value = True
 
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._nm_client = MagicMock()
         applet._nm_client.get_devices.return_value = [wifi_device]
 
@@ -418,7 +418,7 @@ class TestNetworkApplet:
             SimpleNamespace(WIFI=2, ETHERNET=1),
             raising=False,
         )
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         assert applet._available_networks() == []
 
         ethernet = MagicMock()
@@ -447,7 +447,7 @@ class TestNetworkApplet:
         device = MagicMock()
         device.request_scan.side_effect = RuntimeError("scan failed")
         device.get_iface.return_value = "wlan0"
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
 
         applet._request_wifi_scan(device=device)
 
@@ -476,7 +476,7 @@ class TestNetworkApplet:
         vpn_connection.get_uuid.return_value = "vpn-1"
         vpn_connection.get_id.return_value = "Work VPN"
 
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._nm_client = MagicMock()
         applet._nm_client.get_devices.return_value = [wifi_device]
         applet._nm_client.get_connections.return_value = [vpn_connection]
@@ -513,7 +513,7 @@ class TestNetworkApplet:
         ethernet_device = MagicMock()
         ethernet_device.get_device_type.return_value = 1
 
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._nm_client = MagicMock()
         applet._nm_client.get_devices.return_value = [ethernet_device]
         applet._nm_client.networking_get_enabled.return_value = True
@@ -523,7 +523,7 @@ class TestNetworkApplet:
         assert "Enable Wi-Fi" not in labels
 
     def test_tooltip_wifi_shows_ssid(self):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._state = NetworkState(
             is_connected=True,
             is_wifi=True,
@@ -537,14 +537,14 @@ class TestNetworkApplet:
         assert "72%" in applet.item.name
 
     def test_tooltip_ethernet(self):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._state = NetworkState(is_connected=True, is_wifi=False, iface="eth0")
         applet.refresh_tooltip()
         assert "Ethernet" in applet.item.name
         assert "eth0" in applet.item.name
 
     def test_icon_changes_with_state(self):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         # Disconnected
         applet._state = NetworkState(is_connected=False)
         icon1 = signal_to_icon(
@@ -570,7 +570,7 @@ class TestNmDevicePriority:
         # This is tested implicitly by the priority logic:
         # wifi=2 > ethernet=1 > other=0
         # tun/bridge are skipped entirely
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._state = NetworkState(
             is_connected=True,
             is_wifi=True,
@@ -585,7 +585,7 @@ class TestNetworkAppletInternals:
     def test_connect_available_network_uses_saved_connection_when_present(
         self, monkeypatch
     ):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._nm_client = MagicMock()
         saved_connection = MagicMock()
         device = MagicMock()
@@ -622,7 +622,7 @@ class TestNetworkAppletInternals:
         applet._nm_client.add_and_activate_connection_async.assert_not_called()
 
     def test_connect_available_network_adds_connection_when_unsaved(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._nm_client = MagicMock()
         device = MagicMock()
         access_point = MagicMock()
@@ -658,7 +658,7 @@ class TestNetworkAppletInternals:
         applet._nm_client.activate_connection_async.assert_not_called()
 
     def test_toggle_vpn_connection_activates_saved_vpn(self):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._nm_client = MagicMock()
         connection = MagicMock()
 
@@ -678,7 +678,7 @@ class TestNetworkAppletInternals:
         )
 
     def test_toggle_vpn_connection_deactivates_active_vpn(self):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._nm_client = MagicMock()
         connection = MagicMock()
         active_connection = MagicMock()
@@ -697,7 +697,7 @@ class TestNetworkAppletInternals:
         )
 
     def test_connect_available_network_no_client_no_match_and_error(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         network = AvailableNetwork("DockNet", 70, "/ap/known", False)
         applet._connect_available_network(network=network)
 
@@ -727,7 +727,7 @@ class TestNetworkAppletInternals:
         applet._connect_available_network(network=network)
 
     def test_toggle_vpn_connection_no_client_and_error(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         connection = MagicMock()
         applet._toggle_vpn_connection(
             connection=connection,
@@ -753,7 +753,7 @@ class TestNetworkAppletInternals:
         )
 
     def test_set_networking_enabled_updates_client_and_refreshes(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._nm_client = MagicMock()
         refresh = MagicMock()
         monkeypatch.setattr(applet, "_refresh_state", refresh)
@@ -764,7 +764,7 @@ class TestNetworkAppletInternals:
         refresh.assert_called_once()
 
     def test_set_networking_enabled_no_client_and_error(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._set_networking_enabled(enabled=True)
 
         monkeypatch.setattr(
@@ -783,7 +783,7 @@ class TestNetworkAppletInternals:
         refresh.assert_not_called()
 
     def test_set_wireless_enabled_updates_client_and_refreshes(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._nm_client = MagicMock()
         refresh = MagicMock()
         monkeypatch.setattr(applet, "_refresh_state", refresh)
@@ -794,7 +794,7 @@ class TestNetworkAppletInternals:
         refresh.assert_called_once()
 
     def test_set_wireless_enabled_no_client_and_error(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._set_wireless_enabled(enabled=True)
 
         monkeypatch.setattr(
@@ -814,7 +814,7 @@ class TestNetworkAppletInternals:
 
     def test_start_connects_nm_and_timer(self, monkeypatch):
         # Given
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         notify = MagicMock()
         nm_client = MagicMock()
         monkeypatch.setattr(network_applet_mod.NM.Client, "new", lambda _arg: nm_client)
@@ -833,7 +833,7 @@ class TestNetworkAppletInternals:
 
     def test_start_handles_nm_error(self, monkeypatch):
         # Given
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         notify = MagicMock()
         monkeypatch.setattr(
             network_applet_mod.GLib, "Error", RuntimeError, raising=False
@@ -854,7 +854,7 @@ class TestNetworkAppletInternals:
 
     def test_stop_disconnects_signal_and_timer(self, monkeypatch):
         # Given
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         nm_client = MagicMock()
         applet._nm_client = nm_client
         applet._nm_handler_id = 17
@@ -876,7 +876,7 @@ class TestNetworkAppletInternals:
 
     def test_on_nm_changed_refreshes(self, monkeypatch):
         # Given
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         refresh = MagicMock()
         monkeypatch.setattr(applet, "_refresh_state", refresh)
         # When
@@ -886,7 +886,7 @@ class TestNetworkAppletInternals:
 
     def test_refresh_state_prefers_wifi_and_reads_ip_and_signal(self, monkeypatch):
         # Given
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         monkeypatch.setattr(
             network_applet_mod.NM,
             "DeviceType",
@@ -957,7 +957,7 @@ class TestNetworkAppletInternals:
 
     def test_refresh_state_skips_non_activated_and_tun_bridge(self, monkeypatch):
         # Given
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         monkeypatch.setattr(
             network_applet_mod.NM,
             "DeviceType",
@@ -991,7 +991,7 @@ class TestNetworkAppletInternals:
         self, monkeypatch
     ):
         # Given
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         monkeypatch.setattr(
             network_applet_mod.NM,
             "DeviceType",
@@ -1052,14 +1052,14 @@ class TestNetworkAppletInternals:
         assert applet._state.signal_strength == 73
 
     def test_tick_delegates_to_refresh_state(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         refresh = MagicMock()
         monkeypatch.setattr(applet, "_refresh_state", refresh)
         assert applet._tick() is True
         refresh.assert_called_once()
 
     def test_apply_traffic_no_iface_resets_speeds(self):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         new = applet._apply_traffic(
             state=NetworkState(rx_speed=10.0, tx_speed=20.0, iface="")
         )
@@ -1067,7 +1067,7 @@ class TestNetworkAppletInternals:
         assert new.tx_speed == 0.0
 
     def test_apply_traffic_handles_proc_read_error(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         monkeypatch.setattr(
             type(network_applet_mod._PROC_NET_DEV),
             "open",
@@ -1079,7 +1079,7 @@ class TestNetworkAppletInternals:
         assert result.tx_speed == 0.0
 
     def test_apply_traffic_computes_and_updates_previous(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._prev_counters = TrafficCounters(1000, 2000)
         applet._prev_time = 10.0
         data = (
@@ -1105,7 +1105,7 @@ class TestNetworkAppletInternals:
         assert applet._prev_time == 12.0
 
     def test_refresh_wifi_signal_reads_strength(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         monkeypatch.setattr(
             network_applet_mod.NM,
             "ActiveConnectionState",
@@ -1131,7 +1131,7 @@ class TestNetworkAppletInternals:
         assert signal == 81
 
     def test_refresh_wifi_signal_ignores_unavailable_states(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         # No NM client -> previous value preserved.
         assert (
             applet._refresh_wifi_signal(state=NetworkState(is_wifi=True))
@@ -1154,7 +1154,7 @@ class TestNetworkAppletInternals:
         assert applet._refresh_wifi_signal(state=NetworkState(is_wifi=True)) == 0
 
     def test_refresh_wifi_signal_handles_wifi_without_ap(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         applet._nm_client = MagicMock()
         monkeypatch.setattr(
             network_applet_mod.NM,
@@ -1187,7 +1187,7 @@ class TestNetworkAppletInternals:
     def test_refresh_wifi_signal_skips_non_wifi_active_connection_first(
         self, monkeypatch
     ):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         monkeypatch.setattr(
             network_applet_mod.NM,
             "ActiveConnectionState",
@@ -1221,7 +1221,7 @@ class TestNetworkAppletInternals:
         assert applet._refresh_wifi_signal(state=NetworkState(is_wifi=True)) == 67
 
     def test_refresh_wifi_signal_skips_loopback_device_before_wifi(self, monkeypatch):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         monkeypatch.setattr(
             network_applet_mod.NM,
             "ActiveConnectionState",
@@ -1251,7 +1251,7 @@ class TestNetworkAppletInternals:
         assert applet._refresh_wifi_signal(state=NetworkState(is_wifi=True)) == 67
 
     def test_build_tooltip_disconnected_and_connected(self):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         assert applet._build_tooltip() == "Network\nNot connected"
 
         applet._state = NetworkState(
@@ -1275,7 +1275,7 @@ class TestNetworkAppletInternals:
             SimpleNamespace(WIFI=2, ETHERNET=1),
             raising=False,
         )
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         network = AvailableNetwork("DockNet", 70, "/ap/known", False)
 
         assert applet._find_wifi_access_point(network=network) is None
@@ -1299,7 +1299,7 @@ class TestNetworkAppletInternals:
         )
 
     def test_find_saved_wifi_connection(self):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         assert applet._find_saved_wifi_connection(ssid="DockNet") is None
 
         no_wifi = MagicMock()
@@ -1315,7 +1315,7 @@ class TestNetworkAppletInternals:
         assert applet._find_saved_wifi_connection(ssid="Other") is None
 
     def test_vpn_connections_filters_and_sorts_active_first(self):
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         assert applet._vpn_connections() == []
 
         plain = MagicMock()
@@ -1347,7 +1347,7 @@ class TestNetworkAppletInternals:
             RuntimeError,
             raising=False,
         )
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         client = MagicMock()
         applet._on_activate_connection_finished(client, "result", None)
         client.activate_connection_finish.assert_called_once_with("result")
@@ -1373,7 +1373,7 @@ class TestNetworkAppletInternals:
             SimpleNamespace(WIFI=2, ETHERNET=1, TUN=3, BRIDGE=4, LOOPBACK=5),
             raising=False,
         )
-        applet = NetworkApplet(48)
+        applet = NetworkApplet(48, config=Config())
         assert applet._has_wifi_device() is False
 
         wifi = MagicMock()

--- a/tests/applets/test_news.py
+++ b/tests/applets/test_news.py
@@ -181,7 +181,7 @@ def _rss_item(
 
 def _make_applet(config: Config | None = None) -> NewsApplet:
     with patch("docking.applets.news.applet.BackgroundWorker", _ImmediateWorker):
-        return NewsApplet(48, config=config)
+        return NewsApplet(48, config=config or Config())
 
 
 class TestCountries:

--- a/tests/applets/test_notifications.py
+++ b/tests/applets/test_notifications.py
@@ -25,6 +25,7 @@ from docking.applets.notifications.state import (
     tooltip_text,
     unavailable_state,
 )
+from docking.core.config import Config
 
 
 def _state(**overrides: object) -> NotificationsState:
@@ -303,7 +304,7 @@ def _make_applet(
 ) -> tuple[NotificationsApplet, _StubBackend]:
     backend = _StubBackend(state=state, supports_clear=supports_clear)
     monkeypatch.setattr(notifications_applet_mod, "detect_backend", lambda: backend)
-    return NotificationsApplet(48), backend
+    return NotificationsApplet(48, config=Config()), backend
 
 
 class TestNotificationsApplet:

--- a/tests/applets/test_pet.py
+++ b/tests/applets/test_pet.py
@@ -28,6 +28,7 @@ from docking.applets.pet.state import (
     tick,
     tooltip_text,
 )
+from docking.core.config import Config
 
 # ---------------------------------------------------------------------------
 # resolve_mood
@@ -278,20 +279,20 @@ class TestPetApplet:
     def test_creates_with_happy_mood(self):
         from docking.applets.pet.applet import PetApplet
 
-        applet = PetApplet(icon_size=48)
+        applet = PetApplet(icon_size=48, config=Config())
         assert applet._state.mood == Mood.HAPPY
 
     def test_create_icon_returns_pixbuf(self):
         from docking.applets.pet.applet import PetApplet
 
-        applet = PetApplet(icon_size=48)
+        applet = PetApplet(icon_size=48, config=Config())
         result = applet.create_icon(size=48)
         assert result is not None
 
     def test_refresh_tooltip_sets_name(self):
         from docking.applets.pet.applet import PetApplet
 
-        applet = PetApplet(icon_size=48)
+        applet = PetApplet(icon_size=48, config=Config())
         applet.refresh_tooltip()
         assert applet.item.name
         assert "Happy" in applet.item.name
@@ -299,7 +300,7 @@ class TestPetApplet:
     def test_on_clicked_resets_to_happy(self):
         from docking.applets.pet.applet import PetApplet
 
-        applet = PetApplet(icon_size=48)
+        applet = PetApplet(icon_size=48, config=Config())
         applet._state = PetState(mood=Mood.SLEEPING)
         applet.item.is_urgent = True
         applet.on_clicked()
@@ -316,7 +317,7 @@ class TestPetApplet:
             "timeout_add_seconds",
             lambda _s, _cb: next(timer_ids),
         )
-        applet = PetApplet(icon_size=48)
+        applet = PetApplet(icon_size=48, config=Config())
         applet.start(notify=MagicMock())
         assert applet._timer_id == 42
 
@@ -335,7 +336,7 @@ class TestPetApplet:
             "source_remove",
             lambda sid: removed.append(sid),
         )
-        applet = PetApplet(icon_size=48)
+        applet = PetApplet(icon_size=48, config=Config())
         applet.start(notify=MagicMock())
         applet.stop()
         assert removed == [42]
@@ -345,7 +346,7 @@ class TestPetApplet:
         from docking.applets.pet.applet import PetApplet
 
         proc_data = "cpu  100 0 50 800 10 5 3\n"
-        applet = PetApplet(icon_size=48)
+        applet = PetApplet(icon_size=48, config=Config())
         # First tick just records the sample
         with patch("builtins.open", mock_open(read_data=proc_data)):
             applet._tick()
@@ -357,7 +358,7 @@ class TestPetApplet:
     def test_tick_handles_proc_stat_error(self):
         from docking.applets.pet.applet import PetApplet
 
-        applet = PetApplet(icon_size=48)
+        applet = PetApplet(icon_size=48, config=Config())
         with patch("builtins.open", side_effect=OSError("nope")):
             result = applet._tick()
         assert result is True
@@ -367,7 +368,7 @@ class TestPetApplet:
         from docking.applets.pet.applet import PetApplet
 
         monkeypatch.setattr(pet_mod.GLib, "get_monotonic_time", lambda: 999)
-        applet = PetApplet(icon_size=48)
+        applet = PetApplet(icon_size=48, config=Config())
         # Force state one tick away from committing EXCITED
         applet._state = PetState(
             mood=Mood.HAPPY,

--- a/tests/applets/test_plantcare.py
+++ b/tests/applets/test_plantcare.py
@@ -403,14 +403,14 @@ class TestPlantCareApplet:
     def test_creates_with_icon_and_empty_tooltip(self, monkeypatch):
         monkeypatch.setattr(PlantCareApplet, "_today", staticmethod(lambda: TODAY))
 
-        applet = PlantCareApplet(48)
+        applet = PlantCareApplet(48, config=Config())
 
         assert applet.item.icon is not None
         assert "No plants" in applet.item.name
 
     def test_menu_contains_manage_actions(self, monkeypatch):
         monkeypatch.setattr(PlantCareApplet, "_today", staticmethod(lambda: TODAY))
-        applet = PlantCareApplet(48)
+        applet = PlantCareApplet(48, config=Config())
 
         labels = [item.get_label() for item in applet.get_menu_items()]
 
@@ -420,7 +420,7 @@ class TestPlantCareApplet:
 
     def test_due_menu_exposes_done_and_snooze(self, monkeypatch):
         monkeypatch.setattr(PlantCareApplet, "_today", staticmethod(lambda: TODAY))
-        applet = PlantCareApplet(48)
+        applet = PlantCareApplet(48, config=Config())
         applet._state = PlantCareState(plants=(_plant(),))
 
         menu = applet.get_menu_items()
@@ -453,7 +453,7 @@ class TestPlantCareApplet:
 
     def test_completion_clears_urgency_when_last_task_is_done(self, monkeypatch):
         monkeypatch.setattr(PlantCareApplet, "_today", staticmethod(lambda: TODAY))
-        applet = PlantCareApplet(48)
+        applet = PlantCareApplet(48, config=Config())
         applet._state = PlantCareState(plants=(_plant(),))
         applet._known_due_count = 0
         applet._refresh_due_state()
@@ -469,7 +469,7 @@ class TestPlantCareApplet:
         monkeypatch.setattr(PlantCareApplet, "_today", staticmethod(lambda: TODAY))
         monotonic = MagicMock(side_effect=[100, 200])
         monkeypatch.setattr(plantcare_mod.GLib, "get_monotonic_time", monotonic)
-        applet = PlantCareApplet(48)
+        applet = PlantCareApplet(48, config=Config())
         applet._state = PlantCareState(plants=(_plant(),))
 
         applet._refresh_due_state()
@@ -480,7 +480,7 @@ class TestPlantCareApplet:
 
     def test_start_and_stop_manage_timer(self, monkeypatch):
         monkeypatch.setattr(PlantCareApplet, "_today", staticmethod(lambda: TODAY))
-        applet = PlantCareApplet(48)
+        applet = PlantCareApplet(48, config=Config())
         monkeypatch.setattr(
             plantcare_mod.GLib,
             "timeout_add_seconds",

--- a/tests/applets/test_pomodoro.py
+++ b/tests/applets/test_pomodoro.py
@@ -13,6 +13,7 @@ from docking.applets.pomodoro.state import (
     format_time,
     tooltip_text,
 )
+from docking.core.config import Config
 
 # -- Pure functions -----------------------------------------------------------
 
@@ -56,25 +57,25 @@ class TestTooltipText:
 
 class TestStateMachine:
     def test_starts_idle(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         assert applet._state == State.IDLE
         assert applet._remaining == 0
 
     def test_click_starts_work(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet.on_clicked()
         assert applet._state == State.WORK
         assert applet._remaining == DEFAULT_WORK * 60
 
     def test_click_pauses_work(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet.on_clicked()  # idle → work
         applet.on_clicked()  # work → paused
         assert applet._state == State.PAUSED
         assert applet._paused_from == State.WORK
 
     def test_click_resumes_from_pause(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet.on_clicked()  # idle → work
         remaining = applet._remaining
         applet.on_clicked()  # work → paused
@@ -83,7 +84,7 @@ class TestStateMachine:
         assert applet._remaining == remaining
 
     def test_work_transitions_to_break(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet.on_clicked()  # idle → work
         applet._remaining = 1
         applet._tick()  # remaining → 0 → auto-transition
@@ -91,7 +92,7 @@ class TestStateMachine:
         assert applet._remaining == DEFAULT_BREAK * 60
 
     def test_auto_transition_triggers_urgent(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet.on_clicked()  # idle → work
         applet._remaining = 1
         applet._tick()  # triggers auto-transition
@@ -99,7 +100,7 @@ class TestStateMachine:
         assert applet.item.last_urgent > 0
 
     def test_break_transitions_to_work(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet._state = State.BREAK
         applet._remaining = 1
         applet._tick()
@@ -107,7 +108,7 @@ class TestStateMachine:
         assert applet._remaining == DEFAULT_WORK * 60
 
     def test_long_break_every_n_cycles(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         # Simulate completing LONG_BREAK_EVERY work sessions
         for i in range(LONG_BREAK_EVERY):
             applet._state = State.WORK
@@ -123,19 +124,19 @@ class TestStateMachine:
         assert applet._remaining == DEFAULT_LONG_BREAK * 60
 
     def test_long_break_transitions_to_work(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet._state = State.LONG_BREAK
         applet._remaining = 1
         applet._tick()
         assert applet._state == State.WORK
 
     def test_tick_noop_when_idle(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         assert applet._tick() is True
         assert applet._state == State.IDLE
 
     def test_tick_noop_when_paused(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet.on_clicked()  # idle → work
         remaining = applet._remaining
         applet.on_clicked()  # work → paused
@@ -145,7 +146,7 @@ class TestStateMachine:
 
 class TestReset:
     def test_reset_from_work(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet.on_clicked()  # idle → work
         applet._reset()
         assert applet._state == State.IDLE
@@ -158,7 +159,7 @@ class TestReset:
 
 class TestCreateIcon:
     def test_renders_at_various_sizes(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         for size in [32, 48, 64]:
             pixbuf = applet.create_icon(size=size)
             assert pixbuf is not None
@@ -166,20 +167,20 @@ class TestCreateIcon:
             assert pixbuf.get_height() == size
 
     def test_renders_in_work_state(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet.on_clicked()
         pixbuf = applet.create_icon(size=48)
         assert pixbuf is not None
 
     def test_renders_in_paused_state(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet.on_clicked()
         applet.on_clicked()  # paused
         pixbuf = applet.create_icon(size=48)
         assert pixbuf is not None
 
     def test_renders_in_break_state(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet._state = State.BREAK
         applet._remaining = 300
         pixbuf = applet.create_icon(size=48)
@@ -191,20 +192,20 @@ class TestCreateIcon:
 
 class TestMenu:
     def test_has_reset_item(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         items = applet.get_menu_items()
         labels = [mi.get_label() for mi in items if mi.get_label()]
         assert "Reset" in labels
 
     def test_has_work_presets(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         items = applet.get_menu_items()
         labels = [mi.get_label() for mi in items if mi.get_label()]
         assert "25 min" in labels
         assert "45 min" in labels
 
     def test_has_break_presets(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         items = applet.get_menu_items()
         labels = [mi.get_label() for mi in items if mi.get_label()]
         assert "5 min" in labels
@@ -216,17 +217,17 @@ class TestMenu:
 
 class TestTooltip:
     def test_idle_tooltip(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         assert applet.item.name == "Pomodoro"
 
     def test_work_tooltip(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet.on_clicked()
         assert "Work" in applet.item.name
         assert "remaining" in applet.item.name
 
     def test_paused_tooltip(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet.on_clicked()
         applet.on_clicked()
         assert "Paused" in applet.item.name
@@ -234,7 +235,7 @@ class TestTooltip:
 
 class TestPomodoroInternals:
     def test_property_setters_cover_internal_mutators(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet._paused_from = State.WORK
         applet._work_count = 2
         applet._work_min = 30
@@ -250,7 +251,7 @@ class TestPomodoroInternals:
         assert applet._show_timer is False
 
     def test_start_and_stop_manage_timer(self, monkeypatch):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         monkeypatch.setattr(
             pomodoro_mod.GLib, "timeout_add_seconds", lambda _s, _cb: 515
         )
@@ -269,7 +270,7 @@ class TestPomodoroInternals:
         assert applet._timer_id == 0
 
     def test_toggle_and_duration_setters_save(self):
-        applet = PomodoroApplet(48)
+        applet = PomodoroApplet(48, config=Config())
         applet._save = MagicMock()
         applet.present = MagicMock()
 

--- a/tests/applets/test_powerprofiles.py
+++ b/tests/applets/test_powerprofiles.py
@@ -22,6 +22,7 @@ from docking.applets.powerprofiles.state import (
     tooltip_text,
     unavailable_state,
 )
+from docking.core.config import Config
 
 
 def _state(**overrides: object) -> PowerProfilesState:
@@ -481,7 +482,7 @@ def _make_applet(
 ) -> tuple[PowerProfilesApplet, _StubBackend]:
     backend = _StubBackend(state=state)
     monkeypatch.setattr(powerprofiles_applet_mod, "detect_backend", lambda: backend)
-    applet = PowerProfilesApplet(48)
+    applet = PowerProfilesApplet(48, config=Config())
     return applet, backend
 
 

--- a/tests/applets/test_quicknote.py
+++ b/tests/applets/test_quicknote.py
@@ -21,6 +21,7 @@ from docking.applets.quicknote.state import (
     prefs_from_note,
     tooltip_text,
 )
+from docking.core.config import Config
 
 
 class TestState:
@@ -100,7 +101,7 @@ class TestApplet:
         """Given no config, applet starts with empty note."""
         from docking.applets.quicknote.applet import QuickNoteApplet
 
-        applet = QuickNoteApplet(48)
+        applet = QuickNoteApplet(48, config=Config())
         assert applet._note == ""
         assert applet.item.name == "Empty note"
 
@@ -128,7 +129,7 @@ class TestApplet:
         """Given an applet, create_icon returns pixbuf."""
         from docking.applets.quicknote.applet import QuickNoteApplet
 
-        applet = QuickNoteApplet(48)
+        applet = QuickNoteApplet(48, config=Config())
         pixbuf = applet.create_icon(size=48)
         assert pixbuf is not None
 
@@ -136,14 +137,14 @@ class TestApplet:
         """Given an applet, menu has edit and clear items."""
         from docking.applets.quicknote.applet import QuickNoteApplet
 
-        applet = QuickNoteApplet(48)
+        applet = QuickNoteApplet(48, config=Config())
         items = applet.get_menu_items()
         assert [item.get_label() for item in items] == ["Edit Note", "", "Clear Note"]
 
     def test_on_clicked_opens_edit_dialog(self, monkeypatch):
         from docking.applets.quicknote.applet import QuickNoteApplet
 
-        applet = QuickNoteApplet(48)
+        applet = QuickNoteApplet(48, config=Config())
         show = MagicMock()
         monkeypatch.setattr(applet, "_show_edit_dialog", show)
 
@@ -166,7 +167,7 @@ class TestApplet:
 
         monkeypatch.setattr(quicknote_applet_mod.Gtk, "MenuItem", _FakeMenuItem)
 
-        applet = QuickNoteApplet(48)
+        applet = QuickNoteApplet(48, config=Config())
         show = MagicMock()
         clear = MagicMock()
         monkeypatch.setattr(applet, "_show_edit_dialog", show)

--- a/tests/applets/test_quote.py
+++ b/tests/applets/test_quote.py
@@ -62,12 +62,12 @@ class TestFetchQuotes:
 
 class TestQuoteApplet:
     def test_creates_with_icon(self):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         assert applet.item.icon is not None
         assert applet._source == DEFAULT_SOURCE
 
     def test_click_advances_quotes(self):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         applet._quotes = [
             QuoteEntry(text="one"),
             QuoteEntry(text="two"),
@@ -82,7 +82,7 @@ class TestQuoteApplet:
         assert applet._current == QuoteEntry(text="two")
 
     def test_exhausted_click_triggers_fetch(self):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         applet._quotes = [QuoteEntry(text="only")]
         applet._index = 0
         applet._current = QuoteEntry(text="only")
@@ -92,7 +92,7 @@ class TestQuoteApplet:
         fetch_mock.assert_called_once_with(show_first=True)
 
     def test_menu_contains_core_actions(self):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         labels = [item.get_label() for item in applet.get_menu_items()]
         assert "Next Quote" in labels
         assert "Copy Quote" in labels
@@ -100,7 +100,7 @@ class TestQuoteApplet:
         assert "Source" in labels
 
     def test_menu_contains_legacy_source_labels(self):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         labels = [item.get_label() for item in applet.get_menu_items()]
         for label in SOURCE_LABELS.values():
             assert label in labels
@@ -121,7 +121,7 @@ class TestQuoteApplet:
 
 class TestQuoteAppletBranches:
     def test_on_source_toggled_ignores_inactive_widget(self):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         applet._set_source = MagicMock()
         widget = MagicMock()
         widget.get_active.return_value = False
@@ -129,20 +129,20 @@ class TestQuoteAppletBranches:
         applet._set_source.assert_not_called()
 
     def test_set_source_ignores_invalid_and_same_source(self):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         applet._fetch_async = MagicMock()
         applet._set_source("invalid-source")
         applet._set_source(applet._source)
         applet._fetch_async.assert_not_called()
 
     def test_refresh_from_web_delegates_to_async_fetch(self):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         applet._fetch_async = MagicMock()
         applet._refresh_from_web()
         applet._fetch_async.assert_called_once_with(show_first=True)
 
     def test_copy_current_quote_uses_clipboard(self, monkeypatch):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         applet._current = QuoteEntry(text="hello", author="world")
         clipboard = MagicMock()
         monkeypatch.setattr(quote_mod.Gtk.Clipboard, "get", lambda *_a, **_k: clipboard)
@@ -153,7 +153,7 @@ class TestQuoteAppletBranches:
         clipboard.store.assert_called_once()
 
     def test_copy_current_quote_handles_clipboard_errors(self):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         applet._current = QuoteEntry(text="x")
         applet._clipboard = MagicMock()
         applet._clipboard.set_text.side_effect = RuntimeError("boom")
@@ -161,14 +161,14 @@ class TestQuoteAppletBranches:
         applet._copy_current_quote()
 
     def test_fetch_async_noop_when_loading(self):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         applet._loading = True
         applet.present = MagicMock()
         applet._fetch_async(show_first=True)
         applet.present.assert_not_called()
 
     def test_fetch_async_runs_worker_and_posts_idle_result(self, monkeypatch):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         monkeypatch.setattr(
             quote_mod, "fetch_quotes", lambda source, limit: [QuoteEntry(text="q")]
         )
@@ -197,7 +197,7 @@ class TestQuoteAppletBranches:
         assert calls[0][3] is True
 
     def test_on_fetch_result_ignores_stale_source(self):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         applet._source = "qdb"
         applet._loading = True
         assert (
@@ -206,7 +206,7 @@ class TestQuoteAppletBranches:
         )
 
     def test_on_fetch_result_applies_quotes_and_fallback(self, monkeypatch):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         applet._source = "qdb"
         applet._loading = True
         applet.present = MagicMock()
@@ -223,7 +223,7 @@ class TestQuoteAppletBranches:
         assert applet._current == QuoteEntry(text="fallback")
 
     def test_refresh_tooltip_loading_state(self):
-        applet = QuoteApplet(48)
+        applet = QuoteApplet(48, config=Config())
         applet._loading = True
         applet._current = None
         applet.refresh_tooltip()

--- a/tests/applets/test_recentfiles.py
+++ b/tests/applets/test_recentfiles.py
@@ -8,6 +8,7 @@ from docking.applets.recentfiles.state import (
     tooltip_text,
     truncate_name,
 )
+from docking.core.config import Config
 
 
 class TestState:
@@ -100,7 +101,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48)
+            applet = RecentFilesApplet(48, config=Config())
 
         # Then
         assert len(applet._entries) == 2
@@ -117,7 +118,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48)
+            applet = RecentFilesApplet(48, config=Config())
 
         # Then
         assert applet._entries == []
@@ -136,7 +137,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48)
+            applet = RecentFilesApplet(48, config=Config())
 
         # Then only existing entries kept
         assert len(applet._entries) == 1
@@ -154,7 +155,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48)
+            applet = RecentFilesApplet(48, config=Config())
 
         # When
         with patch(
@@ -175,7 +176,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48)
+            applet = RecentFilesApplet(48, config=Config())
 
         # When
         with patch(
@@ -200,7 +201,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48)
+            applet = RecentFilesApplet(48, config=Config())
 
         # When / Then (no exception raised)
         with patch(
@@ -222,7 +223,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48)
+            applet = RecentFilesApplet(48, config=Config())
 
         # When
         items = applet.get_menu_items()
@@ -240,7 +241,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48)
+            applet = RecentFilesApplet(48, config=Config())
 
         # When
         items = applet.get_menu_items()
@@ -260,7 +261,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48)
+            applet = RecentFilesApplet(48, config=Config())
 
             # When start
             applet.start(lambda: None)

--- a/tests/applets/test_reddit.py
+++ b/tests/applets/test_reddit.py
@@ -112,7 +112,7 @@ def _make_applet(config: Config | None = None) -> RedditApplet:
         "docking.applets.reddit.applet.BackgroundWorker",
         _ImmediateWorker,
     ):
-        return RedditApplet(48, config=config)
+        return RedditApplet(48, config=config or Config())
 
 
 class TestRedditSources:

--- a/tests/applets/test_runcommand.py
+++ b/tests/applets/test_runcommand.py
@@ -22,6 +22,7 @@ from docking.applets.runcommand.state import (
     normalize_history,
     updated_history,
 )
+from docking.core.config import Config
 
 
 class _FakeAppInfo:
@@ -140,7 +141,7 @@ class _FakeRow:
 
 
 def _make_applet() -> RunCommandApplet:
-    return RunCommandApplet(48)
+    return RunCommandApplet(48, config=Config())
 
 
 class TestRunCommandState:

--- a/tests/applets/test_screenshot.py
+++ b/tests/applets/test_screenshot.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import docking.applets.screenshot.state as screenshot_state
 from docking.applets.screenshot.applet import ScreenshotApplet
 from docking.applets.screenshot.state import _TOOLS, Tool, _detect_tool, _run
+from docking.core.config import Config
 
 _MATE = Tool("mate-screenshot", [], ["-w"], ["-a"])
 _GNOME = Tool("gnome-screenshot", [], ["-w"], ["-a"])
@@ -372,7 +373,7 @@ class TestScreenshotApplet:
         with patch(
             "docking.applets.screenshot.applet._detect_tool", return_value=_MATE
         ):
-            applet = ScreenshotApplet(48)
+            applet = ScreenshotApplet(48, config=Config())
         assert applet.item.icon is not None
         assert applet.item.name == "Screenshot"
 
@@ -381,7 +382,7 @@ class TestScreenshotApplet:
             "docking.applets.screenshot.applet._detect_tool", return_value=_MATE
         ):
             for size in [32, 48, 64]:
-                applet = ScreenshotApplet(size)
+                applet = ScreenshotApplet(size, config=Config())
                 pixbuf = applet.create_icon(size)
                 assert pixbuf is not None
                 assert pixbuf.get_width() == size
@@ -390,7 +391,7 @@ class TestScreenshotApplet:
         with patch(
             "docking.applets.screenshot.applet._detect_tool", return_value=_MATE
         ):
-            applet = ScreenshotApplet(48)
+            applet = ScreenshotApplet(48, config=Config())
         labels = [mi.get_label() for mi in applet.get_menu_items() if mi.get_label()]
         assert labels == [
             "Full Screen",
@@ -404,21 +405,21 @@ class TestScreenshotApplet:
 
     def test_menu_empty_when_no_tool(self):
         with patch("docking.applets.screenshot.applet._detect_tool", return_value=None):
-            applet = ScreenshotApplet(48)
+            applet = ScreenshotApplet(48, config=Config())
         assert applet.get_menu_items() == []
 
     def test_on_clicked_calls_popen(self):
         with patch(
             "docking.applets.screenshot.applet._detect_tool", return_value=_MATE
         ):
-            applet = ScreenshotApplet(48)
+            applet = ScreenshotApplet(48, config=Config())
         with patch("docking.applets.screenshot.state.subprocess.Popen") as mock_popen:
             applet.on_clicked()
         mock_popen.assert_called_once_with(["mate-screenshot"], start_new_session=True)
 
     def test_on_clicked_noop_when_no_tool(self):
         with patch("docking.applets.screenshot.applet._detect_tool", return_value=None):
-            applet = ScreenshotApplet(48)
+            applet = ScreenshotApplet(48, config=Config())
         with patch("docking.applets.screenshot.state.subprocess.Popen") as mock_popen:
             applet.on_clicked()
         mock_popen.assert_not_called()
@@ -427,7 +428,7 @@ class TestScreenshotApplet:
         with patch(
             "docking.applets.screenshot.applet._detect_tool", return_value=_MATE
         ):
-            applet = ScreenshotApplet(48)
+            applet = ScreenshotApplet(48, config=Config())
         with patch("docking.applets.screenshot.applet._run") as mock_run:
             applet._run_mode(mode="full", delay_seconds=9)
         mock_run.assert_called_once_with(tool=_MATE, mode="full", delay_seconds=9)

--- a/tests/applets/test_separator.py
+++ b/tests/applets/test_separator.py
@@ -13,6 +13,7 @@ from docking.applets.separator.state import (
     STYLE_LINE,
     STYLE_SPACE,
 )
+from docking.core.config import Config
 
 
 class FakeMenu:
@@ -95,16 +96,16 @@ class TestSeparatorApplet:
         monkeypatch.setattr(separator_applet_mod, "Gtk", fake_gtk)
 
     def test_creates_with_icon(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         assert applet.item.icon is not None
         assert applet.item.name == "Separator"
 
     def test_default_gap(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         assert applet.item.main_size == DEFAULT_SIZE
 
     def test_icon_width_matches_gap(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         pixbuf = applet.create_icon(size=48)
         assert pixbuf is not None
         assert pixbuf.get_width() == DEFAULT_SIZE
@@ -112,13 +113,13 @@ class TestSeparatorApplet:
 
     def test_menu_has_increase_decrease(self, monkeypatch):
         self._fake_gtk(monkeypatch)
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         labels = [mi.get_label() for mi in applet.get_menu_items()]
         assert labels == ["Increase Gap", "Decrease Gap", "", "Style", "Invert Color"]
 
     def test_style_menu_has_line_and_space(self, monkeypatch):
         self._fake_gtk(monkeypatch)
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         style_item = next(
             mi for mi in applet.get_menu_items() if mi.get_label() == "Style"
         )
@@ -127,38 +128,38 @@ class TestSeparatorApplet:
         assert [mi.get_label() for mi in submenu.get_children()] == ["Line", "Space"]
 
     def test_scroll_up_increases_gap(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         before = applet._gap
         applet.on_scroll(direction_up=True)
         assert applet._gap == before + STEP
         assert applet.item.main_size == applet._gap
 
     def test_scroll_down_decreases_gap(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         before = applet._gap
         applet.on_scroll(direction_up=False)
         assert applet._gap == before - STEP
         assert applet.item.main_size == applet._gap
 
     def test_gap_clamps_at_min(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         applet._gap = MIN_SIZE
         applet.on_scroll(direction_up=False)
         assert applet._gap == MIN_SIZE
 
     def test_gap_clamps_at_max(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         applet._gap = MAX_SIZE
         applet.on_scroll(direction_up=True)
         assert applet._gap == MAX_SIZE
 
     def test_desktop_id_can_be_overridden(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         applet.item.desktop_id = "applet://separator#5"
         assert applet.item.desktop_id == "applet://separator#5"
 
     def test_apply_prefs_clamps_loaded_gap_above_max(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         applet.item.desktop_id = "applet://separator#0"
         applet.load_instance_prefs = lambda: {"gap": MAX_SIZE + 100}
 
@@ -168,7 +169,7 @@ class TestSeparatorApplet:
         assert applet.item.main_size == MAX_SIZE
 
     def test_apply_prefs_clamps_loaded_gap_below_min(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         applet.item.desktop_id = "applet://separator#0"
         applet.load_instance_prefs = lambda: {"gap": -999}
 
@@ -178,7 +179,7 @@ class TestSeparatorApplet:
         assert applet.item.main_size == MIN_SIZE
 
     def test_apply_prefs_invalid_gap_falls_back_to_default(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         applet.item.desktop_id = "applet://separator#0"
         applet.load_instance_prefs = lambda: {"gap": "bad"}
 
@@ -188,7 +189,7 @@ class TestSeparatorApplet:
         assert applet.item.main_size == DEFAULT_SIZE
 
     def test_apply_prefs_loads_style_and_invert_color(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         applet.item.desktop_id = "applet://separator#0"
         applet.load_instance_prefs = lambda: {
             "gap": DEFAULT_SIZE,
@@ -203,7 +204,7 @@ class TestSeparatorApplet:
         assert applet.item.allow_zoom is False
 
     def test_invalid_style_falls_back_to_space(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         applet.item.desktop_id = "applet://separator#0"
         applet.load_instance_prefs = lambda: {"style": "bad"}
 
@@ -233,7 +234,7 @@ class TestSeparatorApplet:
         assert config.saved == 1
 
     def test_set_style_and_invert_ignore_same_value(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         applet._save_current_prefs = lambda: (_ for _ in ()).throw(
             AssertionError("no save")
         )
@@ -242,7 +243,7 @@ class TestSeparatorApplet:
         applet._set_invert_color(False)
 
     def test_set_style_and_invert_save_changed_values(self):
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         saved: list[str] = []
         applet._save_current_prefs = lambda: saved.append("save")
         applet.present = lambda: saved.append("present")
@@ -256,7 +257,7 @@ class TestSeparatorApplet:
 
     def test_menu_callbacks_update_gap_style_and_invert(self, monkeypatch):
         self._fake_gtk(monkeypatch)
-        applet = SeparatorApplet(48)
+        applet = SeparatorApplet(48, config=Config())
         applet._save_current_prefs = lambda: None
         items = applet.get_menu_items()
 

--- a/tests/applets/test_session.py
+++ b/tests/applets/test_session.py
@@ -6,23 +6,24 @@ import docking.applets.session.applet as session_applet_mod
 import docking.applets.session.state as session_state_mod
 from docking.applets.session.applet import SessionApplet
 from docking.applets.session.state import _ACTIONS, lock_screen
+from docking.core.config import Config
 
 
 class TestSessionApplet:
     def test_creates_with_icon(self):
-        applet = SessionApplet(48)
+        applet = SessionApplet(48, config=Config())
         assert applet.item.icon is not None
         assert applet.item.name == "Session"
 
     def test_icon_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            applet = SessionApplet(size)
+            applet = SessionApplet(size, config=Config())
             pixbuf = applet.create_icon(size)
             assert pixbuf is not None
             assert pixbuf.get_width() == size
 
     def test_menu_has_all_actions(self):
-        applet = SessionApplet(48)
+        applet = SessionApplet(48, config=Config())
         items = applet.get_menu_items()
         labels = [mi.get_label() for mi in items]
         assert labels == [
@@ -47,7 +48,7 @@ class TestSessionApplet:
             "lock_screen",
             lambda: calls.append("lock") or True,
         )
-        applet = SessionApplet(48)
+        applet = SessionApplet(48, config=Config())
         applet.on_clicked()
         assert calls == ["lock"]
 
@@ -85,7 +86,7 @@ class TestSessionApplet:
             lambda **kwargs: calls.append("run"),
         )
 
-        applet = SessionApplet(48)
+        applet = SessionApplet(48, config=Config())
         items = applet.get_menu_items()
         items[0].activate()
         items[1].activate()

--- a/tests/applets/test_speedtest.py
+++ b/tests/applets/test_speedtest.py
@@ -80,7 +80,7 @@ def _make_applet(
     icon_size: int = 48, *, config: Config | None = None
 ) -> SpeedtestApplet:
     with patch("docking.applets.speedtest.applet.BackgroundWorker", _ImmediateWorker):
-        return SpeedtestApplet(icon_size, config=config)
+        return SpeedtestApplet(icon_size, config=config or Config())
 
 
 class TestFormatSpeed:

--- a/tests/applets/test_stretchcoach.py
+++ b/tests/applets/test_stretchcoach.py
@@ -195,13 +195,13 @@ class TestRenderIcon:
 class TestStretchCoachApplet:
     def test_creates_with_icon(self, monkeypatch):
         monkeypatch.setattr(stretchcoach_applet_mod, "load_cards", lambda: [CARD])
-        applet = StretchCoachApplet(48)
+        applet = StretchCoachApplet(48, config=Config())
         assert applet.item.icon is not None
         assert applet.item.name == "Next stretch in 30:00"
 
     def test_click_triggers_then_acknowledges_break(self, monkeypatch):
         monkeypatch.setattr(stretchcoach_applet_mod, "load_cards", lambda: [CARD])
-        applet = StretchCoachApplet(48)
+        applet = StretchCoachApplet(48, config=Config())
 
         applet.on_clicked()
         assert applet._state.due is True
@@ -215,7 +215,7 @@ class TestStretchCoachApplet:
 
     def test_menu_contains_core_actions(self, monkeypatch):
         monkeypatch.setattr(stretchcoach_applet_mod, "load_cards", lambda: [CARD])
-        applet = StretchCoachApplet(48)
+        applet = StretchCoachApplet(48, config=Config())
         labels = [
             item.get_label() for item in applet.get_menu_items() if item.get_label()
         ]
@@ -226,7 +226,7 @@ class TestStretchCoachApplet:
 
     def test_due_menu_uses_acknowledge_label(self, monkeypatch):
         monkeypatch.setattr(stretchcoach_applet_mod, "load_cards", lambda: [CARD])
-        applet = StretchCoachApplet(48)
+        applet = StretchCoachApplet(48, config=Config())
         applet._state = trigger_reminder(
             applet._state,
             cards=[CARD],
@@ -239,13 +239,13 @@ class TestStretchCoachApplet:
 
     def test_show_random_stretch_updates_tooltip(self, monkeypatch):
         monkeypatch.setattr(stretchcoach_applet_mod, "load_cards", lambda: [CARD])
-        applet = StretchCoachApplet(48)
+        applet = StretchCoachApplet(48, config=Config())
         applet._show_random_stretch()
         assert "Shoulder Roll" in applet.item.name
 
     def test_toggle_cards_updates_state_and_saves(self, monkeypatch):
         monkeypatch.setattr(stretchcoach_applet_mod, "load_cards", lambda: [CARD])
-        applet = StretchCoachApplet(48)
+        applet = StretchCoachApplet(48, config=Config())
         widget = MagicMock()
         widget.get_active.return_value = False
         applet._save = MagicMock()
@@ -259,7 +259,7 @@ class TestStretchCoachApplet:
 
     def test_set_interval_saves_and_refreshes(self, monkeypatch):
         monkeypatch.setattr(stretchcoach_applet_mod, "load_cards", lambda: [CARD])
-        applet = StretchCoachApplet(48)
+        applet = StretchCoachApplet(48, config=Config())
         applet._save = MagicMock()
         applet.present = MagicMock()
 
@@ -272,7 +272,7 @@ class TestStretchCoachApplet:
 
     def test_tick_due_branch_marks_urgent(self, monkeypatch):
         monkeypatch.setattr(stretchcoach_applet_mod, "load_cards", lambda: [CARD])
-        applet = StretchCoachApplet(48)
+        applet = StretchCoachApplet(48, config=Config())
         applet._state = StretchCoachState(remaining=1)
         applet.present = MagicMock()
 
@@ -283,7 +283,7 @@ class TestStretchCoachApplet:
 
     def test_start_and_stop_manage_timer(self, monkeypatch):
         monkeypatch.setattr(stretchcoach_applet_mod, "load_cards", lambda: [CARD])
-        applet = StretchCoachApplet(48)
+        applet = StretchCoachApplet(48, config=Config())
         monkeypatch.setattr(
             stretchcoach_applet_mod.GLib,
             "timeout_add_seconds",
@@ -325,7 +325,7 @@ class TestStretchCoachApplet:
 class TestStretchCoachAppletBranches:
     def test_tick_refresh_branch_updates_presentation(self, monkeypatch):
         monkeypatch.setattr(stretchcoach_applet_mod, "load_cards", lambda: [CARD])
-        applet = StretchCoachApplet(48)
+        applet = StretchCoachApplet(48, config=Config())
         applet.present = MagicMock()
         monkeypatch.setattr(
             stretchcoach_applet_mod,
@@ -342,7 +342,7 @@ class TestStretchCoachAppletBranches:
 
     def test_tick_tooltip_only_branch_notifies_without_icon_refresh(self, monkeypatch):
         monkeypatch.setattr(stretchcoach_applet_mod, "load_cards", lambda: [CARD])
-        applet = StretchCoachApplet(48)
+        applet = StretchCoachApplet(48, config=Config())
         applet.present = MagicMock()
         applet._notify = MagicMock()
         monkeypatch.setattr(

--- a/tests/applets/test_sunrise.py
+++ b/tests/applets/test_sunrise.py
@@ -152,12 +152,12 @@ class TestSunriseState:
 
 class TestSunriseApplet:
     def test_creates_with_icon(self):
-        applet = SunriseApplet(48)
+        applet = SunriseApplet(48, config=Config())
         assert applet.item.icon is not None
 
     def test_icon_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            applet = SunriseApplet(size)
+            applet = SunriseApplet(size, config=Config())
             pixbuf = applet.create_icon(size=size)
             assert pixbuf is not None
             assert pixbuf.get_width() == size
@@ -177,7 +177,7 @@ class TestSunriseApplet:
         ]
 
     def test_scroll_cycles_city(self):
-        applet = SunriseApplet(48)
+        applet = SunriseApplet(48, config=Config())
         applet._cities = [_BERLIN, _TOKYO]
         applet._active_index = 0
 

--- a/tests/applets/test_systemmonitor.py
+++ b/tests/applets/test_systemmonitor.py
@@ -38,6 +38,7 @@ from docking.applets.systemmonitor.temperature import (
     read_command_temperature,
     read_temperature_file,
 )
+from docking.core.config import Config
 
 
 class TestParseProcStat:
@@ -514,20 +515,20 @@ class TestCpuHueRgb:
 class TestSystemMonitorRendering:
     @pytest.mark.parametrize("size", [32, 48, 64])
     def test_renders_valid_pixbuf(self, size):
-        applet = SystemMonitorApplet(size)
+        applet = SystemMonitorApplet(size, config=Config())
         pixbuf = applet.create_icon(size)
         assert pixbuf is not None
         assert pixbuf.get_width() == size
         assert pixbuf.get_height() == size
 
     def test_menu_has_show_disk(self):
-        applet = SystemMonitorApplet(48)
+        applet = SystemMonitorApplet(48, config=Config())
         items = applet.get_menu_items()
         assert items[0].get_label() == "Show Disk Usage"
         assert items[1].get_label() == "Temperature Unit"
 
     def test_tooltip_format(self):
-        applet = SystemMonitorApplet(48)
+        applet = SystemMonitorApplet(48, config=Config())
         applet._cpu = 0.423
         applet._mem = 0.671
         applet._temperature_c = 58.4
@@ -544,7 +545,7 @@ class TestSystemMonitorRendering:
         assert "GPU: 33%" in applet.item.name
 
     def test_tooltip_uses_selected_temperature_unit(self):
-        applet = SystemMonitorApplet(48)
+        applet = SystemMonitorApplet(48, config=Config())
         applet._cpu = 0.423
         applet._mem = 0.671
         applet._temperature_c = 58.4
@@ -572,7 +573,7 @@ class TestSystemMonitorRendering:
         }
 
     def test_icon_has_visible_content(self):
-        applet = SystemMonitorApplet(48)
+        applet = SystemMonitorApplet(48, config=Config())
         applet._cpu = 0.5
         applet._mem = 0.3
         pixbuf = applet.create_icon(48)
@@ -583,7 +584,7 @@ class TestSystemMonitorRendering:
 
 class TestSystemMonitorLifecycle:
     def test_start_registers_timer(self, monkeypatch):
-        applet = SystemMonitorApplet(48)
+        applet = SystemMonitorApplet(48, config=Config())
         monkeypatch.setattr(
             systemmonitor_mod.GLib, "timeout_add_seconds", lambda _s, _cb: 123
         )
@@ -591,7 +592,7 @@ class TestSystemMonitorLifecycle:
         assert applet._timer_id == 123
 
     def test_stop_removes_timer(self, monkeypatch):
-        applet = SystemMonitorApplet(48)
+        applet = SystemMonitorApplet(48, config=Config())
         applet._timer_id = 77
         removed = []
         monkeypatch.setattr(
@@ -612,7 +613,7 @@ class TestSystemMonitorLifecycle:
             encoding="utf-8",
         )
 
-        applet = SystemMonitorApplet(48)
+        applet = SystemMonitorApplet(48, config=Config())
         monkeypatch.setattr(systemmonitor_mod, "_PROC_STAT", proc_stat)
         monkeypatch.setattr(systemmonitor_mod, "_PROC_MEMINFO", proc_meminfo)
         monkeypatch.setattr(applet._temperature_reader, "read", lambda: 55.2)
@@ -625,7 +626,7 @@ class TestSystemMonitorLifecycle:
         assert refresh == [True]
 
     def test_tick_handles_proc_stat_read_error(self, tmp_path, monkeypatch):
-        applet = SystemMonitorApplet(48)
+        applet = SystemMonitorApplet(48, config=Config())
         monkeypatch.setattr(systemmonitor_mod, "_PROC_STAT", tmp_path / "missing-stat")
         assert applet._tick() is True
 
@@ -633,7 +634,7 @@ class TestSystemMonitorLifecycle:
         proc_stat = tmp_path / "stat"
         proc_stat.write_text("cpu  200 0 100 100 0 0 0\n", encoding="utf-8")
 
-        applet = SystemMonitorApplet(48)
+        applet = SystemMonitorApplet(48, config=Config())
         monkeypatch.setattr(systemmonitor_mod, "_PROC_STAT", proc_stat)
         monkeypatch.setattr(
             systemmonitor_mod,
@@ -654,7 +655,7 @@ class TestSystemMonitorLifecycle:
             encoding="utf-8",
         )
 
-        applet = SystemMonitorApplet(48)
+        applet = SystemMonitorApplet(48, config=Config())
         applet._cpu = 0.5
         applet._mem = 0.25
         applet._temperature_c = 55.0
@@ -686,7 +687,7 @@ class TestSystemMonitorLifecycle:
             encoding="utf-8",
         )
 
-        applet = SystemMonitorApplet(48)
+        applet = SystemMonitorApplet(48, config=Config())
         applet._cpu = 0.5
         applet._mem = 0.25
         applet._temperature_c = 55.0
@@ -720,7 +721,7 @@ class TestSystemMonitorLifecycle:
             encoding="utf-8",
         )
 
-        applet = SystemMonitorApplet(48)
+        applet = SystemMonitorApplet(48, config=Config())
         applet._cpu = 0.5
         applet._mem = 0.25
         applet._temperature_c = 55.0

--- a/tests/applets/test_thermals.py
+++ b/tests/applets/test_thermals.py
@@ -74,7 +74,7 @@ def _snapshot() -> ThermalSnapshot:
 
 def _make_applet(config: Config | None = None) -> ThermalsApplet:
     with patch("docking.applets.thermals.applet.BackgroundWorker", _ImmediateWorker):
-        return ThermalsApplet(48, config=config)
+        return ThermalsApplet(48, config=config or Config())
 
 
 class TestThermalsState:

--- a/tests/applets/test_todayinhistory.py
+++ b/tests/applets/test_todayinhistory.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from docking.core.config import Config
+
 pytest.importorskip(
     "docking.applets.todayinhistory",
     reason="Today in History applet is not available in this checkout",
@@ -178,13 +180,13 @@ class TestHistoryHelpers:
 
 class TestTodayInHistoryApplet:
     def test_creates_with_icon_and_initial_event(self):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
 
         assert applet.item.icon is not None
         assert applet._current is not None
 
     def test_start_and_stop_timer(self, monkeypatch):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         fetch = MagicMock()
         removed: list[int] = []
         monkeypatch.setattr(applet, "_fetch_async", fetch)
@@ -207,7 +209,7 @@ class TestTodayInHistoryApplet:
         assert applet._timer_id == 0
 
     def test_click_without_events_fetches(self, monkeypatch):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         applet._events = []
         fetch = MagicMock()
         monkeypatch.setattr(applet, "_fetch_async", fetch)
@@ -218,7 +220,7 @@ class TestTodayInHistoryApplet:
         fetch.assert_called_once_with(show_first=True)
 
     def test_click_advances_and_wraps_events(self):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         second = HistoryEvent(
             year=1989,
             title="World Wide Web proposal",
@@ -240,7 +242,7 @@ class TestTodayInHistoryApplet:
         assert applet._current == ENTRY
 
     def test_menu_contains_core_actions(self):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         applet._current = ENTRY
 
         labels = [
@@ -253,7 +255,7 @@ class TestTodayInHistoryApplet:
         assert "Open Article" in labels
 
     def test_menu_omits_open_article_without_url(self):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         applet._current = HistoryEvent(
             year=44,
             title="Julius Caesar assassinated",
@@ -269,7 +271,7 @@ class TestTodayInHistoryApplet:
         assert "Open Article" not in labels
 
     def test_source_label_date_and_tooltip_defaults(self):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         applet._current = None
         assert applet._date_key(month=3, day=4) == "03-04"
         assert applet._source_label() == "Today in History"
@@ -278,7 +280,7 @@ class TestTodayInHistoryApplet:
         assert applet.item.name == "Today in History"
 
     def test_on_fetch_result_uses_fallback_when_api_returns_empty(self, monkeypatch):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         applet._current_month = 7
         applet._current_day = 20
         applet._current = None
@@ -298,7 +300,7 @@ class TestTodayInHistoryApplet:
         assert applet._current == ENTRY
 
     def test_on_fetch_result_ignores_stale_day_results(self):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         current = HistoryEvent(
             year=2001,
             title="Current day event",
@@ -333,7 +335,7 @@ class TestTodayInHistoryApplet:
         assert applet._loading_key == "03-15"
 
     def test_on_fetch_result_entries_keep_current_when_not_show_first(self):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         applet._current_month = 7
         applet._current_day = 20
         current = HistoryEvent(1, "Current", "Current summary")
@@ -349,7 +351,7 @@ class TestTodayInHistoryApplet:
         assert applet._loading is False
 
     def test_on_fetch_result_empty_keeps_existing_current(self, monkeypatch):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         applet._current_month = 7
         applet._current_day = 20
         current = HistoryEvent(1, "Current", "Current summary")
@@ -365,7 +367,7 @@ class TestTodayInHistoryApplet:
         assert applet._current == current
 
     def test_refresh_from_web_syncs_to_new_local_day_immediately(self, monkeypatch):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         old_entry = HistoryEvent(
             year=1900,
             title="Old day event",
@@ -414,7 +416,7 @@ class TestTodayInHistoryApplet:
         assert started
 
     def test_sync_to_local_day_no_change_and_poll_day_change(self, monkeypatch):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         applet._current_month = 3
         applet._current_day = 14
         monkeypatch.setattr(applet, "_current_date", lambda: (3, 14))
@@ -435,7 +437,7 @@ class TestTodayInHistoryApplet:
         applet._fetch_async.assert_called_once_with(show_first=False)
 
     def test_advance_event_without_events(self):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         applet._events = []
         applet._advance_event()
 
@@ -443,7 +445,7 @@ class TestTodayInHistoryApplet:
         assert applet._current is None
 
     def test_fetch_async_dedupes_same_loading_request(self, monkeypatch):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         applet._current_month = 7
         applet._current_day = 20
         applet._loading = True
@@ -458,7 +460,7 @@ class TestTodayInHistoryApplet:
         applet._fetch_async(show_first=True)
 
     def test_fetch_async_worker_posts_idle_result(self, monkeypatch):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         applet._current_month = 7
         applet._current_day = 20
         idle_calls = []
@@ -490,7 +492,7 @@ class TestTodayInHistoryApplet:
         assert idle_calls[0][1:4] == (7, 20, [ENTRY])
 
     def test_refresh_tooltip_loading_state(self):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         applet._loading = True
         applet._current = None
 
@@ -499,7 +501,7 @@ class TestTodayInHistoryApplet:
         assert "loading" in applet.item.name.lower()
 
     def test_open_current_article_noop_success_and_error(self, monkeypatch):
-        applet = TodayInHistoryApplet(48)
+        applet = TodayInHistoryApplet(48, config=Config())
         applet._current = None
         applet._open_current_article()
 

--- a/tests/applets/test_trash.py
+++ b/tests/applets/test_trash.py
@@ -27,6 +27,7 @@ from docking.applets.trash.backend import (
     _visible_trash_info_directory,
     select_trash_backend,
 )
+from docking.core.config import Config
 from docking.platform.environment import Desktop
 
 
@@ -1254,7 +1255,7 @@ def _make_applet(monkeypatch, backend: _StubBackend) -> TrashApplet:
         "select_trash_backend",
         lambda **_: backend,
     )
-    return TrashApplet(48)
+    return TrashApplet(48, config=Config())
 
 
 class TestTrashAppletIcon:

--- a/tests/applets/test_trivia.py
+++ b/tests/applets/test_trivia.py
@@ -14,6 +14,7 @@ from docking.applets.trivia.state import (
     format_trivia,
     normalize_text,
 )
+from docking.core.config import Config
 
 ENTRY = TriviaEntry(
     category="Science",
@@ -94,12 +95,12 @@ class TestFetchTrivia:
 
 class TestTriviaApplet:
     def test_creates_with_icon(self):
-        applet = TriviaApplet(48)
+        applet = TriviaApplet(48, config=Config())
         assert applet.item.icon is not None
         assert applet._current is not None
 
     def test_click_advances_questions(self):
-        applet = TriviaApplet(48)
+        applet = TriviaApplet(48, config=Config())
         applet._entries = [
             ENTRY,
             TriviaEntry(
@@ -121,7 +122,7 @@ class TestTriviaApplet:
         assert "1984" in applet._current.question
 
     def test_exhausted_click_triggers_fetch(self):
-        applet = TriviaApplet(48)
+        applet = TriviaApplet(48, config=Config())
         applet._entries = [ENTRY]
         applet._index = 0
         applet._current = ENTRY
@@ -132,7 +133,7 @@ class TestTriviaApplet:
         fetch_mock.assert_called_once_with(show_first=True)
 
     def test_menu_contains_answers_and_actions(self):
-        applet = TriviaApplet(48)
+        applet = TriviaApplet(48, config=Config())
         applet._current = ENTRY
 
         labels = [
@@ -144,7 +145,7 @@ class TestTriviaApplet:
         assert "Refresh Now" in labels
 
     def test_select_answer_updates_current_entry(self):
-        applet = TriviaApplet(48)
+        applet = TriviaApplet(48, config=Config())
         applet._current = ENTRY
 
         applet._select_answer("Venus")
@@ -154,7 +155,7 @@ class TestTriviaApplet:
         assert "Correct answer: Mars" in applet.item.name
 
     def test_next_trivia_clears_answered_icon_state(self):
-        applet = TriviaApplet(48)
+        applet = TriviaApplet(48, config=Config())
         first = answer_entry(ENTRY, "Venus")
         second = TriviaEntry(
             category="Books",
@@ -192,7 +193,7 @@ class TestTriviaRender:
 
 class TestTriviaAppletBranches:
     def test_refresh_from_web_delegates(self):
-        applet = TriviaApplet(48)
+        applet = TriviaApplet(48, config=Config())
         applet._fetch_async = MagicMock()
 
         applet._refresh_from_web()
@@ -200,7 +201,7 @@ class TestTriviaAppletBranches:
         applet._fetch_async.assert_called_once_with(show_first=True)
 
     def test_fetch_async_noop_when_loading(self):
-        applet = TriviaApplet(48)
+        applet = TriviaApplet(48, config=Config())
         applet._loading = True
         applet.present = MagicMock()
 
@@ -209,7 +210,7 @@ class TestTriviaAppletBranches:
         applet.present.assert_not_called()
 
     def test_fetch_async_runs_worker_and_posts_idle_result(self, monkeypatch):
-        applet = TriviaApplet(48)
+        applet = TriviaApplet(48, config=Config())
         monkeypatch.setattr(
             trivia_mod,
             "fetch_trivia",
@@ -240,7 +241,7 @@ class TestTriviaAppletBranches:
         assert calls[0][2] is True
 
     def test_on_fetch_result_applies_entries_and_fallback(self, monkeypatch):
-        applet = TriviaApplet(48)
+        applet = TriviaApplet(48, config=Config())
         applet._loading = True
         applet.present = MagicMock()
 
@@ -253,7 +254,7 @@ class TestTriviaAppletBranches:
         assert applet._current == ENTRY
 
     def test_refresh_tooltip_loading_state(self):
-        applet = TriviaApplet(48)
+        applet = TriviaApplet(48, config=Config())
         applet._loading = True
         applet._current = None
 

--- a/tests/applets/test_unitconverter.py
+++ b/tests/applets/test_unitconverter.py
@@ -43,7 +43,7 @@ def _make_applet(config: Config | None = None) -> UnitConverterApplet:
     with patch(
         "docking.applets.unitconverter.applet.BackgroundWorker", _ImmediateWorker
     ):
-        return UnitConverterApplet(48, config=config)
+        return UnitConverterApplet(48, config=config or Config())
 
 
 def _unit(cat: Category, symbol: str) -> Unit:
@@ -608,7 +608,7 @@ class TestAppletCreation:
                 "docking.applets.unitconverter.applet.BackgroundWorker",
                 _ImmediateWorker,
             ):
-                applet = UnitConverterApplet(size)
+                applet = UnitConverterApplet(size, config=Config())
             pixbuf = applet.create_icon(size)
             assert pixbuf is not None
 

--- a/tests/applets/test_urlshortener.py
+++ b/tests/applets/test_urlshortener.py
@@ -12,7 +12,7 @@ from docking.core.config import Config
 
 
 def _make_applet(config: Config | None = None) -> UrlShortenerApplet:
-    return UrlShortenerApplet(48, config=config)
+    return UrlShortenerApplet(48, config=config or Config())
 
 
 class _FakeContentArea:
@@ -243,7 +243,7 @@ class TestAppletCreation:
 
     def test_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            applet = UrlShortenerApplet(size)
+            applet = UrlShortenerApplet(size, config=Config())
             pixbuf = applet.create_icon(size)
             assert pixbuf is not None
 

--- a/tests/applets/test_usbwatch.py
+++ b/tests/applets/test_usbwatch.py
@@ -9,6 +9,7 @@ import docking.applets.usbwatch.applet as usbwatch_applet_mod
 from docking.applets.usbwatch.applet import UsbWatchApplet
 from docking.applets.usbwatch.render import create_usbwatch_icon
 from docking.applets.usbwatch.state import mounted_usb_devices, usbwatch_tooltip
+from docking.core.config import Config
 
 
 class _FakeRoot:
@@ -237,7 +238,7 @@ class TestUsbWatchApplet:
             lambda: _FakeMonitor(),
         )
 
-        applet = UsbWatchApplet(48)
+        applet = UsbWatchApplet(48, config=Config())
         items = applet.get_menu_items()
 
         assert len(items) == 1
@@ -254,7 +255,7 @@ class TestUsbWatchApplet:
             lambda: monitor,
         )
 
-        applet = UsbWatchApplet(48)
+        applet = UsbWatchApplet(48, config=Config())
         applet.present = MagicMock()
         items = applet.get_menu_items()
         remove_item = next(
@@ -275,7 +276,7 @@ class TestUsbWatchApplet:
             lambda: monitor,
         )
 
-        applet = UsbWatchApplet(48)
+        applet = UsbWatchApplet(48, config=Config())
         applet.start(MagicMock())
         applet.stop()
 
@@ -298,7 +299,7 @@ class TestUsbWatchApplet:
             side_effect=RuntimeError("busy")
         )
 
-        applet = UsbWatchApplet(48)
+        applet = UsbWatchApplet(48, config=Config())
         applet.present = MagicMock()
         applet._safe_remove(device=applet._devices[0])
 

--- a/tests/applets/test_volume.py
+++ b/tests/applets/test_volume.py
@@ -192,7 +192,7 @@ def _make_applet(
         mock_backend = mock_detect.return_value
         mock_backend.command = "pactl"
         mock_backend.get_state.return_value = state
-        applet = VolumeApplet(48, config=config)
+        applet = VolumeApplet(48, config=config or Config())
     # Re-attach the mock backend so tests can inspect calls
     applet._backend = mock_backend
     return applet
@@ -295,7 +295,7 @@ class TestVolumeApplet:
 
 def _make_applet_no_backend() -> VolumeApplet:
     with patch("docking.applets.volume.applet._detect_backend", return_value=None):
-        return VolumeApplet(48)
+        return VolumeApplet(48, config=Config())
 
 
 class TestVolumeStateBackendHelpers:

--- a/tests/applets/test_weather.py
+++ b/tests/applets/test_weather.py
@@ -77,7 +77,7 @@ class _PendingWorker:
 
 def _make_applet(icon_size: int = 48, *, config: Config | None = None) -> WeatherApplet:
     with patch("docking.applets.weather.applet.BackgroundWorker", _ImmediateWorker):
-        return WeatherApplet(icon_size, config=config)
+        return WeatherApplet(icon_size, config=config or Config())
 
 
 # -- State-level tests -------------------------------------------------------

--- a/tests/applets/test_whatsapp.py
+++ b/tests/applets/test_whatsapp.py
@@ -28,6 +28,7 @@ from docking.applets.whatsapp.state import (
     parse_unread_count,
     tooltip_text,
 )
+from docking.core.config import Config
 
 
 class _FakeBrowser:
@@ -247,7 +248,7 @@ class TestWhatsAppApplet:
             "timeout_add_seconds",
             lambda seconds, callback: callbacks.append((seconds, callback)) or 17,
         )
-        applet = WhatsAppApplet(icon_size=48)
+        applet = WhatsAppApplet(icon_size=48, config=Config())
 
         applet.start(lambda: None)
 
@@ -267,7 +268,7 @@ class TestWhatsAppApplet:
             "source_remove",
             lambda source_id: removed.append(source_id),
         )
-        applet = WhatsAppApplet(icon_size=48)
+        applet = WhatsAppApplet(icon_size=48, config=Config())
         applet.start(lambda: None)
 
         applet.on_clicked()
@@ -276,7 +277,7 @@ class TestWhatsAppApplet:
         assert fake_browser.instances[0].toggled == 1
 
     def test_browser_callbacks_update_tooltip_and_badge(self, fake_browser):
-        applet = WhatsAppApplet(icon_size=48)
+        applet = WhatsAppApplet(icon_size=48, config=Config())
         browser = fake_browser.instances[0]
 
         browser.on_phase(BrowserPhase.READY, "")
@@ -295,7 +296,7 @@ class TestWhatsAppApplet:
         assert applet.item.badge_visible is True
 
     def test_notification_fallback_clears_when_window_is_opened(self, fake_browser):
-        applet = WhatsAppApplet(icon_size=48)
+        applet = WhatsAppApplet(icon_size=48, config=Config())
         browser = fake_browser.instances[0]
         browser.on_phase(BrowserPhase.READY, "")
 
@@ -321,7 +322,7 @@ class TestWhatsAppApplet:
             "source_remove",
             lambda source_id: removed.append(source_id),
         )
-        applet = WhatsAppApplet(icon_size=48)
+        applet = WhatsAppApplet(icon_size=48, config=Config())
         applet.start(lambda: None)
 
         applet.stop()
@@ -486,7 +487,10 @@ class TestDesktopNotifier:
     def test_default_action_presents_window_and_activates_web_notification(self):
         activated = []
         notification = MagicMock()
-        notifier = DesktopNotifier(on_activate=lambda: activated.append(True))
+        notifier = DesktopNotifier(
+            on_activate=lambda: activated.append(True),
+            on_shown=lambda: None,
+        )
         notifier._notifications[12] = notification
 
         notifier._on_action_invoked(
@@ -504,7 +508,10 @@ class TestDesktopNotifier:
 
     def test_desktop_dismissal_closes_web_notification(self):
         notification = MagicMock()
-        notifier = DesktopNotifier(on_activate=lambda: None)
+        notifier = DesktopNotifier(
+            on_activate=lambda: None,
+            on_shown=lambda: None,
+        )
         notifier._notifications[12] = notification
         notifier._notification_ids[id(notification)] = 12
 

--- a/tests/applets/test_windowkiller.py
+++ b/tests/applets/test_windowkiller.py
@@ -9,6 +9,7 @@ import docking.applets.windowkiller.applet as windowkiller_applet_mod
 from docking.applets.services import AppletServices
 from docking.applets.windowkiller.applet import WindowKillerApplet
 from docking.applets.windowkiller.state import kill_pid
+from docking.core.config import Config
 from docking.platform.backends.base import WindowId, WindowSnapshot
 
 
@@ -32,31 +33,31 @@ class TestKillPid:
 
 class TestAppletCreation:
     def test_creates_with_icon(self):
-        applet = WindowKillerApplet(48)
+        applet = WindowKillerApplet(48, config=Config())
         assert applet.item.icon is not None
 
     def test_tooltip(self):
-        applet = WindowKillerApplet(48)
+        applet = WindowKillerApplet(48, config=Config())
         applet.refresh_tooltip()
         assert "kill" in applet.item.name.lower()
 
     def test_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            applet = WindowKillerApplet(size)
+            applet = WindowKillerApplet(size, config=Config())
             pixbuf = applet.create_icon(size)
             assert pixbuf is not None
 
 
 class TestAppletOverlay:
     def test_on_clicked_starts_pick(self, monkeypatch):
-        applet = WindowKillerApplet(48)
+        applet = WindowKillerApplet(48, config=Config())
         pick = MagicMock()
         monkeypatch.setattr(applet, "_start_pick", pick)
         applet.on_clicked()
         pick.assert_called_once()
 
     def test_stop_dismisses_overlay(self, monkeypatch):
-        applet = WindowKillerApplet(48)
+        applet = WindowKillerApplet(48, config=Config())
         overlay = MagicMock()
         applet._overlay = overlay
         seat = MagicMock()
@@ -70,11 +71,11 @@ class TestAppletOverlay:
         assert applet._overlay is None
 
     def test_dismiss_without_overlay_is_safe(self):
-        applet = WindowKillerApplet(48)
+        applet = WindowKillerApplet(48, config=Config())
         applet._dismiss_overlay()  # should not raise
 
     def test_start_pick_noop_when_overlay_exists(self):
-        applet = WindowKillerApplet(48)
+        applet = WindowKillerApplet(48, config=Config())
         marker = object()
         applet._overlay = marker
         applet.set_services(AppletServices(window_picker=object()))
@@ -84,14 +85,14 @@ class TestAppletOverlay:
         assert applet._overlay is marker
 
     def test_start_pick_noop_without_window_picker_service(self):
-        applet = WindowKillerApplet(48)
+        applet = WindowKillerApplet(48, config=Config())
 
         applet._start_pick()
 
         assert applet._overlay is None
 
     def test_start_pick_creates_overlay_and_grabs_input(self, monkeypatch):
-        applet = WindowKillerApplet(48)
+        applet = WindowKillerApplet(48, config=Config())
         applet.set_services(AppletServices(window_picker=object()))
         calls: list[object] = []
 
@@ -170,7 +171,7 @@ class TestAppletOverlay:
         assert "grab" in calls
 
     def test_overlay_draw_paints_transparent_mask(self):
-        applet = WindowKillerApplet(48)
+        applet = WindowKillerApplet(48, config=Config())
         cr = MagicMock()
 
         assert applet._on_overlay_draw(MagicMock(), cr) is True
@@ -178,7 +179,7 @@ class TestAppletOverlay:
         cr.paint.assert_called_once_with()
 
     def test_overlay_click_kills_selected_window(self, monkeypatch):
-        applet = WindowKillerApplet(48)
+        applet = WindowKillerApplet(48, config=Config())
         dismiss = []
         monkeypatch.setattr(applet, "_dismiss_overlay", lambda: dismiss.append(True))
         window_id = WindowId.x11(7)
@@ -204,7 +205,7 @@ class TestAppletOverlay:
         logger.info.assert_called_once()
 
     def test_overlay_click_warns_when_window_has_no_pid(self, monkeypatch):
-        applet = WindowKillerApplet(48)
+        applet = WindowKillerApplet(48, config=Config())
         monkeypatch.setattr(applet, "_dismiss_overlay", lambda: None)
         window_id = WindowId.x11(7)
         target = WindowSnapshot(id=window_id, desktop_id="", title="Nameless")
@@ -224,7 +225,7 @@ class TestAppletOverlay:
         logger.warning.assert_called_once()
 
     def test_overlay_key_other_key_is_noop(self):
-        applet = WindowKillerApplet(48)
+        applet = WindowKillerApplet(48, config=Config())
         dismiss = []
         applet._dismiss_overlay = lambda: dismiss.append(True)  # type: ignore[method-assign]
 

--- a/tests/applets/test_workspaces.py
+++ b/tests/applets/test_workspaces.py
@@ -8,6 +8,7 @@ import pytest
 from docking.applets.services import AppletServices
 from docking.applets.workspaces.applet import WorkspacesApplet
 from docking.applets.workspaces.render import _render_grid
+from docking.core.config import Config
 from docking.platform.backends.base import WorkspaceSnapshot
 
 
@@ -69,19 +70,19 @@ class TestRenderGrid:
 class TestWorkspacesApplet:
     def test_creates_with_icon(self):
         # Given no Wnck screen, falls back to default 4-cell grid
-        applet = WorkspacesApplet(48)
+        applet = WorkspacesApplet(48, config=Config())
         assert applet.item.icon is not None
 
     def test_icon_renders_at_various_sizes(self):
         for size in [32, 48, 64]:
-            applet = WorkspacesApplet(size)
+            applet = WorkspacesApplet(size, config=Config())
             pixbuf = applet.create_icon(size)
             assert pixbuf is not None
             assert pixbuf.get_width() == size
 
     def test_item_name_uses_workspace_number_even_if_wnck_name_is_stale(self):
         # Given
-        applet = WorkspacesApplet(48)
+        applet = WorkspacesApplet(48, config=Config())
         service = MagicMock()
         service.list_workspaces.return_value = [
             _workspace(0),
@@ -100,7 +101,7 @@ class TestWorkspacesApplet:
 class TestWorkspacesBehavior:
     def test_on_clicked_activates_next_workspace(self):
         # Given
-        applet = WorkspacesApplet(48)
+        applet = WorkspacesApplet(48, config=Config())
         service = MagicMock()
         service.list_workspaces.return_value = [
             _workspace(0),
@@ -116,7 +117,7 @@ class TestWorkspacesBehavior:
 
     def test_on_clicked_activates_next_workspace_by_snapshot_id(self):
         # Given
-        applet = WorkspacesApplet(48)
+        applet = WorkspacesApplet(48, config=Config())
         service = MagicMock()
         service.list_workspaces.return_value = [
             _workspace(0, workspace_id="first"),
@@ -131,7 +132,7 @@ class TestWorkspacesBehavior:
 
     def test_on_clicked_no_screen_or_active_is_safe(self):
         # Given
-        applet = WorkspacesApplet(48)
+        applet = WorkspacesApplet(48, config=Config())
         applet._workspace_service = None
         # When / Then
         applet.on_clicked()
@@ -146,7 +147,7 @@ class TestWorkspacesBehavior:
 
     def test_on_scroll_switches_workspace(self):
         # Given
-        applet = WorkspacesApplet(48)
+        applet = WorkspacesApplet(48, config=Config())
         service = MagicMock()
         service.list_workspaces.return_value = [
             _workspace(0, active=True),
@@ -162,7 +163,7 @@ class TestWorkspacesBehavior:
 
     def test_on_scroll_activates_workspace_by_snapshot_id(self):
         # Given
-        applet = WorkspacesApplet(48)
+        applet = WorkspacesApplet(48, config=Config())
         service = MagicMock()
         service.list_workspaces.return_value = [
             _workspace(0, workspace_id="previous"),
@@ -177,7 +178,7 @@ class TestWorkspacesBehavior:
 
     def test_get_menu_items_builds_radios_for_workspaces(self):
         # Given
-        applet = WorkspacesApplet(48)
+        applet = WorkspacesApplet(48, config=Config())
         service = MagicMock()
         service.list_workspaces.return_value = [
             _workspace(0, name="One"),
@@ -192,7 +193,7 @@ class TestWorkspacesBehavior:
 
     def test_start_and_stop_manage_screen_signal(self, monkeypatch):
         # Given
-        applet = WorkspacesApplet(48)
+        applet = WorkspacesApplet(48, config=Config())
         service = MagicMock()
         handle = object()
         service.list_workspaces.return_value = []
@@ -215,7 +216,7 @@ class TestWorkspacesBehavior:
         assert applet._watch_handle is None
 
     def test_start_is_idempotent_for_workspace_watch(self, monkeypatch):
-        applet = WorkspacesApplet(48)
+        applet = WorkspacesApplet(48, config=Config())
         service = MagicMock()
         handle = object()
         service.list_workspaces.return_value = []
@@ -235,7 +236,7 @@ class TestWorkspacesBehavior:
         assert refresh.call_count == 2
 
     def test_set_services_rewatches_when_already_started(self, monkeypatch):
-        applet = WorkspacesApplet(48)
+        applet = WorkspacesApplet(48, config=Config())
         old_service = MagicMock()
         old_handle = object()
         applet._workspace_service = old_service
@@ -257,7 +258,7 @@ class TestWorkspacesBehavior:
 
     def test_on_workspace_activate_and_changed_refresh(self, monkeypatch):
         # Given
-        applet = WorkspacesApplet(48)
+        applet = WorkspacesApplet(48, config=Config())
         service = MagicMock()
         service.list_workspaces.return_value = []
         service.active_workspace.return_value = None

--- a/tests/platform/test_hyprland_ipc.py
+++ b/tests/platform/test_hyprland_ipc.py
@@ -182,6 +182,7 @@ def test_hyprland_window_service_publishes_snapshot_and_actions():
         model=model,
         launcher=_launcher(),
         client=client,
+        event_stream_factory=lambda _callback: None,
     )
 
     service.start()
@@ -229,6 +230,7 @@ def test_hyprland_window_service_resolves_preview_handle_from_companion_source()
         launcher=_launcher(),
         client=client,
         preview_handle_source=source,
+        event_stream_factory=lambda _callback: None,
     )
 
     service.start()
@@ -299,6 +301,7 @@ def test_hyprland_window_service_ignores_other_backend_window_ids():
         model=_model(),
         launcher=_launcher(),
         client=client,
+        event_stream_factory=lambda _callback: None,
     )
 
     service.start()

--- a/tests/platform/test_niri_ipc.py
+++ b/tests/platform/test_niri_ipc.py
@@ -215,6 +215,7 @@ def test_niri_window_service_publishes_snapshot_and_actions():
         model=model,
         launcher=_launcher(),
         client=client,
+        event_stream_factory=lambda _callback: None,
     )
 
     service.start()
@@ -260,6 +261,7 @@ def test_niri_window_service_minimize_unsupported():
         model=_model(),
         launcher=_launcher(),
         client=client,
+        event_stream_factory=lambda _callback: None,
     )
     service.start()
 
@@ -273,6 +275,7 @@ def test_niri_window_service_ignores_other_backend_window_ids():
         model=_model(),
         launcher=_launcher(),
         client=client,
+        event_stream_factory=lambda _callback: None,
     )
     service.start()
 
@@ -486,6 +489,7 @@ def test_niri_window_service_close_all():
         model=_model(),
         launcher=_launcher(),
         client=client,
+        event_stream_factory=lambda _callback: None,
     )
     service.start()
 
@@ -502,6 +506,7 @@ def test_niri_window_service_close_all_not_found():
         model=_model(),
         launcher=_launcher(),
         client=client,
+        event_stream_factory=lambda _callback: None,
     )
     service.start()
 
@@ -544,7 +549,9 @@ def test_niri_workspace_service_lists_and_activates_workspaces():
             ]
         }
     )
-    service = NiriWorkspaceService(client=client)
+    service = NiriWorkspaceService(
+        client=client, event_stream_factory=lambda _callback: None
+    )
 
     service.start()
 

--- a/tests/platform/test_wayland_layer_shell_session.py
+++ b/tests/platform/test_wayland_layer_shell_session.py
@@ -210,6 +210,7 @@ def test_hyprland_session_uses_ipc_windows_and_layer_shell_capabilities():
         ),
         launcher=SimpleNamespace(resolve=MagicMock(), resolve_by_wm_class=MagicMock()),
         client=SimpleNamespace(paths=HyprlandSocketPaths(command="", events="")),
+        event_stream_factory=lambda _callback: None,
     )
     backend = HyprlandSessionBackend(
         layer_shell=_layer_shell(),
@@ -388,6 +389,7 @@ def test_niri_session_uses_ipc_windows_and_layer_shell_capabilities():
         ),
         launcher=SimpleNamespace(resolve=MagicMock(), resolve_by_wm_class=MagicMock()),
         client=MagicMock(),
+        event_stream_factory=lambda _callback: None,
     )
     backend = NiriSessionBackend(
         layer_shell=_layer_shell(),

--- a/tests/platform/test_window_tracker_integration.py
+++ b/tests/platform/test_window_tracker_integration.py
@@ -17,6 +17,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for non-GI environmen
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
 import docking.platform.backends.x11.impl.window_tracker as window_tracker_mod
+from docking.core.config import Config
 from docking.platform.backends.base import ActionResult, DisplayServer, WindowId
 from docking.platform.desktop_entries import DesktopInfo
 from docking.platform.model import DockItem
@@ -135,7 +136,11 @@ def tracker_env(monkeypatch):
     ]
     launcher = MagicMock()
     launcher.resolve_by_wm_class.return_value = None
-    tracker = window_tracker_mod.WindowTracker(model=model, launcher=launcher)
+    tracker = window_tracker_mod.WindowTracker(
+        model=model,
+        launcher=launcher,
+        config=Config(),
+    )
     return tracker, model, launcher
 
 

--- a/tests/platform/test_x11_window_service.py
+++ b/tests/platform/test_x11_window_service.py
@@ -15,6 +15,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for non-GI environmen
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
 import docking.platform.backends.x11.impl.window_tracker as tracker_mod
+from docking.core.config import Config
 from docking.platform.backends.base import ActionResult, DisplayServer, WindowId
 from docking.platform.backends.x11.services.windows import X11WindowService
 from docking.platform.running import RunningAppInfo
@@ -119,7 +120,7 @@ def make_service(
 ) -> X11WindowService:
     service = X11WindowService.__new__(X11WindowService)
     service._screen = FakeScreen(windows=windows, active_window=active)
-    service._config = None
+    service._config = Config()
     service._model = MagicMock()
     service._launcher = MagicMock()
     service._running_xids_by_desktop = {

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -768,6 +768,7 @@ def handler(monkeypatch):
         config=config,
         runtime=runtime,
         launcher=launcher,
+        dock_window=runtime.window,
     )
     return menu_mod.MenuHandler(
         about=about,

--- a/tests/ui/test_pointer_scenarios.py
+++ b/tests/ui/test_pointer_scenarios.py
@@ -436,6 +436,7 @@ class TestMenuLifecycleScenarios:
             config=cast(Any, harness.config),
             runtime=runtime,
             launcher=harness.launcher,
+            dock_window=cast(Any, harness),
         )
         handler = MenuHandler(
             about=MagicMock(),

--- a/tests/ui/test_stack.py
+++ b/tests/ui/test_stack.py
@@ -18,6 +18,7 @@ def _controller() -> StackPopupController:
     return StackPopupController(
         config=SimpleNamespace(icon_size=48, pos="bottom"),
         runtime=MagicMock(),
+        dock_window=MagicMock(),
     )
 
 

--- a/tests/ui/test_update_popup.py
+++ b/tests/ui/test_update_popup.py
@@ -266,15 +266,9 @@ class TestUpdateCheckControllerInit:
         assert controller._latest_release is None
         assert controller._start_source_id == 0
 
-    def test_init_without_window(self):
-        config = MagicMock()
-        controller = UpdateCheckController(config=config)
-        assert controller._window is None
-        assert controller._config is config
-
     def test_set_window_attaches_window(self):
         config = MagicMock()
-        controller = UpdateCheckController(config=config)
+        controller = UpdateCheckController(window=MagicMock(), config=config)
         window = MagicMock()
         controller.set_window(window)
         assert controller._window is window
@@ -663,15 +657,6 @@ class TestUpdateCheckShowPending:
 
 
 class TestUpdateCheckShowPopup:
-    def test_show_popup_skips_null_window(self):
-        config = MagicMock()
-        controller = UpdateCheckController(config=config)
-        release = ReleaseInfo(version="3.0.0", name="v3", url="https://x.com")
-
-        result = controller._show_popup(release=release)
-
-        assert result is False
-
     def test_show_popup_skips_unrealized_window(self, monkeypatch):
         window = _FakeWindow(realized=False)
         config = MagicMock()
@@ -969,14 +954,6 @@ class TestUpdateCheckPositionPopup:
         config = MagicMock()
         controller = UpdateCheckController(window=window, config=config)
         controller._popup = None
-
-        # Should not raise
-        controller._position_popup()
-
-    def test_position_popup_no_window_returns_early(self):
-        config = MagicMock()
-        controller = UpdateCheckController(config=config)
-        controller._popup = MagicMock()
 
         # Should not raise
         controller._position_popup()

--- a/tests/visual/render_cases.py
+++ b/tests/visual/render_cases.py
@@ -235,6 +235,7 @@ def _folder_stack_handler() -> MenuHandler:
         config=config,
         runtime=runtime,
         launcher=launcher,
+        dock_window=runtime.window,
     )
     handler = MenuHandler(
         about=MagicMock(),


### PR DESCRIPTION
## Summary

- require concrete Config instances across applet constructors and simplify preference access
- make runtime, launcher, model, window, and event-stream dependencies non-null where construction already guarantees them
- update scaffolding and test call sites to provide explicit constructor dependencies
- preserve the application status-notification tests merged in #270 via a clean three-way patch application