### PR TITLE
Compose native Wayland session services

### DIFF
--- a/docking/platform/backends/cinnamon/session.py
+++ b/docking/platform/backends/cinnamon/session.py
@@ -9,10 +9,14 @@ from docking.platform.backends.cinnamon.muffin import (
     MuffinDebugClient,
     MuffinWindowService,
 )
+from docking.platform.backends.reduced.services import ReducedPreviewService
+from docking.platform.backends.wayland.runtime import STANDARD_PROTOCOL_PROFILE
 from docking.platform.backends.wayland.session import WaylandLayerShellSessionBackend
 
 
 class CinnamonWaylandSessionBackend(WaylandLayerShellSessionBackend):
+    protocol_profile = STANDARD_PROTOCOL_PROFILE
+
     def __init__(
         self, *, layer_shell: object, model, launcher, client: MuffinDebugClient
     ):
@@ -24,6 +28,7 @@ class CinnamonWaylandSessionBackend(WaylandLayerShellSessionBackend):
                 launcher=launcher,
                 client=client,
             ),
+            previews=ReducedPreviewService(),
         )
 
     @property

--- a/docking/platform/backends/wayland/composed_session.py
+++ b/docking/platform/backends/wayland/composed_session.py
@@ -1,0 +1,113 @@
+"""Shared service composition and lifecycle for native Wayland sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from docking.platform.backends.base import (
+    DesktopActionService,
+    DisplayServer,
+    IdleService,
+    PreviewService,
+    ScreenCaptureService,
+    Service,
+    SessionBackend,
+    SurfaceService,
+    VisibilityService,
+    WindowPickService,
+    WindowService,
+    WorkspaceService,
+)
+
+if TYPE_CHECKING:
+    from docking.platform.backends.wayland.runtime import WaylandProtocolRuntime
+
+
+@dataclass(frozen=True)
+class WaylandSessionServices:
+    """Services owned by one native Wayland session backend."""
+
+    windows: WindowService
+    previews: PreviewService
+    surface: SurfaceService
+    visibility: VisibilityService
+    workspaces: WorkspaceService | None = None
+    desktop_actions: DesktopActionService | None = None
+    screen_capture: ScreenCaptureService | None = None
+    idle: IdleService | None = None
+    window_picker: WindowPickService | None = None
+    protocol_runtime: WaylandProtocolRuntime | None = None
+
+    def lifecycle_order(self) -> tuple[Service | None, ...]:
+        """Return services in dependency-safe startup order."""
+        return (
+            self.previews,
+            self.windows,
+            self.surface,
+            self.visibility,
+            self.workspaces,
+            self.desktop_actions,
+            self.screen_capture,
+            self.idle,
+            self.window_picker,
+        )
+
+
+class ComposedWaylandSessionBackend(SessionBackend):
+    """Provide common service access and lifecycle for Wayland backends."""
+
+    def __init__(self, *, services: WaylandSessionServices) -> None:
+        self._services = services
+
+    @property
+    def display_server(self) -> DisplayServer:
+        return DisplayServer.WAYLAND
+
+    @property
+    def windows(self) -> WindowService:
+        return self._services.windows
+
+    @property
+    def surface(self) -> SurfaceService:
+        return self._services.surface
+
+    @property
+    def visibility(self) -> VisibilityService:
+        return self._services.visibility
+
+    @property
+    def previews(self) -> PreviewService:
+        return self._services.previews
+
+    @property
+    def workspaces(self) -> WorkspaceService | None:
+        return self._services.workspaces
+
+    @property
+    def desktop_actions(self) -> DesktopActionService | None:
+        return self._services.desktop_actions
+
+    @property
+    def screen_capture(self) -> ScreenCaptureService | None:
+        return self._services.screen_capture
+
+    @property
+    def idle(self) -> IdleService | None:
+        return self._services.idle
+
+    @property
+    def window_picker(self) -> WindowPickService | None:
+        return self._services.window_picker
+
+    def start(self) -> None:
+        for service in self._services.lifecycle_order():
+            if service is not None:
+                service.start()
+
+    def stop(self) -> None:
+        for service in reversed(self._services.lifecycle_order()):
+            if service is not None:
+                service.stop()
+        if self._services.protocol_runtime is not None:
+            self._services.protocol_runtime.stop()

--- a/docking/platform/backends/wayland/cosmic_session.py
+++ b/docking/platform/backends/wayland/cosmic_session.py
@@ -33,28 +33,27 @@ Backend selection
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from docking.platform.backends.base import (
-    DesktopActionService,
-    DisplayServer,
     IdleService,
     PlatformCapabilities,
     PreviewService,
     Rect,
     ScreenCaptureService,
-    SessionBackend,
-    SurfaceService,
     VisibilityMonitor,
     VisibilityService,
-    WindowPickService,
     WindowService,
     WorkspaceService,
 )
 from docking.platform.backends.reduced.services import (
     ReducedPreviewService,
 )
+from docking.platform.backends.wayland.composed_session import (
+    ComposedWaylandSessionBackend,
+    WaylandSessionServices,
+)
+from docking.platform.backends.wayland.idle import WaylandIdleService
 from docking.platform.backends.wayland.portals import (
     load_portal_color_picker,
 )
@@ -62,7 +61,10 @@ from docking.platform.backends.wayland.previews import (
     WaylandPreviewHandleTracker,
     WaylandPreviewService,
 )
-from docking.platform.backends.wayland.runtime import WaylandProtocolRuntime
+from docking.platform.backends.wayland.runtime import (
+    COSMIC_PROTOCOL_PROFILE,
+    WaylandProtocolRuntime,
+)
 from docking.platform.backends.wayland.services import WaylandLayerShellSurfaceService
 from docking.platform.backends.wayland.toplevels import (
     WaylandForeignToplevelWindowService,
@@ -71,19 +73,6 @@ from docking.platform.backends.wayland.toplevels import (
 if TYPE_CHECKING:
     from docking.platform.launcher import Launcher
     from docking.platform.model import DockModel
-
-
-@dataclass(frozen=True)
-class CosmicRuntimeServices:
-    """Concrete services selected for COSMIC native Wayland support."""
-
-    windows: WindowService
-    previews: PreviewService
-    surface: WaylandLayerShellSurfaceService
-    visibility: VisibilityService
-    workspaces: WorkspaceService | None
-    screen_capture: ScreenCaptureService | None
-    protocol_runtime: WaylandProtocolRuntime | None
 
 
 class CosmicOverlapVisibilityService(VisibilityService):
@@ -166,7 +155,7 @@ class CosmicOverlapMonitor(VisibilityMonitor):
             self._adapter.start(self._layer_surface, self._on_change)
 
 
-class CosmicSessionBackend(SessionBackend):
+class CosmicSessionBackend(ComposedWaylandSessionBackend):
     """SessionBackend with COSMIC protocols for toplevel, workspace, and overlap."""
 
     def __init__(
@@ -180,7 +169,7 @@ class CosmicSessionBackend(SessionBackend):
     ) -> None:
         runtime = protocol_runtime
         if runtime is None:
-            candidate_runtime = WaylandProtocolRuntime()
+            candidate_runtime = WaylandProtocolRuntime(profile=COSMIC_PROTOCOL_PROFILE)
             if candidate_runtime.start():
                 runtime = candidate_runtime
 
@@ -293,17 +282,26 @@ class CosmicSessionBackend(SessionBackend):
             )
         else:
             previews = ReducedPreviewService()
+        idle_protocol = runtime.idle_protocol if runtime is not None else None
+        idle: IdleService | None = (
+            WaylandIdleService(protocol=idle_protocol)
+            if idle_protocol is not None
+            else None
+        )
 
-        self._services = CosmicRuntimeServices(
-            windows=windows,
-            previews=previews,
-            surface=surface,
-            visibility=visibility,
-            workspaces=workspaces,
-            screen_capture=screen_capture
-            if screen_capture is not None
-            else load_portal_color_picker(),
-            protocol_runtime=runtime,
+        super().__init__(
+            services=WaylandSessionServices(
+                windows=windows,
+                previews=previews,
+                surface=surface,
+                visibility=visibility,
+                workspaces=workspaces,
+                screen_capture=screen_capture
+                if screen_capture is not None
+                else load_portal_color_picker(),
+                idle=idle,
+                protocol_runtime=runtime,
+            )
         )
 
         # Stash overlap adapter for late binding to the layer surface
@@ -312,10 +310,6 @@ class CosmicSessionBackend(SessionBackend):
     @property
     def name(self) -> str:
         return "cosmic"
-
-    @property
-    def display_server(self) -> DisplayServer:
-        return DisplayServer.WAYLAND
 
     @property
     def capabilities(self) -> PlatformCapabilities:
@@ -350,65 +344,8 @@ class CosmicSessionBackend(SessionBackend):
             supports_overlap_active=supports_overlap,
             supports_overlap_any=supports_overlap,
             supports_overlap_maximized=supports_overlap,
+            supports_idle_time=isinstance(self._services.idle, WaylandIdleService),
         )
-
-    @property
-    def windows(self) -> WindowService:
-        return self._services.windows
-
-    @property
-    def surface(self) -> SurfaceService:
-        return self._services.surface
-
-    @property
-    def visibility(self) -> VisibilityService:
-        return self._services.visibility
-
-    @property
-    def previews(self) -> PreviewService:
-        return self._services.previews
-
-    @property
-    def workspaces(self) -> WorkspaceService | None:
-        return self._services.workspaces
-
-    @property
-    def desktop_actions(self) -> DesktopActionService | None:
-        return None
-
-    @property
-    def screen_capture(self) -> ScreenCaptureService | None:
-        return self._services.screen_capture
-
-    @property
-    def idle(self) -> IdleService | None:
-        return None
-
-    @property
-    def window_picker(self) -> WindowPickService | None:
-        return None
-
-    def start(self) -> None:
-        self._services.previews.start()
-        self._services.windows.start()
-        self._services.surface.start()
-        self._services.visibility.start()
-        if self._services.workspaces is not None:
-            self._services.workspaces.start()
-        if self._services.screen_capture is not None:
-            self._services.screen_capture.start()
-
-    def stop(self) -> None:
-        if self._services.screen_capture is not None:
-            self._services.screen_capture.stop()
-        if self._services.workspaces is not None:
-            self._services.workspaces.stop()
-        self._services.visibility.stop()
-        self._services.surface.stop()
-        self._services.windows.stop()
-        self._services.previews.stop()
-        if self._services.protocol_runtime is not None:
-            self._services.protocol_runtime.stop()
 
     def _attach_overlap(self, layer_surface: object) -> None:
         """Bind the overlap notification to the realized layer surface."""

--- a/docking/platform/backends/wayland/hyprland_session.py
+++ b/docking/platform/backends/wayland/hyprland_session.py
@@ -15,32 +15,29 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from docking.platform.backends.base import (
-    DesktopActionService,
-    DisplayServer,
     IdleService,
     PlatformCapabilities,
     PreviewService,
     ScreenCaptureService,
-    SessionBackend,
-    SurfaceService,
-    VisibilityService,
-    WindowPickService,
     WindowService,
-    WorkspaceService,
 )
 from docking.platform.backends.reduced.services import (
     ReducedPreviewService,
     ReducedVisibilityService,
     ReducedWindowService,
 )
+from docking.platform.backends.wayland.composed_session import (
+    ComposedWaylandSessionBackend,
+    WaylandSessionServices,
+)
 from docking.platform.backends.wayland.hyprland_ipc import (
     HyprlandWindowService,
     load_hyprland_window_service,
 )
+from docking.platform.backends.wayland.idle import WaylandIdleService
 from docking.platform.backends.wayland.portals import (
     WaylandPortalColorPickerService,
     load_portal_color_picker,
@@ -49,7 +46,10 @@ from docking.platform.backends.wayland.previews import (
     HyprlandPreviewService,
     WaylandPreviewHandleTracker,
 )
-from docking.platform.backends.wayland.runtime import WaylandProtocolRuntime
+from docking.platform.backends.wayland.runtime import (
+    HYPRLAND_PROTOCOL_PROFILE,
+    WaylandProtocolRuntime,
+)
 from docking.platform.backends.wayland.services import WaylandLayerShellSurfaceService
 from docking.platform.backends.wayland.workspaces import WaylandWorkspaceService
 
@@ -58,20 +58,7 @@ if TYPE_CHECKING:
     from docking.platform.model import DockModel
 
 
-@dataclass(frozen=True)
-class HyprlandRuntimeServices:
-    """Concrete services selected for the Hyprland Wayland backend."""
-
-    windows: WindowService
-    previews: PreviewService
-    surface: WaylandLayerShellSurfaceService
-    visibility: ReducedVisibilityService
-    workspaces: WorkspaceService | None
-    screen_capture: ScreenCaptureService | None
-    protocol_runtime: WaylandProtocolRuntime | None
-
-
-class HyprlandSessionBackend(SessionBackend):
+class HyprlandSessionBackend(ComposedWaylandSessionBackend):
     """SessionBackend using Hyprland IPC for windows and layer-shell surfaces."""
 
     def __init__(
@@ -86,7 +73,9 @@ class HyprlandSessionBackend(SessionBackend):
     ) -> None:
         runtime = protocol_runtime
         if runtime is None:
-            candidate_runtime = WaylandProtocolRuntime()
+            candidate_runtime = WaylandProtocolRuntime(
+                profile=HYPRLAND_PROTOCOL_PROFILE
+            )
             if candidate_runtime.start():
                 runtime = candidate_runtime
 
@@ -130,26 +119,31 @@ class HyprlandSessionBackend(SessionBackend):
             if workspace_protocol is not None
             else None
         )
+        idle_protocol = runtime.idle_protocol if runtime is not None else None
+        idle: IdleService | None = (
+            WaylandIdleService(protocol=idle_protocol)
+            if idle_protocol is not None
+            else None
+        )
 
-        self._services = HyprlandRuntimeServices(
-            windows=windows,
-            previews=previews,
-            surface=WaylandLayerShellSurfaceService(layer_shell=layer_shell),
-            visibility=ReducedVisibilityService(),
-            workspaces=workspaces,
-            screen_capture=screen_capture
-            if screen_capture is not None
-            else load_portal_color_picker(),
-            protocol_runtime=runtime,
+        super().__init__(
+            services=WaylandSessionServices(
+                windows=windows,
+                previews=previews,
+                surface=WaylandLayerShellSurfaceService(layer_shell=layer_shell),
+                visibility=ReducedVisibilityService(),
+                workspaces=workspaces,
+                screen_capture=screen_capture
+                if screen_capture is not None
+                else load_portal_color_picker(),
+                idle=idle,
+                protocol_runtime=runtime,
+            )
         )
 
     @property
     def name(self) -> str:
         return "hyprland"
-
-    @property
-    def display_server(self) -> DisplayServer:
-        return DisplayServer.WAYLAND
 
     @property
     def capabilities(self) -> PlatformCapabilities:
@@ -177,62 +171,5 @@ class HyprlandSessionBackend(SessionBackend):
             supports_screen_reservation=True,
             supports_input_region=True,
             supports_screen_color_pick=supports_color_pick,
+            supports_idle_time=isinstance(self._services.idle, WaylandIdleService),
         )
-
-    @property
-    def windows(self) -> WindowService:
-        return self._services.windows
-
-    @property
-    def surface(self) -> SurfaceService:
-        return self._services.surface
-
-    @property
-    def visibility(self) -> VisibilityService:
-        return self._services.visibility
-
-    @property
-    def previews(self) -> PreviewService:
-        return self._services.previews
-
-    @property
-    def workspaces(self) -> WorkspaceService | None:
-        return self._services.workspaces
-
-    @property
-    def desktop_actions(self) -> DesktopActionService | None:
-        return None
-
-    @property
-    def screen_capture(self) -> ScreenCaptureService | None:
-        return self._services.screen_capture
-
-    @property
-    def idle(self) -> IdleService | None:
-        return None
-
-    @property
-    def window_picker(self) -> WindowPickService | None:
-        return None
-
-    def start(self) -> None:
-        self._services.previews.start()
-        self._services.windows.start()
-        self._services.surface.start()
-        self._services.visibility.start()
-        if self._services.workspaces is not None:
-            self._services.workspaces.start()
-        if self._services.screen_capture is not None:
-            self._services.screen_capture.start()
-
-    def stop(self) -> None:
-        if self._services.screen_capture is not None:
-            self._services.screen_capture.stop()
-        if self._services.workspaces is not None:
-            self._services.workspaces.stop()
-        self._services.visibility.stop()
-        self._services.surface.stop()
-        self._services.windows.stop()
-        self._services.previews.stop()
-        if self._services.protocol_runtime is not None:
-            self._services.protocol_runtime.stop()

--- a/docking/platform/backends/wayland/niri_session.py
+++ b/docking/platform/backends/wayland/niri_session.py
@@ -10,27 +10,23 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from docking.platform.backends.base import (
-    DesktopActionService,
-    DisplayServer,
     IdleService,
     PlatformCapabilities,
     PreviewService,
     ScreenCaptureService,
-    SessionBackend,
-    SurfaceService,
-    VisibilityService,
-    WindowPickService,
     WindowService,
-    WorkspaceService,
 )
 from docking.platform.backends.reduced.services import (
     ReducedPreviewService,
     ReducedVisibilityService,
     ReducedWindowService,
+)
+from docking.platform.backends.wayland.composed_session import (
+    ComposedWaylandSessionBackend,
+    WaylandSessionServices,
 )
 from docking.platform.backends.wayland.idle import WaylandIdleService
 from docking.platform.backends.wayland.niri_ipc import (
@@ -47,7 +43,10 @@ from docking.platform.backends.wayland.portals import (
     WaylandPortalColorPickerService,
     load_portal_color_picker,
 )
-from docking.platform.backends.wayland.runtime import WaylandProtocolRuntime
+from docking.platform.backends.wayland.runtime import (
+    STANDARD_PROTOCOL_PROFILE,
+    WaylandProtocolRuntime,
+)
 from docking.platform.backends.wayland.services import WaylandLayerShellSurfaceService
 from docking.platform.backends.wayland.workspaces import WaylandWorkspaceService
 
@@ -56,22 +55,7 @@ if TYPE_CHECKING:
     from docking.platform.model import DockModel
 
 
-@dataclass(frozen=True)
-class NiriRuntimeServices:
-    """Concrete services selected for the Niri Wayland backend."""
-
-    windows: WindowService
-    previews: PreviewService
-    surface: WaylandLayerShellSurfaceService
-    visibility: ReducedVisibilityService
-    workspaces: WorkspaceService | None
-    screen_capture: ScreenCaptureService | None
-    desktop_actions: DesktopActionService | None
-    idle: IdleService | None
-    protocol_runtime: WaylandProtocolRuntime | None
-
-
-class NiriSessionBackend(SessionBackend):
+class NiriSessionBackend(ComposedWaylandSessionBackend):
     """SessionBackend using Niri IPC for windows and layer-shell surfaces."""
 
     def __init__(
@@ -86,7 +70,9 @@ class NiriSessionBackend(SessionBackend):
     ) -> None:
         runtime = protocol_runtime
         if runtime is None:
-            candidate_runtime = WaylandProtocolRuntime()
+            candidate_runtime = WaylandProtocolRuntime(
+                profile=STANDARD_PROTOCOL_PROFILE
+            )
             if candidate_runtime.start():
                 runtime = candidate_runtime
 
@@ -126,25 +112,23 @@ class NiriSessionBackend(SessionBackend):
             else:
                 screen_capture = load_portal_color_picker()
 
-        self._services = NiriRuntimeServices(
-            windows=windows,
-            previews=previews,
-            surface=WaylandLayerShellSurfaceService(layer_shell=layer_shell),
-            visibility=ReducedVisibilityService(),
-            workspaces=workspaces,
-            screen_capture=screen_capture,
-            desktop_actions=desktop_actions,
-            idle=idle,
-            protocol_runtime=runtime,
+        super().__init__(
+            services=WaylandSessionServices(
+                windows=windows,
+                previews=previews,
+                surface=WaylandLayerShellSurfaceService(layer_shell=layer_shell),
+                visibility=ReducedVisibilityService(),
+                workspaces=workspaces,
+                screen_capture=screen_capture,
+                desktop_actions=desktop_actions,
+                idle=idle,
+                protocol_runtime=runtime,
+            )
         )
 
     @property
     def name(self) -> str:
         return "niri"
-
-    @property
-    def display_server(self) -> DisplayServer:
-        return DisplayServer.WAYLAND
 
     @property
     def capabilities(self) -> PlatformCapabilities:
@@ -178,69 +162,3 @@ class NiriSessionBackend(SessionBackend):
             supports_screen_color_pick=supports_color_pick,
             supports_idle_time=isinstance(self._services.idle, WaylandIdleService),
         )
-
-    @property
-    def windows(self) -> WindowService:
-        return self._services.windows
-
-    @property
-    def surface(self) -> SurfaceService:
-        return self._services.surface
-
-    @property
-    def visibility(self) -> VisibilityService:
-        return self._services.visibility
-
-    @property
-    def previews(self) -> PreviewService:
-        return self._services.previews
-
-    @property
-    def workspaces(self) -> WorkspaceService | None:
-        return self._services.workspaces
-
-    @property
-    def desktop_actions(self) -> DesktopActionService | None:
-        return self._services.desktop_actions
-
-    @property
-    def screen_capture(self) -> ScreenCaptureService | None:
-        return self._services.screen_capture
-
-    @property
-    def idle(self) -> IdleService | None:
-        return self._services.idle
-
-    @property
-    def window_picker(self) -> WindowPickService | None:
-        return None
-
-    def start(self) -> None:
-        self._services.previews.start()
-        self._services.windows.start()
-        self._services.surface.start()
-        self._services.visibility.start()
-        if self._services.workspaces is not None:
-            self._services.workspaces.start()
-        if self._services.desktop_actions is not None:
-            self._services.desktop_actions.start()
-        if self._services.screen_capture is not None:
-            self._services.screen_capture.start()
-        if self._services.idle is not None:
-            self._services.idle.start()
-
-    def stop(self) -> None:
-        if self._services.idle is not None:
-            self._services.idle.stop()
-        if self._services.screen_capture is not None:
-            self._services.screen_capture.stop()
-        if self._services.desktop_actions is not None:
-            self._services.desktop_actions.stop()
-        if self._services.workspaces is not None:
-            self._services.workspaces.stop()
-        self._services.visibility.stop()
-        self._services.surface.stop()
-        self._services.windows.stop()
-        self._services.previews.stop()
-        if self._services.protocol_runtime is not None:
-            self._services.protocol_runtime.stop()

--- a/docking/platform/backends/wayland/runtime.py
+++ b/docking/platform/backends/wayland/runtime.py
@@ -62,6 +62,36 @@ class WaylandProtocolFactories:
     glib: object
 
 
+@dataclass(frozen=True)
+class WaylandProtocolProfile:
+    """Compositor-specific protocol adapters enabled for one session."""
+
+    hyprland_previews: bool = False
+    phoc_previews: bool = False
+    cosmic: bool = False
+    treeland: bool = False
+
+
+STANDARD_PROTOCOL_PROFILE = WaylandProtocolProfile()
+GENERIC_LAYER_SHELL_PROTOCOL_PROFILE = WaylandProtocolProfile(phoc_previews=True)
+HYPRLAND_PROTOCOL_PROFILE = WaylandProtocolProfile(hyprland_previews=True)
+COSMIC_PROTOCOL_PROFILE = WaylandProtocolProfile(cosmic=True)
+TREELAND_PROTOCOL_PROFILE = WaylandProtocolProfile(treeland=True)
+
+_STANDARD_GLOBAL_INTERFACES = frozenset(
+    {
+        "zwlr_foreign_toplevel_manager_v1",
+        "wl_seat",
+        "ext_workspace_manager_v1",
+        "ext_foreign_toplevel_list_v1",
+        "ext_foreign_toplevel_image_capture_source_manager_v1",
+        "ext_image_copy_capture_manager_v1",
+        "wl_shm",
+        "ext_idle_notifier_v1",
+    }
+)
+
+
 class ForeignToplevelProtocolAdapter:
     """Adapter from generated foreign-toplevel callbacks to Docking service."""
 
@@ -753,6 +783,7 @@ class WaylandProtocolRuntime:
         self,
         *,
         factories: WaylandProtocolFactories | None = None,
+        profile: WaylandProtocolProfile = GENERIC_LAYER_SHELL_PROTOCOL_PROFILE,
         foreign_adapter: ForeignToplevelProtocolAdapter | None = None,
         workspace_adapter: WorkspaceProtocolAdapter | None = None,
         preview_adapter: PreviewProtocolAdapter | None = None,
@@ -762,30 +793,45 @@ class WaylandProtocolRuntime:
         cosmic_toplevel_adapter: object | None = None,
         cosmic_overlap_adapter: object | None = None,
     ) -> None:
-        from docking.platform.backends.wayland.cosmic import (
-            CosmicOverlapAdapter,
-            CosmicToplevelAdapter,
-        )
-        from docking.platform.backends.wayland.treeland import (
-            TreelandOverlapAdapter,
-            TreelandWindowManagementAdapter,
-        )
-
         self._factories = factories
+        self._profile = profile
         self.foreign_toplevel = foreign_adapter or ForeignToplevelProtocolAdapter()
         self.workspaces = workspace_adapter or WorkspaceProtocolAdapter()
         self.previews = preview_adapter or PreviewProtocolAdapter()
         self.hyprland_previews = (
             hyprland_preview_adapter or HyprlandPreviewProtocolAdapter()
+            if profile.hyprland_previews
+            else None
         )
-        self.phoc_previews = phoc_preview_adapter or PhocPreviewProtocolAdapter()
+        self.phoc_previews = (
+            phoc_preview_adapter or PhocPreviewProtocolAdapter()
+            if profile.phoc_previews
+            else None
+        )
         self.idle = idle_adapter or IdleProtocolAdapter()
-        self.cosmic_toplevel = cosmic_toplevel_adapter or CosmicToplevelAdapter()
-        self.cosmic_overlap = cosmic_overlap_adapter or CosmicOverlapAdapter()
-        self.treeland_overlap = TreelandOverlapAdapter()
-        self.treeland_window_management = TreelandWindowManagementAdapter()
+        self.cosmic_toplevel = None
+        self.cosmic_overlap = None
+        if profile.cosmic:
+            from docking.platform.backends.wayland.cosmic import (
+                CosmicOverlapAdapter,
+                CosmicToplevelAdapter,
+            )
+
+            self.cosmic_toplevel = cosmic_toplevel_adapter or CosmicToplevelAdapter()
+            self.cosmic_overlap = cosmic_overlap_adapter or CosmicOverlapAdapter()
+        self.treeland_overlap = None
+        self.treeland_window_management = None
+        if profile.treeland:
+            from docking.platform.backends.wayland.treeland import (
+                TreelandOverlapAdapter,
+                TreelandWindowManagementAdapter,
+            )
+
+            self.treeland_overlap = TreelandOverlapAdapter()
+            self.treeland_window_management = TreelandWindowManagementAdapter()
         self._display = None
         self._registry = None
+        self._global_interfaces: dict[int, str] = {}
         self._glib_source_id = 0
         self._running = False
 
@@ -804,12 +850,19 @@ class WaylandProtocolRuntime:
     @property
     def hyprland_preview_protocol(self) -> object | None:
         return (
-            self.hyprland_previews if self.hyprland_previews.capture_available else None
+            self.hyprland_previews
+            if self.hyprland_previews is not None
+            and self.hyprland_previews.capture_available
+            else None
         )
 
     @property
     def phoc_preview_protocol(self) -> object | None:
-        return self.phoc_previews if self.phoc_previews.capture_available else None
+        return (
+            self.phoc_previews
+            if self.phoc_previews is not None and self.phoc_previews.capture_available
+            else None
+        )
 
     @property
     def idle_protocol(self) -> object | None:
@@ -817,15 +870,27 @@ class WaylandProtocolRuntime:
 
     @property
     def cosmic_toplevel_protocol(self) -> object | None:
-        return self.cosmic_toplevel if self.cosmic_toplevel.available else None
+        return (
+            self.cosmic_toplevel
+            if self.cosmic_toplevel is not None and self.cosmic_toplevel.available
+            else None
+        )
 
     @property
     def cosmic_overlap_protocol(self) -> object | None:
-        return self.cosmic_overlap if self.cosmic_overlap.available else None
+        return (
+            self.cosmic_overlap
+            if self.cosmic_overlap is not None and self.cosmic_overlap.available
+            else None
+        )
 
     @property
     def treeland_overlap_protocol(self) -> TreelandOverlapAdapter | None:
-        return self.treeland_overlap if self.treeland_overlap.available else None
+        return (
+            self.treeland_overlap
+            if self.treeland_overlap is not None and self.treeland_overlap.available
+            else None
+        )
 
     @property
     def treeland_window_management_protocol(
@@ -833,11 +898,14 @@ class WaylandProtocolRuntime:
     ) -> TreelandWindowManagementAdapter | None:
         return (
             self.treeland_window_management
-            if self.treeland_window_management.available
+            if self.treeland_window_management is not None
+            and self.treeland_window_management.available
             else None
         )
 
     def start(self) -> bool:
+        if self._running:
+            return True
         factories = self._factories or load_protocol_factories()
         if factories is None:
             log.info("Wayland protocol runtime unavailable: pywayland not installed")
@@ -853,13 +921,19 @@ class WaylandProtocolRuntime:
             self.foreign_toplevel.set_flush_callback(display.flush)
             self.workspaces.set_flush_callback(display.flush)
             self.previews.set_flush_callback(display.flush)
-            self.hyprland_previews.set_flush_callback(display.flush)
-            self.phoc_previews.set_flush_callback(display.flush)
+            if self.hyprland_previews is not None:
+                self.hyprland_previews.set_flush_callback(display.flush)
+            if self.phoc_previews is not None:
+                self.phoc_previews.set_flush_callback(display.flush)
             self.idle.set_flush_callback(display.flush)
-            self.cosmic_toplevel.set_flush_callback(display.flush)
-            self.cosmic_overlap.set_flush_callback(display.flush)
-            self.treeland_overlap.set_flush_callback(display.flush)
-            self.treeland_window_management.set_flush_callback(display.flush)
+            if self.cosmic_toplevel is not None:
+                self.cosmic_toplevel.set_flush_callback(display.flush)
+            if self.cosmic_overlap is not None:
+                self.cosmic_overlap.set_flush_callback(display.flush)
+            if self.treeland_overlap is not None:
+                self.treeland_overlap.set_flush_callback(display.flush)
+            if self.treeland_window_management is not None:
+                self.treeland_window_management.set_flush_callback(display.flush)
             display.dispatch(block=False)
             display.roundtrip()
             # The roundtrip discovers globals and binds protocol managers. Flush
@@ -873,8 +947,8 @@ class WaylandProtocolRuntime:
                 "cosmic_toplevel=%s cosmic_overlap=%s",
                 self.foreign_toplevel.available,
                 self.workspaces.available,
-                self.cosmic_toplevel.available,
-                self.cosmic_overlap.available,
+                self.cosmic_toplevel is not None and self.cosmic_toplevel.available,
+                self.cosmic_overlap is not None and self.cosmic_overlap.available,
             )
             return True
         except Exception as exc:
@@ -886,13 +960,19 @@ class WaylandProtocolRuntime:
         self.foreign_toplevel.stop()
         self.workspaces.stop()
         self.previews.stop()
-        self.hyprland_previews.stop()
-        self.phoc_previews.stop()
+        if self.hyprland_previews is not None:
+            self.hyprland_previews.stop()
+        if self.phoc_previews is not None:
+            self.phoc_previews.stop()
         self.idle.stop()
-        self.cosmic_toplevel.stop()
-        self.cosmic_overlap.stop()
-        self.treeland_overlap.stop()
-        self.treeland_window_management.stop()
+        if self.cosmic_toplevel is not None:
+            self.cosmic_toplevel.stop()
+        if self.cosmic_overlap is not None:
+            self.cosmic_overlap.stop()
+        if self.treeland_overlap is not None:
+            self.treeland_overlap.stop()
+        if self.treeland_window_management is not None:
+            self.treeland_window_management.stop()
         source_id = self._glib_source_id
         factories = self._factories or load_protocol_factories()
         if source_id and factories is not None:
@@ -905,9 +985,12 @@ class WaylandProtocolRuntime:
                 disconnect()
         self._display = None
         self._registry = None
+        self._global_interfaces.clear()
         self._running = False
 
     def _on_global(self, registry, name: int, interface: str, version: int) -> None:
+        if self._tracks_global(interface):
+            self._global_interfaces[name] = interface
         if interface == "zwlr_foreign_toplevel_manager_v1":
             self.foreign_toplevel.bind(registry=registry, name=name, version=version)
         elif interface == "wl_seat":
@@ -916,22 +999,24 @@ class WaylandProtocolRuntime:
                 name=name,
                 version=version,
             )
-            self.cosmic_toplevel.bind_seat(
-                registry=registry,
-                name=name,
-                version=version,
-            )
+            if self.cosmic_toplevel is not None:
+                self.cosmic_toplevel.bind_seat(
+                    registry=registry,
+                    name=name,
+                    version=version,
+                )
             self.idle.bind_seat(
                 registry=registry,
                 name=name,
                 version=version,
             )
         elif interface == "wl_output":
-            self.treeland_overlap.bind_output(
-                registry=registry,
-                name=name,
-                version=version,
-            )
+            if self.treeland_overlap is not None:
+                self.treeland_overlap.bind_output(
+                    registry=registry,
+                    name=name,
+                    version=version,
+                )
         elif interface == "ext_workspace_manager_v1":
             self.workspaces.bind(registry=registry, name=name, version=version)
         elif interface == "ext_foreign_toplevel_list_v1":
@@ -940,36 +1025,50 @@ class WaylandProtocolRuntime:
                 name=name,
                 version=version,
             )
-            self.cosmic_toplevel.bind_toplevel_list(
-                registry=registry,
-                name=name,
-                version=version,
-            )
-        elif interface == "zcosmic_toplevel_info_v1":
+            if self.cosmic_toplevel is not None:
+                self.cosmic_toplevel.bind_toplevel_list(
+                    registry=registry,
+                    name=name,
+                    version=version,
+                )
+        elif (
+            interface == "zcosmic_toplevel_info_v1" and self.cosmic_toplevel is not None
+        ):
             self.cosmic_toplevel.bind_toplevel_info(
                 registry=registry,
                 name=name,
                 version=version,
             )
-        elif interface == "zcosmic_toplevel_manager_v1":
+        elif (
+            interface == "zcosmic_toplevel_manager_v1"
+            and self.cosmic_toplevel is not None
+        ):
             self.cosmic_toplevel.bind_toplevel_manager(
                 registry=registry,
                 name=name,
                 version=version,
             )
-        elif interface == "zcosmic_overlap_notify_v1":
+        elif (
+            interface == "zcosmic_overlap_notify_v1" and self.cosmic_overlap is not None
+        ):
             self.cosmic_overlap.bind(
                 registry=registry,
                 name=name,
                 version=version,
             )
-        elif interface == "treeland_dde_shell_manager_v1":
+        elif (
+            interface == "treeland_dde_shell_manager_v1"
+            and self.treeland_overlap is not None
+        ):
             self.treeland_overlap.bind(
                 registry=registry,
                 name=name,
                 version=version,
             )
-        elif interface == "treeland_window_management_v1":
+        elif (
+            interface == "treeland_window_management_v1"
+            and self.treeland_window_management is not None
+        ):
             self.treeland_window_management.bind(
                 registry=registry,
                 name=name,
@@ -989,23 +1088,28 @@ class WaylandProtocolRuntime:
             )
         elif interface == "wl_shm":
             self.previews.bind_shm(registry=registry, name=name, version=version)
-            self.hyprland_previews.bind_shm(
-                registry=registry,
-                name=name,
-                version=version,
-            )
-            self.phoc_previews.bind_shm(
-                registry=registry,
-                name=name,
-                version=version,
-            )
-        elif interface == "hyprland_toplevel_export_manager_v1":
+            if self.hyprland_previews is not None:
+                self.hyprland_previews.bind_shm(
+                    registry=registry,
+                    name=name,
+                    version=version,
+                )
+            if self.phoc_previews is not None:
+                self.phoc_previews.bind_shm(
+                    registry=registry,
+                    name=name,
+                    version=version,
+                )
+        elif (
+            interface == "hyprland_toplevel_export_manager_v1"
+            and self.hyprland_previews is not None
+        ):
             self.hyprland_previews.bind_export_manager(
                 registry=registry,
                 name=name,
                 version=version,
             )
-        elif interface == "phosh_private":
+        elif interface == "phosh_private" and self.phoc_previews is not None:
             self.phoc_previews.bind(
                 registry=registry,
                 name=name,
@@ -1014,8 +1118,41 @@ class WaylandProtocolRuntime:
         elif interface == "ext_idle_notifier_v1":
             self.idle.bind(registry=registry, name=name, version=version)
 
+    def _tracks_global(self, interface: str) -> bool:
+        if interface in _STANDARD_GLOBAL_INTERFACES:
+            return True
+        if (
+            self.hyprland_previews is not None
+            and interface == "hyprland_toplevel_export_manager_v1"
+        ):
+            return True
+        if self.phoc_previews is not None and interface == "phosh_private":
+            return True
+        if self.cosmic_toplevel is not None and interface in {
+            "zcosmic_toplevel_info_v1",
+            "zcosmic_toplevel_manager_v1",
+        }:
+            return True
+        if self.cosmic_overlap is not None and interface == "zcosmic_overlap_notify_v1":
+            return True
+        if self.treeland_overlap is not None and interface in {
+            "wl_output",
+            "treeland_dde_shell_manager_v1",
+        }:
+            return True
+        return (
+            self.treeland_window_management is not None
+            and interface == "treeland_window_management_v1"
+        )
+
     def _on_global_remove(self, _registry, name: int) -> None:
-        self.treeland_overlap.unbind_output(name)
+        interface = self._global_interfaces.pop(name, None)
+        if interface == "wl_output" and self.treeland_overlap is not None:
+            self.treeland_overlap.unbind_output(name)
+            return
+        if interface is not None:
+            log.info("Wayland global removed, stopping protocol runtime: %s", interface)
+            self.stop()
 
     def _install_glib_watch(
         self, *, factories: WaylandProtocolFactories, display

--- a/docking/platform/backends/wayland/session.py
+++ b/docking/platform/backends/wayland/session.py
@@ -15,26 +15,21 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from docking.platform.backends.base import (
-    DesktopActionService,
-    DisplayServer,
     IdleService,
     PlatformCapabilities,
     PreviewService,
     ScreenCaptureService,
-    SessionBackend,
-    SurfaceService,
-    VisibilityService,
-    WindowPickService,
     WindowService,
-    WorkspaceService,
 )
 from docking.platform.backends.reduced.services import (
     ReducedPreviewService,
     ReducedVisibilityService,
     ReducedWindowService,
+)
+from docking.platform.backends.wayland.composed_session import (
+    ComposedWaylandSessionBackend,
+    WaylandSessionServices,
 )
 from docking.platform.backends.wayland.idle import WaylandIdleService
 from docking.platform.backends.wayland.portals import (
@@ -47,7 +42,11 @@ from docking.platform.backends.wayland.previews import (
     WaylandPreviewHandleTracker,
     WaylandPreviewService,
 )
-from docking.platform.backends.wayland.runtime import WaylandProtocolRuntime
+from docking.platform.backends.wayland.runtime import (
+    GENERIC_LAYER_SHELL_PROTOCOL_PROFILE,
+    WaylandProtocolProfile,
+    WaylandProtocolRuntime,
+)
 from docking.platform.backends.wayland.services import WaylandLayerShellSurfaceService
 from docking.platform.backends.wayland.toplevels import (
     WaylandForeignToplevelWindowService,
@@ -59,22 +58,10 @@ from docking.platform.backends.wayland.workspaces import (
 )
 
 
-@dataclass(frozen=True)
-class WaylandLayerShellRuntimeServices:
-    """Concrete services selected for native Wayland support."""
-
-    windows: WindowService
-    previews: PreviewService
-    surface: WaylandLayerShellSurfaceService
-    visibility: ReducedVisibilityService
-    workspaces: WorkspaceService | None
-    screen_capture: ScreenCaptureService | None
-    idle: IdleService | None
-    protocol_runtime: WaylandProtocolRuntime | None
-
-
-class WaylandLayerShellSessionBackend(SessionBackend):
+class WaylandLayerShellSessionBackend(ComposedWaylandSessionBackend):
     """SessionBackend with native Wayland surface placement and optional windows."""
+
+    protocol_profile: WaylandProtocolProfile = GENERIC_LAYER_SHELL_PROTOCOL_PROFILE
 
     def __init__(
         self,
@@ -91,7 +78,7 @@ class WaylandLayerShellSessionBackend(SessionBackend):
         if runtime is None and (
             foreign_toplevel_protocol is None or workspace_protocol is None
         ):
-            candidate_runtime = WaylandProtocolRuntime()
+            candidate_runtime = WaylandProtocolRuntime(profile=self.protocol_profile)
             if candidate_runtime.start():
                 runtime = candidate_runtime
         foreign_protocol = (
@@ -181,26 +168,24 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             if idle_protocol is not None
             else None
         )
-        self._services = WaylandLayerShellRuntimeServices(
-            windows=windows,
-            previews=previews,
-            surface=WaylandLayerShellSurfaceService(layer_shell=layer_shell),
-            visibility=ReducedVisibilityService(),
-            workspaces=workspaces,
-            screen_capture=screen_capture
-            if screen_capture is not None
-            else load_portal_color_picker(),
-            idle=idle,
-            protocol_runtime=runtime,
+        super().__init__(
+            services=WaylandSessionServices(
+                windows=windows,
+                previews=previews,
+                surface=WaylandLayerShellSurfaceService(layer_shell=layer_shell),
+                visibility=ReducedVisibilityService(),
+                workspaces=workspaces,
+                screen_capture=screen_capture
+                if screen_capture is not None
+                else load_portal_color_picker(),
+                idle=idle,
+                protocol_runtime=runtime,
+            )
         )
 
     @property
     def name(self) -> str:
         return "wayland-layer-shell"
-
-    @property
-    def display_server(self) -> DisplayServer:
-        return DisplayServer.WAYLAND
 
     @property
     def capabilities(self) -> PlatformCapabilities:
@@ -231,65 +216,3 @@ class WaylandLayerShellSessionBackend(SessionBackend):
             supports_input_region=True,
             supports_idle_time=isinstance(self._services.idle, WaylandIdleService),
         )
-
-    @property
-    def windows(self) -> WindowService:
-        return self._services.windows
-
-    @property
-    def surface(self) -> SurfaceService:
-        return self._services.surface
-
-    @property
-    def visibility(self) -> VisibilityService:
-        return self._services.visibility
-
-    @property
-    def previews(self) -> PreviewService:
-        return self._services.previews
-
-    @property
-    def workspaces(self) -> WorkspaceService | None:
-        return self._services.workspaces
-
-    @property
-    def desktop_actions(self) -> DesktopActionService | None:
-        return None
-
-    @property
-    def screen_capture(self) -> ScreenCaptureService | None:
-        return self._services.screen_capture
-
-    @property
-    def idle(self) -> IdleService | None:
-        return self._services.idle
-
-    @property
-    def window_picker(self) -> WindowPickService | None:
-        return None
-
-    def start(self) -> None:
-        self._services.previews.start()
-        self._services.windows.start()
-        self._services.surface.start()
-        self._services.visibility.start()
-        if self._services.workspaces is not None:
-            self._services.workspaces.start()
-        if self._services.screen_capture is not None:
-            self._services.screen_capture.start()
-        if self._services.idle is not None:
-            self._services.idle.start()
-
-    def stop(self) -> None:
-        if self._services.idle is not None:
-            self._services.idle.stop()
-        if self._services.screen_capture is not None:
-            self._services.screen_capture.stop()
-        if self._services.workspaces is not None:
-            self._services.workspaces.stop()
-        self._services.visibility.stop()
-        self._services.surface.stop()
-        self._services.windows.stop()
-        self._services.previews.stop()
-        if self._services.protocol_runtime is not None:
-            self._services.protocol_runtime.stop()

--- a/docking/platform/backends/wayland/treeland_session.py
+++ b/docking/platform/backends/wayland/treeland_session.py
@@ -6,10 +6,9 @@ from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from docking.platform.backends.base import (
-    DesktopActionService,
     PlatformCapabilities,
-    VisibilityService,
 )
+from docking.platform.backends.wayland.runtime import TREELAND_PROTOCOL_PROFILE
 from docking.platform.backends.wayland.session import WaylandLayerShellSessionBackend
 from docking.platform.backends.wayland.treeland import (
     TreelandDesktopActionService,
@@ -25,6 +24,8 @@ if TYPE_CHECKING:
 
 class TreelandSessionBackend(WaylandLayerShellSessionBackend):
     """Decorate the generic backend with overlap and Show Desktop support."""
+
+    protocol_profile = TREELAND_PROTOCOL_PROFILE
 
     def __init__(
         self,
@@ -47,13 +48,18 @@ class TreelandSessionBackend(WaylandLayerShellSessionBackend):
         window_management = (
             runtime.treeland_window_management_protocol if runtime is not None else None
         )
-        self._treeland_visibility = (
+        visibility = (
             TreelandVisibilityService(adapter=overlap) if overlap is not None else None
         )
-        self._treeland_desktop_actions = (
+        desktop_actions = (
             TreelandDesktopActionService(adapter=window_management)
             if window_management is not None
             else None
+        )
+        self._services = replace(
+            self._services,
+            visibility=visibility or self._services.visibility,
+            desktop_actions=desktop_actions,
         )
 
     @property
@@ -65,28 +71,9 @@ class TreelandSessionBackend(WaylandLayerShellSessionBackend):
         base = super().capabilities
         return replace(
             base,
-            supports_show_desktop=self._treeland_desktop_actions is not None,
-            supports_overlap_any=self._treeland_visibility is not None,
+            supports_show_desktop=self._services.desktop_actions is not None,
+            supports_overlap_any=isinstance(
+                self._services.visibility,
+                TreelandVisibilityService,
+            ),
         )
-
-    @property
-    def visibility(self) -> VisibilityService:
-        return self._treeland_visibility or super().visibility
-
-    @property
-    def desktop_actions(self) -> DesktopActionService | None:
-        return self._treeland_desktop_actions
-
-    def start(self) -> None:
-        super().start()
-        if self._treeland_visibility is not None:
-            self._treeland_visibility.start()
-        if self._treeland_desktop_actions is not None:
-            self._treeland_desktop_actions.start()
-
-    def stop(self) -> None:
-        if self._treeland_desktop_actions is not None:
-            self._treeland_desktop_actions.stop()
-        if self._treeland_visibility is not None:
-            self._treeland_visibility.stop()
-        super().stop()

--- a/docking/platform/backends/wayland/wayfire_session.py
+++ b/docking/platform/backends/wayland/wayfire_session.py
@@ -10,18 +10,14 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from docking.platform.backends.base import (
     DesktopActionService,
-    DisplayServer,
     IdleService,
     PlatformCapabilities,
     PreviewService,
     ScreenCaptureService,
-    SessionBackend,
-    SurfaceService,
     VisibilityService,
     WindowPickService,
     WindowService,
@@ -31,11 +27,19 @@ from docking.platform.backends.reduced.services import (
     ReducedVisibilityService,
     ReducedWindowService,
 )
+from docking.platform.backends.wayland.composed_session import (
+    ComposedWaylandSessionBackend,
+    WaylandSessionServices,
+)
+from docking.platform.backends.wayland.idle import WaylandIdleService
 from docking.platform.backends.wayland.portals import (
     WaylandPortalColorPickerService,
     load_portal_color_picker,
 )
-from docking.platform.backends.wayland.runtime import WaylandProtocolRuntime
+from docking.platform.backends.wayland.runtime import (
+    STANDARD_PROTOCOL_PROFILE,
+    WaylandProtocolRuntime,
+)
 from docking.platform.backends.wayland.services import WaylandLayerShellSurfaceService
 from docking.platform.backends.wayland.wayfire_ipc import (
     WayfireDesktopActionService,
@@ -56,22 +60,7 @@ if TYPE_CHECKING:
     from docking.platform.model import DockModel
 
 
-@dataclass(frozen=True)
-class WayfireRuntimeServices:
-    """Concrete services selected for the Wayfire Wayland backend."""
-
-    windows: WindowService
-    previews: PreviewService
-    surface: WaylandLayerShellSurfaceService
-    visibility: VisibilityService
-    workspaces: WorkspaceService | None
-    desktop_actions: DesktopActionService | None
-    screen_capture: ScreenCaptureService | None
-    window_picker: WindowPickService | None
-    protocol_runtime: WaylandProtocolRuntime | None
-
-
-class WayfireSessionBackend(SessionBackend):
+class WayfireSessionBackend(ComposedWaylandSessionBackend):
     """SessionBackend using Wayfire IPC for windows and layer-shell surfaces."""
 
     def __init__(
@@ -92,7 +81,9 @@ class WayfireSessionBackend(SessionBackend):
     ) -> None:
         runtime = protocol_runtime
         if runtime is None:
-            candidate_runtime = WaylandProtocolRuntime()
+            candidate_runtime = WaylandProtocolRuntime(
+                profile=STANDARD_PROTOCOL_PROFILE
+            )
             if candidate_runtime.start():
                 runtime = candidate_runtime
 
@@ -122,28 +113,33 @@ class WayfireSessionBackend(SessionBackend):
             )
 
             previews = ReducedPreviewService()
+        idle_protocol = runtime.idle_protocol if runtime is not None else None
+        idle: IdleService | None = (
+            WaylandIdleService(protocol=idle_protocol)
+            if idle_protocol is not None
+            else None
+        )
 
-        self._services = WayfireRuntimeServices(
-            windows=windows,
-            previews=previews,
-            surface=WaylandLayerShellSurfaceService(layer_shell=layer_shell),
-            visibility=visibility,
-            workspaces=workspaces,
-            desktop_actions=desktop_actions,
-            screen_capture=screen_capture
-            if screen_capture is not None
-            else load_portal_color_picker(),
-            window_picker=picker,
-            protocol_runtime=runtime,
+        super().__init__(
+            services=WaylandSessionServices(
+                windows=windows,
+                previews=previews,
+                surface=WaylandLayerShellSurfaceService(layer_shell=layer_shell),
+                visibility=visibility,
+                workspaces=workspaces,
+                desktop_actions=desktop_actions,
+                screen_capture=screen_capture
+                if screen_capture is not None
+                else load_portal_color_picker(),
+                idle=idle,
+                window_picker=picker,
+                protocol_runtime=runtime,
+            )
         )
 
     @property
     def name(self) -> str:
         return "wayfire"
-
-    @property
-    def display_server(self) -> DisplayServer:
-        return DisplayServer.WAYLAND
 
     @property
     def capabilities(self) -> PlatformCapabilities:
@@ -199,70 +195,5 @@ class WayfireSessionBackend(SessionBackend):
             supports_window_pick=supports_window_pick,
             supports_window_pid=supports_window_pick,
             supports_process_kill=supports_window_pick,
+            supports_idle_time=isinstance(self._services.idle, WaylandIdleService),
         )
-
-    @property
-    def windows(self) -> WindowService:
-        return self._services.windows
-
-    @property
-    def surface(self) -> SurfaceService:
-        return self._services.surface
-
-    @property
-    def visibility(self) -> VisibilityService:
-        return self._services.visibility
-
-    @property
-    def previews(self) -> PreviewService:
-        return self._services.previews
-
-    @property
-    def workspaces(self) -> WorkspaceService | None:
-        return self._services.workspaces
-
-    @property
-    def desktop_actions(self) -> DesktopActionService | None:
-        return self._services.desktop_actions
-
-    @property
-    def screen_capture(self) -> ScreenCaptureService | None:
-        return self._services.screen_capture
-
-    @property
-    def idle(self) -> IdleService | None:
-        return None
-
-    @property
-    def window_picker(self) -> WindowPickService | None:
-        return self._services.window_picker
-
-    def start(self) -> None:
-        self._services.previews.start()
-        self._services.windows.start()
-        self._services.surface.start()
-        self._services.visibility.start()
-        if self._services.workspaces is not None:
-            self._services.workspaces.start()
-        if self._services.desktop_actions is not None:
-            self._services.desktop_actions.start()
-        if self._services.screen_capture is not None:
-            self._services.screen_capture.start()
-        if self._services.window_picker is not None:
-            self._services.window_picker.start()
-
-    def stop(self) -> None:
-        if self._services.window_picker is not None:
-            self._services.window_picker.stop()
-        if self._services.screen_capture is not None:
-            self._services.screen_capture.stop()
-        if self._services.desktop_actions is not None:
-            self._services.desktop_actions.stop()
-        if self._services.workspaces is not None:
-            self._services.workspaces.stop()
-        self._services.visibility.stop()
-        self._services.surface.stop()
-        self._services.windows.stop()
-        self._services.previews.stop()
-        if self._services.protocol_runtime is not None:
-            self._services.protocol_runtime.stop()

--- a/tests/platform/test_cosmic_wayland.py
+++ b/tests/platform/test_cosmic_wayland.py
@@ -134,6 +134,7 @@ def test_cosmic_session_reports_only_delivered_toplevel_capabilities() -> None:
         hyprland_preview_protocol=None,
         foreign_toplevel_protocol=None,
         workspace_protocol=None,
+        idle_protocol=None,
         stop=MagicMock(),
     )
     backend = CosmicSessionBackend(

--- a/tests/platform/test_wayfire_session.py
+++ b/tests/platform/test_wayfire_session.py
@@ -24,7 +24,6 @@ def test_wayfire_session_capabilities_reflect_supported_ipc_surface(monkeypatch)
         "WaylandLayerShellSurfaceService",
         MagicMock(return_value=surface),
     )
-    monkeypatch.setattr(wayfire_session, "WaylandProtocolRuntime", MagicMock())
     monkeypatch.setattr(wayfire_session, "load_portal_color_picker", lambda: None)
     monkeypatch.setattr(
         wayfire_session, "load_wayfire_desktop_action_service", lambda: None
@@ -42,7 +41,7 @@ def test_wayfire_session_capabilities_reflect_supported_ipc_surface(monkeypatch)
         model=MagicMock(),
         launcher=MagicMock(),
         config=MagicMock(),
-        protocol_runtime=None,
+        protocol_runtime=SimpleNamespace(idle_protocol=None, stop=MagicMock()),
         screen_capture=None,
         window_service=windows,
         workspace_service=workspaces,

--- a/tests/platform/test_wayland_composed_session.py
+++ b/tests/platform/test_wayland_composed_session.py
@@ -1,0 +1,72 @@
+"""Tests for shared native Wayland service composition."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from docking.platform.backends.base import PlatformCapabilities
+from docking.platform.backends.wayland.composed_session import (
+    ComposedWaylandSessionBackend,
+    WaylandSessionServices,
+)
+
+
+class _Backend(ComposedWaylandSessionBackend):
+    @property
+    def name(self) -> str:
+        return "test-wayland"
+
+    @property
+    def capabilities(self) -> PlatformCapabilities:
+        return PlatformCapabilities()
+
+
+def test_composed_session_starts_and_stops_services_in_reverse_order() -> None:
+    events: list[str] = []
+
+    def service(name: str) -> MagicMock:
+        value = MagicMock()
+        value.start.side_effect = lambda: events.append(f"start:{name}")
+        value.stop.side_effect = lambda: events.append(f"stop:{name}")
+        return value
+
+    runtime = MagicMock()
+    runtime.stop.side_effect = lambda: events.append("stop:runtime")
+    services = WaylandSessionServices(
+        windows=service("windows"),
+        previews=service("previews"),
+        surface=service("surface"),
+        visibility=service("visibility"),
+        workspaces=service("workspaces"),
+        desktop_actions=service("desktop-actions"),
+        screen_capture=service("screen-capture"),
+        idle=service("idle"),
+        window_picker=service("window-picker"),
+        protocol_runtime=runtime,
+    )
+    backend = _Backend(services=services)
+
+    backend.start()
+    backend.stop()
+
+    assert events == [
+        "start:previews",
+        "start:windows",
+        "start:surface",
+        "start:visibility",
+        "start:workspaces",
+        "start:desktop-actions",
+        "start:screen-capture",
+        "start:idle",
+        "start:window-picker",
+        "stop:window-picker",
+        "stop:idle",
+        "stop:screen-capture",
+        "stop:desktop-actions",
+        "stop:workspaces",
+        "stop:visibility",
+        "stop:surface",
+        "stop:windows",
+        "stop:previews",
+        "stop:runtime",
+    ]

--- a/tests/platform/test_wayland_layer_shell_session.py
+++ b/tests/platform/test_wayland_layer_shell_session.py
@@ -309,6 +309,27 @@ def test_hyprland_session_falls_back_to_reduced_windows_when_ipc_unavailable(
     assert backend.capabilities.supports_layer_shell is True
 
 
+def test_hyprland_session_uses_generic_idle_protocol() -> None:
+    idle_protocol = MagicMock()
+    runtime = _empty_runtime()
+    runtime.idle_protocol = idle_protocol
+    backend = HyprlandSessionBackend(
+        layer_shell=_layer_shell(),
+        model=SimpleNamespace(),
+        launcher=SimpleNamespace(),
+        protocol_runtime=runtime,
+        window_service=ReducedWindowService(),
+    )
+
+    assert isinstance(backend.idle, WaylandIdleService)
+    assert backend.capabilities.supports_idle_time is True
+
+    backend.start()
+    idle_protocol.start.assert_called_once_with(backend.idle)
+    backend.stop()
+    idle_protocol.stop.assert_called_once_with()
+
+
 def test_wayland_layer_shell_session_lifecycle_is_safe():
     backend = WaylandLayerShellSessionBackend(
         layer_shell=_layer_shell(),

--- a/tests/platform/test_wayland_protocol_runtime.py
+++ b/tests/platform/test_wayland_protocol_runtime.py
@@ -39,6 +39,8 @@ from docking.platform.backends.wayland.protocols.wlr_foreign_toplevel_management
     ZwlrForeignToplevelManagerV1,
 )
 from docking.platform.backends.wayland.runtime import (
+    HYPRLAND_PROTOCOL_PROFILE,
+    TREELAND_PROTOCOL_PROFILE,
     ForeignToplevelProtocolAdapter,
     IdleProtocolAdapter,
     PhocPreviewProtocolAdapter,
@@ -209,7 +211,6 @@ def test_wayland_protocol_runtime_binds_known_globals_and_installs_watch():
         (11, ExtWorkspaceManagerV1, ExtWorkspaceManagerV1.version),
         (12, WlSeat, WlSeat.version),
         (12, WlSeat, WlSeat.version),
-        (12, WlSeat, WlSeat.version),
     ]
     assert glib.watch is not None
 
@@ -238,7 +239,6 @@ def test_wayland_protocol_runtime_binds_preview_protocol_set():
     assert runtime.preview_protocol is runtime.previews
     assert registry.bound == [
         (20, ExtForeignToplevelListV1, ExtForeignToplevelListV1.version),
-        (20, ExtForeignToplevelListV1, ExtForeignToplevelListV1.version),
         (
             21,
             ExtForeignToplevelImageCaptureSourceManagerV1,
@@ -247,13 +247,15 @@ def test_wayland_protocol_runtime_binds_preview_protocol_set():
         (22, ExtImageCopyCaptureManagerV1, ExtImageCopyCaptureManagerV1.version),
         (23, WlShm, WlShm.version),
         (23, WlShm, WlShm.version),
-        (23, WlShm, WlShm.version),
     ]
 
 
 def test_wayland_protocol_runtime_binds_hyprland_preview_protocol():
     glib = FakeGLib()
-    runtime = WaylandProtocolRuntime(factories=_factories(glib))
+    runtime = WaylandProtocolRuntime(
+        factories=_factories(glib),
+        profile=HYPRLAND_PROTOCOL_PROFILE,
+    )
 
     assert runtime.start() is True
     registry = FakeDisplay.registry
@@ -272,7 +274,6 @@ def test_wayland_protocol_runtime_binds_hyprland_preview_protocol():
             HyprlandToplevelExportManagerV1,
             HyprlandToplevelExportManagerV1.version,
         ),
-        (31, WlShm, WlShm.version),
         (31, WlShm, WlShm.version),
         (31, WlShm, WlShm.version),
     ]
@@ -318,13 +319,15 @@ def test_wayland_protocol_runtime_binds_idle_protocol():
         (40, ExtIdleNotifierV1, ExtIdleNotifierV1.version),
         (41, WlSeat, WlSeat.version),
         (41, WlSeat, WlSeat.version),
-        (41, WlSeat, WlSeat.version),
     ]
 
 
 def test_wayland_protocol_runtime_binds_treeland_extensions_and_outputs():
     glib = FakeGLib()
-    runtime = WaylandProtocolRuntime(factories=_factories(glib))
+    runtime = WaylandProtocolRuntime(
+        factories=_factories(glib),
+        profile=TREELAND_PROTOCOL_PROFILE,
+    )
 
     assert runtime.start() is True
     registry = FakeDisplay.registry
@@ -363,6 +366,36 @@ def test_wayland_protocol_runtime_binds_treeland_extensions_and_outputs():
 
     registry.dispatcher["global_remove"](registry, 52)
     assert runtime.treeland_overlap._outputs == []
+
+
+def test_wayland_protocol_runtime_stops_when_manager_global_is_removed() -> None:
+    glib = FakeGLib()
+    runtime = WaylandProtocolRuntime(factories=_factories(glib))
+    assert runtime.start() is True
+    registry = FakeDisplay.registry
+    registry.dispatcher["global"](
+        registry,
+        60,
+        "zwlr_foreign_toplevel_manager_v1",
+        99,
+    )
+
+    registry.dispatcher["global_remove"](registry, 60)
+
+    assert glib.removed == [77]
+    assert runtime.foreign_toplevel_protocol is None
+
+
+def test_wayland_protocol_runtime_ignores_unowned_global_removal() -> None:
+    glib = FakeGLib()
+    runtime = WaylandProtocolRuntime(factories=_factories(glib))
+    assert runtime.start() is True
+    registry = FakeDisplay.registry
+    registry.dispatcher["global"](registry, 61, "unrelated_protocol_v1", 1)
+
+    registry.dispatcher["global_remove"](registry, 61)
+
+    assert glib.removed == []
 
 
 def test_wayland_protocol_runtime_fd_read_receives_initial_workspaces():


### PR DESCRIPTION
## Summary

- add one shared service container and lifecycle for native Wayland sessions
- remove repeated service properties and start/stop implementations
- compose Treeland and Cinnamon replacements through the shared container
- enable advertised standard idle support consistently on COSMIC, Hyprland, Niri, and Wayfire
- activate compositor-specific protocol adapters only for the selected backend
- fail closed when an owned Wayland global disappears

## Stack

Depends on #293.

## Validation

- Ruff check and format check
- Vulture
- 635 platform tests passed, 1 skipped