### PR TITLE
Add Jay compositor desktop detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ one with `DOCKING_BACKEND`.
 | **Hyprland** | Hyprland Wayland | Dock placement (layer-shell), IPC-based window tracking, active state, window actions, geometry, workspace association, and optional previews |
 | **Niri** | Niri Wayland | Dock placement (layer-shell), IPC-based window tracking, active state, window actions (focus, close), window previews, workspace association |
 | **Native layer-shell** | wlroots-based (Sway, labwc, river, Wayfire) | Dock placement, window tracking, workspace switching (varies by compositor protocol support) |
+| **Native layer-shell** | Jay | Dock placement, window actions, workspaces, previews, and idle time after granting Docking the required Jay client capabilities |
 | **Native layer-shell** | Phosh / phoc | Dock placement and window actions through standard protocols, with native per-window thumbnails when phoc exposes `phosh_private` to the client |
 | **Reduced** | Cage | Launcher-only mode. Cage is a single-application kiosk and does not provide a layer-shell surface suitable for a dock |
 | **Reduced** | Weston | Launcher-only mode. Weston's shell protocols are reserved for its configured shell or IVI controller, not general third-party docks |
@@ -237,6 +238,35 @@ DOCKING_BACKEND=wayland-layer-shell docking   # wlroots compositors
 DOCKING_BACKEND=reduced docking               # any Wayland (no WM integration)
 DOCKING_BACKEND=x11 docking                   # X11 (full support)
 ```
+
+#### Jay client capabilities
+
+Jay restricts window-management, workspace, capture, and idle protocols to
+approved clients. Launch Docking with a connection tag:
+
+```bash
+jay run-tagged docking docking
+```
+
+Then grant that tag the protocols used by the generic Wayland backend:
+
+```toml
+[[clients]]
+match.tag = "docking"
+capabilities = [
+    "layer-shell",
+    "foreign-toplevel-manager",
+    "foreign-toplevel-list",
+    "workspace-manager",
+    "screencopy",
+    "idle-notifier",
+]
+```
+
+Jay replaces its default permissions when a client rule matches, so
+`layer-shell` must remain in the explicit list. A connection tag is preferred
+over matching the process name because it grants these privileges only to the
+Docking instance launched through `jay run-tagged`.
 
 ## First Use
 

--- a/docking/platform/environment/environment.py
+++ b/docking/platform/environment/environment.py
@@ -65,6 +65,7 @@ class Desktop(enum.Flag):
     WESTON = enum.auto()
     LOUVRE = enum.auto()
     PHOSH = enum.auto()
+    JAY = enum.auto()
 
     @property
     def uses_monitor_geometry(self) -> bool:
@@ -115,6 +116,7 @@ _DESKTOP_MAP: dict[str, Desktop] = {
     "louvre": Desktop.LOUVRE,
     "phosh": Desktop.PHOSH,
     "phoc": Desktop.PHOSH,
+    "jay": Desktop.JAY,
 }
 
 

--- a/tests/platform/test_environment.py
+++ b/tests/platform/test_environment.py
@@ -75,6 +75,7 @@ class TestParseDesktop:
         assert _parse_desktop("louvre") == Desktop.LOUVRE
         assert _parse_desktop("phosh") == Desktop.PHOSH
         assert _parse_desktop("phoc") == Desktop.PHOSH
+        assert _parse_desktop("jay") == Desktop.JAY
 
 
 class TestDetectDesktop:


### PR DESCRIPTION
## Summary
Add Desktop.JAY enum entry and desktop string mapping for the Jay Wayland compositor.

## Research findings
Jay (github.com/mahkoh/jay, v1.14.0, Rust) sets XDG_CURRENT_DESKTOP=jay with full standard protocol support: layer-shell v5, foreign-toplevel v3, ext-workspace v1, ext-idle-notify v2.

Important quirk: Jay gates protocols behind per-client capability grants. Default caps are only layer-shell + drm-lease. Users must configure:
```toml
[[clients]]
match.comm = "docking"
capabilities = ["layer-shell", "foreign-toplevel-list", "workspace-manager", "idle-notifier"]
```

## Changes
- Add Desktop.JAY to the Desktop enum
- Add "jay" to _DESKTOP_MAP
- Add test for desktop string parsing