### PR TITLE
Hide empty Devices stack

### DIFF
--- a/docking/applets/devices/applet.py
+++ b/docking/applets/devices/applet.py
@@ -92,7 +92,9 @@ class DevicesApplet(Applet):
     def refresh_tooltip(self) -> None:
         self.item.name = devices_tooltip(self._devices)
 
-    def stack_content(self, icon_size: int) -> StackContent:
+    def stack_content(self, icon_size: int) -> StackContent | None:
+        if not self._devices:
+            return None
         return StackContent(
             entries=tuple(
                 StackEntry(
@@ -103,7 +105,6 @@ class DevicesApplet(Applet):
                 )
                 for device in self._devices
             ),
-            empty_label=_("No mounted devices"),
         )
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:

--- a/docking/locale/docking.pot
+++ b/docking/locale/docking.pot
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "Devices"
 msgstr ""
 
-#: docking/applets/devices/applet.py:106 docking/applets/devices/state.py:125
+#: docking/applets/devices/state.py:125
 msgid "No mounted devices"
 msgstr ""
 

--- a/tests/applets/test_devices.py
+++ b/tests/applets/test_devices.py
@@ -290,13 +290,12 @@ class TestDevicesApplet:
 
         launch.assert_called_once_with("smb://fileserver/team", None)
 
-    def test_empty_stack_uses_mounted_devices_message(self, monkeypatch):
+    def test_empty_stack_is_suppressed(self, monkeypatch):
         applet = _applet(monkeypatch, _FakeMonitor())
 
         content = applet.stack_content(32)
 
-        assert content.entries == ()
-        assert content.empty_label == "No mounted devices"
+        assert content is None
 
     def test_mount_and_unmount_signals_refresh_live_stack(self, monkeypatch):
         monitor = _FakeMonitor([_mount("Data")])
@@ -320,7 +319,7 @@ class TestDevicesApplet:
         monitor.mounts = []
         monitor.emit("mount-removed")
 
-        assert applet.stack_content(32).entries == ()
+        assert applet.stack_content(32) is None
         notify.assert_called_once()
 
     def test_native_network_mount_signal_refreshes_and_opens_stack_entry(


### PR DESCRIPTION
## Summary

- suppress the Devices item stack when no devices are mounted
- keep the existing empty-state tooltip as the single status message
- retain live stack behavior for mounted devices and when the final device is removed