### PR TITLE
Add Show HN and jobs feeds

### DIFF
--- a/docking/applets/hackernews/applet.py
+++ b/docking/applets/hackernews/applet.py
@@ -36,10 +36,12 @@ from docking.applets.hackernews.state import (
     MAX_STORIES,
     REFRESH_INTERVAL_S,
     STARTUP_FETCH_DELAY_S,
+    HackerNewsFeed,
     HackerNewsPage,
     HackerNewsStory,
     append_unique_stories,
     build_tooltip,
+    feed_label,
     fetch_hn_story_page,
     normalize_active_index,
     prefs_from_mapping,
@@ -50,7 +52,7 @@ from docking.applets.live_state import (
     live_state_label,
     resolve_live_status,
 )
-from docking.applets.menu import disabled_menu_item, menu_sections
+from docking.applets.menu import disabled_menu_item, menu_sections, radio_submenu
 from docking.applets.worker import BackgroundWorker
 from docking.i18n import _
 from docking.log import get_logger, with_context
@@ -63,7 +65,7 @@ log = with_context(get_logger(name="hackernews"), applet_id=meta.id)
 
 
 class HackerNewsApplet(Applet):
-    """Show Hacker News top headlines."""
+    """Browse top, Show HN, and jobs headlines."""
 
     id = meta.id
     name = _("Hacker News")
@@ -71,6 +73,7 @@ class HackerNewsApplet(Applet):
 
     def __init__(self, icon_size: int, config: Config) -> None:
         prefs = prefs_from_mapping(config.applet_prefs.get(meta.id, {}))
+        self._feed = prefs.feed
         self._stories: list[HackerNewsStory] = list(prefs.stories)
         self._active_index = prefs.active_index
         self._next_story_offset = prefs.next_offset
@@ -114,6 +117,7 @@ class HackerNewsApplet(Applet):
             story=self._current_story,
             index=self._active_index,
             count=len(self._stories),
+            feed=self._feed,
             loading=self._loading,
             page_loading=self._page_loading,
             error=self._error,
@@ -155,6 +159,7 @@ class HackerNewsApplet(Applet):
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         status: list[Gtk.MenuItem] = [
             disabled_menu_item(HN_SOURCE_LABEL, gtk=Gtk),
+            disabled_menu_item(feed_label(self._feed), gtk=Gtk),
             disabled_menu_item(
                 cadence_label(seconds=REFRESH_INTERVAL_S, verb=_("Refreshes")),
                 gtk=Gtk,
@@ -204,11 +209,22 @@ class HackerNewsApplet(Applet):
         refresh = Gtk.MenuItem(label=_("Refresh Now"))
         refresh.connect("activate", lambda _w: self._fetch_async())
 
+        display = [
+            radio_submenu(
+                label=_("Page"),
+                choices=tuple((feed_label(feed), feed) for feed in HackerNewsFeed),
+                active_value=self._feed,
+                on_selected=lambda _widget, feed: self._set_feed(feed=feed),
+                gtk=Gtk,
+            )
+        ]
+
         return menu_sections(
             status=status,
             primary=primary,
             navigation=[next_item],
             refresh=[refresh],
+            display=display,
             gtk=Gtk,
         )
 
@@ -262,12 +278,27 @@ class HackerNewsApplet(Applet):
         self._save_prefs()
         self.present()
 
+    def _set_feed(self, *, feed: HackerNewsFeed) -> None:
+        if feed is self._feed:
+            return
+        self._feed = feed
+        self._stories = []
+        self._active_index = 0
+        self._next_story_offset = 0
+        self._has_more_stories = True
+        self._fetched_at = None
+        self._error = ""
+        self._save_prefs()
+        self.present()
+        self._fetch_async()
+
     def _fetch_async(self) -> None:
         if self._startup_fetch_timer_id:
             GLib.source_remove(self._startup_fetch_timer_id)
             self._startup_fetch_timer_id = 0
         self._fetch_request_id += 1
         request_id = self._fetch_request_id
+        feed = self._feed
         self._loading = True
         self._page_loading = False
         self._error = ""
@@ -276,6 +307,7 @@ class HackerNewsApplet(Applet):
         self._worker.run(
             name="hackernews-fetch",
             fn=lambda: fetch_hn_story_page(
+                feed=feed,
                 limit=self._refresh_fetch_limit(),
                 offset=0,
             ),
@@ -360,6 +392,7 @@ class HackerNewsApplet(Applet):
             return
 
         offset = self._next_story_offset
+        feed = self._feed
         self._page_loading = True
         self._fetch_request_id += 1
         request_id = self._fetch_request_id
@@ -368,6 +401,7 @@ class HackerNewsApplet(Applet):
         self._worker.run(
             name="hackernews-page-fetch",
             fn=lambda: fetch_hn_story_page(
+                feed=feed,
                 limit=DEFAULT_FETCH_LIMIT,
                 offset=offset,
             ),
@@ -442,6 +476,7 @@ class HackerNewsApplet(Applet):
     def _save_prefs(self) -> None:
         self.save_prefs(
             prefs=prefs_payload(
+                feed=self._feed,
                 stories=tuple(self._stories),
                 active_index=self._active_index,
                 next_offset=self._next_story_offset,

--- a/docking/applets/hackernews/state.py
+++ b/docking/applets/hackernews/state.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import datetime as dt
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, cast
 
 from docking.applets.http import http_get_json
@@ -56,6 +57,34 @@ REFRESH_INTERVAL_S = 10 * 60
 STARTUP_FETCH_DELAY_S = 2
 
 
+class HackerNewsFeed(str, Enum):
+    """HN story lists supported by the applet."""
+
+    TOP = "top"
+    SHOW = "show"
+    JOBS = "jobs"
+
+
+def feed_label(feed: HackerNewsFeed) -> str:
+    """Return the translated label for an HN story list."""
+    labels = {
+        HackerNewsFeed.TOP: _("Top Stories"),
+        HackerNewsFeed.SHOW: _("Show HN"),
+        HackerNewsFeed.JOBS: _("Jobs"),
+    }
+    return labels[feed]
+
+
+def feed_endpoint(feed: HackerNewsFeed) -> str:
+    """Return the Firebase endpoint name for an HN story list."""
+    endpoints = {
+        HackerNewsFeed.TOP: "topstories",
+        HackerNewsFeed.SHOW: "showstories",
+        HackerNewsFeed.JOBS: "jobstories",
+    }
+    return endpoints[feed]
+
+
 @dataclass(frozen=True, slots=True)
 class HackerNewsStory:
     """One displayable HN story."""
@@ -80,6 +109,7 @@ class HackerNewsPrefs:
     stable across restarts.
     """
 
+    feed: HackerNewsFeed = HackerNewsFeed.TOP
     stories: tuple[HackerNewsStory, ...] = ()
     active_index: int = 0
     next_offset: int = 0
@@ -89,7 +119,7 @@ class HackerNewsPrefs:
 
 @dataclass(frozen=True, slots=True)
 class HackerNewsPage:
-    """One fetched page from HN's topstories id list."""
+    """One fetched page from an HN story id list."""
 
     stories: tuple[HackerNewsStory, ...]
     next_offset: int
@@ -139,6 +169,7 @@ def build_tooltip(
     story: HackerNewsStory | None,
     index: int,
     count: int,
+    feed: HackerNewsFeed = HackerNewsFeed.TOP,
     loading: bool = False,
     page_loading: bool = False,
     error: str = "",
@@ -146,6 +177,10 @@ def build_tooltip(
     cadence_seconds: int | None = None,
 ) -> str:
     """Build tooltip text for the current applet state."""
+    source_title = _("{source} - {feed}").format(
+        source=HN_SOURCE_LABEL,
+        feed=feed_label(feed),
+    )
     status = resolve_live_status(
         has_data=story is not None,
         loading=loading,
@@ -154,7 +189,7 @@ def build_tooltip(
     )
     if story is None:
         return structured_tooltip(
-            title=_("Hacker News"),
+            title=source_title,
             primary=live_state_label(status),
             freshness=live_freshness_lines(
                 status=status,
@@ -170,7 +205,7 @@ def build_tooltip(
     header = (
         _("{source} {rank}")
         .format(
-            source=HN_SOURCE_LABEL,
+            source=source_title,
             rank=rank,
         )
         .strip()
@@ -203,16 +238,15 @@ def build_tooltip(
 def parse_story_payload(data: object) -> HackerNewsStory | None:
     """Parse one HN item payload into a story.
 
-    Deleted, dead, non-story, or untitled items are ignored. Ask/Show HN items
-    are normal HN stories, so they pass through as long as the API reports
-    ``type == "story"``.
+    Deleted, dead, unsupported, or untitled items are ignored. Ask/Show HN items
+    use ``type == "story"``; items from the jobs list use ``type == "job"``.
     """
     if not isinstance(data, Mapping):
         return None
     raw = cast(Mapping[str, Any], data)
     if raw.get("deleted") or raw.get("dead"):
         return None
-    if raw.get("type") != "story":
+    if raw.get("type") not in {"story", "job"}:
         return None
     try:
         story_id = int(raw.get("id", 0))
@@ -395,7 +429,12 @@ def prefs_from_mapping(prefs: Mapping[str, Any] | None) -> HackerNewsPrefs:
         active_index = int(prefs.get("active_index", 0))
     except (TypeError, ValueError):
         active_index = 0
+    try:
+        feed = HackerNewsFeed(normalize_text(prefs.get("feed")) or "top")
+    except ValueError:
+        feed = HackerNewsFeed.TOP
     return HackerNewsPrefs(
+        feed=feed,
         stories=tuple(stories),
         active_index=normalize_active_index(index=active_index, count=len(stories)),
         next_offset=max(0, _int_from_pref(prefs.get("next_offset"), 0)),
@@ -415,6 +454,7 @@ def _int_from_pref(value: object, fallback: int) -> int:
 
 def prefs_payload(
     *,
+    feed: HackerNewsFeed = HackerNewsFeed.TOP,
     stories: Sequence[HackerNewsStory],
     active_index: int,
     next_offset: int,
@@ -426,6 +466,7 @@ def prefs_payload(
     timestamp = fetched_at or dt.datetime.now(dt.timezone.utc)
     return {
         "source": HN_SOURCE,
+        "feed": feed.value,
         "active_index": normalize_active_index(index=active_index, count=len(kept)),
         "next_offset": max(0, next_offset),
         "has_more_stories": has_more_stories,
@@ -436,19 +477,21 @@ def prefs_payload(
 
 def fetch_hn_stories(
     *,
+    feed: HackerNewsFeed = HackerNewsFeed.TOP,
     limit: int = DEFAULT_FETCH_LIMIT,
     offset: int = 0,
 ) -> tuple[HackerNewsStory, ...]:
-    """Fetch HN top stories using the official Firebase API."""
-    return fetch_hn_story_page(limit=limit, offset=offset).stories
+    """Fetch stories from one HN list using the official Firebase API."""
+    return fetch_hn_story_page(feed=feed, limit=limit, offset=offset).stories
 
 
 def fetch_hn_story_page(
     *,
+    feed: HackerNewsFeed = HackerNewsFeed.TOP,
     limit: int = DEFAULT_FETCH_LIMIT,
     offset: int = 0,
 ) -> HackerNewsPage:
-    """Fetch one cursor page using HN topstories ids.
+    """Fetch one cursor page using the selected HN story ids.
 
     ``has_more`` is based on the id cursor, not on the number of displayable
     stories. That lets paging continue even when a fetched id is dead/deleted
@@ -456,7 +499,8 @@ def fetch_hn_story_page(
     """
     try:
         raw_ids = http_get_json(
-            f"{HN_BASE_URL}/topstories.json", timeout=FETCH_TIMEOUT_S
+            f"{HN_BASE_URL}/{feed_endpoint(feed)}.json",
+            timeout=FETCH_TIMEOUT_S,
         )
         ids, next_offset, has_more = parse_top_story_id_page(
             raw_ids,

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -1400,6 +1400,18 @@ msgstr ""
 msgid "Hacker News"
 msgstr ""
 
+#: docking/applets/hackernews/state.py:71
+msgid "Top Stories"
+msgstr ""
+
+#: docking/applets/hackernews/state.py:72
+msgid "Show HN"
+msgstr ""
+
+#: docking/applets/hackernews/state.py:73
+msgid "Jobs"
+msgstr ""
+
 #: docking/applets/hackernews/applet.py:161
 #: docking/applets/hackernews/state.py:163
 #: docking/applets/hackernews/state.py:196 docking/applets/news/applet.py:240
@@ -1426,6 +1438,10 @@ msgstr ""
 #: docking/applets/hackernews/applet.py:202 docking/applets/news/applet.py:290
 #: docking/applets/reddit/applet.py:208
 msgid "Next Headline"
+msgstr ""
+
+#: docking/applets/hackernews/applet.py:214
+msgid "Page"
 msgstr ""
 
 #: docking/applets/hackernews/applet.py:328
@@ -1934,7 +1950,7 @@ msgstr ""
 msgid "{count} sources - updated {time}"
 msgstr ""
 
-#: docking/applets/news/applet.py:811
+#: docking/applets/hackernews/state.py:180 docking/applets/news/applet.py:811
 #, python-brace-format
 msgid "{source} - {feed}"
 msgstr ""

--- a/tests/applets/test_hackernews.py
+++ b/tests/applets/test_hackernews.py
@@ -13,12 +13,15 @@ from docking.applets.hackernews.state import (
     HN_SOURCE,
     HN_WEB_URL,
     MAX_STORIES,
+    HackerNewsFeed,
     HackerNewsPage,
     HackerNewsPrefs,
     HackerNewsStory,
     append_unique_stories,
     build_tooltip,
     comments_url,
+    feed_endpoint,
+    feed_label,
     fetch_hn_stories,
     fetch_hn_story_page,
     normalize_active_index,
@@ -92,6 +95,18 @@ class TestHackerNewsState:
     def test_comments_url(self):
         assert comments_url(123) == f"{HN_WEB_URL}/item?id=123"
 
+    def test_supported_feeds(self):
+        assert [feed_label(feed) for feed in HackerNewsFeed] == [
+            "Top Stories",
+            "Show HN",
+            "Jobs",
+        ]
+        assert [feed_endpoint(feed) for feed in HackerNewsFeed] == [
+            "topstories",
+            "showstories",
+            "jobstories",
+        ]
+
     def test_story_rank_and_age_edges(self):
         assert story_rank(index=0, count=0) == ""
         assert story_age(story=_story(time=0)) == ""
@@ -157,6 +172,22 @@ class TestHackerNewsState:
         assert story.hn_url == f"{HN_WEB_URL}/item?id=123"
         assert story.score == 42
         assert story.comments == 7
+
+    def test_parse_job_payload(self):
+        story = parse_story_payload(
+            {
+                "id": 456,
+                "type": "job",
+                "title": "Example is hiring",
+                "url": "https://example.test/jobs",
+                "time": 1000,
+            }
+        )
+
+        assert story is not None
+        assert story.title == "Example is hiring"
+        assert story.score == 0
+        assert story.comments == 0
 
     def test_parse_story_payload_rejects_dead_and_non_story_items(self):
         assert parse_story_payload("bad") is None
@@ -227,7 +258,7 @@ class TestHackerNewsState:
             fetched_at=dt.datetime(2026, 4, 27, tzinfo=dt.timezone.utc),
             cadence_seconds=10 * 60,
         )
-        assert "Hacker News 2/3" in text
+        assert "Hacker News - Top Stories 2/3" in text
         assert "SQLite on the Edge" in text
         assert "456 points" in text
         assert "Updated:" in text
@@ -242,6 +273,7 @@ class TestHackerNewsState:
     def test_prefs_round_trip(self):
         story = _story()
         payload = prefs_payload(
+            feed=HackerNewsFeed.SHOW,
             stories=(story,),
             active_index=4,
             next_offset=20,
@@ -249,6 +281,7 @@ class TestHackerNewsState:
         )
         prefs = prefs_from_mapping(payload)
 
+        assert prefs.feed is HackerNewsFeed.SHOW
         assert prefs.stories == (story,)
         assert prefs.active_index == 0
         assert prefs.next_offset == 20
@@ -304,6 +337,17 @@ class TestHackerNewsState:
                 "has_more_stories": False,
             }
         ) == HackerNewsPrefs(has_more_stories=False)
+        assert (
+            prefs_from_mapping(
+                {
+                    "feed": "unknown",
+                    "stories": [],
+                    "next_offset": 0,
+                    "has_more_stories": True,
+                }
+            ).feed
+            is HackerNewsFeed.TOP
+        )
 
     def test_normalize_active_index(self):
         assert normalize_active_index(index=5, count=2) == 1
@@ -363,6 +407,27 @@ class TestFetchHnStories:
         assert [story.id for story in page.stories] == [1]
         assert page.next_offset == 2
         assert page.has_more is True
+
+    def test_fetches_selected_feed(self, monkeypatch):
+        import docking.applets.hackernews.state as hn_state
+
+        seen = []
+
+        def get_json(url, *, timeout=None):
+            seen.append(url)
+            if url == f"{HN_BASE_URL}/showstories.json":
+                return [123]
+            return {"id": 123, "type": "story", "title": "Show HN: Example"}
+
+        monkeypatch.setattr(hn_state, "http_get_json", get_json)
+
+        page = fetch_hn_story_page(feed=HackerNewsFeed.SHOW)
+
+        assert [story.title for story in page.stories] == ["Show HN: Example"]
+        assert seen == [
+            f"{HN_BASE_URL}/showstories.json",
+            f"{HN_BASE_URL}/item/123.json",
+        ]
 
     def test_fetch_failure_returns_empty(self, monkeypatch):
         import docking.applets.hackernews.state as hn_state
@@ -451,7 +516,11 @@ class TestHackerNewsApplet:
         ) as fetch:
             applet.on_scroll(direction_up=False)
 
-        fetch.assert_called_once_with(limit=20, offset=20)
+        fetch.assert_called_once_with(
+            feed=HackerNewsFeed.TOP,
+            limit=20,
+            offset=20,
+        )
         assert applet._active_index == 19
         assert applet._next_story_offset == 40
         assert applet._has_more_stories is True
@@ -635,6 +704,50 @@ class TestHackerNewsApplet:
         assert "Next Headline" in labels
         assert "Refreshes every 10 minutes" in labels
         assert "Refresh Now" in labels
+        assert "Page" in labels
+
+        page = next(
+            item for item in applet.get_menu_items() if item.get_label() == "Page"
+        )
+        submenu = page.get_submenu()
+        assert submenu is not None
+        assert [item.get_label() for item in submenu.children] == [
+            "Top Stories",
+            "Show HN",
+            "Jobs",
+        ]
+
+    def test_switching_feed_clears_cache_and_fetches_selected_page(self):
+        applet = _make_applet()
+        applet._stories = [_story()]
+        applet._next_story_offset = 20
+
+        with patch(
+            "docking.applets.hackernews.applet.fetch_hn_story_page",
+            return_value=HackerNewsPage(
+                stories=(_story(id=456, title="A job"),),
+                next_offset=1,
+                has_more=False,
+            ),
+        ) as fetch:
+            applet._set_feed(feed=HackerNewsFeed.JOBS)
+
+        fetch.assert_called_once_with(
+            feed=HackerNewsFeed.JOBS,
+            limit=20,
+            offset=0,
+        )
+        assert applet._feed is HackerNewsFeed.JOBS
+        assert [story.title for story in applet._stories] == ["A job"]
+        assert applet._next_story_offset == 1
+
+    def test_selecting_current_feed_is_noop(self):
+        applet = _make_applet()
+        applet._fetch_async = MagicMock()
+
+        applet._set_feed(feed=HackerNewsFeed.TOP)
+
+        applet._fetch_async.assert_not_called()
 
     def test_menu_without_story_disables_navigation(self):
         applet = _make_applet()
@@ -852,7 +965,11 @@ class TestHackerNewsApplet:
         ) as fetch:
             applet._fetch_async()
 
-        fetch.assert_called_once_with(limit=40, offset=0)
+        fetch.assert_called_once_with(
+            feed=HackerNewsFeed.TOP,
+            limit=40,
+            offset=0,
+        )
         assert applet._active_index == 38
         assert len(applet._stories) == 40
 


### PR DESCRIPTION
## Summary
- add a Page selector for Top Stories, Show HN, and Jobs
- accept HN job items and persist the selected page
- identify the active page in menus and tooltips