### PR TITLE
Add Miriway compositor desktop detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ one with `DOCKING_BACKEND`.
 | **Niri** | Niri Wayland | Dock placement (layer-shell), IPC-based window tracking, active state, window actions (focus, close), window previews, workspace association |
 | **Native layer-shell** | wlroots-based (Sway, labwc, river, Wayfire) | Dock placement, window tracking, workspace switching (varies by compositor protocol support) |
 | **Native layer-shell** | Jay | Dock placement, window actions, workspaces, previews, and idle time after granting Docking the required Jay client capabilities |
+| **Native layer-shell** | Miriway | Dock placement, window actions, and workspaces when Docking is launched as a trusted Miriway shell component |
 | **Native layer-shell** | Phosh / phoc | Dock placement and window actions through standard protocols, with native per-window thumbnails when phoc exposes `phosh_private` to the client |
 | **Reduced** | Cage | Launcher-only mode. Cage is a single-application kiosk and does not provide a layer-shell surface suitable for a dock |
 | **Reduced** | Weston | Launcher-only mode. Weston's shell protocols are reserved for its configured shell or IVI controller, not general third-party docks |
@@ -267,6 +268,20 @@ Jay replaces its default permissions when a client rule matches, so
 `layer-shell` must remain in the explicit list. A connection tag is preferred
 over matching the process name because it grants these privileges only to the
 Docking instance launched through `jay run-tagged`.
+
+#### Miriway shell component
+
+Miriway deliberately limits layer-shell, foreign-toplevel management, and
+workspace management to trusted shell components. Add Docking to
+`~/.config/miriway-shell.config`:
+
+```ini
+shell-component=docking
+```
+
+Restart Miriway after changing this file. Miriway then launches Docking with
+the privileged Wayland socket. Starting Docking as an ordinary application
+leaves these protocols hidden and results in reduced launcher-only behavior.
 
 ## First Use
 

--- a/docking/platform/backends/selection.py
+++ b/docking/platform/backends/selection.py
@@ -246,10 +246,17 @@ def _create_wayland_layer_shell_backend(
         log.info("Wayland layer-shell backend unavailable: GtkLayerShell not installed")
         return None
     if not layer_shell_is_supported(layer_shell):
-        log.info(
-            "Wayland layer-shell backend unavailable: compositor does not support "
-            "layer-shell"
-        )
+        if detect_desktop() & Desktop.MIRIWAY:
+            log.info(
+                "Wayland layer-shell backend unavailable: Miriway exposes shell "
+                "protocols only to configured shell components; add "
+                "shell-component=docking to miriway-shell.config"
+            )
+        else:
+            log.info(
+                "Wayland layer-shell backend unavailable: compositor does not support "
+                "layer-shell"
+            )
         return None
     backend = WaylandLayerShellSessionBackend(
         layer_shell=layer_shell,

--- a/docking/platform/environment/environment.py
+++ b/docking/platform/environment/environment.py
@@ -66,6 +66,7 @@ class Desktop(enum.Flag):
     LOUVRE = enum.auto()
     PHOSH = enum.auto()
     JAY = enum.auto()
+    MIRIWAY = enum.auto()
 
     @property
     def uses_monitor_geometry(self) -> bool:
@@ -117,6 +118,7 @@ _DESKTOP_MAP: dict[str, Desktop] = {
     "phosh": Desktop.PHOSH,
     "phoc": Desktop.PHOSH,
     "jay": Desktop.JAY,
+    "miriway": Desktop.MIRIWAY,
 }
 
 

--- a/tests/platform/test_backend_selection.py
+++ b/tests/platform/test_backend_selection.py
@@ -143,6 +143,29 @@ def test_create_session_backend_selects_layer_shell_for_supported_wayland(monkey
     create_wayland.assert_called_once()
 
 
+def test_miriway_layer_shell_failure_logs_shell_component_hint(monkeypatch, caplog):
+    caplog.set_level("INFO")
+    layer_shell = MagicMock()
+    monkeypatch.setattr(
+        "docking.platform.backends.wayland.services.load_gtk_layer_shell",
+        lambda: layer_shell,
+    )
+    monkeypatch.setattr(
+        "docking.platform.backends.wayland.services.layer_shell_is_supported",
+        lambda _layer_shell: False,
+    )
+    monkeypatch.setattr(selection, "detect_desktop", lambda: selection.Desktop.MIRIWAY)
+
+    result = selection._create_wayland_layer_shell_backend(
+        launcher=MagicMock(),
+        model=MagicMock(),
+        reason="test",
+    )
+
+    assert result is None
+    assert "shell-component=docking" in caplog.text
+
+
 def test_create_session_backend_selects_gnome_bridge_after_layer_shell_fallback(
     monkeypatch,
 ):

--- a/tests/platform/test_environment.py
+++ b/tests/platform/test_environment.py
@@ -76,6 +76,7 @@ class TestParseDesktop:
         assert _parse_desktop("phosh") == Desktop.PHOSH
         assert _parse_desktop("phoc") == Desktop.PHOSH
         assert _parse_desktop("jay") == Desktop.JAY
+        assert _parse_desktop("miriway") == Desktop.MIRIWAY
 
 
 class TestDetectDesktop:


### PR DESCRIPTION
## Summary
Add Desktop.MIRIWAY enum entry and desktop string mapping for Miriway (Canonical's Mir-based reference desktop).

## Research findings
Miriway (github.com/Miriway/Miriway) sets XDG_CURRENT_DESKTOP=Miriway. Mir supports layer-shell v4 (needs enabling via --add-wayland-extension), foreign-toplevel v2. Miriway adds custom ext-workspace v1 (activate only).

Mir core has no ext-workspace and no ext-idle-notifier. Layer-shell must be explicitly enabled by the compositor.

## Changes
- Add Desktop.MIRIWAY to the Desktop enum
- Add "miriway" to _DESKTOP_MAP
- Add test for desktop string parsing