### PR TITLE
Recognize Louvre-based Wayland sessions

### DIFF
--- a/docking/platform/environment/environment.py
+++ b/docking/platform/environment/environment.py
@@ -63,6 +63,7 @@ class Desktop(enum.Flag):
     COSMIC = enum.auto()
     CAGE = enum.auto()
     WESTON = enum.auto()
+    LOUVRE = enum.auto()
 
     @property
     def uses_monitor_geometry(self) -> bool:
@@ -110,6 +111,7 @@ _DESKTOP_MAP: dict[str, Desktop] = {
     "cosmic": Desktop.COSMIC,
     "cage": Desktop.CAGE,
     "weston": Desktop.WESTON,
+    "louvre": Desktop.LOUVRE,
 }
 
 

--- a/tests/platform/test_environment.py
+++ b/tests/platform/test_environment.py
@@ -72,6 +72,7 @@ class TestParseDesktop:
         assert _parse_desktop("cosmic") == Desktop.COSMIC
         assert _parse_desktop("cage") == Desktop.CAGE
         assert _parse_desktop("weston") == Desktop.WESTON
+        assert _parse_desktop("louvre") == Desktop.LOUVRE
 
 
 class TestDetectDesktop:


### PR DESCRIPTION
## Summary

Recognize Louvre-based Wayland sessions in Docking's desktop-environment model.

## Why

Louvre-based compositors use the generic native Wayland backend because their useful integration points are standard Wayland protocols. Explicit detection still makes the session identity available to diagnostics and future capability decisions without introducing a duplicate backend.

Generic `ext-idle-notify-v1` integration has been separated into its own PR because it is not Louvre-specific.

## Changes

- Add the `Desktop.LOUVRE` environment flag.
- Map the `louvre` desktop-session name to that flag.
- Cover the mapping with an environment parser test.

## Validation

- The branch diff contains only Louvre detection and its test.
- Ruff, ty, and Vulture passed before the split.
