### PR TITLE
Add Phosh and Phoc detection with native window thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ one with `DOCKING_BACKEND`.
 | **Hyprland** | Hyprland Wayland | Dock placement (layer-shell), IPC-based window tracking, active state, window actions, geometry, workspace association, and optional previews |
 | **Niri** | Niri Wayland | Dock placement (layer-shell), IPC-based window tracking, active state, window actions (focus, close), window previews, workspace association |
 | **Native layer-shell** | wlroots-based (Sway, labwc, river, Wayfire) | Dock placement, window tracking, workspace switching (varies by compositor protocol support) |
+| **Native layer-shell** | Phosh / phoc | Dock placement and window actions through standard protocols, with native per-window thumbnails when phoc exposes `phosh_private` to the client |
 | **Reduced** | Cage | Launcher-only mode. Cage is a single-application kiosk and does not provide a layer-shell surface suitable for a dock |
 | **Reduced** | Weston | Launcher-only mode. Weston's shell protocols are reserved for its configured shell or IVI controller, not general third-party docks |
 | **Reduced** | Any Wayland | Dock visible but no window management (no running indicators, no previews, no workspace switching) |

--- a/docking/platform/backends/wayland/previews.py
+++ b/docking/platform/backends/wayland/previews.py
@@ -90,6 +90,23 @@ class _HyprlandCaptureRequest:
     y_inverted: bool = False
 
 
+@dataclass
+class _PhocCaptureRequest:
+    window_id: WindowId
+    requested_width: int
+    requested_height: int
+    frame: object
+    width: int = 0
+    height: int = 0
+    fd: int | None = None
+    mmap_obj: mmap.mmap | None = None
+    pool: object | None = None
+    buffer: object | None = None
+    stride: int = 0
+    format: int = SHM_ARGB8888
+    y_inverted: bool = False
+
+
 class WaylandPreviewHandleTracker:
     """Tracks ext-foreign-toplevel-list handles for preview capture."""
 
@@ -497,8 +514,147 @@ class HyprlandPreviewService(PreviewService):
             os.close(request.fd)
 
 
+class PhocPreviewService(PreviewService):
+    """Window thumbnails provided by phoc's optional phosh_private protocol."""
+
+    def __init__(self, *, protocol: object, windows: object):
+        self._protocol = protocol
+        self._windows = windows
+        self._cache: dict[WindowId, PreviewImage] = {}
+        self._pending: dict[WindowId, _PhocCaptureRequest] = {}
+
+    def start(self) -> None:
+        """The generic window service owns the foreign-toplevel handles."""
+
+    def stop(self) -> None:
+        for request in tuple(self._pending.values()):
+            self._cleanup_request(request)
+        self._pending.clear()
+        self._cache.clear()
+
+    def capture(
+        self, window_id: WindowId, *, width: int, height: int
+    ) -> PreviewImage | None:
+        return self._preview(window_id=window_id, width=width, height=height)
+
+    def thumbnail(
+        self, window_id: WindowId, *, width: int, height: int
+    ) -> PreviewImage | None:
+        return self._preview(window_id=window_id, width=width, height=height)
+
+    def _preview(
+        self, *, window_id: WindowId, width: int, height: int
+    ) -> PreviewImage | None:
+        if window_id.backend is not DisplayServer.WAYLAND:
+            return None
+        cached = self._cache.get(window_id)
+        if cached is not None:
+            return cached
+        if window_id not in self._pending:
+            self._start_capture(window_id=window_id, width=width, height=height)
+        return None
+
+    def _start_capture(self, *, window_id: WindowId, width: int, height: int) -> None:
+        handle_for_window_id = getattr(
+            self._windows, "protocol_handle_for_window_id", None
+        )
+        if not callable(handle_for_window_id):
+            return
+        handle = handle_for_window_id(window_id)
+        if handle is None:
+            return
+        try:
+            frame = self._protocol.create_frame(handle, width, height)
+        except Exception:
+            return
+        request = _PhocCaptureRequest(
+            window_id=window_id,
+            requested_width=width,
+            requested_height=height,
+            frame=frame,
+        )
+        self._pending[window_id] = request
+        frame.dispatcher["buffer"] = lambda _frame, fmt, w, h, stride: self._on_buffer(
+            request, fmt, w, h, stride
+        )
+        frame.dispatcher["flags"] = lambda _frame, flags: self._on_flags(request, flags)
+        frame.dispatcher["ready"] = lambda _frame, *_timestamp: self._on_ready(request)
+        frame.dispatcher["failed"] = lambda _frame: self._finish_failed(request)
+        self._protocol.flush()
+
+    def _on_buffer(
+        self,
+        request: _PhocCaptureRequest,
+        format_: int,
+        width: int,
+        height: int,
+        stride: int,
+    ) -> None:
+        format_ = int(format_)
+        if format_ not in _PREFERRED_SHM_FORMATS:
+            self._finish_failed(request)
+            return
+        request.format = format_
+        request.width = int(width)
+        request.height = int(height)
+        request.stride = int(stride)
+        if request.width <= 0 or request.height <= 0 or request.stride <= 0:
+            self._finish_failed(request)
+            return
+        try:
+            size = request.stride * request.height
+            fd = os.memfd_create("docking-phoc-preview")
+            os.ftruncate(fd, size)
+            mmap_obj = mmap.mmap(fd, size)
+            pool = self._protocol.create_shm_pool(fd, size)
+            buffer = pool.create_buffer(
+                0,
+                request.width,
+                request.height,
+                request.stride,
+                request.format,
+            )
+            pool.destroy()
+            request.fd = fd
+            request.mmap_obj = mmap_obj
+            request.pool = pool
+            request.buffer = buffer
+            request.frame.copy(buffer)
+            self._protocol.flush()
+        except Exception:
+            self._finish_failed(request)
+
+    def _on_flags(self, request: _PhocCaptureRequest, flags: int) -> None:
+        request.y_inverted = bool(int(flags) & 1)
+
+    def _on_ready(self, request: _PhocCaptureRequest) -> None:
+        with suppress(Exception):
+            self._cache[request.window_id] = _pixbuf_from_request(request)
+        self._finish_request(request)
+
+    def _finish_failed(self, request: _PhocCaptureRequest) -> None:
+        self._cache.pop(request.window_id, None)
+        self._finish_request(request)
+
+    def _finish_request(self, request: _PhocCaptureRequest) -> None:
+        self._pending.pop(request.window_id, None)
+        self._cleanup_request(request)
+
+    def _cleanup_request(self, request: _PhocCaptureRequest) -> None:
+        for attr in ("frame", "buffer"):
+            obj = getattr(request, attr, None)
+            destroy = getattr(obj, "destroy", None)
+            if callable(destroy):
+                with suppress(Exception):
+                    destroy()
+        if request.mmap_obj is not None:
+            request.mmap_obj.close()
+        if request.fd is not None:
+            os.close(request.fd)
+
+
 def _pixbuf_from_request(
-    request: _CaptureRequest | _HyprlandCaptureRequest,
+    request: _CaptureRequest | _HyprlandCaptureRequest | _PhocCaptureRequest,
 ) -> PreviewImage:
     assert request.mmap_obj is not None
     source = request.mmap_obj[: request.stride * request.height]

--- a/docking/platform/backends/wayland/protocols/phosh_private/__init__.py
+++ b/docking/platform/backends/wayland/protocols/phosh_private/__init__.py
@@ -1,0 +1,6 @@
+# ruff: noqa
+
+from .phosh_private import PhoshPrivate
+from .zwlr_screencopy_frame_v1 import ZwlrScreencopyFrameV1
+
+__all__ = ["PhoshPrivate", "ZwlrScreencopyFrameV1"]

--- a/docking/platform/backends/wayland/protocols/phosh_private/phosh_private.py
+++ b/docking/platform/backends/wayland/protocols/phosh_private/phosh_private.py
@@ -1,0 +1,108 @@
+# Minimal pywayland binding for phosh_private.get_thumbnail.
+# ruff: noqa
+
+from __future__ import annotations
+
+from pywayland.protocol_core import (
+    Argument,
+    ArgumentType,
+    Global,
+    Interface,
+    Proxy,
+    Resource,
+)
+from pywayland.protocol.wayland import WlSurface
+
+from ..wlr_foreign_toplevel_management_unstable_v1 import ZwlrForeignToplevelHandleV1
+from .zwlr_screencopy_frame_v1 import ZwlrScreencopyFrameV1
+
+
+class PhoshPrivateXdgSwitcher(Interface):
+    name = "phosh_private_xdg_switcher"
+    version = 7
+
+
+class PhoshPrivateKeyboardEvent(Interface):
+    name = "phosh_private_keyboard_event"
+    version = 7
+
+
+class PhoshPrivateStartupTracker(Interface):
+    name = "phosh_private_startup_tracker"
+    version = 7
+
+
+class PhoshPrivate(Interface):
+    name = "phosh_private"
+    version = 7
+
+
+class PhoshPrivateProxy(Proxy[PhoshPrivate]):
+    interface = PhoshPrivate
+
+    @PhoshPrivate.request(
+        Argument(ArgumentType.Object, interface=WlSurface),
+        Argument(ArgumentType.Uint),
+    )
+    def rotate_display(self, surface: WlSurface, degree: int) -> None:
+        self._marshal(0, surface, degree)
+
+    @PhoshPrivate.request(
+        Argument(ArgumentType.NewId, interface=PhoshPrivateXdgSwitcher), version=2
+    )
+    def get_xdg_switcher(self) -> Proxy[PhoshPrivateXdgSwitcher]:
+        return self._marshal_constructor(1, PhoshPrivateXdgSwitcher)
+
+    @PhoshPrivate.request(
+        Argument(ArgumentType.NewId, interface=ZwlrScreencopyFrameV1),
+        Argument(ArgumentType.Object, interface=ZwlrForeignToplevelHandleV1),
+        Argument(ArgumentType.Uint),
+        Argument(ArgumentType.Uint),
+        version=4,
+    )
+    def get_thumbnail(
+        self,
+        toplevel: ZwlrForeignToplevelHandleV1,
+        max_width: int,
+        max_height: int,
+    ) -> Proxy[ZwlrScreencopyFrameV1]:
+        return self._marshal_constructor(
+            2, ZwlrScreencopyFrameV1, toplevel, max_width, max_height
+        )
+
+    @PhoshPrivate.request(
+        Argument(ArgumentType.NewId, interface=PhoshPrivateKeyboardEvent), version=5
+    )
+    def get_keyboard_event(self) -> Proxy[PhoshPrivateKeyboardEvent]:
+        return self._marshal_constructor(3, PhoshPrivateKeyboardEvent)
+
+    @PhoshPrivate.request(
+        Argument(ArgumentType.NewId, interface=PhoshPrivateStartupTracker), version=6
+    )
+    def get_startup_tracker(self) -> Proxy[PhoshPrivateStartupTracker]:
+        return self._marshal_constructor(4, PhoshPrivateStartupTracker)
+
+    @PhoshPrivate.request(Argument(ArgumentType.Uint), version=6)
+    def set_shell_state(self, state: int) -> None:
+        self._marshal(5, state)
+
+
+class PhoshPrivateResource(Resource):
+    interface = PhoshPrivate
+
+
+class PhoshPrivateGlobal(Global):
+    interface = PhoshPrivate
+
+
+for interface in (
+    PhoshPrivateXdgSwitcher,
+    PhoshPrivateKeyboardEvent,
+    PhoshPrivateStartupTracker,
+    PhoshPrivate,
+):
+    interface._gen_c()
+
+PhoshPrivate.proxy_class = PhoshPrivateProxy
+PhoshPrivate.resource_class = PhoshPrivateResource
+PhoshPrivate.global_class = PhoshPrivateGlobal

--- a/docking/platform/backends/wayland/protocols/phosh_private/zwlr_screencopy_frame_v1.py
+++ b/docking/platform/backends/wayland/protocols/phosh_private/zwlr_screencopy_frame_v1.py
@@ -1,0 +1,105 @@
+# Minimal pywayland binding for zwlr_screencopy_frame_v1 used by phosh_private.
+# ruff: noqa
+
+from __future__ import annotations
+
+import enum
+
+from pywayland.protocol_core import (
+    Argument,
+    ArgumentType,
+    Global,
+    Interface,
+    Proxy,
+    Resource,
+)
+from pywayland.protocol.wayland import WlBuffer
+
+
+class ZwlrScreencopyFrameV1(Interface):
+    name = "zwlr_screencopy_frame_v1"
+    version = 3
+
+    class flags(enum.IntFlag):
+        y_invert = 1
+
+
+class ZwlrScreencopyFrameV1Proxy(Proxy[ZwlrScreencopyFrameV1]):
+    interface = ZwlrScreencopyFrameV1
+
+    @ZwlrScreencopyFrameV1.request(Argument(ArgumentType.Object, interface=WlBuffer))
+    def copy(self, buffer: WlBuffer) -> None:
+        self._marshal(0, buffer)
+
+    @ZwlrScreencopyFrameV1.request()
+    def destroy(self) -> None:
+        self._marshal(1)
+        self._destroy()
+
+    @ZwlrScreencopyFrameV1.request(
+        Argument(ArgumentType.Object, interface=WlBuffer), version=2
+    )
+    def copy_with_damage(self, buffer: WlBuffer) -> None:
+        self._marshal(2, buffer)
+
+
+class ZwlrScreencopyFrameV1Resource(Resource):
+    interface = ZwlrScreencopyFrameV1
+
+    @ZwlrScreencopyFrameV1.event(
+        Argument(ArgumentType.Uint),
+        Argument(ArgumentType.Uint),
+        Argument(ArgumentType.Uint),
+        Argument(ArgumentType.Uint),
+    )
+    def buffer(self, format_: int, width: int, height: int, stride: int) -> None:
+        self._post_event(0, format_, width, height, stride)
+
+    @ZwlrScreencopyFrameV1.event(Argument(ArgumentType.Uint))
+    def flags(self, flags: int) -> None:
+        self._post_event(1, flags)
+
+    @ZwlrScreencopyFrameV1.event(
+        Argument(ArgumentType.Uint),
+        Argument(ArgumentType.Uint),
+        Argument(ArgumentType.Uint),
+    )
+    def ready(self, tv_sec_hi: int, tv_sec_lo: int, tv_nsec: int) -> None:
+        self._post_event(2, tv_sec_hi, tv_sec_lo, tv_nsec)
+
+    @ZwlrScreencopyFrameV1.event()
+    def failed(self) -> None:
+        self._post_event(3)
+
+    @ZwlrScreencopyFrameV1.event(
+        Argument(ArgumentType.Uint),
+        Argument(ArgumentType.Uint),
+        Argument(ArgumentType.Uint),
+        Argument(ArgumentType.Uint),
+        version=2,
+    )
+    def damage(self, x: int, y: int, width: int, height: int) -> None:
+        self._post_event(4, x, y, width, height)
+
+    @ZwlrScreencopyFrameV1.event(
+        Argument(ArgumentType.Uint),
+        Argument(ArgumentType.Uint),
+        Argument(ArgumentType.Uint),
+        version=3,
+    )
+    def linux_dmabuf(self, format_: int, width: int, height: int) -> None:
+        self._post_event(5, format_, width, height)
+
+    @ZwlrScreencopyFrameV1.event(version=3)
+    def buffer_done(self) -> None:
+        self._post_event(6)
+
+
+class ZwlrScreencopyFrameV1Global(Global):
+    interface = ZwlrScreencopyFrameV1
+
+
+ZwlrScreencopyFrameV1._gen_c()
+ZwlrScreencopyFrameV1.proxy_class = ZwlrScreencopyFrameV1Proxy
+ZwlrScreencopyFrameV1.resource_class = ZwlrScreencopyFrameV1Resource
+ZwlrScreencopyFrameV1.global_class = ZwlrScreencopyFrameV1Global

--- a/docking/platform/backends/wayland/runtime.py
+++ b/docking/platform/backends/wayland/runtime.py
@@ -682,6 +682,61 @@ class HyprlandPreviewProtocolAdapter:
             self._flush()
 
 
+class PhocPreviewProtocolAdapter:
+    """Adapter for phoc's window-specific phosh_private thumbnail request."""
+
+    def __init__(self) -> None:
+        self._manager = None
+        self._shm = None
+        self._flush: Callable[[], None] | None = None
+        self.available = False
+
+    @property
+    def capture_available(self) -> bool:
+        return self.available and self._manager is not None and self._shm is not None
+
+    def set_flush_callback(self, callback: Callable[[], None] | None) -> None:
+        self._flush = callback
+
+    def bind(self, *, registry, name: int, version: int) -> None:
+        from docking.platform.backends.wayland.protocols.phosh_private import (
+            PhoshPrivate,
+        )
+
+        bind_version = min(version, PhoshPrivate.version)
+        self._manager = registry.bind(name, PhoshPrivate, bind_version)
+        self.available = bind_version >= 4
+
+    def bind_shm(self, *, registry, name: int, version: int) -> None:
+        from pywayland.protocol.wayland import WlShm
+
+        self._shm = registry.bind(name, WlShm, min(version, WlShm.version))
+
+    def create_frame(self, handle: object, width: int, height: int) -> object:
+        if not self.capture_available or self._manager is None:
+            raise RuntimeError("Phoc preview capture is unavailable")
+        return self._manager.get_thumbnail(handle, width, height)
+
+    def create_shm_pool(self, fd: int, size: int) -> object:
+        if not self.capture_available or self._shm is None:
+            raise RuntimeError("Phoc preview shm is unavailable")
+        return self._shm.create_pool(fd, size)
+
+    def flush(self) -> None:
+        if self._flush is not None:
+            self._flush()
+
+    def stop(self) -> None:
+        for obj in (self._manager, self._shm):
+            destroy = getattr(obj, "destroy", None)
+            if callable(destroy):
+                destroy()
+        self._manager = None
+        self._shm = None
+        self._flush = None
+        self.available = False
+
+
 class WaylandProtocolRuntime:
     """Owns direct Wayland protocol connection and event-loop integration."""
 
@@ -693,6 +748,7 @@ class WaylandProtocolRuntime:
         workspace_adapter: WorkspaceProtocolAdapter | None = None,
         preview_adapter: PreviewProtocolAdapter | None = None,
         hyprland_preview_adapter: HyprlandPreviewProtocolAdapter | None = None,
+        phoc_preview_adapter: PhocPreviewProtocolAdapter | None = None,
         idle_adapter: IdleProtocolAdapter | None = None,
         cosmic_toplevel_adapter: object | None = None,
         cosmic_workspace_adapter: object | None = None,
@@ -711,6 +767,7 @@ class WaylandProtocolRuntime:
         self.hyprland_previews = (
             hyprland_preview_adapter or HyprlandPreviewProtocolAdapter()
         )
+        self.phoc_previews = phoc_preview_adapter or PhocPreviewProtocolAdapter()
         self.idle = idle_adapter or IdleProtocolAdapter()
         self.cosmic_toplevel = cosmic_toplevel_adapter or CosmicToplevelAdapter()
         self.cosmic_workspace = cosmic_workspace_adapter or CosmicWorkspaceAdapter()
@@ -737,6 +794,10 @@ class WaylandProtocolRuntime:
         return (
             self.hyprland_previews if self.hyprland_previews.capture_available else None
         )
+
+    @property
+    def phoc_preview_protocol(self) -> object | None:
+        return self.phoc_previews if self.phoc_previews.capture_available else None
 
     @property
     def idle_protocol(self) -> object | None:
@@ -770,6 +831,7 @@ class WaylandProtocolRuntime:
             self.workspaces.set_flush_callback(display.flush)
             self.previews.set_flush_callback(display.flush)
             self.hyprland_previews.set_flush_callback(display.flush)
+            self.phoc_previews.set_flush_callback(display.flush)
             self.idle.set_flush_callback(display.flush)
             self.cosmic_toplevel.set_flush_callback(display.flush)
             self.cosmic_workspace.set_flush_callback(display.flush)
@@ -802,6 +864,7 @@ class WaylandProtocolRuntime:
         self.workspaces.stop()
         self.previews.stop()
         self.hyprland_previews.stop()
+        self.phoc_previews.stop()
         self.idle.stop()
         self.cosmic_toplevel.stop()
         self.cosmic_workspace.stop()
@@ -895,8 +958,19 @@ class WaylandProtocolRuntime:
                 name=name,
                 version=version,
             )
+            self.phoc_previews.bind_shm(
+                registry=registry,
+                name=name,
+                version=version,
+            )
         elif interface == "hyprland_toplevel_export_manager_v1":
             self.hyprland_previews.bind_export_manager(
+                registry=registry,
+                name=name,
+                version=version,
+            )
+        elif interface == "phosh_private":
+            self.phoc_previews.bind(
                 registry=registry,
                 name=name,
                 version=version,

--- a/docking/platform/backends/wayland/session.py
+++ b/docking/platform/backends/wayland/session.py
@@ -42,6 +42,7 @@ from docking.platform.backends.wayland.portals import (
 )
 from docking.platform.backends.wayland.previews import (
     HyprlandPreviewService,
+    PhocPreviewService,
     WaylandPreviewHandleTracker,
     WaylandPreviewService,
 )
@@ -117,6 +118,11 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             if runtime is not None
             else None
         )
+        phoc_preview_protocol = (
+            getattr(runtime, "phoc_preview_protocol", None)
+            if runtime is not None
+            else None
+        )
         windows: WindowService
         preview_handles: WaylandPreviewHandleTracker | None = None
         if foreign_protocol is not None and model is not None and launcher is not None:
@@ -132,7 +138,10 @@ class WaylandLayerShellSessionBackend(SessionBackend):
                 protocol=foreign_protocol,
                 preview_handles=preview_handles,
                 can_preview=preview_protocol is None
-                and hyprland_preview_protocol is not None,
+                and (
+                    hyprland_preview_protocol is not None
+                    or phoc_preview_protocol is not None
+                ),
             )
         else:
             windows = ReducedWindowService()
@@ -146,6 +155,13 @@ class WaylandLayerShellSessionBackend(SessionBackend):
         ):
             previews = HyprlandPreviewService(
                 protocol=hyprland_preview_protocol,
+                windows=windows,
+            )
+        elif phoc_preview_protocol is not None and isinstance(
+            windows, WaylandForeignToplevelWindowService
+        ):
+            previews = PhocPreviewService(
+                protocol=phoc_preview_protocol,
                 windows=windows,
             )
         else:

--- a/docking/platform/environment/environment.py
+++ b/docking/platform/environment/environment.py
@@ -114,6 +114,7 @@ _DESKTOP_MAP: dict[str, Desktop] = {
     "weston": Desktop.WESTON,
     "louvre": Desktop.LOUVRE,
     "phosh": Desktop.PHOSH,
+    "phoc": Desktop.PHOSH,
 }
 
 

--- a/docking/platform/environment/environment.py
+++ b/docking/platform/environment/environment.py
@@ -64,6 +64,7 @@ class Desktop(enum.Flag):
     CAGE = enum.auto()
     WESTON = enum.auto()
     LOUVRE = enum.auto()
+    PHOSH = enum.auto()
 
     @property
     def uses_monitor_geometry(self) -> bool:
@@ -112,6 +113,7 @@ _DESKTOP_MAP: dict[str, Desktop] = {
     "cage": Desktop.CAGE,
     "weston": Desktop.WESTON,
     "louvre": Desktop.LOUVRE,
+    "phosh": Desktop.PHOSH,
 }
 
 

--- a/tests/platform/test_environment.py
+++ b/tests/platform/test_environment.py
@@ -73,6 +73,7 @@ class TestParseDesktop:
         assert _parse_desktop("cage") == Desktop.CAGE
         assert _parse_desktop("weston") == Desktop.WESTON
         assert _parse_desktop("louvre") == Desktop.LOUVRE
+        assert _parse_desktop("phosh") == Desktop.PHOSH
 
 
 class TestDetectDesktop:

--- a/tests/platform/test_environment.py
+++ b/tests/platform/test_environment.py
@@ -74,6 +74,7 @@ class TestParseDesktop:
         assert _parse_desktop("weston") == Desktop.WESTON
         assert _parse_desktop("louvre") == Desktop.LOUVRE
         assert _parse_desktop("phosh") == Desktop.PHOSH
+        assert _parse_desktop("phoc") == Desktop.PHOSH
 
 
 class TestDetectDesktop:

--- a/tests/platform/test_wayland_layer_shell_session.py
+++ b/tests/platform/test_wayland_layer_shell_session.py
@@ -29,6 +29,7 @@ from docking.platform.backends.wayland.niri_session import NiriSessionBackend
 from docking.platform.backends.wayland.portals import WaylandPortalColorPickerService
 from docking.platform.backends.wayland.previews import (
     HyprlandPreviewService,
+    PhocPreviewService,
     WaylandPreviewService,
 )
 from docking.platform.backends.wayland.services import (
@@ -75,6 +76,7 @@ def _empty_runtime() -> SimpleNamespace:
         workspace_protocol=None,
         preview_protocol=None,
         hyprland_preview_protocol=None,
+        phoc_preview_protocol=None,
         idle_protocol=None,
         stop=MagicMock(),
     )
@@ -183,6 +185,37 @@ def test_wayland_layer_shell_session_uses_hyprland_previews_when_available():
 
     assert isinstance(backend.windows, WaylandForeignToplevelWindowService)
     assert isinstance(backend.previews, HyprlandPreviewService)
+
+
+def test_wayland_layer_shell_session_uses_phoc_previews_when_available():
+    phoc_preview_protocol = SimpleNamespace(
+        capture_available=True,
+        create_frame=MagicMock(),
+        create_shm_pool=MagicMock(),
+        flush=MagicMock(),
+    )
+    backend = WaylandLayerShellSessionBackend(
+        layer_shell=_layer_shell(),
+        model=SimpleNamespace(
+            visible_items=MagicMock(return_value=[]),
+            update_running=MagicMock(),
+        ),
+        launcher=SimpleNamespace(resolve=MagicMock(), resolve_by_wm_class=MagicMock()),
+        foreign_toplevel_protocol=SimpleNamespace(),
+        protocol_runtime=SimpleNamespace(
+            foreign_toplevel_protocol=None,
+            workspace_protocol=None,
+            preview_protocol=None,
+            hyprland_preview_protocol=None,
+            phoc_preview_protocol=phoc_preview_protocol,
+            idle_protocol=None,
+            stop=MagicMock(),
+        ),
+    )
+
+    assert isinstance(backend.windows, WaylandForeignToplevelWindowService)
+    assert backend.windows._can_preview is True
+    assert isinstance(backend.previews, PhocPreviewService)
 
 
 def test_wayland_layer_shell_session_uses_workspace_and_capture_services_when_available():

--- a/tests/platform/test_wayland_previews.py
+++ b/tests/platform/test_wayland_previews.py
@@ -10,6 +10,7 @@ from docking.platform.backends.wayland import previews as preview_mod
 from docking.platform.backends.wayland.previews import (
     SHM_ARGB8888,
     HyprlandPreviewService,
+    PhocPreviewService,
     WaylandPreviewHandleTracker,
     WaylandPreviewService,
 )
@@ -160,3 +161,34 @@ def test_hyprland_preview_service_uses_wlr_handle_and_returns_cached_frame(
     frame.dispatcher["ready"](frame, 0, 0, 0)
 
     assert service.capture(window_id, width=100, height=60) is image
+
+
+def test_phoc_preview_service_copies_thumbnail_frame_immediately(monkeypatch):
+    window_id = WindowId(backend=DisplayServer.WAYLAND, value=8)
+    handle = object()
+    frame = FakeFrame()
+    pool = FakePool()
+    protocol = SimpleNamespace(
+        create_frame=MagicMock(return_value=frame),
+        create_shm_pool=MagicMock(return_value=pool),
+        flush=MagicMock(),
+    )
+    windows = SimpleNamespace(
+        protocol_handle_for_window_id=MagicMock(return_value=handle),
+    )
+    image = PreviewImage(image=object(), width=96, height=64)
+    monkeypatch.setattr(
+        preview_mod,
+        "_pixbuf_from_request",
+        MagicMock(return_value=image),
+    )
+    service = PhocPreviewService(protocol=protocol, windows=windows)
+
+    assert service.thumbnail(window_id, width=96, height=64) is None
+    protocol.create_frame.assert_called_once_with(handle, 96, 64)
+
+    frame.dispatcher["buffer"](frame, SHM_ARGB8888, 192, 128, 768)
+    frame.copy.assert_called_once_with(pool.buffer)
+    frame.dispatcher["ready"](frame, 0, 0, 0)
+
+    assert service.thumbnail(window_id, width=96, height=64) is image

--- a/tests/platform/test_wayland_protocol_runtime.py
+++ b/tests/platform/test_wayland_protocol_runtime.py
@@ -30,12 +30,14 @@ from docking.platform.backends.wayland.protocols.ext_workspace_v1.ext_workspace_
 from docking.platform.backends.wayland.protocols.hyprland_toplevel_export_v1 import (
     HyprlandToplevelExportManagerV1,
 )
+from docking.platform.backends.wayland.protocols.phosh_private import PhoshPrivate
 from docking.platform.backends.wayland.protocols.wlr_foreign_toplevel_management_unstable_v1 import (
     ZwlrForeignToplevelManagerV1,
 )
 from docking.platform.backends.wayland.runtime import (
     ForeignToplevelProtocolAdapter,
     IdleProtocolAdapter,
+    PhocPreviewProtocolAdapter,
     PreviewProtocolAdapter,
     WaylandProtocolFactories,
     WaylandProtocolRuntime,
@@ -241,6 +243,7 @@ def test_wayland_protocol_runtime_binds_preview_protocol_set():
         (22, ExtImageCopyCaptureManagerV1, ExtImageCopyCaptureManagerV1.version),
         (23, WlShm, WlShm.version),
         (23, WlShm, WlShm.version),
+        (23, WlShm, WlShm.version),
     ]
 
 
@@ -267,7 +270,34 @@ def test_wayland_protocol_runtime_binds_hyprland_preview_protocol():
         ),
         (31, WlShm, WlShm.version),
         (31, WlShm, WlShm.version),
+        (31, WlShm, WlShm.version),
     ]
+
+
+def test_wayland_protocol_runtime_binds_phoc_preview_protocol():
+    glib = FakeGLib()
+    runtime = WaylandProtocolRuntime(factories=_factories(glib))
+
+    assert runtime.start() is True
+    registry = FakeDisplay.registry
+    registry.dispatcher["global"](registry, 35, "phosh_private", 7)
+    registry.dispatcher["global"](registry, 36, "wl_shm", 99)
+
+    assert runtime.phoc_preview_protocol is runtime.phoc_previews
+    assert (35, PhoshPrivate, PhoshPrivate.version) in registry.bound
+    assert (36, WlShm, WlShm.version) in registry.bound
+
+
+def test_phoc_preview_adapter_requires_protocol_v4_and_shm():
+    registry = FakeRegistry()
+    adapter = PhocPreviewProtocolAdapter()
+
+    adapter.bind(registry=registry, name=1, version=3)
+    adapter.bind_shm(registry=registry, name=2, version=1)
+    assert adapter.capture_available is False
+
+    adapter.bind(registry=registry, name=3, version=7)
+    assert adapter.capture_available is True
 
 
 def test_wayland_protocol_runtime_binds_idle_protocol():


### PR DESCRIPTION
## Summary

Add Phosh and Phoc session detection plus native Phoc window thumbnails.

## Why

Phoc provides the standard wlroots foreign-toplevel protocol for window tracking and a private `phosh_private.get_thumbnail` request for per-window screencopy. Docking can combine those interfaces without introducing a separate session backend.

## Changes

- Detect both `phosh` and `phoc` desktop identifiers.
- Add minimal PyWayland bindings for `phosh_private` and its screencopy frame.
- Bind the protocol and `wl_shm` in the shared Wayland runtime.
- Capture, cache, scale, and clean up Phoc thumbnail buffers asynchronously.
- Advertise preview availability to window snapshots when the Phoc path is selected.
- Keep the complete standard ext-image-copy path preferred when available.

## Validation

- Protocol bindings import against PyWayland 0.4.18.
- Ruff, ty, Vulture, and package-data checks pass.
- 55 focused environment, runtime, session, and preview tests pass.
