### PR TITLE
Show application search results directly

### DIFF
--- a/docking/applets/applications/applet.py
+++ b/docking/applets/applications/applet.py
@@ -88,7 +88,7 @@ class ApplicationsApplet(Applet):
         """Build the categorized launcher menu lazily on each open."""
         menu = Gtk.Menu()
         categories = _build_app_categories()
-        category_rows: list[tuple[Gtk.MenuItem, Gtk.Menu, list[ApplicationEntry]]] = []
+        category_rows: list[tuple[Gtk.MenuItem, list[ApplicationEntry]]] = []
 
         search_entry = Gtk.Entry()
         search_entry.set_placeholder_text(_("Search applications..."))
@@ -116,21 +116,33 @@ class ApplicationsApplet(Applet):
 
             cat_item.set_submenu(submenu)
             menu.append(cat_item)
-            category_rows.append((cat_item, submenu, apps))
+            category_rows.append((cat_item, apps))
+
+        search_results: list[Gtk.MenuItem] = []
 
         def apply_filter(query: str) -> None:
+            nonlocal search_results
             lowered = query.strip().lower()
-            for cat_item, submenu, apps in category_rows:
-                matched = list(_filter_apps(apps=apps, query=lowered))
-                _populate_app_submenu(
-                    submenu=submenu,
-                    apps=matched,
+            for result in search_results:
+                menu.remove(result)
+            search_results = []
+
+            matches: list[ApplicationEntry] = []
+            for cat_item, apps in category_rows:
+                if lowered:
+                    cat_item.hide()
+                    matches.extend(_filter_apps(apps=apps, query=lowered))
+                else:
+                    cat_item.show()
+
+            for app_info in sorted(matches, key=lambda app: _app_name(app).lower()):
+                result = _application_menu_item(
+                    app_info=app_info,
                     config=self._config,
                 )
-                if matched:
-                    cat_item.show()
-                else:
-                    cat_item.hide()
+                menu.append(result)
+                result.show_all()
+                search_results.append(result)
 
         def on_search_changed(entry: Gtk.Entry) -> None:
             apply_filter(entry.get_text())
@@ -162,21 +174,34 @@ def _populate_app_submenu(
 ) -> None:
     _clear_menu(menu=submenu)
     for app_info in apps:
-        menu_item = make_menu_item_with_icon(
-            label=_app_name(app_info),
-            gicon=app_info.get_icon(),
+        submenu.append(
+            _application_menu_item(
+                app_info=app_info,
+                config=config,
+            )
         )
-        menu_item.connect(
-            "activate",
-            lambda _, info=app_info: _launch_app(app_info=info),
-        )
-        _configure_drag_source(
-            menu_item=menu_item,
-            app_info=app_info,
-            config=config,
-        )
-        submenu.append(menu_item)
     submenu.show_all()
+
+
+def _application_menu_item(
+    *,
+    app_info: ApplicationEntry,
+    config: Config | None,
+) -> Gtk.MenuItem:
+    menu_item = make_menu_item_with_icon(
+        label=_app_name(app_info),
+        gicon=app_info.get_icon(),
+    )
+    menu_item.connect(
+        "activate",
+        lambda _, info=app_info: _launch_app(app_info=info),
+    )
+    _configure_drag_source(
+        menu_item=menu_item,
+        app_info=app_info,
+        config=config,
+    )
+    return menu_item
 
 
 def _configure_drag_source(

--- a/tests/applets/test_applications.py
+++ b/tests/applets/test_applications.py
@@ -209,6 +209,9 @@ class TestApplicationsApplet:
             def show(self) -> None:
                 self.visible = True
 
+            def show_all(self) -> None:
+                self.visible = True
+
             def hide(self) -> None:
                 self.visible = False
 
@@ -302,7 +305,7 @@ class TestApplicationsApplet:
             pixbuf = d.create_icon(size)
             assert pixbuf is not None
 
-    def test_search_filters_categories_and_submenus(self, monkeypatch):
+    def test_search_shows_direct_results_without_losing_focus(self, monkeypatch):
         self._fake_gtk(monkeypatch)
 
         firefox = MagicMock()
@@ -322,9 +325,12 @@ class TestApplicationsApplet:
                 "Office": [writer],
             },
         )
+        launch = MagicMock()
+        monkeypatch.setattr(applications_applet_mod, "_launch_app", launch)
 
         applet = ApplicationsApplet(48, config=Config())
-        items = applet._build_launcher_menu().get_children()
+        menu = applet._build_launcher_menu()
+        items = menu.get_children()
         search_entry = items[0]._child.children[0]
         internet_item = items[2]
         office_item = items[3]
@@ -348,20 +354,34 @@ class TestApplicationsApplet:
         search_entry.set_text("fire")
         search_entry.emit("changed")
 
-        assert internet_item.visible is True
+        assert internet_item.visible is False
         assert office_item.visible is False
-        assert [
-            child.get_label() for child in internet_item.get_submenu().get_children()
-        ] == [
-            "Firefox",
-        ]
-        assert internet_item.get_submenu().shown is True
+        assert search_entry.focused is True
+        assert len(menu.get_children()) == 5
+        result = menu.get_children()[-1]
+        assert result.get_label() == "Firefox"
+        assert result.get_submenu() is None
+
+        callback, args = result._signals["activate"][0]
+        callback(result, *args)
+        launch.assert_called_once_with(app_info=firefox)
+
+        search_entry.set_text("writer")
+        search_entry.emit("changed")
+
+        assert internet_item.visible is False
+        assert office_item.visible is False
+        assert search_entry.focused is True
+        assert len(menu.get_children()) == 5
+        assert menu.get_children()[-1].get_label() == "LibreOffice Writer"
 
         search_entry.set_text("")
         search_entry.emit("changed")
 
         assert internet_item.visible is True
         assert office_item.visible is True
+        assert search_entry.focused is True
+        assert len(menu.get_children()) == 4
         assert len(internet_item.get_submenu().get_children()) == 2
 
     def test_application_rows_drag_desktop_uri_to_dock(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- show matching applications directly beneath the search box
- keep typing active by avoiding a nested GTK submenu keyboard grab
- launch filtered applications with one click
- restore the categorized submenu layout when the query is cleared
- reuse the existing launch and drag behavior for search result rows