### PR TITLE
Wrap long Today in History tooltips

### DIFF
--- a/docking/applets/todayinhistory/applet.py
+++ b/docking/applets/todayinhistory/applet.py
@@ -32,6 +32,7 @@ from docking.applets.menu import disabled_menu_item, menu_sections
 from docking.applets.todayinhistory import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
+from docking.ui.tooltip import wrapped_tooltip_label
 
 from .render import render_icon
 from .state import (
@@ -121,6 +122,7 @@ class TodayInHistoryApplet(Applet):
         )
 
     def refresh_tooltip(self) -> None:
+        self.item.tooltip_builder = lambda: wrapped_tooltip_label(self.item.name)
         if self._loading and self._current is None:
             self.item.name = _("Today in History: loading...")
             return

--- a/docking/ui/tooltip.py
+++ b/docking/ui/tooltip.py
@@ -169,7 +169,8 @@ import gi
 
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gdk", "3.0")
-from gi.repository import Gdk, GLib, Gtk
+gi.require_version("Pango", "1.0")
+from gi.repository import Gdk, GLib, Gtk, Pango
 
 from docking.core.position import Position
 from docking.i18n import _
@@ -252,6 +253,34 @@ TOOLTIP_CORNER_RADIUS_PX = 6
 TOOLTIP_CONTENT_MARGIN_PX = 6
 TOOLTIP_BACKGROUND_ALPHA = 0.85
 TOOLTIP_BOUNCE_HEADROOM_FACTOR = 0.5
+WRAPPED_TOOLTIP_MAX_WIDTH_CHARS = 48
+
+
+def wrapped_tooltip_label(
+    text: str,
+    *,
+    max_width_chars: int = WRAPPED_TOOLTIP_MAX_WIDTH_CHARS,
+) -> Gtk.Label:
+    """Build a reusable tooltip label whose text wraps within a readable width."""
+    label = Gtk.Label(label=text)
+    return _configure_wrapped_tooltip_label(
+        label,
+        max_width_chars=max_width_chars,
+    )
+
+
+def _configure_wrapped_tooltip_label(
+    label: Gtk.Label,
+    *,
+    max_width_chars: int,
+) -> Gtk.Label:
+    label.set_xalign(0.0)
+    label.set_justify(Gtk.Justification.LEFT)
+    label.set_line_wrap(True)
+    label.set_line_wrap_mode(Pango.WrapMode.WORD_CHAR)
+    label.set_max_width_chars(max_width_chars)
+    label.override_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(1, 1, 1, 1))
+    return label
 
 
 def compute_tooltip_position(

--- a/run.py
+++ b/run.py
@@ -1,7 +1,15 @@
 #!/usr/bin/env python3
-"""Dev entry point for Docking."""
+"""Launch Docking directly from a source checkout.
+
+This small development entry point mirrors the installed ``docking`` command,
+letting contributors run ``python run.py`` without installing a console script.
+Application startup remains in :mod:`docking.app` so both launch paths behave
+the same way.
+"""
 
 from docking.app import main
 
+# Keep this wrapper free of startup logic; it should only delegate to the
+# canonical application entry point.
 if __name__ == "__main__":
     main()

--- a/tests/applets/test_todayinhistory.py
+++ b/tests/applets/test_todayinhistory.py
@@ -500,6 +500,18 @@ class TestTodayInHistoryApplet:
 
         assert "loading" in applet.item.name.lower()
 
+    def test_tooltip_uses_wrapped_label(self, monkeypatch):
+        applet = TodayInHistoryApplet(48, config=Config())
+        applet._current = ENTRY
+        label = object()
+        build_label = MagicMock(return_value=label)
+        monkeypatch.setattr(today_applet_mod, "wrapped_tooltip_label", build_label)
+
+        applet.refresh_tooltip()
+
+        assert applet.item.tooltip_builder() is label
+        build_label.assert_called_once_with(format_history_event(ENTRY))
+
     def test_open_current_article_noop_success_and_error(self, monkeypatch):
         applet = TodayInHistoryApplet(48, config=Config())
         applet._current = None

--- a/tests/ui/test_tooltip.py
+++ b/tests/ui/test_tooltip.py
@@ -14,6 +14,7 @@ from docking.core.position import Position
 from docking.ui.geometry import DockGeometryFrame, ItemGeometry, Rect
 from docking.ui.tooltip import (
     TOOLTIP_BASE_GAP,
+    WRAPPED_TOOLTIP_MAX_WIDTH_CHARS,
     TooltipManager,
     compute_tooltip_position,
 )
@@ -37,6 +38,25 @@ class TestTooltipManagerInit:
 
         # When / Then - gap should be small positive value
         assert 5 <= TOOLTIP_BASE_GAP <= 50
+
+
+def test_wrapped_tooltip_label_uses_readable_paragraph_width():
+    label = MagicMock()
+
+    result = tooltip_mod._configure_wrapped_tooltip_label(
+        label,
+        max_width_chars=WRAPPED_TOOLTIP_MAX_WIDTH_CHARS,
+    )
+
+    assert result is label
+    label.set_xalign.assert_called_once_with(0.0)
+    label.set_justify.assert_called_once_with(tooltip_mod.Gtk.Justification.LEFT)
+    label.set_line_wrap.assert_called_once_with(True)
+    label.set_line_wrap_mode.assert_called_once_with(
+        tooltip_mod.Pango.WrapMode.WORD_CHAR
+    )
+    label.set_max_width_chars.assert_called_once_with(WRAPPED_TOOLTIP_MAX_WIDTH_CHARS)
+    label.override_color.assert_called_once()
 
 
 class TestTooltipHide:


### PR DESCRIPTION
## Summary

- add a reusable wrapped tooltip label with a readable 48-character maximum width
- use word-aware paragraph wrapping for Today in History event tooltips
- document the purpose of the source-checkout `run.py` launcher
- cover both the shared wrapping configuration and applet integration