### PR TITLE
Expose idle notifications in generic Wayland sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ one with `DOCKING_BACKEND`.
 | **KWin** | KDE Plasma 6 Wayland | Dock placement (layer-shell), window tracking with titles via AT-SPI accessibility bus, workspace switching via KWin D-Bus. No window actions (KWin 6 does not expose a public activate/close/minimize protocol) |
 | **Hyprland** | Hyprland Wayland | Dock placement (layer-shell), IPC-based window tracking, active state, window actions, geometry, workspace association, and optional previews |
 | **Niri** | Niri Wayland | Dock placement (layer-shell), IPC-based window tracking, active state, window actions (focus, close), window previews, workspace association |
-| **Native layer-shell** | wlroots-based (Sway, labwc, river, Wayfire) | Dock placement, window tracking, workspace switching (varies by compositor protocol support) |
+| **Native layer-shell** | Protocol-capable Wayland compositors | Dock placement. Window tracking, workspace switching, previews, and idle-time support are enabled independently when the compositor publishes the corresponding standard protocols |
 | **Cinnamon Wayland** | Current Muffin | Dock placement plus read-only running, active, attention, geometry, and workspace state through Muffin's `org.cinnamon.Muffin.Debug.ListWindows` snapshot API. Muffin does not expose window actions, previews, or change signals, so Docking polls every two seconds |
 | **Native layer-shell** | GameScope | Dock placement as a GameScope external overlay. Docking automatically uses `GAMESCOPE_WAYLAND_DISPLAY`, including sessions started without `--expose-wayland`. GameScope does not expose general window management |
 | **Native layer-shell** | Jay | Dock placement, window actions, workspaces, previews, and idle time after granting Docking the required Jay client capabilities |

--- a/docking/platform/backends/wayland/runtime.py
+++ b/docking/platform/backends/wayland/runtime.py
@@ -369,6 +369,7 @@ class IdleProtocolAdapter:
 
     def __init__(self) -> None:
         self._notifier = None
+        self._notifier_version = 0
         self._seat = None
         self._notification = None
         self._flush: Callable[[], None] | None = None
@@ -383,6 +384,7 @@ class IdleProtocolAdapter:
 
         bind_version = min(version, ExtIdleNotifierV1.version)
         self._notifier = registry.bind(name, ExtIdleNotifierV1, bind_version)
+        self._notifier_version = bind_version
         self.available = True
         self._maybe_create_notification()
 
@@ -408,6 +410,7 @@ class IdleProtocolAdapter:
             if callable(destroy):
                 destroy()
         self._notifier = None
+        self._notifier_version = 0
         self._seat = None
         self._notification = None
         self._flush = None
@@ -422,7 +425,9 @@ class IdleProtocolAdapter:
             or self._service is None
         ):
             return
-        create = getattr(self._notifier, "get_input_idle_notification", None)
+        create = None
+        if self._notifier_version >= 2:
+            create = getattr(self._notifier, "get_input_idle_notification", None)
         if not callable(create):
             create = getattr(self._notifier, "get_idle_notification", None)
         if not callable(create):

--- a/docking/platform/backends/wayland/session.py
+++ b/docking/platform/backends/wayland/session.py
@@ -36,6 +36,7 @@ from docking.platform.backends.reduced.services import (
     ReducedVisibilityService,
     ReducedWindowService,
 )
+from docking.platform.backends.wayland.idle import WaylandIdleService
 from docking.platform.backends.wayland.portals import (
     WaylandPortalColorPickerService,
     load_portal_color_picker,
@@ -68,6 +69,7 @@ class WaylandLayerShellRuntimeServices:
     visibility: ReducedVisibilityService
     workspaces: WorkspaceService | None
     screen_capture: ScreenCaptureService | None
+    idle: IdleService | None
     protocol_runtime: WaylandProtocolRuntime | None
 
 
@@ -171,6 +173,14 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             if workspace_protocol is not None
             else None
         )
+        idle_protocol = (
+            getattr(runtime, "idle_protocol", None) if runtime is not None else None
+        )
+        idle: IdleService | None = (
+            WaylandIdleService(protocol=idle_protocol)
+            if idle_protocol is not None
+            else None
+        )
         self._services = WaylandLayerShellRuntimeServices(
             windows=windows,
             previews=previews,
@@ -180,6 +190,7 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             screen_capture=screen_capture
             if screen_capture is not None
             else load_portal_color_picker(),
+            idle=idle,
             protocol_runtime=runtime,
         )
 
@@ -218,6 +229,7 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             supports_layer_shell=True,
             supports_screen_reservation=True,
             supports_input_region=True,
+            supports_idle_time=isinstance(self._services.idle, WaylandIdleService),
         )
 
     @property
@@ -250,7 +262,7 @@ class WaylandLayerShellSessionBackend(SessionBackend):
 
     @property
     def idle(self) -> IdleService | None:
-        return None
+        return self._services.idle
 
     @property
     def window_picker(self) -> WindowPickService | None:
@@ -265,8 +277,12 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             self._services.workspaces.start()
         if self._services.screen_capture is not None:
             self._services.screen_capture.start()
+        if self._services.idle is not None:
+            self._services.idle.start()
 
     def stop(self) -> None:
+        if self._services.idle is not None:
+            self._services.idle.stop()
         if self._services.screen_capture is not None:
             self._services.screen_capture.stop()
         if self._services.workspaces is not None:

--- a/tests/platform/test_wayland_idle.py
+++ b/tests/platform/test_wayland_idle.py
@@ -1,0 +1,43 @@
+"""Tests for generic Wayland idle notifications."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from docking.platform.backends.wayland.runtime import IdleProtocolAdapter
+
+
+class _Notifier:
+    def __init__(self) -> None:
+        self.get_idle_notification = MagicMock(
+            return_value=SimpleNamespace(dispatcher={})
+        )
+        self.get_input_idle_notification = MagicMock(
+            return_value=SimpleNamespace(dispatcher={})
+        )
+
+
+def _started_adapter(*, version: int) -> tuple[IdleProtocolAdapter, _Notifier, object]:
+    notifier = _Notifier()
+    seat = object()
+    adapter = IdleProtocolAdapter()
+    adapter._notifier = notifier
+    adapter._notifier_version = version
+    adapter._seat = seat
+    adapter.start(MagicMock())
+    return adapter, notifier, seat
+
+
+def test_idle_adapter_uses_version_one_request_for_version_one_compositors():
+    _adapter, notifier, seat = _started_adapter(version=1)
+
+    notifier.get_idle_notification.assert_called_once_with(0, seat)
+    notifier.get_input_idle_notification.assert_not_called()
+
+
+def test_idle_adapter_uses_input_only_request_when_version_two_is_available():
+    _adapter, notifier, seat = _started_adapter(version=2)
+
+    notifier.get_input_idle_notification.assert_called_once_with(0, seat)
+    notifier.get_idle_notification.assert_not_called()

--- a/tests/platform/test_wayland_layer_shell_session.py
+++ b/tests/platform/test_wayland_layer_shell_session.py
@@ -24,6 +24,7 @@ from docking.platform.backends.wayland.hyprland_ipc import (
     HyprlandWindowService,
 )
 from docking.platform.backends.wayland.hyprland_session import HyprlandSessionBackend
+from docking.platform.backends.wayland.idle import WaylandIdleService
 from docking.platform.backends.wayland.niri_ipc import NiriWindowService
 from docking.platform.backends.wayland.niri_session import NiriSessionBackend
 from docking.platform.backends.wayland.portals import WaylandPortalColorPickerService
@@ -233,6 +234,24 @@ def test_wayland_layer_shell_session_uses_workspace_and_capture_services_when_av
     assert backend.capabilities.supports_workspace_list is True
     assert backend.capabilities.supports_workspace_switch is True
     assert backend.capabilities.supports_screen_color_pick is True
+
+
+def test_wayland_layer_shell_session_uses_idle_protocol_when_available():
+    idle_protocol = MagicMock()
+    runtime = _empty_runtime()
+    runtime.idle_protocol = idle_protocol
+    backend = WaylandLayerShellSessionBackend(
+        layer_shell=_layer_shell(),
+        protocol_runtime=runtime,
+    )
+
+    assert isinstance(backend.idle, WaylandIdleService)
+    assert backend.capabilities.supports_idle_time is True
+
+    backend.start()
+    idle_protocol.start.assert_called_once_with(backend.idle)
+    backend.stop()
+    idle_protocol.stop.assert_called_once()
 
 
 def test_hyprland_session_uses_ipc_windows_and_layer_shell_capabilities():


### PR DESCRIPTION
## Summary

Expose standard Wayland idle notifications through Docking's generic native layer-shell backend.

## Why

The protocol runtime already discovers `ext-idle-notify-v1`, but the generic session backend did not turn that adapter into an `IdleService`. Consequently applets such as Desk Presence could not use idle information on otherwise compatible Wayland compositors.

This belongs to the generic backend because the capability is determined by the advertised protocol, not by compositor identity.

## Changes

- Create and lifecycle-manage `WaylandIdleService` when `ext_idle_notifier_v1` is available.
- Advertise idle-time capability only while the protocol is available.
- Use the version 1 request for version 1 compositors and the input-only request when version 2 is negotiated.
- Document native layer-shell support in terms of independently advertised standard protocols.
- Add generic session and protocol-version tests.

## Validation

- 19 focused platform tests pass.
- Ruff check and format pass across `docking/` and `tests/`.
- Ty passes for the changed production modules.
- Vulture and package-data synchronization checks pass.
