### PR TITLE
Add Weston compositor desktop detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ one with `DOCKING_BACKEND`.
 | **Niri** | Niri Wayland | Dock placement (layer-shell), IPC-based window tracking, active state, window actions (focus, close), window previews, workspace association |
 | **Native layer-shell** | wlroots-based (Sway, labwc, river, Wayfire) | Dock placement, window tracking, workspace switching (varies by compositor protocol support) |
 | **Reduced** | Cage | Launcher-only mode. Cage is a single-application kiosk and does not provide a layer-shell surface suitable for a dock |
+| **Reduced** | Weston | Launcher-only mode. Weston's shell protocols are reserved for its configured shell or IVI controller, not general third-party docks |
 | **Reduced** | Any Wayland | Dock visible but no window management (no running indicators, no previews, no workspace switching) |
 
 #### GNOME Shell Bridge

--- a/docking/platform/backends/selection.py
+++ b/docking/platform/backends/selection.py
@@ -207,6 +207,11 @@ def create_session_backend(
                 "Cage is a single-application kiosk compositor and does not expose "
                 "a layer-shell surface suitable for a dock"
             )
+        elif detect_desktop() & Desktop.WESTON:
+            reason = (
+                "Weston does not expose a general-purpose layer-shell or window "
+                "management protocol to third-party dock clients"
+            )
         return _create_reduced_backend(reason=reason)
 
     return _create_x11_backend(

--- a/docking/platform/environment/environment.py
+++ b/docking/platform/environment/environment.py
@@ -62,6 +62,7 @@ class Desktop(enum.Flag):
     NIRI = enum.auto()
     COSMIC = enum.auto()
     CAGE = enum.auto()
+    WESTON = enum.auto()
 
     @property
     def uses_monitor_geometry(self) -> bool:
@@ -108,6 +109,7 @@ _DESKTOP_MAP: dict[str, Desktop] = {
     "niri": Desktop.NIRI,
     "cosmic": Desktop.COSMIC,
     "cage": Desktop.CAGE,
+    "weston": Desktop.WESTON,
 }
 
 

--- a/tests/platform/test_backend_selection.py
+++ b/tests/platform/test_backend_selection.py
@@ -95,6 +95,32 @@ def test_create_session_backend_explains_cage_reduced_mode(monkeypatch):
     assert "layer-shell" in reason
 
 
+def test_create_session_backend_explains_weston_reduced_mode(monkeypatch):
+    monkeypatch.delenv("DOCKING_BACKEND", raising=False)
+    monkeypatch.setattr(selection, "is_x11_backend", lambda: False)
+    monkeypatch.setattr(selection, "detect_desktop", lambda: selection.Desktop.WESTON)
+    monkeypatch.setattr(selection, "is_kde_session", lambda: False)
+    monkeypatch.setattr(selection, "_wayfire_ipc_available", lambda: False)
+    monkeypatch.setattr(
+        selection, "_create_wayland_layer_shell_backend", lambda **_: None
+    )
+    monkeypatch.setattr(
+        selection, "_create_gnome_shell_bridge_backend", lambda **_: None
+    )
+    create_reduced = MagicMock(return_value=MagicMock(name="reduced"))
+    monkeypatch.setattr(selection, "_create_reduced_backend", create_reduced)
+
+    selection.create_session_backend(
+        config=MagicMock(),
+        launcher=MagicMock(),
+        model=MagicMock(),
+    )
+
+    reason = create_reduced.call_args.kwargs["reason"]
+    assert "Weston" in reason
+    assert "third-party dock clients" in reason
+
+
 def test_create_session_backend_selects_layer_shell_for_supported_wayland(monkeypatch):
     monkeypatch.delenv("DOCKING_BACKEND", raising=False)
     monkeypatch.setattr(selection, "is_x11_backend", lambda: False)

--- a/tests/platform/test_environment.py
+++ b/tests/platform/test_environment.py
@@ -71,6 +71,7 @@ class TestParseDesktop:
         assert _parse_desktop("niri") == Desktop.NIRI
         assert _parse_desktop("cosmic") == Desktop.COSMIC
         assert _parse_desktop("cage") == Desktop.CAGE
+        assert _parse_desktop("weston") == Desktop.WESTON
 
 
 class TestDetectDesktop:


### PR DESCRIPTION
## Summary
Add `Desktop.WESTON` enum entry and desktop string mapping for the Weston reference Wayland compositor.

## Research findings
Weston (gitlab.freedesktop.org/wayland/weston, v16.0.90) does **not** implement `wlr_layer_shell_v1`, `wlr_foreign_toplevel_manager_v1`, or `ext_workspace_manager_v1`. Verified by source grep — zero hits for these protocols.

Weston's `weston_desktop_shell` protocol has a `set_panel` request but it is gated exclusively to the compositor's own child process. No third-party dock can bind it on stock Weston.

Docking falls through to reduced mode, which is the only viable path.

## Changes
- Add `Desktop.WESTON` to the `Desktop` enum
- Add `"weston"` to `_DESKTOP_MAP`
- Add test for desktop string parsing