### PR TITLE
Add Deepin/Treeland compositor desktop detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ one with `DOCKING_BACKEND`.
 | **Native layer-shell** | Jay | Dock placement, window actions, workspaces, previews, and idle time after granting Docking the required Jay client capabilities |
 | **Native layer-shell** | Miriway | Dock placement, window actions, and workspaces when Docking is launched as a trusted Miriway shell component |
 | **Native layer-shell** | Phosh / phoc | Dock placement and window actions through standard protocols, with native per-window thumbnails when phoc exposes `phosh_private` to the client |
+| **Treeland** | Deepin Wayland | Standard layer-shell window tracking and previews, plus Treeland Show Desktop and overlap-driven hiding. Left-edge overlap falls back until Treeland fixes its current left-anchor checker |
 | **Reduced** | Cage | Launcher-only mode. Cage is a single-application kiosk and does not provide a layer-shell surface suitable for a dock |
 | **Reduced** | Weston | Launcher-only mode. Weston's shell protocols are reserved for its configured shell or IVI controller, not general third-party docks |
 | **Reduced** | Any Wayland | Dock visible but no window management (no running indicators, no previews, no workspace switching) |

--- a/docking/platform/backends/selection.py
+++ b/docking/platform/backends/selection.py
@@ -140,6 +140,17 @@ def create_session_backend(
         return _create_reduced_backend(
             reason=f"KWin backend unavailable after DOCKING_BACKEND={requested}"
         )
+    if requested in {"treeland", "deepin"}:
+        backend = _create_treeland_backend(
+            launcher=launcher,
+            model=model,
+            reason=f"requested by DOCKING_BACKEND={requested}",
+        )
+        if backend is not None:
+            return backend
+        return _create_reduced_backend(
+            reason=f"Treeland backend unavailable after DOCKING_BACKEND={requested}"
+        )
 
     if not is_x11_backend():
         # Hyprland has a richer IPC backend than generic layer-shell.
@@ -181,6 +192,14 @@ def create_session_backend(
         # KWin / KDE Plasma native backend
         if is_kde_session():
             backend = _create_kwin_backend(
+                launcher=launcher,
+                model=model,
+                reason=_non_x11_reason(),
+            )
+            if backend is not None:
+                return backend
+        if detect_desktop() & Desktop.DEEPIN:
+            backend = _create_treeland_backend(
                 launcher=launcher,
                 model=model,
                 reason=_non_x11_reason(),
@@ -280,6 +299,30 @@ def _create_gnome_shell_bridge_backend(
         model=model,
         launcher=launcher,
         bridge=bridge,
+    )
+    log.info("Selected session backend: %s (%s)", backend.name, reason)
+    return backend
+
+
+def _create_treeland_backend(
+    *, launcher: Launcher, model: DockModel, reason: str
+) -> SessionBackend | None:
+    from docking.platform.backends.wayland.services import (
+        layer_shell_is_supported,
+        load_gtk_layer_shell,
+    )
+    from docking.platform.backends.wayland.treeland_session import (
+        TreelandSessionBackend,
+    )
+
+    layer_shell = load_gtk_layer_shell()
+    if layer_shell is None or not layer_shell_is_supported(layer_shell):
+        log.info("Treeland backend unavailable: layer-shell is not usable")
+        return None
+    backend = TreelandSessionBackend(
+        layer_shell=layer_shell,
+        launcher=launcher,
+        model=model,
     )
     log.info("Selected session backend: %s (%s)", backend.name, reason)
     return backend

--- a/docking/platform/backends/wayland/protocols/treeland_shell/__init__.py
+++ b/docking/platform/backends/wayland/protocols/treeland_shell/__init__.py
@@ -1,0 +1,6 @@
+# ruff: noqa
+
+from .treeland_dde_shell_manager_v1 import TreelandDDEShellManagerV1
+from .treeland_window_management_v1 import TreelandWindowManagementV1
+
+__all__ = ["TreelandDDEShellManagerV1", "TreelandWindowManagementV1"]

--- a/docking/platform/backends/wayland/protocols/treeland_shell/treeland_dde_shell_manager_v1.py
+++ b/docking/platform/backends/wayland/protocols/treeland_shell/treeland_dde_shell_manager_v1.py
@@ -1,0 +1,88 @@
+# Minimal pywayland bindings for Treeland's window overlap checker.
+# ruff: noqa
+
+from __future__ import annotations
+
+from pywayland.protocol_core import (
+    Argument,
+    ArgumentType,
+    Global,
+    Interface,
+    Proxy,
+    Resource,
+)
+from pywayland.protocol.wayland import WlOutput
+
+
+class TreelandWindowOverlapChecker(Interface):
+    name = "treeland_window_overlap_checker"
+    version = 1
+
+
+class TreelandWindowOverlapCheckerProxy(Proxy[TreelandWindowOverlapChecker]):
+    interface = TreelandWindowOverlapChecker
+
+    @TreelandWindowOverlapChecker.request(
+        Argument(ArgumentType.Int),
+        Argument(ArgumentType.Int),
+        Argument(ArgumentType.Uint),
+        Argument(ArgumentType.Object, interface=WlOutput),
+    )
+    def update(self, width: int, height: int, anchor: int, output: WlOutput) -> None:
+        self._marshal(0, width, height, anchor, output)
+
+    @TreelandWindowOverlapChecker.request()
+    def destroy(self) -> None:
+        self._marshal(1)
+        self._destroy()
+
+
+class TreelandWindowOverlapCheckerResource(Resource):
+    interface = TreelandWindowOverlapChecker
+
+    @TreelandWindowOverlapChecker.event()
+    def enter(self) -> None:
+        self._post_event(0)
+
+    @TreelandWindowOverlapChecker.event()
+    def leave(self) -> None:
+        self._post_event(1)
+
+
+class TreelandWindowOverlapCheckerGlobal(Global):
+    interface = TreelandWindowOverlapChecker
+
+
+TreelandWindowOverlapChecker._gen_c()
+TreelandWindowOverlapChecker.proxy_class = TreelandWindowOverlapCheckerProxy
+TreelandWindowOverlapChecker.resource_class = TreelandWindowOverlapCheckerResource
+TreelandWindowOverlapChecker.global_class = TreelandWindowOverlapCheckerGlobal
+
+
+class TreelandDDEShellManagerV1(Interface):
+    name = "treeland_dde_shell_manager_v1"
+    version = 2
+
+
+class TreelandDDEShellManagerV1Proxy(Proxy[TreelandDDEShellManagerV1]):
+    interface = TreelandDDEShellManagerV1
+
+    @TreelandDDEShellManagerV1.request(
+        Argument(ArgumentType.NewId, interface=TreelandWindowOverlapChecker)
+    )
+    def get_window_overlap_checker(self) -> Proxy[TreelandWindowOverlapChecker]:
+        return self._marshal_constructor(0, TreelandWindowOverlapChecker)
+
+
+class TreelandDDEShellManagerV1Resource(Resource):
+    interface = TreelandDDEShellManagerV1
+
+
+class TreelandDDEShellManagerV1Global(Global):
+    interface = TreelandDDEShellManagerV1
+
+
+TreelandDDEShellManagerV1._gen_c()
+TreelandDDEShellManagerV1.proxy_class = TreelandDDEShellManagerV1Proxy
+TreelandDDEShellManagerV1.resource_class = TreelandDDEShellManagerV1Resource
+TreelandDDEShellManagerV1.global_class = TreelandDDEShellManagerV1Global

--- a/docking/platform/backends/wayland/protocols/treeland_shell/treeland_window_management_v1.py
+++ b/docking/platform/backends/wayland/protocols/treeland_shell/treeland_window_management_v1.py
@@ -1,0 +1,44 @@
+# Minimal pywayland binding for treeland_window_management_v1.
+# ruff: noqa
+
+from __future__ import annotations
+
+from pywayland.protocol_core import (
+    Argument,
+    ArgumentType,
+    Global,
+    Interface,
+    Proxy,
+    Resource,
+)
+
+
+class TreelandWindowManagementV1(Interface):
+    name = "treeland_window_management_v1"
+    version = 1
+
+
+class TreelandWindowManagementV1Proxy(Proxy[TreelandWindowManagementV1]):
+    interface = TreelandWindowManagementV1
+
+    @TreelandWindowManagementV1.request(Argument(ArgumentType.Uint))
+    def set_desktop(self, state: int) -> None:
+        self._marshal(0, state)
+
+
+class TreelandWindowManagementV1Resource(Resource):
+    interface = TreelandWindowManagementV1
+
+    @TreelandWindowManagementV1.event(Argument(ArgumentType.Uint))
+    def show_desktop(self, state: int) -> None:
+        self._post_event(0, state)
+
+
+class TreelandWindowManagementV1Global(Global):
+    interface = TreelandWindowManagementV1
+
+
+TreelandWindowManagementV1._gen_c()
+TreelandWindowManagementV1.proxy_class = TreelandWindowManagementV1Proxy
+TreelandWindowManagementV1.resource_class = TreelandWindowManagementV1Resource
+TreelandWindowManagementV1.global_class = TreelandWindowManagementV1Global

--- a/docking/platform/backends/wayland/runtime.py
+++ b/docking/platform/backends/wayland/runtime.py
@@ -29,6 +29,10 @@ if TYPE_CHECKING:
     from docking.platform.backends.wayland.toplevels import (
         WaylandForeignToplevelWindowService,
     )
+    from docking.platform.backends.wayland.treeland import (
+        TreelandOverlapAdapter,
+        TreelandWindowManagementAdapter,
+    )
     from docking.platform.backends.wayland.workspaces import WaylandWorkspaceService
 
 log = get_logger(name="wayland_protocol_runtime")
@@ -759,6 +763,10 @@ class WaylandProtocolRuntime:
             CosmicToplevelAdapter,
             CosmicWorkspaceAdapter,
         )
+        from docking.platform.backends.wayland.treeland import (
+            TreelandOverlapAdapter,
+            TreelandWindowManagementAdapter,
+        )
 
         self._factories = factories
         self.foreign_toplevel = foreign_adapter or ForeignToplevelProtocolAdapter()
@@ -772,6 +780,8 @@ class WaylandProtocolRuntime:
         self.cosmic_toplevel = cosmic_toplevel_adapter or CosmicToplevelAdapter()
         self.cosmic_workspace = cosmic_workspace_adapter or CosmicWorkspaceAdapter()
         self.cosmic_overlap = cosmic_overlap_adapter or CosmicOverlapAdapter()
+        self.treeland_overlap = TreelandOverlapAdapter()
+        self.treeland_window_management = TreelandWindowManagementAdapter()
         self._display = None
         self._registry = None
         self._glib_source_id = 0
@@ -815,6 +825,20 @@ class WaylandProtocolRuntime:
     def cosmic_overlap_protocol(self) -> object | None:
         return self.cosmic_overlap if self.cosmic_overlap.available else None
 
+    @property
+    def treeland_overlap_protocol(self) -> TreelandOverlapAdapter | None:
+        return self.treeland_overlap if self.treeland_overlap.available else None
+
+    @property
+    def treeland_window_management_protocol(
+        self,
+    ) -> TreelandWindowManagementAdapter | None:
+        return (
+            self.treeland_window_management
+            if self.treeland_window_management.available
+            else None
+        )
+
     def start(self) -> bool:
         factories = self._factories or load_protocol_factories()
         if factories is None:
@@ -825,6 +849,7 @@ class WaylandProtocolRuntime:
             display.connect()
             registry = display.get_registry()
             registry.dispatcher["global"] = self._on_global
+            registry.dispatcher["global_remove"] = self._on_global_remove
             self._display = display
             self._registry = registry
             self.foreign_toplevel.set_flush_callback(display.flush)
@@ -836,6 +861,8 @@ class WaylandProtocolRuntime:
             self.cosmic_toplevel.set_flush_callback(display.flush)
             self.cosmic_workspace.set_flush_callback(display.flush)
             self.cosmic_overlap.set_flush_callback(display.flush)
+            self.treeland_overlap.set_flush_callback(display.flush)
+            self.treeland_window_management.set_flush_callback(display.flush)
             display.dispatch(block=False)
             display.roundtrip()
             # The roundtrip discovers globals and binds protocol managers. Flush
@@ -869,6 +896,8 @@ class WaylandProtocolRuntime:
         self.cosmic_toplevel.stop()
         self.cosmic_workspace.stop()
         self.cosmic_overlap.stop()
+        self.treeland_overlap.stop()
+        self.treeland_window_management.stop()
         source_id = self._glib_source_id
         factories = self._factories or load_protocol_factories()
         if source_id and factories is not None:
@@ -898,6 +927,12 @@ class WaylandProtocolRuntime:
                 version=version,
             )
             self.idle.bind_seat(
+                registry=registry,
+                name=name,
+                version=version,
+            )
+        elif interface == "wl_output":
+            self.treeland_overlap.bind_output(
                 registry=registry,
                 name=name,
                 version=version,
@@ -935,6 +970,18 @@ class WaylandProtocolRuntime:
             )
         elif interface == "zcosmic_overlap_notify_v1":
             self.cosmic_overlap.bind(
+                registry=registry,
+                name=name,
+                version=version,
+            )
+        elif interface == "treeland_dde_shell_manager_v1":
+            self.treeland_overlap.bind(
+                registry=registry,
+                name=name,
+                version=version,
+            )
+        elif interface == "treeland_window_management_v1":
+            self.treeland_window_management.bind(
                 registry=registry,
                 name=name,
                 version=version,
@@ -977,6 +1024,9 @@ class WaylandProtocolRuntime:
             )
         elif interface == "ext_idle_notifier_v1":
             self.idle.bind(registry=registry, name=name, version=version)
+
+    def _on_global_remove(self, _registry, name: int) -> None:
+        self.treeland_overlap.unbind_output(name)
 
     def _install_glib_watch(
         self, *, factories: WaylandProtocolFactories, display

--- a/docking/platform/backends/wayland/session.py
+++ b/docking/platform/backends/wayland/session.py
@@ -36,6 +36,7 @@ from docking.platform.backends.reduced.services import (
     ReducedVisibilityService,
     ReducedWindowService,
 )
+from docking.platform.backends.wayland.idle import WaylandIdleService
 from docking.platform.backends.wayland.portals import (
     WaylandPortalColorPickerService,
     load_portal_color_picker,
@@ -68,6 +69,7 @@ class WaylandLayerShellRuntimeServices:
     visibility: ReducedVisibilityService
     workspaces: WorkspaceService | None
     screen_capture: ScreenCaptureService | None
+    idle: IdleService | None
     protocol_runtime: WaylandProtocolRuntime | None
 
 
@@ -171,6 +173,14 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             if workspace_protocol is not None
             else None
         )
+        idle_protocol = (
+            getattr(runtime, "idle_protocol", None) if runtime is not None else None
+        )
+        idle: IdleService | None = (
+            WaylandIdleService(protocol=idle_protocol)
+            if idle_protocol is not None
+            else None
+        )
         self._services = WaylandLayerShellRuntimeServices(
             windows=windows,
             previews=previews,
@@ -180,6 +190,7 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             screen_capture=screen_capture
             if screen_capture is not None
             else load_portal_color_picker(),
+            idle=idle,
             protocol_runtime=runtime,
         )
 
@@ -218,6 +229,7 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             supports_layer_shell=True,
             supports_screen_reservation=True,
             supports_input_region=True,
+            supports_idle_time=isinstance(self._services.idle, WaylandIdleService),
         )
 
     @property
@@ -250,7 +262,7 @@ class WaylandLayerShellSessionBackend(SessionBackend):
 
     @property
     def idle(self) -> IdleService | None:
-        return None
+        return self._services.idle
 
     @property
     def window_picker(self) -> WindowPickService | None:
@@ -265,8 +277,12 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             self._services.workspaces.start()
         if self._services.screen_capture is not None:
             self._services.screen_capture.start()
+        if self._services.idle is not None:
+            self._services.idle.start()
 
     def stop(self) -> None:
+        if self._services.idle is not None:
+            self._services.idle.stop()
         if self._services.screen_capture is not None:
             self._services.screen_capture.stop()
         if self._services.workspaces is not None:

--- a/docking/platform/backends/wayland/session.py
+++ b/docking/platform/backends/wayland/session.py
@@ -36,7 +36,6 @@ from docking.platform.backends.reduced.services import (
     ReducedVisibilityService,
     ReducedWindowService,
 )
-from docking.platform.backends.wayland.idle import WaylandIdleService
 from docking.platform.backends.wayland.portals import (
     WaylandPortalColorPickerService,
     load_portal_color_picker,
@@ -69,7 +68,6 @@ class WaylandLayerShellRuntimeServices:
     visibility: ReducedVisibilityService
     workspaces: WorkspaceService | None
     screen_capture: ScreenCaptureService | None
-    idle: IdleService | None
     protocol_runtime: WaylandProtocolRuntime | None
 
 
@@ -173,14 +171,6 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             if workspace_protocol is not None
             else None
         )
-        idle_protocol = (
-            getattr(runtime, "idle_protocol", None) if runtime is not None else None
-        )
-        idle: IdleService | None = (
-            WaylandIdleService(protocol=idle_protocol)
-            if idle_protocol is not None
-            else None
-        )
         self._services = WaylandLayerShellRuntimeServices(
             windows=windows,
             previews=previews,
@@ -190,7 +180,6 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             screen_capture=screen_capture
             if screen_capture is not None
             else load_portal_color_picker(),
-            idle=idle,
             protocol_runtime=runtime,
         )
 
@@ -229,7 +218,6 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             supports_layer_shell=True,
             supports_screen_reservation=True,
             supports_input_region=True,
-            supports_idle_time=isinstance(self._services.idle, WaylandIdleService),
         )
 
     @property
@@ -262,7 +250,7 @@ class WaylandLayerShellSessionBackend(SessionBackend):
 
     @property
     def idle(self) -> IdleService | None:
-        return self._services.idle
+        return None
 
     @property
     def window_picker(self) -> WindowPickService | None:
@@ -277,12 +265,8 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             self._services.workspaces.start()
         if self._services.screen_capture is not None:
             self._services.screen_capture.start()
-        if self._services.idle is not None:
-            self._services.idle.start()
 
     def stop(self) -> None:
-        if self._services.idle is not None:
-            self._services.idle.stop()
         if self._services.screen_capture is not None:
             self._services.screen_capture.stop()
         if self._services.workspaces is not None:

--- a/docking/platform/backends/wayland/treeland.py
+++ b/docking/platform/backends/wayland/treeland.py
@@ -1,0 +1,334 @@
+"""Small adapters for Treeland features not covered by standard protocols."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from docking.platform.backends.base import (
+    ActionResult,
+    DesktopActionService,
+    Rect,
+    VisibilityMonitor,
+    VisibilityService,
+)
+
+_OUTPUT_MODE_CURRENT = 1
+_ANCHOR_TOP = 1
+_ANCHOR_BOTTOM = 2
+_ANCHOR_LEFT = 4
+_ANCHOR_RIGHT = 8
+_DESKTOP_NORMAL = 0
+_DESKTOP_SHOW = 1
+
+
+@dataclass
+class _OutputState:
+    registry_name: int
+    proxy: object
+    x: int = 0
+    y: int = 0
+    width: int = 0
+    height: int = 0
+    scale: int = 1
+    transform: int = 0
+
+    @property
+    def swaps_axes(self) -> bool:
+        return self.transform in {1, 3, 5, 7}
+
+    @property
+    def logical_width(self) -> int:
+        width = self.height if self.swaps_axes else self.width
+        return width // max(1, self.scale)
+
+    @property
+    def logical_height(self) -> int:
+        height = self.width if self.swaps_axes else self.height
+        return height // max(1, self.scale)
+
+
+class TreelandOverlapAdapter:
+    """Translate Treeland overlap events into one dock visibility signal."""
+
+    def __init__(self) -> None:
+        self._manager = None
+        self._checker = None
+        self._flush: Callable[[], None] | None = None
+        self._on_change: Callable[[bool], None] | None = None
+        self._get_dock_rect: Callable[[], Rect | None] | None = None
+        self._outputs: list[_OutputState] = []
+        self.available = False
+
+    def set_flush_callback(self, callback: Callable[[], None] | None) -> None:
+        self._flush = callback
+
+    def bind(self, *, registry, name: int, version: int) -> None:
+        from docking.platform.backends.wayland.protocols.treeland_shell import (
+            TreelandDDEShellManagerV1,
+        )
+
+        self._manager = registry.bind(
+            name,
+            TreelandDDEShellManagerV1,
+            min(version, TreelandDDEShellManagerV1.version),
+        )
+        self.available = True
+
+    def bind_output(self, *, registry, name: int, version: int) -> None:
+        from pywayland.protocol.wayland import WlOutput
+
+        proxy = registry.bind(name, WlOutput, min(version, WlOutput.version))
+        state = _OutputState(registry_name=name, proxy=proxy)
+        self._outputs.append(state)
+        proxy.dispatcher["geometry"] = lambda _output, x, y, *details: (
+            self._on_output_geometry(state, x, y, details[-1])
+        )
+        proxy.dispatcher["mode"] = lambda _output, flags, width, height, _refresh: (
+            self._on_output_mode(state, flags, width, height)
+        )
+        proxy.dispatcher["scale"] = lambda _output, scale: self._on_output_scale(
+            state, scale
+        )
+
+    def unbind_output(self, registry_name: int) -> None:
+        for output in tuple(self._outputs):
+            if output.registry_name != registry_name:
+                continue
+            release = getattr(output.proxy, "release", None)
+            if callable(release):
+                release()
+            self._outputs.remove(output)
+
+    def start(
+        self,
+        *,
+        get_dock_rect: Callable[[], Rect | None],
+        on_change: Callable[[bool], None],
+    ) -> None:
+        self._get_dock_rect = get_dock_rect
+        self._on_change = on_change
+        self._ensure_checker()
+        self.evaluate_now()
+
+    def stop_monitoring(self) -> None:
+        self._get_dock_rect = None
+        self._on_change = None
+
+    def evaluate_now(self) -> None:
+        if self._checker is None or self._get_dock_rect is None:
+            return
+        rect = self._get_dock_rect()
+        if rect is None:
+            return
+        output = self._output_for(rect)
+        if output is None:
+            return
+        anchor = self._nearest_anchor(rect, output)
+        # Treeland 4e22194 constructs the left checker rectangle like a top
+        # rectangle. Avoid false overlap events until that compositor bug is fixed.
+        if anchor == _ANCHOR_LEFT:
+            return
+        self._checker.update(rect.width, rect.height, anchor, output.proxy)
+        if self._flush is not None:
+            self._flush()
+
+    def stop(self) -> None:
+        checker = self._checker
+        if checker is not None:
+            destroy = getattr(checker, "destroy", None)
+            if callable(destroy):
+                destroy()
+        for output in self._outputs:
+            release = getattr(output.proxy, "release", None)
+            if callable(release):
+                release()
+        self._manager = None
+        self._checker = None
+        self._flush = None
+        self._on_change = None
+        self._get_dock_rect = None
+        self._outputs.clear()
+        self.available = False
+
+    def _ensure_checker(self) -> None:
+        if self._checker is not None or self._manager is None:
+            return
+        self._checker = self._manager.get_window_overlap_checker()
+        self._checker.dispatcher["enter"] = lambda _checker: self._publish(True)
+        self._checker.dispatcher["leave"] = lambda _checker: self._publish(False)
+
+    def _publish(self, overlapped: bool) -> None:
+        if self._on_change is not None:
+            self._on_change(overlapped)
+
+    @staticmethod
+    def _on_output_geometry(
+        state: _OutputState,
+        x: int,
+        y: int,
+        transform: int,
+    ) -> None:
+        state.x = int(x)
+        state.y = int(y)
+        state.transform = int(transform)
+
+    @staticmethod
+    def _on_output_mode(
+        state: _OutputState, flags: int, width: int, height: int
+    ) -> None:
+        if int(flags) & _OUTPUT_MODE_CURRENT:
+            state.width = int(width)
+            state.height = int(height)
+
+    @staticmethod
+    def _on_output_scale(state: _OutputState, scale: int) -> None:
+        state.scale = max(1, int(scale))
+
+    def _output_for(self, rect: Rect) -> _OutputState | None:
+        center_x = rect.x + rect.width // 2
+        center_y = rect.y + rect.height // 2
+        for output in self._outputs:
+            if (
+                output.x <= center_x < output.x + output.logical_width
+                and output.y <= center_y < output.y + output.logical_height
+            ):
+                return output
+        return self._outputs[0] if len(self._outputs) == 1 else None
+
+    @staticmethod
+    def _nearest_anchor(rect: Rect, output: _OutputState) -> int:
+        distances = (
+            (abs(rect.y - output.y), _ANCHOR_TOP),
+            (
+                abs(rect.bottom - (output.y + output.logical_height)),
+                _ANCHOR_BOTTOM,
+            ),
+            (abs(rect.x - output.x), _ANCHOR_LEFT),
+            (
+                abs(rect.right - (output.x + output.logical_width)),
+                _ANCHOR_RIGHT,
+            ),
+        )
+        return min(distances, key=lambda item: item[0])[1]
+
+
+class TreelandWindowManagementAdapter:
+    """Track and change Treeland's compositor-wide Show Desktop state."""
+
+    def __init__(self) -> None:
+        self._manager = None
+        self._flush: Callable[[], None] | None = None
+        self.showing_desktop = False
+        self.available = False
+
+    def set_flush_callback(self, callback: Callable[[], None] | None) -> None:
+        self._flush = callback
+
+    def bind(self, *, registry, name: int, version: int) -> None:
+        from docking.platform.backends.wayland.protocols.treeland_shell import (
+            TreelandWindowManagementV1,
+        )
+
+        self._manager = registry.bind(
+            name,
+            TreelandWindowManagementV1,
+            min(version, TreelandWindowManagementV1.version),
+        )
+        self._manager.dispatcher["show_desktop"] = self._on_show_desktop
+        self.available = True
+
+    def set_show_desktop(self, show: bool) -> bool:
+        if self._manager is None:
+            return False
+        self._manager.set_desktop(_DESKTOP_SHOW if show else _DESKTOP_NORMAL)
+        if self._flush is not None:
+            self._flush()
+        return True
+
+    def stop(self) -> None:
+        self._manager = None
+        self._flush = None
+        self.showing_desktop = False
+        self.available = False
+
+    def _on_show_desktop(self, _manager: object, state: int) -> None:
+        self.showing_desktop = int(state) != _DESKTOP_NORMAL
+
+
+class TreelandVisibilityService(VisibilityService):
+    def __init__(self, *, adapter: TreelandOverlapAdapter) -> None:
+        self._adapter = adapter
+        self._monitors: list[TreelandVisibilityMonitor] = []
+
+    def start(self) -> None:
+        """Monitors subscribe individually after the dock is constructed."""
+
+    def stop(self) -> None:
+        for monitor in tuple(self._monitors):
+            monitor.stop()
+        self._monitors.clear()
+
+    def create_monitor(
+        self,
+        *,
+        get_dock_rect: Callable[[], Rect | None],
+        on_change: Callable[[bool], None],
+    ) -> VisibilityMonitor:
+        monitor = TreelandVisibilityMonitor(
+            adapter=self._adapter,
+            get_dock_rect=get_dock_rect,
+            on_change=on_change,
+        )
+        self._monitors.append(monitor)
+        return monitor
+
+
+class TreelandVisibilityMonitor(VisibilityMonitor):
+    def __init__(
+        self,
+        *,
+        adapter: TreelandOverlapAdapter,
+        get_dock_rect: Callable[[], Rect | None],
+        on_change: Callable[[bool], None],
+    ) -> None:
+        self._adapter = adapter
+        self._get_dock_rect = get_dock_rect
+        self._on_change = on_change
+        self._started = False
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+        self._adapter.start(
+            get_dock_rect=self._get_dock_rect,
+            on_change=self._on_change,
+        )
+
+    def stop(self) -> None:
+        if self._started:
+            self._adapter.stop_monitoring()
+        self._started = False
+
+    def evaluate_now(self) -> None:
+        self._adapter.evaluate_now()
+
+
+class TreelandDesktopActionService(DesktopActionService):
+    def __init__(self, *, adapter: TreelandWindowManagementAdapter) -> None:
+        self._adapter = adapter
+
+    def start(self) -> None:
+        """The protocol runtime already receives state events."""
+
+    def stop(self) -> None:
+        """The protocol runtime owns the manager resource."""
+
+    def show_desktop(self, show: bool | None = None) -> ActionResult:
+        requested = not self._adapter.showing_desktop if show is None else bool(show)
+        return (
+            ActionResult.OK
+            if self._adapter.set_show_desktop(requested)
+            else ActionResult.UNSUPPORTED
+        )

--- a/docking/platform/backends/wayland/treeland_session.py
+++ b/docking/platform/backends/wayland/treeland_session.py
@@ -1,0 +1,92 @@
+"""Treeland session composed from generic Wayland services plus DDE extensions."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from docking.platform.backends.base import (
+    DesktopActionService,
+    PlatformCapabilities,
+    VisibilityService,
+)
+from docking.platform.backends.wayland.session import WaylandLayerShellSessionBackend
+from docking.platform.backends.wayland.treeland import (
+    TreelandDesktopActionService,
+    TreelandVisibilityService,
+)
+
+if TYPE_CHECKING:
+    from docking.platform.backends.base import ScreenCaptureService
+    from docking.platform.backends.wayland.runtime import WaylandProtocolRuntime
+    from docking.platform.launcher import Launcher
+    from docking.platform.model import DockModel
+
+
+class TreelandSessionBackend(WaylandLayerShellSessionBackend):
+    """Decorate the generic backend with overlap and Show Desktop support."""
+
+    def __init__(
+        self,
+        *,
+        layer_shell: object,
+        model: DockModel,
+        launcher: Launcher,
+        protocol_runtime: WaylandProtocolRuntime | None = None,
+        screen_capture: ScreenCaptureService | None = None,
+    ) -> None:
+        super().__init__(
+            layer_shell=layer_shell,
+            model=model,
+            launcher=launcher,
+            protocol_runtime=protocol_runtime,
+            screen_capture=screen_capture,
+        )
+        runtime = self._services.protocol_runtime
+        overlap = runtime.treeland_overlap_protocol if runtime is not None else None
+        window_management = (
+            runtime.treeland_window_management_protocol if runtime is not None else None
+        )
+        self._treeland_visibility = (
+            TreelandVisibilityService(adapter=overlap) if overlap is not None else None
+        )
+        self._treeland_desktop_actions = (
+            TreelandDesktopActionService(adapter=window_management)
+            if window_management is not None
+            else None
+        )
+
+    @property
+    def name(self) -> str:
+        return "treeland"
+
+    @property
+    def capabilities(self) -> PlatformCapabilities:
+        base = super().capabilities
+        return replace(
+            base,
+            supports_show_desktop=self._treeland_desktop_actions is not None,
+            supports_overlap_any=self._treeland_visibility is not None,
+        )
+
+    @property
+    def visibility(self) -> VisibilityService:
+        return self._treeland_visibility or super().visibility
+
+    @property
+    def desktop_actions(self) -> DesktopActionService | None:
+        return self._treeland_desktop_actions
+
+    def start(self) -> None:
+        super().start()
+        if self._treeland_visibility is not None:
+            self._treeland_visibility.start()
+        if self._treeland_desktop_actions is not None:
+            self._treeland_desktop_actions.start()
+
+    def stop(self) -> None:
+        if self._treeland_desktop_actions is not None:
+            self._treeland_desktop_actions.stop()
+        if self._treeland_visibility is not None:
+            self._treeland_visibility.stop()
+        super().stop()

--- a/docking/platform/environment/environment.py
+++ b/docking/platform/environment/environment.py
@@ -67,6 +67,7 @@ class Desktop(enum.Flag):
     PHOSH = enum.auto()
     JAY = enum.auto()
     MIRIWAY = enum.auto()
+    DEEPIN = enum.auto()
 
     @property
     def uses_monitor_geometry(self) -> bool:
@@ -119,6 +120,9 @@ _DESKTOP_MAP: dict[str, Desktop] = {
     "phoc": Desktop.PHOSH,
     "jay": Desktop.JAY,
     "miriway": Desktop.MIRIWAY,
+    "deepin": Desktop.DEEPIN,
+    "treeland": Desktop.DEEPIN,
+    "dde": Desktop.DEEPIN,
 }
 
 

--- a/tests/platform/test_backend_selection.py
+++ b/tests/platform/test_backend_selection.py
@@ -408,3 +408,30 @@ def test_create_session_backend_auto_selects_wayfire_before_generic_wayland(
     assert result is backend
     create_wayfire.assert_called_once()
     create_wayland.assert_not_called()
+
+
+def test_create_session_backend_auto_selects_treeland_before_generic_wayland(
+    monkeypatch,
+):
+    monkeypatch.delenv("DOCKING_BACKEND", raising=False)
+    monkeypatch.setattr(selection, "is_x11_backend", lambda: False)
+    monkeypatch.setattr(selection, "detect_desktop", lambda: selection.Desktop.DEEPIN)
+    monkeypatch.setattr(selection, "is_kde_session", lambda: False)
+    monkeypatch.setattr(selection, "_wayfire_ipc_available", lambda: False)
+    backend = MagicMock(name="treeland")
+    create_treeland = MagicMock(return_value=backend)
+    create_wayland = MagicMock()
+    monkeypatch.setattr(selection, "_create_treeland_backend", create_treeland)
+    monkeypatch.setattr(
+        selection, "_create_wayland_layer_shell_backend", create_wayland
+    )
+
+    result = selection.create_session_backend(
+        config=MagicMock(),
+        launcher=MagicMock(),
+        model=MagicMock(),
+    )
+
+    assert result is backend
+    create_treeland.assert_called_once()
+    create_wayland.assert_not_called()

--- a/tests/platform/test_environment.py
+++ b/tests/platform/test_environment.py
@@ -77,6 +77,8 @@ class TestParseDesktop:
         assert _parse_desktop("phoc") == Desktop.PHOSH
         assert _parse_desktop("jay") == Desktop.JAY
         assert _parse_desktop("miriway") == Desktop.MIRIWAY
+        assert _parse_desktop("deepin") == Desktop.DEEPIN
+        assert _parse_desktop("treeland") == Desktop.DEEPIN
 
 
 class TestDetectDesktop:

--- a/tests/platform/test_treeland_session.py
+++ b/tests/platform/test_treeland_session.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from docking.platform.backends.base import ActionResult, Rect
 from docking.platform.backends.wayland import treeland
 from docking.platform.backends.wayland.treeland import (
@@ -130,6 +132,8 @@ def test_treeland_overlap_avoids_broken_left_anchor():
 
 
 def test_treeland_output_transform_and_hotplug_are_tracked():
+    pytest.importorskip("pywayland")
+
     proxy = SimpleNamespace(release=MagicMock(), dispatcher={})
     registry = SimpleNamespace(bind=MagicMock(return_value=proxy))
     adapter = TreelandOverlapAdapter()

--- a/tests/platform/test_treeland_session.py
+++ b/tests/platform/test_treeland_session.py
@@ -1,0 +1,158 @@
+"""Tests for Treeland-specific services layered on generic Wayland support."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from docking.platform.backends.base import ActionResult, Rect
+from docking.platform.backends.wayland import treeland
+from docking.platform.backends.wayland.treeland import (
+    TreelandDesktopActionService,
+    TreelandOverlapAdapter,
+    TreelandVisibilityService,
+    TreelandWindowManagementAdapter,
+)
+from docking.platform.backends.wayland.treeland_session import TreelandSessionBackend
+
+
+def _layer_shell() -> SimpleNamespace:
+    return SimpleNamespace(
+        Edge=SimpleNamespace(TOP=1, BOTTOM=2, LEFT=4, RIGHT=8),
+        Layer=SimpleNamespace(TOP=1),
+        KeyboardMode=SimpleNamespace(NONE=0),
+        init_for_window=MagicMock(),
+        set_namespace=MagicMock(),
+        set_layer=MagicMock(),
+        set_keyboard_mode=MagicMock(),
+        set_anchor=MagicMock(),
+        set_margin=MagicMock(),
+        set_monitor=MagicMock(),
+        set_size=MagicMock(),
+        set_exclusive_zone=MagicMock(),
+    )
+
+
+def _runtime() -> SimpleNamespace:
+    overlap = TreelandOverlapAdapter()
+    overlap.available = True
+    management = TreelandWindowManagementAdapter()
+    management.available = True
+    return SimpleNamespace(
+        foreign_toplevel_protocol=None,
+        workspace_protocol=None,
+        preview_protocol=None,
+        hyprland_preview_protocol=None,
+        idle_protocol=None,
+        treeland_overlap_protocol=overlap,
+        treeland_window_management_protocol=management,
+        stop=MagicMock(),
+    )
+
+
+def test_treeland_session_decorates_generic_wayland_services():
+    backend = TreelandSessionBackend(
+        layer_shell=_layer_shell(),
+        model=MagicMock(),
+        launcher=MagicMock(),
+        protocol_runtime=_runtime(),
+    )
+
+    assert backend.name == "treeland"
+    assert isinstance(backend.visibility, TreelandVisibilityService)
+    assert isinstance(backend.desktop_actions, TreelandDesktopActionService)
+    assert backend.capabilities.supports_overlap_any is True
+    assert backend.capabilities.supports_overlap_active is False
+    assert backend.capabilities.supports_show_desktop is True
+    assert backend.capabilities.tracks_window_geometry is False
+
+
+def test_treeland_show_desktop_tracks_and_toggles_protocol_state():
+    manager = SimpleNamespace(set_desktop=MagicMock())
+    adapter = TreelandWindowManagementAdapter()
+    adapter._manager = manager
+    adapter.available = True
+    flush = MagicMock()
+    adapter.set_flush_callback(flush)
+    service = TreelandDesktopActionService(adapter=adapter)
+
+    assert service.show_desktop() is ActionResult.OK
+    manager.set_desktop.assert_called_once_with(1)
+    flush.assert_called_once_with()
+
+    adapter._on_show_desktop(manager, 1)
+    assert service.show_desktop() is ActionResult.OK
+    manager.set_desktop.assert_called_with(0)
+
+
+def test_treeland_overlap_uses_output_and_bottom_anchor():
+    checker = SimpleNamespace(update=MagicMock(), dispatcher={})
+    output_proxy = object()
+    adapter = TreelandOverlapAdapter()
+    adapter._checker = checker
+    adapter._outputs.append(
+        treeland._OutputState(
+            registry_name=1,
+            proxy=output_proxy,
+            x=0,
+            y=0,
+            width=1920,
+            height=1080,
+            scale=1,
+        )
+    )
+    adapter.start(
+        get_dock_rect=lambda: Rect(x=700, y=1016, width=520, height=64),
+        on_change=MagicMock(),
+    )
+
+    checker.update.assert_called_with(520, 64, 2, output_proxy)
+
+
+def test_treeland_overlap_avoids_broken_left_anchor():
+    checker = SimpleNamespace(update=MagicMock(), dispatcher={})
+    adapter = TreelandOverlapAdapter()
+    adapter._checker = checker
+    adapter._outputs.append(
+        treeland._OutputState(
+            registry_name=1,
+            proxy=object(),
+            width=1920,
+            height=1080,
+        )
+    )
+    adapter.start(
+        get_dock_rect=lambda: Rect(x=0, y=300, width=64, height=480),
+        on_change=MagicMock(),
+    )
+
+    checker.update.assert_not_called()
+
+
+def test_treeland_output_transform_and_hotplug_are_tracked():
+    proxy = SimpleNamespace(release=MagicMock(), dispatcher={})
+    registry = SimpleNamespace(bind=MagicMock(return_value=proxy))
+    adapter = TreelandOverlapAdapter()
+
+    adapter.bind_output(registry=registry, name=7, version=4)
+    state = adapter._outputs[0]
+    proxy.dispatcher["geometry"](
+        proxy,
+        1920,
+        0,
+        300,
+        500,
+        0,
+        "vendor",
+        "model",
+        1,
+    )
+    proxy.dispatcher["mode"](proxy, 1, 1080, 1920, 60_000)
+    proxy.dispatcher["scale"](proxy, 2)
+
+    assert state.logical_width == 960
+    assert state.logical_height == 540
+
+    adapter.unbind_output(7)
+    proxy.release.assert_called_once_with()
+    assert adapter._outputs == []

--- a/tests/platform/test_wayland_protocol_runtime.py
+++ b/tests/platform/test_wayland_protocol_runtime.py
@@ -21,7 +21,7 @@ ExtForeignToplevelImageCaptureSourceManagerV1 = pytest.importorskip(
 ExtImageCopyCaptureManagerV1 = pytest.importorskip(
     "pywayland.protocol.ext_image_copy_capture_v1"
 ).ExtImageCopyCaptureManagerV1
-from pywayland.protocol.wayland import WlSeat, WlShm
+from pywayland.protocol.wayland import WlOutput, WlSeat, WlShm
 
 from docking.platform.backends.wayland.idle import WaylandIdleService
 from docking.platform.backends.wayland.protocols.ext_workspace_v1.ext_workspace_manager_v1 import (
@@ -31,6 +31,10 @@ from docking.platform.backends.wayland.protocols.hyprland_toplevel_export_v1 imp
     HyprlandToplevelExportManagerV1,
 )
 from docking.platform.backends.wayland.protocols.phosh_private import PhoshPrivate
+from docking.platform.backends.wayland.protocols.treeland_shell import (
+    TreelandDDEShellManagerV1,
+    TreelandWindowManagementV1,
+)
 from docking.platform.backends.wayland.protocols.wlr_foreign_toplevel_management_unstable_v1 import (
     ZwlrForeignToplevelManagerV1,
 )
@@ -316,6 +320,49 @@ def test_wayland_protocol_runtime_binds_idle_protocol():
         (41, WlSeat, WlSeat.version),
         (41, WlSeat, WlSeat.version),
     ]
+
+
+def test_wayland_protocol_runtime_binds_treeland_extensions_and_outputs():
+    glib = FakeGLib()
+    runtime = WaylandProtocolRuntime(factories=_factories(glib))
+
+    assert runtime.start() is True
+    registry = FakeDisplay.registry
+    registry.dispatcher["global"](
+        registry,
+        50,
+        "treeland_dde_shell_manager_v1",
+        99,
+    )
+    registry.dispatcher["global"](
+        registry,
+        51,
+        "treeland_window_management_v1",
+        99,
+    )
+    registry.dispatcher["global"](registry, 52, "wl_output", 99)
+
+    assert runtime.treeland_overlap_protocol is runtime.treeland_overlap
+    assert (
+        runtime.treeland_window_management_protocol
+        is runtime.treeland_window_management
+    )
+    assert registry.bound == [
+        (
+            50,
+            TreelandDDEShellManagerV1,
+            TreelandDDEShellManagerV1.version,
+        ),
+        (
+            51,
+            TreelandWindowManagementV1,
+            TreelandWindowManagementV1.version,
+        ),
+        (52, WlOutput, WlOutput.version),
+    ]
+
+    registry.dispatcher["global_remove"](registry, 52)
+    assert runtime.treeland_overlap._outputs == []
 
 
 def test_wayland_protocol_runtime_fd_read_receives_initial_workspaces():


### PR DESCRIPTION
## Summary
Add Desktop.DEEPIN enum entry with detection mappings for the Deepin Desktop Environment's Treeland compositor.

## Research findings
Treeland (github.com/linuxdeepin/treeland) is a Qt/wlroots compositor for DDE. Sets XDG_CURRENT_DESKTOP=Deepin, DDE_CURRENT_COMPOSITOR=TreeLand.

Key finding: Treeland does NOT implement zwlr_foreign_toplevel_manager_v1. It has its own treeland_foreign_toplevel_manager_v1 (v2) with dock preview context, plus treeland_window_management_v1 (show desktop), treeland_dde_shell_v1 (skip-dock-preview, overlay role), and treeland_wallpaper_color_v1.

The generic layer-shell backend provides panel placement (layer-shell v4) but cannot track windows. A dedicated backend implementing treeland_foreign_toplevel_manager_v1 will be needed for full window management support. This PR adds the detection foundation.

## Changes
- Add Desktop.DEEPIN to the Desktop enum
- Add "deepin", "treeland", "dde" to _DESKTOP_MAP
- Add tests for desktop string parsing