### PR TITLE
Add Cage compositor desktop detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ one with `DOCKING_BACKEND`.
 | **Hyprland** | Hyprland Wayland | Dock placement (layer-shell), IPC-based window tracking, active state, window actions, geometry, workspace association, and optional previews |
 | **Niri** | Niri Wayland | Dock placement (layer-shell), IPC-based window tracking, active state, window actions (focus, close), window previews, workspace association |
 | **Native layer-shell** | wlroots-based (Sway, labwc, river, Wayfire) | Dock placement, window tracking, workspace switching (varies by compositor protocol support) |
+| **Reduced** | Cage | Launcher-only mode. Cage is a single-application kiosk and does not provide a layer-shell surface suitable for a dock |
 | **Reduced** | Any Wayland | Dock visible but no window management (no running indicators, no previews, no workspace switching) |
 
 #### GNOME Shell Bridge

--- a/docking/platform/backends/selection.py
+++ b/docking/platform/backends/selection.py
@@ -201,7 +201,13 @@ def create_session_backend(
         )
         if backend is not None:
             return backend
-        return _create_reduced_backend(reason=_non_x11_reason())
+        reason = _non_x11_reason()
+        if detect_desktop() & Desktop.CAGE:
+            reason = (
+                "Cage is a single-application kiosk compositor and does not expose "
+                "a layer-shell surface suitable for a dock"
+            )
+        return _create_reduced_backend(reason=reason)
 
     return _create_x11_backend(
         config=config,

--- a/docking/platform/environment/environment.py
+++ b/docking/platform/environment/environment.py
@@ -61,6 +61,7 @@ class Desktop(enum.Flag):
     HYPRLAND = enum.auto()
     NIRI = enum.auto()
     COSMIC = enum.auto()
+    CAGE = enum.auto()
 
     @property
     def uses_monitor_geometry(self) -> bool:
@@ -106,6 +107,7 @@ _DESKTOP_MAP: dict[str, Desktop] = {
     "hyprland": Desktop.HYPRLAND,
     "niri": Desktop.NIRI,
     "cosmic": Desktop.COSMIC,
+    "cage": Desktop.CAGE,
 }
 
 

--- a/tests/platform/test_backend_selection.py
+++ b/tests/platform/test_backend_selection.py
@@ -69,6 +69,32 @@ def test_create_session_backend_selects_reduced_for_non_x11_without_x11_import(
     assert result.name == "reduced"
 
 
+def test_create_session_backend_explains_cage_reduced_mode(monkeypatch):
+    monkeypatch.delenv("DOCKING_BACKEND", raising=False)
+    monkeypatch.setattr(selection, "is_x11_backend", lambda: False)
+    monkeypatch.setattr(selection, "detect_desktop", lambda: selection.Desktop.CAGE)
+    monkeypatch.setattr(selection, "is_kde_session", lambda: False)
+    monkeypatch.setattr(selection, "_wayfire_ipc_available", lambda: False)
+    monkeypatch.setattr(
+        selection, "_create_wayland_layer_shell_backend", lambda **_: None
+    )
+    monkeypatch.setattr(
+        selection, "_create_gnome_shell_bridge_backend", lambda **_: None
+    )
+    create_reduced = MagicMock(return_value=MagicMock(name="reduced"))
+    monkeypatch.setattr(selection, "_create_reduced_backend", create_reduced)
+
+    selection.create_session_backend(
+        config=MagicMock(),
+        launcher=MagicMock(),
+        model=MagicMock(),
+    )
+
+    reason = create_reduced.call_args.kwargs["reason"]
+    assert "single-application kiosk" in reason
+    assert "layer-shell" in reason
+
+
 def test_create_session_backend_selects_layer_shell_for_supported_wayland(monkeypatch):
     monkeypatch.delenv("DOCKING_BACKEND", raising=False)
     monkeypatch.setattr(selection, "is_x11_backend", lambda: False)

--- a/tests/platform/test_environment.py
+++ b/tests/platform/test_environment.py
@@ -70,6 +70,7 @@ class TestParseDesktop:
         assert _parse_desktop("hyprland") == Desktop.HYPRLAND
         assert _parse_desktop("niri") == Desktop.NIRI
         assert _parse_desktop("cosmic") == Desktop.COSMIC
+        assert _parse_desktop("cage") == Desktop.CAGE
 
 
 class TestDetectDesktop:


### PR DESCRIPTION
## Summary
Add `Desktop.CAGE` enum entry and desktop string mapping for the Cage kiosk Wayland compositor.

## Research findings
Cage (github.com/cage-kiosk/cage) is a kiosk compositor that does **not** implement `wlr_layer_shell_v1`. Without layer-shell, Docking cannot place itself as a panel — the compositor forces every toplevel to fullscreen and only one view is visible at a time.

Cage **does** implement `wlr_foreign_toplevel_manager_v1` (verified from source), but without layer-shell, panel placement is impossible.

The existing reduced-mode fallback already handles Cage correctly — no backend selection changes needed.

## Changes
- Add `Desktop.CAGE` to the `Desktop` enum
- Add `"cage"` to `_DESKTOP_MAP`
- Add test for desktop string parsing