### PR TITLE
Add executable-aware runtime application identity

### DIFF
--- a/docking/core/items.py
+++ b/docking/core/items.py
@@ -53,6 +53,10 @@ class DockItem:
     name: str = ""
     icon_name: str = "application-x-executable"
     wm_class: str = ""
+    # Original desktop Exec line retained for executable-aware window matching.
+    exec_line: str = ""
+    # Direct executable backing a runtime-only transient item.
+    runtime_executable: str = ""
     is_pinned: bool = False
     is_running: bool = False
     is_active: bool = False

--- a/docking/platform/app_matcher.py
+++ b/docking/platform/app_matcher.py
@@ -45,7 +45,7 @@ extract identity strings from their display server and pass them here
 as plain strings.  The matcher owns the heuristics; backends own only
 the display-server extraction.
 
-The public interface has one constructor flag plus two methods:
+The public interface has one constructor flag plus three methods:
 
 ``sync_visible_items(items)``
     Rebuild the fast-path alias cache from the current dock model.
@@ -59,6 +59,10 @@ The public interface has one constructor flag plus two methods:
 
 ``match(...)``
     Map a runtime window identity to a Docking desktop ID.
+
+``match_result(...)``
+    Return the same match plus runtime-only executable metadata when a
+    verified path collision must remain separate from an installed launcher.
 
     ``app_id`` is the primary identity from the display server:
 
@@ -83,22 +87,36 @@ The public interface has one constructor flag plus two methods:
     each increasingly broad candidate can still check its exact alias
     before falling back to the next broader direct desktop ID.
 
+    ``process_id`` is optional. When a backend supplies it, exact Docking
+    launch provenance and canonical process/desktop Exec paths refine the
+    family-level app-ID and WM_CLASS evidence. Missing or inaccessible process
+    metadata leaves the historical matching order unchanged.
+
 Matching priority (strongest first)
 ------------------------------------
 
-1. **Wine detection** - when ``app_id`` is the generic ``"wine"``
+1. **Exact Docking launch provenance** - a process started by Docking keeps
+   its desktop ID even when a shell wrapper replaces itself with another
+   executable.
+
+2. **Verified executable evidence** - among launchers sharing an alias, an
+   exact canonical Exec path wins. Different native binaries with the same
+   basename, and wrapper/native launchers in distinct sibling app bundles,
+   become path-derived runtime items rather than being folded together.
+
+3. **Wine detection** - when ``app_id`` is the generic ``"wine"``
    class group and ``instance_hint`` contains a ``.exe`` path, extract
    the executable name and match against visible aliases and the
    launcher WM_CLASS index.
 
-2. **Visible-item alias cache** - fast-path lookup against currently
+4. **Visible-item alias cache** - fast-path lookup against currently
    pinned and transient dock items (no Gio or filesystem calls).
 
-3. **Instance-hint match** - when ``app_id`` is generic but
+5. **Instance-hint match** - when ``app_id`` is generic but
    ``instance_hint`` is specific and matches a visible item
    (X11 optimization).
 
-4. **Candidate generation + resolution** - for each generated
+6. **Candidate generation + resolution** - for each generated
    candidate string:
 
    a. Check visible aliases (normalized).
@@ -132,9 +150,15 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+from docking.platform import desktop_entries
 from docking.platform.launcher import DESKTOP_SUFFIX, GNOME_APP_PREFIX
+from docking.platform.process_identity import ProcessIdentity, identity_for_pid
+from docking.platform.running import RuntimeAppIdentity
 
 if TYPE_CHECKING:
     from docking.core.items import DockItem
@@ -225,6 +249,117 @@ def _wine_aliases_from_instance(instance: str) -> list[str]:
     return list(dict.fromkeys(aliases))
 
 
+@dataclass(frozen=True)
+class AppMatch:
+    """Structured match result, including optional runtime-only metadata."""
+
+    desktop_id: str
+    runtime_app: RuntimeAppIdentity | None = None
+
+
+@dataclass(frozen=True)
+class _VisibleAppIdentity:
+    desktop_id: str
+    name: str
+    icon_name: str
+    wm_class: str
+    executable_path: Path | None
+
+
+_SCRIPT_LAUNCHER_SUFFIXES = frozenset({".bash", ".sh", ".zsh"})
+_GENERIC_BUNDLE_ROOTS = frozenset(
+    {
+        Path("/"),
+        Path("/bin"),
+        Path("/opt"),
+        Path("/sbin"),
+        Path("/usr"),
+        Path("/usr/local"),
+    }
+)
+
+
+def _executable_paths_conflict(
+    launcher_path: Path | None,
+    runtime_path: Path | None,
+) -> bool:
+    """Return whether two directly comparable executable paths disagree."""
+    if launcher_path is None or runtime_path is None or launcher_path == runtime_path:
+        return False
+    if (
+        launcher_path.name.casefold() == runtime_path.name.casefold()
+        and _is_native_executable(launcher_path)
+        and _is_native_executable(runtime_path)
+    ):
+        return True
+    return _sibling_bundle_launchers_conflict(launcher_path, runtime_path)
+
+
+def _sibling_bundle_launchers_conflict(
+    launcher_path: Path,
+    runtime_path: Path,
+) -> bool:
+    """Detect a wrapper/native pair from different sibling app bundles.
+
+    For example, ``tool-v1/bin/tool.sh`` and ``tool-v2/bin/tool`` are strong
+    evidence for separate installations. Restricting this to non-system sibling
+    roots avoids treating ordinary wrappers such as ``/usr/bin/tool`` as a
+    different application from the binary they eventually execute.
+    """
+    if launcher_path.suffix.casefold() not in _SCRIPT_LAUNCHER_SUFFIXES:
+        return False
+    launcher_name = launcher_path.stem.casefold()
+    if launcher_name != runtime_path.name.casefold():
+        return False
+    launcher_root = _specific_bundle_root(launcher_path)
+    runtime_root = _specific_bundle_root(runtime_path)
+    return bool(
+        launcher_root is not None
+        and runtime_root is not None
+        and launcher_root != runtime_root
+        and launcher_root.parent == runtime_root.parent
+        and _is_native_executable(runtime_path)
+    )
+
+
+def _specific_bundle_root(path: Path) -> Path | None:
+    """Return a non-system application root for ``root/bin/executable``."""
+    if path.parent.name not in {"bin", "sbin"}:
+        return None
+    root = path.parent.parent
+    if root in _GENERIC_BUNDLE_ROOTS:
+        return None
+    # ``~/bin`` is a command collection, not a single application bundle.
+    if len(root.parts) == 3 and root.parts[1] == "home":
+        return None
+    return root
+
+
+@lru_cache(maxsize=512)
+def _is_native_executable(path: Path) -> bool:
+    """Return whether *path* has the Linux ELF executable signature."""
+    try:
+        with path.open("rb") as handle:
+            return handle.read(4) == b"\x7fELF"
+    except OSError:
+        return False
+
+
+def _launcher_path_compatibility(
+    launcher_path: Path | None,
+    runtime_path: Path | None,
+) -> int:
+    """Score a launcher that can legitimately become another executable.
+
+    A script can ``exec`` an interpreter or bundled runtime, so a differing
+    process path does not disqualify it. A native launcher receives no such
+    preference because its process path should normally remain directly useful.
+    """
+    if launcher_path is None or runtime_path is None:
+        return 0
+    return 1 if not _is_native_executable(launcher_path) else 0
+
+
 class AppIdMatcher:
     """Shared window → desktop ID matching for all display-server backends.
 
@@ -242,7 +377,7 @@ class AppIdMatcher:
     ) -> None:
         self._launcher = launcher
         self._cache_missed_desktop_ids = cache_missed_desktop_ids
-        self._visible_aliases: dict[str, str] = {}  # normalized → desktop_id
+        self._visible_aliases: dict[str, list[_VisibleAppIdentity]] = {}
         self._missed_candidates: set[str] = set()
 
     def sync_visible_items(self, items: Iterable[DockItem]) -> None:
@@ -256,6 +391,15 @@ class AppIdMatcher:
         """
         self._visible_aliases.clear()
         for item in items:
+            identity = _VisibleAppIdentity(
+                desktop_id=item.desktop_id,
+                name=getattr(item, "name", "") or item.desktop_id,
+                icon_name=getattr(item, "icon_name", "") or "",
+                wm_class=getattr(item, "wm_class", "") or "",
+                executable_path=desktop_entries.executable_path_from_exec_line(
+                    getattr(item, "exec_line", "") or ""
+                ),
+            )
             aliases = {
                 item.desktop_id,
                 item.desktop_id.removesuffix(DESKTOP_SUFFIX),
@@ -264,7 +408,13 @@ class AppIdMatcher:
             for alias in aliases:
                 normalized = _normalize_alias(alias)
                 if normalized:
-                    self._visible_aliases[normalized] = item.desktop_id
+                    matches = self._visible_aliases.setdefault(normalized, [])
+                    matches[:] = [
+                        match
+                        for match in matches
+                        if match.desktop_id != identity.desktop_id
+                    ]
+                    matches.append(identity)
 
     def match(
         self,
@@ -273,27 +423,36 @@ class AppIdMatcher:
         instance_hint: str | None = None,
         prefer_raw_app_id: bool = True,
         defer_wm_class_lookup: bool = False,
+        process_id: int | None = None,
     ) -> str | None:
-        """Map a runtime window identity to a Docking desktop ID.
+        """Map a runtime window identity to a Docking desktop ID."""
+        result = self.match_result(
+            app_id,
+            instance_hint=instance_hint,
+            prefer_raw_app_id=prefer_raw_app_id,
+            defer_wm_class_lookup=defer_wm_class_lookup,
+            process_id=process_id,
+        )
+        return result.desktop_id if result is not None else None
 
-        Args:
-            app_id: Primary identity from the display server.
-            instance_hint: Secondary identity when the display server
-                provides a split identity model (currently only X11).
-            prefer_raw_app_id: Whether raw compositor-style IDs should
-                be tried before lowercase/X11-derived candidates.
-            defer_wm_class_lookup: Whether to try all direct desktop ID
-                candidates before consulting the launcher WM_CLASS index.
-
-        Returns:
-            The matching desktop ID (e.g. ``"firefox.desktop"``), or
-            ``None`` when no match could be found.
-        """
+    def match_result(
+        self,
+        app_id: str,
+        *,
+        instance_hint: str | None = None,
+        prefer_raw_app_id: bool = True,
+        defer_wm_class_lookup: bool = False,
+        process_id: int | None = None,
+    ) -> AppMatch | None:
+        """Return a structured match using process evidence when available."""
         app_id = app_id.strip()
         if not app_id:
             return None
 
         app_id_lower = app_id.lower().strip()
+        process = identity_for_pid(process_id)
+        if process is not None and process.launch is not None:
+            return AppMatch(process.launch.desktop_id)
 
         # 1. Wine detection - when the primary identity is the generic
         #    "wine" class group, use the instance (exe path) instead.
@@ -303,21 +462,27 @@ class AppIdMatcher:
                 instance_hint=instance_hint,
             )
             if result:
-                return result
+                return AppMatch(result)
 
         # 2. Visible-item alias cache (fast path, no Gio calls).
-        result = self._visible_aliases.get(_normalize_alias(app_id_lower))
-        if result:
+        result = self._match_visible_alias(
+            app_id_lower,
+            process=process,
+            runtime_wm_class=app_id,
+        )
+        if result is not None:
             return result
 
         # 3. Instance hint against visible aliases (X11 optimization:
         #    when class_group is generic but class_instance is specific
         #    and matches a pinned item).
         if instance_hint:
-            result = self._visible_aliases.get(
-                _normalize_alias(instance_hint.lower().strip())
+            result = self._match_visible_alias(
+                instance_hint,
+                process=process,
+                runtime_wm_class=app_id,
             )
-            if result:
+            if result is not None:
                 return result
 
         # 4. Candidate generation + resolution.
@@ -329,8 +494,12 @@ class AppIdMatcher:
         )
         for candidate in candidates:
             # 4a. Visible aliases (normalized).
-            result = self._visible_aliases.get(_normalize_alias(candidate))
-            if result:
+            result = self._match_visible_alias(
+                candidate,
+                process=process,
+                runtime_wm_class=app_id,
+            )
+            if result is not None:
                 return result
 
             # 4b. Direct desktop ID resolution (with missed-candidate
@@ -341,7 +510,11 @@ class AppIdMatcher:
             ):
                 info = self._launcher.resolve(desktop_id, log_failures=False)
                 if info is not None:
-                    return info.desktop_id
+                    return self._match_desktop_infos(
+                        (info,),
+                        process=process,
+                        runtime_wm_class=app_id,
+                    )
                 if self._cache_missed_desktop_ids:
                     self._missed_candidates.add(desktop_id)
 
@@ -349,17 +522,163 @@ class AppIdMatcher:
                 continue
 
             # 4c. WM_CLASS index lookup (lazy-built once, then dict).
-            info = self._launcher.resolve_by_wm_class(candidate)
-            if info is not None:
-                return info.desktop_id
+            result = self._match_desktop_infos(
+                self._desktop_infos_for_alias(candidate),
+                process=process,
+                runtime_wm_class=app_id,
+            )
+            if result is not None:
+                return result
 
         if defer_wm_class_lookup:
             for candidate in candidates:
-                info = self._launcher.resolve_by_wm_class(candidate)
-                if info is not None:
-                    return info.desktop_id
+                result = self._match_desktop_infos(
+                    self._desktop_infos_for_alias(candidate),
+                    process=process,
+                    runtime_wm_class=app_id,
+                )
+                if result is not None:
+                    return result
 
         return None
+
+    def _match_visible_alias(
+        self,
+        alias: str,
+        *,
+        process: ProcessIdentity | None,
+        runtime_wm_class: str,
+    ) -> AppMatch | None:
+        matches = self._visible_aliases.get(_normalize_alias(alias), ())
+        if not matches:
+            return None
+        executable_path = process.executable_path if process is not None else None
+        if executable_path is not None:
+            # Full-path agreement is stronger than the shared WM_CLASS/app ID
+            # and disambiguates multiple visible versions deterministically.
+            exact = next(
+                (
+                    match
+                    for match in reversed(matches)
+                    if match.executable_path == executable_path
+                ),
+                None,
+            )
+            if exact is not None:
+                return AppMatch(exact.desktop_id)
+        # If no exact path exists, prefer a wrapper that could legitimately
+        # have replaced itself with the observed interpreter/runtime. Equal
+        # scores retain the pre-existing last-visible-item behavior.
+        selected = max(
+            enumerate(matches),
+            key=lambda indexed: (
+                _launcher_path_compatibility(
+                    indexed[1].executable_path,
+                    executable_path,
+                ),
+                indexed[0],  # Preserve the historical last-visible-item tie-break.
+            ),
+        )[1]
+        if _executable_paths_conflict(selected.executable_path, executable_path):
+            assert executable_path is not None
+            # Do not attach a verified different installation to the selected
+            # family launcher. A stable path-derived ID creates a transient item
+            # that can later become a generated desktop launcher when pinned.
+            return self._runtime_match(
+                executable_path=executable_path,
+                name=selected.name,
+                icon_name=selected.icon_name,
+                wm_class=runtime_wm_class or selected.wm_class,
+            )
+        return AppMatch(selected.desktop_id)
+
+    def _match_desktop_infos(
+        self,
+        infos: Iterable[object],
+        *,
+        process: ProcessIdentity | None,
+        runtime_wm_class: str,
+    ) -> AppMatch | None:
+        candidates = [
+            info for info in infos if isinstance(getattr(info, "desktop_id", None), str)
+        ]
+        if not candidates:
+            return None
+        executable_path = process.executable_path if process is not None else None
+        if executable_path is not None:
+            # The install-wide alias index can contain several desktop files
+            # with the same StartupWMClass; exact Exec agreement wins.
+            exact = next(
+                (
+                    info
+                    for info in candidates
+                    if desktop_entries.executable_path_from_exec_line(
+                        getattr(info, "exec_line", "") or ""
+                    )
+                    == executable_path
+                ),
+                None,
+            )
+            if exact is not None:
+                return AppMatch(exact.desktop_id)
+        # Installed aliases historically selected the first indexed entry. Keep
+        # that tie-break while allowing wrapper compatibility to refine it.
+        selected = max(
+            enumerate(candidates),
+            key=lambda indexed: (
+                _launcher_path_compatibility(
+                    desktop_entries.executable_path_from_exec_line(
+                        getattr(indexed[1], "exec_line", "") or ""
+                    ),
+                    executable_path,
+                ),
+                -indexed[0],  # Preserve the install-index first-winner tie-break.
+            ),
+        )[1]
+        selected_path = desktop_entries.executable_path_from_exec_line(
+            getattr(selected, "exec_line", "") or ""
+        )
+        if _executable_paths_conflict(selected_path, executable_path):
+            assert executable_path is not None
+            return self._runtime_match(
+                executable_path=executable_path,
+                name=getattr(selected, "name", "") or selected.desktop_id,
+                icon_name=getattr(selected, "icon_name", "") or "",
+                wm_class=runtime_wm_class or (getattr(selected, "wm_class", "") or ""),
+            )
+        return AppMatch(selected.desktop_id)
+
+    def _desktop_infos_for_alias(self, alias: str) -> tuple[object, ...]:
+        resolve_all = getattr(self._launcher, "resolve_all_by_wm_class", None)
+        if callable(resolve_all):
+            infos = resolve_all(alias)
+            if isinstance(infos, (list, tuple)):
+                return tuple(infos)
+        info = self._launcher.resolve_by_wm_class(alias)
+        return (info,) if info is not None else ()
+
+    @staticmethod
+    def _runtime_match(
+        *,
+        executable_path: Path,
+        name: str,
+        icon_name: str,
+        wm_class: str,
+    ) -> AppMatch:
+        # Reuse the same deterministic ID as drag-to-pin generation. This keeps
+        # the transient stable across scans and avoids an identity change when
+        # the user later chooses "Keep in Dock".
+        desktop_id = desktop_entries.generated_desktop_id_for_path(executable_path)
+        return AppMatch(
+            desktop_id=desktop_id,
+            runtime_app=RuntimeAppIdentity(
+                desktop_id=desktop_id,
+                executable_path=str(executable_path),
+                name=name or executable_path.stem or executable_path.name,
+                icon_name=icon_name,
+                wm_class=wm_class,
+            ),
+        )
 
     def _match_wine_instance(
         self, *, app_id_lower: str, instance_hint: str
@@ -377,9 +696,9 @@ class AppIdMatcher:
             return None
         for alias in _wine_aliases_from_instance(instance_hint):
             # Visible aliases (covers pinned Wine launcher items).
-            desktop_id = self._visible_aliases.get(_normalize_alias(alias))
-            if desktop_id:
-                return desktop_id
+            matches = self._visible_aliases.get(_normalize_alias(alias), ())
+            if matches:
+                return matches[-1].desktop_id
             # Launcher WM_CLASS index.
             info = self._launcher.resolve_by_wm_class(alias)
             if info is not None:

--- a/docking/platform/backends/cinnamon/muffin.py
+++ b/docking/platform/backends/cinnamon/muffin.py
@@ -21,7 +21,11 @@ from docking.platform.backends.base import (
     WindowService,
     WindowSnapshot,
 )
-from docking.platform.running import RunningAppInfo, RunningWindowInfo
+from docking.platform.running import (
+    RunningAppInfo,
+    RunningWindowInfo,
+    RuntimeAppIdentity,
+)
 
 if TYPE_CHECKING:
     from docking.platform.launcher import Launcher
@@ -90,6 +94,8 @@ class _MuffinWindow:
     urgent: bool
     geometry: Rect | None
     workspace_id: str | None
+    pid: int | None
+    runtime_app: RuntimeAppIdentity | None
 
     @property
     def window_id(self) -> WindowId:
@@ -198,14 +204,19 @@ class MuffinWindowService(WindowService):
             )
         )
         app_id = identities[0] if identities else ""
-        desktop_id = next(
-            (
-                matched
-                for identity in identities
-                if (matched := self._matcher.match(identity)) is not None
-            ),
-            None,
-        )
+        pid = _int(row, "pid")
+        if pid is not None and pid <= 0:
+            pid = None
+        match = None
+        desktop_id = None
+        for identity in identities:
+            if pid is None:
+                desktop_id = self._matcher.match(identity)
+            else:
+                match = self._matcher.match_result(identity, process_id=pid)
+                desktop_id = match.desktop_id if match is not None else None
+            if desktop_id is not None:
+                break
         return _MuffinWindow(
             muffin_id=muffin_id,
             title=_text(row, "title") or "Window",
@@ -219,6 +230,8 @@ class MuffinWindowService(WindowService):
                 if (workspace := _int(row, "workspace")) is not None
                 else None
             ),
+            pid=pid,
+            runtime_app=match.runtime_app if match is not None else None,
         )
 
     def _publish_running(self) -> None:
@@ -234,6 +247,7 @@ class MuffinWindowService(WindowService):
                     active=window.active,
                     urgent=window.urgent,
                     window=window.muffin_id,
+                    runtime_app=window.runtime_app,
                 )
             )
         self._model.update_running(

--- a/docking/platform/backends/gnome/bridge.py
+++ b/docking/platform/backends/gnome/bridge.py
@@ -49,7 +49,11 @@ from docking.platform.backends.base import (
     WorkspaceService,
     WorkspaceSnapshot,
 )
-from docking.platform.running import RunningAppInfo, RunningWindowInfo
+from docking.platform.running import (
+    RunningAppInfo,
+    RunningWindowInfo,
+    RuntimeAppIdentity,
+)
 
 if TYPE_CHECKING:
     from docking.platform.launcher import Launcher
@@ -232,6 +236,8 @@ class _BridgeWindow:
     monitor: int | None
     workspace_id: str | None
     geometry: Rect | None
+    pid: int | None
+    runtime_app: RuntimeAppIdentity | None
 
     @property
     def window_id(self) -> WindowId:
@@ -368,7 +374,11 @@ class GnomeShellBridgeWindowService(WindowService):
         if bridge_id is None:
             return None
         app_id = _str_from_row(row, "app-id")
-        desktop_id = self._matcher.match(app_id) if app_id else None
+        pid = _int_from_row(row, "pid")
+        if pid is not None and pid <= 0:
+            pid = None
+        match = self._matcher.match_result(app_id, process_id=pid) if app_id else None
+        desktop_id = match.desktop_id if match is not None else None
         geometry = _rect_from_row(row)
         return _BridgeWindow(
             bridge_id=bridge_id,
@@ -382,6 +392,8 @@ class GnomeShellBridgeWindowService(WindowService):
             monitor=_int_from_row(row, "monitor"),
             workspace_id=_workspace_id_from_row(row),
             geometry=geometry,
+            pid=pid,
+            runtime_app=match.runtime_app if match is not None else None,
         )
 
     def _publish_running(self) -> None:
@@ -397,6 +409,7 @@ class GnomeShellBridgeWindowService(WindowService):
                     active=window.active,
                     urgent=False,
                     window=window.bridge_id,
+                    runtime_app=window.runtime_app,
                 )
             )
         self._model.update_running(

--- a/docking/platform/backends/gnome/extension/extension.js
+++ b/docking/platform/backends/gnome/extension/extension.js
@@ -378,6 +378,7 @@ export default class DockingBridgeExtension extends Extension {
         "id": id,
         "title": window.get_title() || "Window",
         "app-id": this._appIdFor(app, window),
+        "pid": window.get_pid ? window.get_pid() : 0,
         "active": global.display.focus_window === window,
         "minimized": Boolean(window.minimized),
         "maximized": this._isMaximized(window),

--- a/docking/platform/backends/kwin/atspi_window.py
+++ b/docking/platform/backends/kwin/atspi_window.py
@@ -45,7 +45,11 @@ from docking.platform.backends.base import (
     WindowService,
     WindowSnapshot,
 )
-from docking.platform.running import RunningAppInfo, RunningWindowInfo
+from docking.platform.running import (
+    RunningAppInfo,
+    RunningWindowInfo,
+    RuntimeAppIdentity,
+)
 
 if TYPE_CHECKING:
     from docking.platform.launcher import Launcher
@@ -337,21 +341,27 @@ class AtspiWindowService(WindowService):
             matcher.sync_visible_items(model.visible_items())
 
         # Group windows by resolved desktop_id
-        by_desktop: dict[str, list[_AtspiWindow]] = {}
+        by_desktop: dict[
+            str,
+            list[tuple[_AtspiWindow, RuntimeAppIdentity | None]],
+        ] = {}
         with self._lock:
             for w in self._windows.values():
-                desktop_id = None
+                match = None
                 if w.app_name:
-                    desktop_id = matcher.match(w.app_name)
+                    match = matcher.match_result(w.app_name, process_id=w.pid)
+                desktop_id = match.desktop_id if match is not None else None
                 if not desktop_id:
                     desktop_id = f"kwin:{w.app_name or w.window_id.value}"
-                by_desktop.setdefault(desktop_id, []).append(w)
+                by_desktop.setdefault(desktop_id, []).append(
+                    (w, match.runtime_app if match is not None else None)
+                )
 
         # Build RunningAppInfo per desktop_id
         running: dict[str, RunningAppInfo] = {}
         for desktop_id, windows in by_desktop.items():
             rwis = []
-            for w in windows:
+            for w, runtime_app in windows:
                 rwis.append(
                     RunningWindowInfo(
                         desktop_id=desktop_id,
@@ -360,6 +370,7 @@ class AtspiWindowService(WindowService):
                         active=w.active,
                         urgent=False,
                         window=None,
+                        runtime_app=runtime_app,
                     )
                 )
             running[desktop_id] = RunningAppInfo.from_windows(rwis)
@@ -623,7 +634,10 @@ class AtspiWindowService(WindowService):
         # app_name with a kwin: prefix so the UI can still show something.
         desktop_id = None
         if w.app_name:
-            desktop_id = self._matcher.match(w.app_name)
+            desktop_id = self._matcher.match(
+                w.app_name,
+                process_id=w.pid,
+            )
         if not desktop_id:
             desktop_id = f"kwin:{w.app_name or w.window_id.value}"
 

--- a/docking/platform/backends/wayland/hyprland_ipc.py
+++ b/docking/platform/backends/wayland/hyprland_ipc.py
@@ -36,7 +36,11 @@ from docking.platform.backends.base import (
     WindowService,
     WindowSnapshot,
 )
-from docking.platform.running import RunningAppInfo, RunningWindowInfo
+from docking.platform.running import (
+    RunningAppInfo,
+    RunningWindowInfo,
+    RuntimeAppIdentity,
+)
 
 log = get_logger(name="hyprland_ipc")
 
@@ -93,6 +97,8 @@ class HyprlandWindowRecord:
     pinned: bool | None
     geometry: Rect | None
     workspace_id: str | None
+    pid: int | None
+    runtime_app: RuntimeAppIdentity | None
 
     @property
     def window_id(self) -> WindowId:
@@ -400,6 +406,7 @@ class HyprlandWindowService(WindowService):
                     active=record.active,
                     urgent=record.urgent,
                     window=record.address,
+                    runtime_app=record.runtime_app,
                 )
             )
         self._model.update_running(
@@ -521,7 +528,9 @@ def _record_from_client(
         or _mapping_value(item, "initialClass", "")
         or ""
     ).strip()
-    desktop_id = matcher.match(app_id) if app_id else None
+    pid = _optional_int(_mapping_value(item, "pid", None))
+    match = matcher.match_result(app_id, process_id=pid) if app_id else None
+    desktop_id = match.desktop_id if match is not None else None
     workspace = _mapping_value(item, "workspace", {})
     workspace_id = None
     if isinstance(workspace, Mapping):
@@ -540,6 +549,8 @@ def _record_from_client(
         pinned=_optional_bool(_mapping_value(item, "pinned", None)),
         geometry=geometry,
         workspace_id=workspace_id,
+        pid=pid,
+        runtime_app=match.runtime_app if match is not None else None,
     )
 
 
@@ -587,6 +598,21 @@ def _optional_bool(value: object) -> bool | None:
     if isinstance(value, int):
         return bool(value)
     return None
+
+
+def _optional_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = int(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    return parsed if parsed > 0 else None
 
 
 def _window_address(window_id: WindowId) -> str | None:

--- a/docking/platform/backends/wayland/niri_ipc.py
+++ b/docking/platform/backends/wayland/niri_ipc.py
@@ -53,7 +53,11 @@ from docking.platform.backends.base import (
     WorkspaceService,
     WorkspaceSnapshot,
 )
-from docking.platform.running import RunningAppInfo, RunningWindowInfo
+from docking.platform.running import (
+    RunningAppInfo,
+    RunningWindowInfo,
+    RuntimeAppIdentity,
+)
 
 log = get_logger(name="niri_ipc")
 
@@ -105,6 +109,8 @@ class NiriWindowRecord:
     urgent: bool
     workspace_id: int | None
     geometry: Rect | None
+    pid: int | None
+    runtime_app: RuntimeAppIdentity | None
 
     @property
     def window_id(self) -> WindowId:
@@ -510,6 +516,8 @@ class NiriWindowService(WindowService):
                     urgent=record.urgent,
                     workspace_id=record.workspace_id,
                     geometry=record.geometry,
+                    pid=record.pid,
+                    runtime_app=record.runtime_app,
                 )
 
     def _apply_urgency_change(self, data: Mapping[str, JsonValue]) -> None:
@@ -529,6 +537,8 @@ class NiriWindowService(WindowService):
             urgent=urgent,
             workspace_id=record.workspace_id,
             geometry=record.geometry,
+            pid=record.pid,
+            runtime_app=record.runtime_app,
         )
 
     def _publish_running(self) -> None:
@@ -544,6 +554,7 @@ class NiriWindowService(WindowService):
                     active=record.active,
                     urgent=record.urgent,
                     window=str(record.id),
+                    runtime_app=record.runtime_app,
                 )
             )
         self._model.update_running(
@@ -1073,7 +1084,16 @@ def _record_from_window(
     if not isinstance(window_id, int):
         return None
     app_id = str(item.get("app_id") or "").strip()
-    desktop_id = matcher.match(app_id) if app_id else None
+    pid_value = item.get("pid")
+    pid = (
+        pid_value
+        if isinstance(pid_value, int)
+        and not isinstance(pid_value, bool)
+        and pid_value > 0
+        else None
+    )
+    match = matcher.match_result(app_id, process_id=pid) if app_id else None
+    desktop_id = match.desktop_id if match is not None else None
     workspace_id = item.get("workspace_id")
     if not isinstance(workspace_id, int):
         workspace_id = None
@@ -1087,6 +1107,8 @@ def _record_from_window(
         urgent=bool(item.get("is_urgent", False)),
         workspace_id=workspace_id,
         geometry=geometry,
+        pid=pid,
+        runtime_app=match.runtime_app if match is not None else None,
     )
 
 

--- a/docking/platform/backends/wayland/wayfire_ipc.py
+++ b/docking/platform/backends/wayland/wayfire_ipc.py
@@ -52,7 +52,11 @@ from docking.platform.backends.base import (
     WorkspaceService,
     WorkspaceSnapshot,
 )
-from docking.platform.running import RunningAppInfo, RunningWindowInfo
+from docking.platform.running import (
+    RunningAppInfo,
+    RunningWindowInfo,
+    RuntimeAppIdentity,
+)
 
 log = get_logger(name="wayfire_ipc")
 
@@ -210,6 +214,7 @@ class WayfireWindowRecord:
     geometry: Rect | None
     workspace_id: str | None
     pid: int | None
+    runtime_app: RuntimeAppIdentity | None
 
     @property
     def window_id(self) -> WindowId:
@@ -446,6 +451,7 @@ class WayfireWindowService(WindowService):
                     active=record.active,
                     urgent=False,
                     window=str(record.id),
+                    runtime_app=record.runtime_app,
                 )
             )
         self._model.update_running(
@@ -1048,7 +1054,18 @@ def _record_from_view(
     if view_id is None:
         return None
     app_id = str(view.get("app-id", "") or "").strip()
-    desktop_id = matcher.match(app_id) if app_id else None
+    pid = _optional_int(view.get("pid"))
+    match_result = getattr(matcher, "match_result", None)
+    match = (
+        match_result(app_id, process_id=pid)
+        if app_id and callable(match_result)
+        else None
+    )
+    desktop_id = (
+        match.desktop_id
+        if match is not None
+        else (matcher.match(app_id) if app_id else None)
+    )
     wset_index = view.get("wset-index")
     workspace_id = str(wset_index) if wset_index not in (None, -1, "") else None
     return WayfireWindowRecord(
@@ -1061,7 +1078,8 @@ def _record_from_view(
         fullscreen=_optional_bool(view.get("fullscreen")),
         geometry=_rect_from_mapping(view.get("geometry")),
         workspace_id=workspace_id,
-        pid=_optional_int(view.get("pid")),
+        pid=pid,
+        runtime_app=match.runtime_app if match is not None else None,
     )
 
 

--- a/docking/platform/backends/x11/impl/window_tracker.py
+++ b/docking/platform/backends/x11/impl/window_tracker.py
@@ -162,7 +162,7 @@ import os
 from gi.repository import GLib, Gtk, Wnck
 
 from docking.log import get_logger, with_context
-from docking.platform.app_matcher import AppIdMatcher
+from docking.platform.app_matcher import AppIdMatcher, AppMatch
 from docking.platform.backends.base import (
     ActionResult,
     DisplayServer,
@@ -212,15 +212,21 @@ class WindowMatcher:
 
     def match(self, window: Wnck.Window) -> str | None:
         """Return the desktop ID for a window, or None when no match is known."""
+        result = self.match_result(window)
+        return result.desktop_id if result is not None else None
+
+    def match_result(self, window: Wnck.Window) -> AppMatch | None:
+        """Return structured identity, including runtime-only app metadata."""
         class_group = self._class_group_for(window=window)
         if not class_group:
             return None
         class_instance = self._class_instance_for(window=window)
-        return self._app_matcher.match(
+        return self._app_matcher.match_result(
             app_id=class_group,
             instance_hint=class_instance,
             prefer_raw_app_id=False,
             defer_wm_class_lookup=True,
+            process_id=self._pid_for(window=window),
         )
 
     def _class_group_for(self, *, window: Wnck.Window) -> str | None:
@@ -240,6 +246,17 @@ class WindowMatcher:
                 f"Failed to read class instance name: {exc}"
             )
             return None
+
+    def _pid_for(self, *, window: Wnck.Window) -> int | None:
+        try:
+            pid = int(window.get_pid())
+        except _GEOMETRY_ERRORS as exc:
+            log.bind(action="window_pid").debug(
+                "Failed to read window process ID: %s",
+                exc,
+            )
+            return None
+        return pid if pid > 0 else None
 
 
 class WindowTracker:
@@ -330,9 +347,10 @@ class WindowTracker:
                 workspace=active_workspace,
             ):
                 continue
-            desktop_id = self._matcher.match(window=window)
-            if desktop_id is None:
+            match = self._matcher.match_result(window=window)
+            if match is None:
                 continue
+            desktop_id = match.desktop_id
             # Preserve the old scan semantics: once a window matched a desktop
             # ID, the app existed in the aggregate even if a later XID read
             # failed. That can produce count=0 for a racey window, but it avoids
@@ -343,6 +361,7 @@ class WindowTracker:
                 window=window,
                 desktop_id=desktop_id,
                 active_xid=active_xid,
+                match=match,
             )
             if snapshot is not None:
                 snapshots_by_desktop[desktop_id].append(snapshot)
@@ -405,7 +424,12 @@ class WindowTracker:
             yield window
 
     def _window_snapshot(
-        self, *, window: Wnck.Window, desktop_id: str, active_xid: int
+        self,
+        *,
+        window: Wnck.Window,
+        desktop_id: str,
+        active_xid: int,
+        match: AppMatch,
     ) -> RunningWindowInfo | None:
         """Convert one live Wnck window into typed running state."""
         # Wnck windows are live wrappers around X11 state. The window can vanish
@@ -434,6 +458,7 @@ class WindowTracker:
             active=xid == active_xid,
             urgent=urgent,
             window=window,
+            runtime_app=match.runtime_app,
         )
 
     @staticmethod

--- a/docking/platform/desktop_entries.py
+++ b/docking/platform/desktop_entries.py
@@ -131,6 +131,31 @@ def normalized_exec_basename(exec_line: str) -> str:
     return Path(argv[0]).name.lower()
 
 
+def executable_path_from_exec_line(exec_line: str) -> Path | None:
+    """Return a canonical direct executable path from a desktop Exec line.
+
+    Only an absolute first argument is strong enough to use as installation
+    identity. Commands resolved through ``PATH`` and wrapper constructs such as
+    ``env`` remain on the existing WM_CLASS/app-ID fallback path.
+    """
+    if not exec_line:
+        return None
+    try:
+        argv = shlex.split(exec_line)
+    except ValueError:
+        return None
+    if not argv:
+        return None
+    path = Path(argv[0]).expanduser()
+    if not path.is_absolute():
+        return None
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+    return resolved if resolved.is_file() else None
+
+
 def wine_executable_aliases(exec_line: str) -> list[str]:
     """Return Wine executable aliases from a desktop Exec line.
 
@@ -245,6 +270,19 @@ def desktop_info_from_file(*, desktop_id: str, path: Path) -> DesktopInfo | None
 
     exec_line = desktop_entry_string(key_file, "Exec")
     wm_class = desktop_entry_string(key_file, "StartupWMClass")
+    icon_name = desktop_entry_string(key_file, "Icon") or FALLBACK_ICON
+    # Older generated entries may already be pinned with the generic icon.
+    # Recover a sibling executable icon at read time so they improve without
+    # requiring users to remove and recreate the launcher.
+    if desktop_id.startswith(GENERATED_DESKTOP_PREFIX) and icon_name == FALLBACK_ICON:
+        source_path = desktop_entry_string(key_file, GENERATED_SOURCE_KEY)
+        source = (
+            Path(source_path)
+            if source_path
+            else executable_path_from_exec_line(exec_line)
+        )
+        if source is not None:
+            icon_name = _icon_name_for_generated_entry(source)
     wine_aliases = wine_executable_aliases(exec_line)
     if wine_aliases and (not wm_class or wm_class.lower() == "wine"):
         wm_class = wine_aliases[0]
@@ -255,7 +293,7 @@ def desktop_info_from_file(*, desktop_id: str, path: Path) -> DesktopInfo | None
     return DesktopInfo(
         desktop_id=desktop_id,
         name=desktop_entry_locale_string(key_file, "Name") or desktop_id,
-        icon_name=desktop_entry_string(key_file, "Icon") or FALLBACK_ICON,
+        icon_name=icon_name,
         wm_class=wm_class,
         exec_line=exec_line,
     )
@@ -268,13 +306,22 @@ def desktop_info_from_app_info(
     icon = app_info.get_icon()
     icon_name = icon.to_string() if icon else None
     wm_class = wm_class_for_app_info(app_info=app_info, desktop_id=desktop_id)
+    commandline = app_info.get_commandline() or ""
+    # Gio is normally the preferred resolver, so mirror the file-parser repair
+    # path here instead of relying on direct .desktop parsing to recover icons.
+    if desktop_id.startswith(GENERATED_DESKTOP_PREFIX) and (
+        not icon_name or icon_name == FALLBACK_ICON
+    ):
+        executable_path = executable_path_from_exec_line(commandline)
+        if executable_path is not None:
+            icon_name = _icon_name_for_generated_entry(executable_path)
 
     return DesktopInfo(
         desktop_id=desktop_id,
         name=app_info.get_display_name() or desktop_id,
         icon_name=icon_name or FALLBACK_ICON,
         wm_class=wm_class,
-        exec_line=app_info.get_commandline() or "",
+        exec_line=commandline,
     )
 
 
@@ -616,6 +663,8 @@ def make_user_executable(path: Path) -> bool:
 
 def create_desktop_entry_for_executable(
     target: str | Path,
+    *,
+    startup_wm_class: str = "",
 ) -> GeneratedDesktopEntry | None:
     """Create or update a generated desktop entry for a launchable local file.
 
@@ -637,6 +686,7 @@ def create_desktop_entry_for_executable(
         name=name,
         exec_path=path,
         icon_name=icon_name,
+        startup_wm_class=startup_wm_class,
     )
 
     try:
@@ -710,6 +760,24 @@ def _slugify_desktop_name(name: str) -> str:
 
 
 def _icon_name_for_generated_entry(path: Path) -> str:
+    """Return a colocated executable icon before using a generic fallback."""
+    stem = (
+        path.name[: -len(".AppImage")]
+        if path.name.lower().endswith(".appimage")
+        else path.stem
+        if path.suffix
+        else path.name
+    )
+    # Standalone application bundles commonly ship ``bin/tool`` together with
+    # ``bin/tool.svg`` or ``bin/tool.png``. This convention is generic and also
+    # avoids application-specific icon-name mappings.
+    for suffix in (".svg", ".png", ".xpm"):
+        candidate = path.with_name(f"{stem}{suffix}")
+        if candidate.is_file():
+            try:
+                return str(candidate.resolve(strict=True))
+            except (OSError, RuntimeError):
+                continue
     if path.name.lower().endswith(".appimage"):
         return "application-x-appimage"
     return FALLBACK_ICON
@@ -720,13 +788,20 @@ def _generated_desktop_entry_content(
     name: str,
     exec_path: Path,
     icon_name: str,
+    startup_wm_class: str = "",
 ) -> str:
-    return "\n".join(
+    lines = [
+        "[Desktop Entry]",
+        "Type=Application",
+        f"Name={_escape_desktop_value(name)}",
+        f"Exec={_quote_exec_arg(str(exec_path))}",
+    ]
+    if startup_wm_class.strip():
+        lines.append(
+            f"StartupWMClass={_escape_desktop_value(startup_wm_class.strip())}"
+        )
+    lines.extend(
         [
-            "[Desktop Entry]",
-            "Type=Application",
-            f"Name={_escape_desktop_value(name)}",
-            f"Exec={_quote_exec_arg(str(exec_path))}",
             "Terminal=false",
             "Categories=Utility;",
             f"Icon={_escape_desktop_value(icon_name)}",
@@ -735,6 +810,7 @@ def _generated_desktop_entry_content(
             "",
         ]
     )
+    return "\n".join(lines)
 
 
 def _escape_desktop_value(value: str) -> str:

--- a/docking/platform/launcher.py
+++ b/docking/platform/launcher.py
@@ -156,7 +156,7 @@ from gi.repository import GdkPixbuf, Gio, GLib, Gtk
 
 from docking.core.config import MiddleClickAction
 from docking.log import get_logger, with_context
-from docking.platform import desktop_entries
+from docking.platform import desktop_entries, process_identity
 from docking.platform.environment import flatpak, is_flatpak
 
 DESKTOP_SUFFIX = ".desktop"
@@ -244,7 +244,10 @@ class Launcher:
         self._file_icon_cache: dict[
             tuple[str, int, int, int], GdkPixbuf.Pixbuf | None
         ] = {}
-        self._wm_class_index: dict[str, desktop_entries.DesktopInfo] | None = None
+        self._wm_class_index: dict[str, list[desktop_entries.DesktopInfo]] | None = None
+        self._executable_path_index: (
+            dict[Path, list[desktop_entries.DesktopInfo]] | None
+        ) = None
 
     def resolve(
         self, desktop_id: str, *, log_failures: bool = True
@@ -271,6 +274,7 @@ class Launcher:
             return None
 
         self._cache_resolved_aliases(info=info)
+        self._cache_resolved_executable(info=info)
         return info
 
     def _desktop_app_info_for_id(
@@ -327,23 +331,61 @@ class Launcher:
         # has been built this keeps later direct resolves visible to
         # resolve_by_wm_class.
         for alias in desktop_entries.desktop_match_aliases(info):
-            self._wm_class_index.setdefault(alias, info)
+            # Multiple versions can intentionally share StartupWMClass. Keep
+            # every candidate so AppIdMatcher can use full Exec paths instead
+            # of freezing whichever desktop file happened to be scanned first.
+            candidates = self._wm_class_index.setdefault(alias, [])
+            if all(candidate.desktop_id != info.desktop_id for candidate in candidates):
+                candidates.append(info)
+
+    def _cache_resolved_executable(self, *, info: desktop_entries.DesktopInfo) -> None:
+        if self._executable_path_index is None:
+            return
+        path = desktop_entries.executable_path_from_exec_line(info.exec_line)
+        if path is None:
+            return
+        candidates = self._executable_path_index.setdefault(path, [])
+        if all(candidate.desktop_id != info.desktop_id for candidate in candidates):
+            candidates.append(info)
 
     def resolve_by_wm_class(self, wm_class: str) -> desktop_entries.DesktopInfo | None:
         """Resolve an installed desktop file by runtime WM_CLASS or executable alias."""
+        matches = self.resolve_all_by_wm_class(wm_class)
+        return matches[0] if matches else None
+
+    def resolve_all_by_wm_class(
+        self, wm_class: str
+    ) -> tuple[desktop_entries.DesktopInfo, ...]:
+        """Return every installed desktop entry sharing a runtime alias."""
         lookup = wm_class.lower().strip()
         if not lookup:
-            return None
+            return ()
         if self._wm_class_index is None:
             self._build_wm_class_index()
         if self._wm_class_index is None:
+            return ()
+        return tuple(self._wm_class_index.get(lookup, ()))
+
+    def resolve_by_executable_path(
+        self, executable_path: Path
+    ) -> desktop_entries.DesktopInfo | None:
+        """Resolve an installed desktop entry by exact canonical Exec path."""
+        try:
+            lookup = executable_path.expanduser().resolve(strict=True)
+        except (OSError, RuntimeError):
             return None
-        return self._wm_class_index.get(lookup)
+        if self._executable_path_index is None:
+            self._build_wm_class_index()
+        if self._executable_path_index is None:
+            return None
+        matches = self._executable_path_index.get(lookup, ())
+        return matches[0] if matches else None
 
     def refresh_desktop_entries(self) -> None:
         """Reload desktop-entry search paths and invalidate runtime alias cache."""
         self._desktop_dirs = desktop_entries.desktop_dirs()
         self._wm_class_index = None
+        self._executable_path_index = None
 
     def load_icon(self, icon_name: str, size: int) -> GdkPixbuf.Pixbuf | None:
         """Load an icon by name at the given size, with caching."""
@@ -520,8 +562,9 @@ class Launcher:
         return app_info.get_display_name() or None
 
     def _build_wm_class_index(self) -> None:
-        """Index installed desktop entries by WM_CLASS-like runtime aliases."""
-        index: dict[str, desktop_entries.DesktopInfo] = {}
+        """Index installed entries by runtime aliases and canonical Exec paths."""
+        alias_index: dict[str, list[desktop_entries.DesktopInfo]] = {}
+        executable_index: dict[Path, list[desktop_entries.DesktopInfo]] = {}
         seen_desktop_ids: set[str] = set()
         for desktop_dir in self._desktop_dirs:
             for path in desktop_dir.rglob(f"*{DESKTOP_SUFFIX}"):
@@ -535,8 +578,14 @@ class Launcher:
                 if info is None:
                     continue
                 for alias in desktop_entries.desktop_match_aliases(info):
-                    index.setdefault(alias, info)
-        self._wm_class_index = index
+                    alias_index.setdefault(alias, []).append(info)
+                executable_path = desktop_entries.executable_path_from_exec_line(
+                    info.exec_line
+                )
+                if executable_path is not None:
+                    executable_index.setdefault(executable_path, []).append(info)
+        self._wm_class_index = alias_index
+        self._executable_path_index = executable_index
 
     def _try_load_gicon(self, gicon: Gio.Icon, size: int) -> GdkPixbuf.Pixbuf | None:
         theme = _create_icon_theme()
@@ -781,13 +830,18 @@ def _launch_exec_line(
             return
         argv = host_argv
     try:
-        subprocess.Popen(
+        process = subprocess.Popen(
             argv,
             shell=False,
             start_new_session=True,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+        )
+        process_identity.record_launch(
+            process=process,
+            desktop_id=desktop_id,
+            executable_path=desktop_entries.executable_path_from_exec_line(exec_line),
         )
     except OSError as e:
         log.bind(desktop_id=desktop_id, action=action).warning(

--- a/docking/platform/model.py
+++ b/docking/platform/model.py
@@ -168,7 +168,7 @@ from docking.core.items import (
 )
 from docking.core.math import clamp
 from docking.log import get_logger, with_context
-from docking.platform import icon_overrides
+from docking.platform import desktop_entries, icon_overrides
 from docking.platform.launcher import fallback_file_icon_name
 from docking.platform.running import RunningAppInfo
 
@@ -337,6 +337,7 @@ class DockModel:
                 name=resolved.name,
                 icon_name=resolved.icon_name,
                 wm_class=resolved.wm_class,
+                exec_line=resolved.exec_line,
                 is_pinned=False,
                 is_running=False,
                 is_recent=True,
@@ -391,6 +392,7 @@ class DockModel:
             name=resolved.name,
             icon_name=resolved.icon_name,
             wm_class=resolved.wm_class,
+            exec_line=resolved.exec_line,
             is_pinned=False,
             is_running=False,
             is_recent=True,
@@ -478,6 +480,7 @@ class DockModel:
                 name=info.name,
                 icon_name=info.icon_name,
                 wm_class=info.wm_class,
+                exec_line=info.exec_line,
                 is_pinned=True,
                 icon=icon,
             )
@@ -516,8 +519,20 @@ class DockModel:
             desktop_id=desktop_id,
             log_failures=False,
         )
+        # A path-disambiguated process has no desktop file yet. Its structured
+        # runtime metadata supplies a useful name/icon and keeps the executable
+        # available for an eventual "Keep in Dock" promotion.
+        runtime = running_info.runtime_app if running_info is not None else None
         icon_size = self._config.scaled_icon_size
-        icon_name = resolved.icon_name if resolved else "application-x-executable"
+        icon_name = (
+            resolved.icon_name
+            if resolved
+            else (
+                runtime.icon_name
+                if runtime is not None and runtime.icon_name
+                else "application-x-executable"
+            )
+        )
         icon = (
             self._launcher.load_desktop_icon(info=resolved, size=icon_size)
             if resolved
@@ -527,9 +542,23 @@ class DockModel:
             desktop_id=desktop_id,
             kind=APP_KIND,
             target=desktop_id,
-            name=resolved.name if resolved else desktop_id,
+            name=(
+                resolved.name
+                if resolved
+                else (runtime.name if runtime is not None else desktop_id)
+            ),
             icon_name=icon_name,
-            wm_class=resolved.wm_class if resolved else "",
+            wm_class=(
+                resolved.wm_class
+                if resolved
+                else (runtime.wm_class if runtime is not None else "")
+            ),
+            exec_line=(
+                resolved.exec_line
+                if resolved
+                else (runtime.executable_path if runtime is not None else "")
+            ),
+            runtime_executable=(runtime.executable_path if runtime is not None else ""),
             is_pinned=is_pinned,
             is_running=running_info is not None,
             is_active=running_info.active if running_info is not None else False,
@@ -558,6 +587,7 @@ class DockModel:
             item.name = resolved.name
             item.icon_name = resolved.icon_name
             item.wm_class = resolved.wm_class
+            item.exec_line = resolved.exec_line
             item.icon = self._launcher.load_desktop_icon(info=resolved, size=icon_size)
             return
 
@@ -1398,12 +1428,48 @@ class DockModel:
                 self._recent_apps.remove(item)
                 self._sync_recent_apps_to_config()
         if item:
+            if not self._prepare_runtime_item_for_pinning(item):
+                return
             if item in self._transient:
                 self._transient.remove(item)
             item.is_pinned = True
             self.pinned_items.append(item)
             self._persist_pinned_changes()
             self.notify()
+
+    def _prepare_runtime_item_for_pinning(self, item: DockItem) -> bool:
+        """Persist a safe launcher before a runtime-only item becomes pinned."""
+        if not item.runtime_executable:
+            return True
+        # Runtime IDs deliberately use generated_desktop_id_for_path(), so this
+        # promotion creates the matching desktop file without changing the
+        # item's identity (and therefore without losing its running windows).
+        generated = desktop_entries.create_desktop_entry_for_executable(
+            item.runtime_executable,
+            startup_wm_class=item.wm_class,
+        )
+        if generated is None:
+            return False
+        self._launcher.refresh_desktop_entries()
+        resolved = self._launcher.resolve(
+            generated.desktop_id,
+            log_failures=False,
+        )
+        if resolved is None:
+            return False
+        item.desktop_id = generated.desktop_id
+        item.target = generated.desktop_id
+        item.prefs_key = generated.desktop_id
+        item.name = resolved.name
+        item.icon_name = resolved.icon_name
+        item.wm_class = resolved.wm_class
+        item.exec_line = resolved.exec_line
+        item.runtime_executable = ""
+        item.icon = self._launcher.load_desktop_icon(
+            info=resolved,
+            size=self._config.scaled_icon_size,
+        )
+        return True
 
     def pin_application(self, desktop_id: str) -> bool:
         """Pin an installed application even when it has no visible dock item."""
@@ -1484,6 +1550,13 @@ class DockModel:
             return
 
         item = items[from_index]
+        target_item = items[to_index]
+        candidates = (item,) if target_item is item else (item, target_item)
+        for candidate in candidates:
+            if not candidate.is_pinned and not self._prepare_runtime_item_for_pinning(
+                candidate
+            ):
+                return
 
         # Auto-pin transient items so they can be reordered among pinned items
         if not item.is_pinned:
@@ -1496,14 +1569,13 @@ class DockModel:
         pinned_from = self.pinned_items.index(item)
 
         # Map visible target index -> pinned index (auto-pin target if transient)
-        target_item = items[to_index] if to_index < len(items) else None
-        if target_item and not target_item.is_pinned:
+        if not target_item.is_pinned:
             if target_item in self._transient:
                 self._transient.remove(target_item)
             target_item.is_pinned = True
             self.pinned_items.append(target_item)
 
-        if target_item and target_item in self.pinned_items:
+        if target_item in self.pinned_items:
             pinned_to = self.pinned_items.index(target_item)
         else:
             pinned_to = len(self.pinned_items) - 1

--- a/docking/platform/process_identity.py
+++ b/docking/platform/process_identity.py
@@ -1,0 +1,114 @@
+"""Runtime process identity and Docking launch provenance."""
+
+from __future__ import annotations
+
+import subprocess
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_MAX_LAUNCH_RECORDS = 256
+
+
+@dataclass(frozen=True)
+class LaunchProvenance:
+    """Desktop launcher identity retained for a process started by Docking."""
+
+    desktop_id: str
+    executable_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class ProcessIdentity:
+    """Process evidence that can refine application-family matching."""
+
+    pid: int
+    executable_path: Path | None = None
+    launch: LaunchProvenance | None = None
+
+
+@dataclass
+class _LaunchRecord:
+    process: subprocess.Popen[Any]
+    provenance: LaunchProvenance
+
+
+_launches: OrderedDict[int, _LaunchRecord] = OrderedDict()
+
+
+def record_launch(
+    *,
+    process: subprocess.Popen[Any],
+    desktop_id: str,
+    executable_path: Path | None,
+) -> None:
+    """Remember the exact process created for a desktop launcher.
+
+    Shell launchers commonly replace themselves with ``exec``. The PID remains
+    stable across that replacement, so retaining the ``Popen`` PID preserves
+    the original desktop identity without leaking it to unrelated descendants.
+    """
+    pid = getattr(process, "pid", None)
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return
+    _prune_finished_launches()
+    _launches[pid] = _LaunchRecord(
+        process=process,
+        provenance=LaunchProvenance(
+            desktop_id=desktop_id,
+            executable_path=executable_path,
+        ),
+    )
+    _launches.move_to_end(pid)
+    while len(_launches) > _MAX_LAUNCH_RECORDS:
+        _launches.popitem(last=False)
+
+
+def identity_for_pid(pid: int | None) -> ProcessIdentity | None:
+    """Return available identity evidence for *pid* without raising."""
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return None
+    return ProcessIdentity(
+        pid=pid,
+        executable_path=_process_executable_path(pid),
+        launch=_launch_provenance(pid),
+    )
+
+
+def clear_launches_for_tests() -> None:
+    """Clear process launch records between isolated tests."""
+    _launches.clear()
+
+
+def _launch_provenance(pid: int) -> LaunchProvenance | None:
+    record = _launches.get(pid)
+    if record is None:
+        return None
+    if _process_finished(record.process):
+        _launches.pop(pid, None)
+        return None
+    _launches.move_to_end(pid)
+    return record.provenance
+
+
+def _process_finished(process: subprocess.Popen[Any]) -> bool:
+    try:
+        status = process.poll()
+    except (OSError, ValueError):
+        return False
+    return isinstance(status, int) and not isinstance(status, bool)
+
+
+def _prune_finished_launches() -> None:
+    for pid, record in list(_launches.items()):
+        if _process_finished(record.process):
+            _launches.pop(pid, None)
+
+
+def _process_executable_path(pid: int) -> Path | None:
+    try:
+        path = (Path("/proc") / str(pid) / "exe").resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+    return path if path.is_file() else None

--- a/docking/platform/running.py
+++ b/docking/platform/running.py
@@ -23,6 +23,17 @@ from docking.platform.backends.base import WindowId
 
 
 @dataclass(frozen=True)
+class RuntimeAppIdentity:
+    """Metadata for a running executable without a matching desktop entry."""
+
+    desktop_id: str
+    executable_path: str
+    name: str
+    icon_name: str
+    wm_class: str
+
+
+@dataclass(frozen=True)
 class RunningWindowInfo:
     """One matched live window from the latest tracker scan."""
 
@@ -44,6 +55,9 @@ class RunningWindowInfo:
     # The live Wnck window is intentionally carried through for callers that
     # need titles, focus, or close/minimize operations. Do not serialize it.
     window: Any
+    # Present only when strong executable evidence deliberately separated this
+    # window from a family-level desktop entry.
+    runtime_app: RuntimeAppIdentity | None = None
 
 
 @dataclass(frozen=True)
@@ -62,6 +76,7 @@ class RunningAppInfo:
     windows: tuple[Any, ...] = ()
     xids: tuple[int, ...] = ()
     window_ids: tuple[WindowId, ...] = ()
+    runtime_app: RuntimeAppIdentity | None = None
 
     @classmethod
     def from_windows(cls, windows: Iterable[RunningWindowInfo]) -> RunningAppInfo:
@@ -70,6 +85,14 @@ class RunningAppInfo:
         # windows, and XIDs. Keeping all fields derived from the same snapshot
         # tuple prevents subtle mismatches if a generator were consumed twice.
         snapshots = tuple(windows)
+        runtime_app = next(
+            (
+                snapshot.runtime_app
+                for snapshot in snapshots
+                if snapshot.runtime_app is not None
+            ),
+            None,
+        )
         return cls(
             count=len(snapshots),
             active=any(snapshot.active for snapshot in snapshots),
@@ -77,4 +100,5 @@ class RunningAppInfo:
             windows=tuple(snapshot.window for snapshot in snapshots),
             xids=tuple(snapshot.xid for snapshot in snapshots),
             window_ids=tuple(snapshot.window_id for snapshot in snapshots),
+            runtime_app=runtime_app,
         )

--- a/docking/ui/dnd.py
+++ b/docking/ui/dnd.py
@@ -767,6 +767,7 @@ class DnDHandler:
                 name=resolved.name,
                 icon_name=resolved.icon_name,
                 wm_class=resolved.wm_class,
+                exec_line=getattr(resolved, "exec_line", "") or "",
                 is_pinned=True,
                 icon=icon,
             )
@@ -798,6 +799,7 @@ class DnDHandler:
                 name=resolved.name,
                 icon_name=resolved.icon_name,
                 wm_class=resolved.wm_class,
+                exec_line=getattr(resolved, "exec_line", "") or "",
                 is_pinned=True,
                 icon=icon,
             )

--- a/tests/platform/test_app_matcher.py
+++ b/tests/platform/test_app_matcher.py
@@ -8,9 +8,11 @@ previously split across X11 and Wayland test files.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import docking.platform.app_matcher as app_matcher_mod
 from docking.platform.app_matcher import (
     AppIdMatcher,
     _app_id_candidates,
@@ -20,6 +22,7 @@ from docking.platform.app_matcher import (
     _wine_aliases_from_instance,
 )
 from docking.platform.launcher import GNOME_APP_PREFIX
+from docking.platform.process_identity import LaunchProvenance, ProcessIdentity
 
 
 def _launcher(*, resolve_by_wm_class=None, resolve=None):
@@ -51,8 +54,21 @@ class _FakeDesktopInfo:
     exec_line: str = ""
 
 
-def _item(desktop_id: str, wm_class: str = "") -> SimpleNamespace:
-    return SimpleNamespace(desktop_id=desktop_id, wm_class=wm_class)
+def _item(
+    desktop_id: str,
+    wm_class: str = "",
+    *,
+    exec_line: str = "",
+    name: str = "Test App",
+    icon_name: str = "test-icon",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        desktop_id=desktop_id,
+        wm_class=wm_class,
+        exec_line=exec_line,
+        name=name,
+        icon_name=icon_name,
+    )
 
 
 class TestNormalizeAlias:
@@ -220,6 +236,215 @@ class TestVisibleAliases:
         matcher.sync_visible_items([_item("chrome.desktop", wm_class="Chrome")])
         assert matcher.match("Firefox") is None
         assert matcher.match("Chrome") == "chrome.desktop"
+
+
+class TestExecutableIdentity:
+    @staticmethod
+    def _binary(tmp_path, version: str):
+        path = tmp_path / version / "bin" / "tool"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"\x7fELF")
+        return path.resolve()
+
+    @staticmethod
+    def _script(tmp_path, version: str):
+        path = tmp_path / version / "bin" / "tool.sh"
+        path.parent.mkdir(parents=True)
+        path.write_text("#!/bin/sh\n", encoding="utf-8")
+        return path.resolve()
+
+    def test_exact_process_path_selects_matching_visible_launcher(
+        self, tmp_path, monkeypatch
+    ):
+        first = self._binary(tmp_path, "tool-v1")
+        second = self._binary(tmp_path, "tool-v2")
+        matcher = AppIdMatcher(launcher=_launcher())
+        matcher.sync_visible_items(
+            [
+                _item(
+                    "tool-v1.desktop",
+                    "SharedTool",
+                    exec_line=str(first),
+                ),
+                _item(
+                    "tool-v2.desktop",
+                    "SharedTool",
+                    exec_line=str(second),
+                ),
+            ]
+        )
+        monkeypatch.setattr(
+            app_matcher_mod,
+            "identity_for_pid",
+            lambda _pid: ProcessIdentity(pid=42, executable_path=first),
+        )
+
+        result = matcher.match_result("SharedTool", process_id=42)
+
+        assert result is not None
+        assert result.desktop_id == "tool-v1.desktop"
+        assert result.runtime_app is None
+
+    def test_conflicting_direct_process_path_creates_runtime_identity(
+        self, tmp_path, monkeypatch
+    ):
+        pinned = self._binary(tmp_path, "tool-v1")
+        running = self._binary(tmp_path, "tool-v2")
+        matcher = AppIdMatcher(launcher=_launcher())
+        matcher.sync_visible_items(
+            [
+                _item(
+                    "tool-v1.desktop",
+                    "SharedTool",
+                    exec_line=str(pinned),
+                    name="Shared Tool",
+                )
+            ]
+        )
+        monkeypatch.setattr(
+            app_matcher_mod,
+            "identity_for_pid",
+            lambda _pid: ProcessIdentity(pid=43, executable_path=running),
+        )
+
+        result = matcher.match_result("SharedTool", process_id=43)
+
+        assert result is not None
+        assert result.desktop_id != "tool-v1.desktop"
+        assert result.runtime_app is not None
+        assert result.runtime_app.executable_path == str(running)
+        assert result.runtime_app.name == "Shared Tool"
+
+    def test_missing_process_path_preserves_visible_alias_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        pinned = self._binary(tmp_path, "tool-v1")
+        matcher = AppIdMatcher(launcher=_launcher())
+        matcher.sync_visible_items(
+            [
+                _item(
+                    "tool-v1.desktop",
+                    "SharedTool",
+                    exec_line=str(pinned),
+                )
+            ]
+        )
+        monkeypatch.setattr(
+            app_matcher_mod,
+            "identity_for_pid",
+            lambda _pid: ProcessIdentity(pid=44),
+        )
+
+        assert matcher.match("SharedTool", process_id=44) == "tool-v1.desktop"
+
+    def test_sibling_bundle_wrapper_and_native_are_distinct(
+        self, tmp_path, monkeypatch
+    ):
+        pinned = self._script(tmp_path, "tool-v1")
+        running = self._binary(tmp_path, "tool-v2")
+        matcher = AppIdMatcher(launcher=_launcher())
+        matcher.sync_visible_items(
+            [
+                _item(
+                    "tool-v1.desktop",
+                    "SharedTool",
+                    exec_line=str(pinned),
+                )
+            ]
+        )
+        monkeypatch.setattr(
+            app_matcher_mod,
+            "identity_for_pid",
+            lambda _pid: ProcessIdentity(pid=45, executable_path=running),
+        )
+
+        result = matcher.match_result("SharedTool", process_id=45)
+
+        assert result is not None
+        assert result.desktop_id != "tool-v1.desktop"
+        assert result.runtime_app is not None
+
+    def test_wrapper_and_native_in_same_bundle_keep_family_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        pinned = self._script(tmp_path, "tool-v1")
+        running = pinned.with_name("tool")
+        running.write_bytes(b"\x7fELF")
+        matcher = AppIdMatcher(launcher=_launcher())
+        matcher.sync_visible_items(
+            [
+                _item(
+                    "tool-v1.desktop",
+                    "SharedTool",
+                    exec_line=str(pinned),
+                )
+            ]
+        )
+        monkeypatch.setattr(
+            app_matcher_mod,
+            "identity_for_pid",
+            lambda _pid: ProcessIdentity(
+                pid=46,
+                executable_path=running.resolve(),
+            ),
+        )
+
+        assert matcher.match("SharedTool", process_id=46) == "tool-v1.desktop"
+
+    def test_wrapper_candidate_is_not_shadowed_by_native_runtime_item(
+        self, tmp_path, monkeypatch
+    ):
+        wrapper = self._script(tmp_path, "tool-v1")
+        native = self._binary(tmp_path, "tool-v2")
+        interpreter = tmp_path / "tool-v1" / "runtime" / "bin" / "interpreter"
+        interpreter.parent.mkdir(parents=True)
+        interpreter.write_bytes(b"\x7fELF")
+        matcher = AppIdMatcher(launcher=_launcher())
+        matcher.sync_visible_items(
+            [
+                _item(
+                    "tool-v1.desktop",
+                    "SharedTool",
+                    exec_line=str(wrapper),
+                ),
+                _item(
+                    "tool-v2.desktop",
+                    "SharedTool",
+                    exec_line=str(native),
+                ),
+            ]
+        )
+        monkeypatch.setattr(
+            app_matcher_mod,
+            "identity_for_pid",
+            lambda _pid: ProcessIdentity(
+                pid=47,
+                executable_path=interpreter.resolve(),
+            ),
+        )
+
+        assert matcher.match("SharedTool", process_id=47) == "tool-v1.desktop"
+
+    def test_system_bin_is_not_treated_as_specific_bundle_root(self):
+        assert app_matcher_mod._specific_bundle_root(Path("/usr/bin/tool")) is None
+
+    def test_launch_provenance_survives_wrapper_exec(self, tmp_path, monkeypatch):
+        java = self._binary(tmp_path, "runtime")
+        matcher = AppIdMatcher(launcher=_launcher())
+        matcher.sync_visible_items([])
+        monkeypatch.setattr(
+            app_matcher_mod,
+            "identity_for_pid",
+            lambda _pid: ProcessIdentity(
+                pid=45,
+                executable_path=java,
+                launch=LaunchProvenance(
+                    desktop_id="tool-wrapper.desktop",
+                ),
+            ),
+        )
+
+        assert matcher.match("SharedTool", process_id=45) == "tool-wrapper.desktop"
 
 
 class TestWineMatching:

--- a/tests/platform/test_desktop_entries.py
+++ b/tests/platform/test_desktop_entries.py
@@ -3,12 +3,33 @@
 from __future__ import annotations
 
 import stat
+from types import SimpleNamespace
 
 from docking.platform import desktop_entries
 
 
 def _make_executable(path) -> None:
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class TestExecutablePath:
+    def test_extracts_canonical_absolute_exec_path(self, tmp_path):
+        executable = tmp_path / "app" / "bin" / "tool"
+        executable.parent.mkdir(parents=True)
+        executable.write_bytes(b"\x7fELF")
+
+        result = desktop_entries.executable_path_from_exec_line(
+            f'"{executable}" --flag %U'
+        )
+
+        assert result == executable.resolve()
+
+    def test_rejects_path_resolved_and_missing_commands(self, tmp_path):
+        assert desktop_entries.executable_path_from_exec_line("tool --flag") is None
+        assert (
+            desktop_entries.executable_path_from_exec_line(str(tmp_path / "missing"))
+            is None
+        )
 
 
 class TestWineDesktopAliases:
@@ -132,6 +153,61 @@ class TestGeneratedDesktopEntries:
         assert info.name == "my tool"
         assert info.icon_name == "application-x-executable"
         assert info.exec_line == f'"{binary.resolve()}"'
+
+    def test_generated_file_can_preserve_runtime_wm_class(self, tmp_path, monkeypatch):
+        binary = tmp_path / "tool"
+        binary.write_text("#!/bin/sh\n", encoding="utf-8")
+        _make_executable(binary)
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+        monkeypatch.setattr(
+            desktop_entries, "_refresh_desktop_database", lambda _d: None
+        )
+
+        generated = desktop_entries.create_desktop_entry_for_executable(
+            binary,
+            startup_wm_class="SharedTool",
+        )
+
+        assert generated is not None
+        text = generated.path.read_text(encoding="utf-8")
+        assert "StartupWMClass=SharedTool\n" in text
+
+    def test_generated_file_uses_icon_next_to_executable(self, tmp_path, monkeypatch):
+        binary = tmp_path / "tool"
+        binary.write_text("#!/bin/sh\n", encoding="utf-8")
+        _make_executable(binary)
+        icon = tmp_path / "tool.svg"
+        icon.write_text("<svg/>", encoding="utf-8")
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+        monkeypatch.setattr(
+            desktop_entries, "_refresh_desktop_database", lambda _d: None
+        )
+
+        generated = desktop_entries.create_desktop_entry_for_executable(binary)
+
+        assert generated is not None
+        text = generated.path.read_text(encoding="utf-8")
+        assert f"Icon={icon.resolve()}\n" in text
+
+    def test_existing_generated_app_info_recovers_sibling_icon(self, tmp_path):
+        binary = tmp_path / "tool"
+        binary.write_bytes(b"\x7fELF")
+        icon_path = tmp_path / "tool.svg"
+        icon_path.write_text("<svg/>", encoding="utf-8")
+        fallback_icon = SimpleNamespace(to_string=lambda: desktop_entries.FALLBACK_ICON)
+        app_info = SimpleNamespace(
+            get_icon=lambda: fallback_icon,
+            get_commandline=lambda: str(binary),
+            get_startup_wm_class=lambda: "SharedTool",
+            get_display_name=lambda: "Tool",
+        )
+
+        info = desktop_entries.desktop_info_from_app_info(
+            desktop_id="docking-generated-tool-123.desktop",
+            app_info=app_info,
+        )
+
+        assert info.icon_name == str(icon_path.resolve())
 
     def test_repeated_generation_is_idempotent(self, tmp_path, monkeypatch):
         binary = tmp_path / "tool"

--- a/tests/platform/test_launcher.py
+++ b/tests/platform/test_launcher.py
@@ -649,6 +649,45 @@ class TestResolve:
         assert info is not None
         assert info.desktop_id == "org.gnome.Calculator.desktop"
 
+    def test_match_indexes_preserve_alias_collisions_and_exact_exec(self, tmp_path):
+        apps_dir = tmp_path / "applications"
+        apps_dir.mkdir()
+        executable_a = tmp_path / "tool-v1" / "bin" / "tool"
+        executable_b = tmp_path / "tool-v2" / "bin" / "tool"
+        executable_a.parent.mkdir(parents=True)
+        executable_b.parent.mkdir(parents=True)
+        executable_a.write_bytes(b"\x7fELF")
+        executable_b.write_bytes(b"\x7fELF")
+        infos = {
+            "tool-v1.desktop": DesktopInfo(
+                "tool-v1.desktop",
+                "Tool v1",
+                "tool",
+                "SharedTool",
+                str(executable_a),
+            ),
+            "tool-v2.desktop": DesktopInfo(
+                "tool-v2.desktop",
+                "Tool v2",
+                "tool",
+                "SharedTool",
+                str(executable_b),
+            ),
+        }
+        for desktop_id in infos:
+            (apps_dir / desktop_id).write_text("[Desktop Entry]\n")
+        launcher = Launcher()
+        launcher._desktop_dirs = [apps_dir]
+        launcher.resolve = MagicMock(
+            side_effect=lambda desktop_id, **_: infos.get(desktop_id)
+        )
+
+        aliases = launcher.resolve_all_by_wm_class("SharedTool")
+        exact = launcher.resolve_by_executable_path(executable_b)
+
+        assert {info.desktop_id for info in aliases} == set(infos)
+        assert exact == infos["tool-v2.desktop"]
+
     def test_resolve_file_uses_image_thumbnail_for_images(self, monkeypatch):
         from docking.platform import launcher as launcher_mod
 
@@ -1092,6 +1131,31 @@ class TestLaunch:
         assert args[0] == ["firefox", "--new-window"]
         assert kwargs["shell"] is False
         assert kwargs["start_new_session"] is True
+
+    @patch("docking.platform.launcher.process_identity.record_launch")
+    @patch("subprocess.Popen")
+    def test_launch_records_exact_process_provenance(
+        self, popen_mock, record_launch, tmp_path
+    ):
+        executable = tmp_path / "app" / "bin" / "tool"
+        executable.parent.mkdir(parents=True)
+        executable.write_bytes(b"\x7fELF")
+        process = MagicMock(pid=4321)
+        popen_mock.return_value = process
+        app_info = MagicMock()
+        app_info.get_commandline.return_value = f'"{executable}" --flag'
+
+        with patch(
+            "docking.platform.launcher.Gio.DesktopAppInfo.new",
+            return_value=app_info,
+        ):
+            launch(desktop_id="tool.desktop")
+
+        record_launch.assert_called_once_with(
+            process=process,
+            desktop_id="tool.desktop",
+            executable_path=executable.resolve(),
+        )
 
     @patch("subprocess.Popen")
     def test_launch_returns_when_desktop_missing(self, popen_mock):

--- a/tests/platform/test_model.py
+++ b/tests/platform/test_model.py
@@ -12,12 +12,14 @@ except ModuleNotFoundError:  # pragma: no cover
     sys.modules.setdefault("gi", gi_mock)
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
+import docking.platform.model as model_mod
 from docking.applets.services import AppletServices
 from docking.core.config import PinnedEntry
 from docking.core.icons import CUSTOM_ICON_PATH_KEY, ICON_SOURCE_PREF_KEY, IconSource
 from docking.core.items import APP_KIND, FILE_KIND, FOLDER_KIND
+from docking.platform.desktop_entries import DesktopInfo, GeneratedDesktopEntry
 from docking.platform.model import DockItem, DockModel, LauncherEntryState
-from docking.platform.running import RunningAppInfo
+from docking.platform.running import RunningAppInfo, RuntimeAppIdentity
 
 
 def _make_launcher(*desktop_ids: str):
@@ -30,6 +32,7 @@ def _make_launcher(*desktop_ids: str):
         info.name = did.removesuffix(".desktop")
         info.icon_name = "test-icon"
         info.wm_class = did.removesuffix(".desktop")
+        info.exec_line = did.removesuffix(".desktop")
         infos[did] = info
 
     def resolve(desktop_id, **_kwargs):
@@ -132,6 +135,36 @@ class TestUpdateRunning:
         assert not items[1].is_pinned
         assert items[1].is_running
 
+    def test_runtime_identity_builds_launchable_transient(self, tmp_path):
+        executable = tmp_path / "tool-v2" / "bin" / "tool"
+        executable.parent.mkdir(parents=True)
+        executable.write_bytes(b"\x7fELF")
+        runtime = RuntimeAppIdentity(
+            desktop_id="docking-generated-tool-runtime.desktop",
+            executable_path=str(executable),
+            name="Shared Tool",
+            icon_name="shared-tool",
+            wm_class="SharedTool",
+        )
+        config = _make_config([])
+        launcher = _make_launcher()
+        model = DockModel(config, launcher, AppletServices())
+
+        model.update_running(
+            {
+                runtime.desktop_id: RunningAppInfo(
+                    count=1,
+                    runtime_app=runtime,
+                )
+            }
+        )
+
+        item = model.visible_items()[0]
+        assert item.desktop_id == runtime.desktop_id
+        assert item.name == "Shared Tool"
+        assert item.wm_class == "SharedTool"
+        assert item.runtime_executable == str(executable)
+
     def test_removes_transient_when_no_longer_running(self):
         # Given
         config = _make_config(["a.desktop"])
@@ -174,6 +207,65 @@ class TestPinUnpin:
         assert items[1].is_pinned
         assert "b.desktop" in config.pinned
         config.save.assert_called_once()
+
+    def test_pin_runtime_transient_generates_persistent_launcher(
+        self, tmp_path, monkeypatch
+    ):
+        executable = tmp_path / "tool"
+        executable.write_bytes(b"\x7fELF")
+        runtime_id = model_mod.desktop_entries.generated_desktop_id_for_path(executable)
+        runtime = RuntimeAppIdentity(
+            desktop_id=runtime_id,
+            executable_path=str(executable),
+            name="Shared Tool",
+            icon_name="shared-tool",
+            wm_class="SharedTool",
+        )
+        config = _make_config([])
+        launcher = _make_launcher()
+        model = DockModel(config, launcher, AppletServices())
+        model.update_running(
+            {
+                runtime_id: RunningAppInfo(
+                    count=1,
+                    runtime_app=runtime,
+                )
+            }
+        )
+        generated = GeneratedDesktopEntry(
+            desktop_id=runtime_id,
+            path=tmp_path / runtime_id,
+            name="tool",
+            icon_name="application-x-executable",
+        )
+        resolved = DesktopInfo(
+            desktop_id=runtime_id,
+            name="tool",
+            icon_name="application-x-executable",
+            wm_class="tool",
+            exec_line=str(executable),
+        )
+        create = MagicMock(return_value=generated)
+        monkeypatch.setattr(
+            model_mod.desktop_entries,
+            "create_desktop_entry_for_executable",
+            create,
+        )
+        launcher.resolve.side_effect = lambda desktop_id, **_: (
+            resolved if desktop_id == runtime_id else None
+        )
+
+        model.pin_item(runtime_id)
+
+        item = model.visible_items()[0]
+        assert item.is_pinned
+        assert item.runtime_executable == ""
+        assert item.target == runtime_id
+        create.assert_called_once_with(
+            str(executable),
+            startup_wm_class="SharedTool",
+        )
+        launcher.refresh_desktop_entries.assert_called_once_with()
 
     def test_unpin_running_becomes_transient(self):
         # Given

--- a/tests/platform/test_process_identity.py
+++ b/tests/platform/test_process_identity.py
@@ -1,0 +1,57 @@
+"""Tests for runtime process identity and launch provenance."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from docking.platform import process_identity
+
+
+@pytest.fixture(autouse=True)
+def _clear_launches():
+    process_identity.clear_launches_for_tests()
+    yield
+    process_identity.clear_launches_for_tests()
+
+
+def test_identity_reads_current_process_executable():
+    identity = process_identity.identity_for_pid(os.getpid())
+
+    assert identity is not None
+    assert identity.executable_path == Path("/proc/self/exe").resolve()
+
+
+def test_recorded_launch_is_bound_to_exact_process_pid(tmp_path):
+    executable = tmp_path / "launcher"
+    executable.write_bytes(b"\x7fELF")
+    process = SimpleNamespace(pid=os.getpid(), poll=lambda: None)
+
+    process_identity.record_launch(
+        process=process,
+        desktop_id="tool.desktop",
+        executable_path=executable.resolve(),
+    )
+    identity = process_identity.identity_for_pid(os.getpid())
+
+    assert identity is not None
+    assert identity.launch is not None
+    assert identity.launch.desktop_id == "tool.desktop"
+    assert identity.launch.executable_path == executable.resolve()
+
+
+def test_finished_launch_record_is_discarded():
+    process = SimpleNamespace(pid=os.getpid(), poll=lambda: 0)
+    process_identity.record_launch(
+        process=process,
+        desktop_id="tool.desktop",
+        executable_path=None,
+    )
+
+    identity = process_identity.identity_for_pid(os.getpid())
+
+    assert identity is not None
+    assert identity.launch is None

--- a/tests/platform/test_window_tracker_integration.py
+++ b/tests/platform/test_window_tracker_integration.py
@@ -16,11 +16,13 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for non-GI environmen
     sys.modules.setdefault("gi", gi_mock)
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
+import docking.platform.app_matcher as app_matcher_mod
 import docking.platform.backends.x11.impl.window_tracker as window_tracker_mod
 from docking.core.config import Config
 from docking.platform.backends.base import ActionResult, DisplayServer, WindowId
 from docking.platform.desktop_entries import DesktopInfo
 from docking.platform.model import DockItem
+from docking.platform.process_identity import ProcessIdentity
 
 
 class FakeWindow:
@@ -33,6 +35,7 @@ class FakeWindow:
         skip_tasklist: bool = False,
         urgent: bool = False,
         minimized: bool = False,
+        pid: int = 99999,
     ) -> None:
         self._xid = xid
         self._class_group = class_group
@@ -41,6 +44,7 @@ class FakeWindow:
         self._skip_tasklist = skip_tasklist
         self._urgent = urgent
         self._minimized = minimized
+        self._pid = pid
         self._name = class_group
         self.activated_with: list[int] = []
         self.closed_with: list[int] = []
@@ -72,7 +76,7 @@ class FakeWindow:
         return self._minimized
 
     def get_pid(self) -> int:
-        return 99999
+        return self._pid
 
     def activate(self, timestamp: int) -> None:
         self.activated_with.append(timestamp)
@@ -237,8 +241,10 @@ class TestWindowTrackerRunningAggregation:
         )
 
         mapping = {w1: "firefox.desktop", w2: "firefox.desktop", w3: "code.desktop"}
-        tracker._matcher.match = MagicMock(
-            side_effect=lambda window: mapping.get(window)
+        tracker._matcher.match_result = MagicMock(
+            side_effect=lambda window: (
+                app_matcher_mod.AppMatch(mapping[window]) if window in mapping else None
+            )
         )
         # When
         tracker._update_running()
@@ -261,6 +267,43 @@ class TestWindowTrackerRunningAggregation:
             "code.desktop": [3],
         }
 
+    def test_update_running_publishes_runtime_only_identity(
+        self, tracker_env, tmp_path, monkeypatch
+    ):
+        tracker, model, _launcher = tracker_env
+        pinned = tmp_path / "tool-v1" / "bin" / "tool"
+        running = tmp_path / "tool-v2" / "bin" / "tool"
+        pinned.parent.mkdir(parents=True)
+        running.parent.mkdir(parents=True)
+        pinned.write_bytes(b"\x7fELF")
+        running.write_bytes(b"\x7fELF")
+        model.visible_items.return_value = [
+            DockItem(
+                desktop_id="tool-v1.desktop",
+                name="Shared Tool",
+                wm_class="SharedTool",
+                exec_line=str(pinned),
+            )
+        ]
+        window = FakeWindow(20, class_group="SharedTool", pid=4243)
+        tracker._screen = FakeScreen(windows=[window], active_window=window)
+        monkeypatch.setattr(
+            app_matcher_mod,
+            "identity_for_pid",
+            lambda pid: ProcessIdentity(
+                pid=pid,
+                executable_path=running.resolve(),
+            ),
+        )
+
+        tracker._update_running()
+
+        published = model.update_running.call_args.kwargs["running"]
+        assert "tool-v1.desktop" not in published
+        runtime_info = next(iter(published.values()))
+        assert runtime_info.runtime_app is not None
+        assert runtime_info.runtime_app.executable_path == str(running.resolve())
+
     def test_update_running_filters_to_current_workspace(self, tracker_env):
         tracker, model, _launcher = tracker_env
         tracker._config = SimpleNamespace(current_workspace_only=True)
@@ -282,9 +325,11 @@ class TestWindowTrackerRunningAggregation:
             active_window=current,
             active_workspace=active_workspace,
         )
-        tracker._matcher.match = MagicMock(
+        tracker._matcher.match_result = MagicMock(
             side_effect=lambda window: (
-                "firefox.desktop" if window in {current, other} else None
+                app_matcher_mod.AppMatch("firefox.desktop")
+                if window in {current, other}
+                else None
             )
         )
 
@@ -383,8 +428,10 @@ class TestWindowTrackerRunningAggregation:
 
         good = FakeWindow(10, class_group="Firefox")
         tracker._screen = FakeScreen(windows=[BrokenWindow(), good], active_window=good)
-        tracker._matcher.match = MagicMock(
-            side_effect=lambda window: "firefox.desktop" if window is good else None
+        tracker._matcher.match_result = MagicMock(
+            side_effect=lambda window: (
+                app_matcher_mod.AppMatch("firefox.desktop") if window is good else None
+            )
         )
         # When
         tracker._update_running()
@@ -405,7 +452,9 @@ class TestWindowTrackerRunningAggregation:
 
         broken = BrokenXidWindow(10, class_group="Firefox")
         tracker._screen = FakeScreen(windows=[broken], active_window=None)
-        tracker._matcher.match = MagicMock(return_value="firefox.desktop")
+        tracker._matcher.match_result = MagicMock(
+            return_value=app_matcher_mod.AppMatch("firefox.desktop")
+        )
 
         tracker._update_running()
 
@@ -423,6 +472,48 @@ class TestWindowMatching:
         # When
         # Then
         assert tracker._matcher.match(win) == "firefox.desktop"
+
+    def test_match_separates_same_class_with_different_direct_exec(
+        self, tracker_env, tmp_path, monkeypatch
+    ):
+        tracker, _model, _launcher = tracker_env
+        pinned = tmp_path / "tool-v1" / "bin" / "tool"
+        running = tmp_path / "tool-v2" / "bin" / "tool"
+        pinned.parent.mkdir(parents=True)
+        running.parent.mkdir(parents=True)
+        pinned.write_bytes(b"\x7fELF")
+        running.write_bytes(b"\x7fELF")
+        tracker._matcher.sync_visible_items(
+            [
+                DockItem(
+                    desktop_id="tool-v1.desktop",
+                    name="Shared Tool",
+                    wm_class="SharedTool",
+                    exec_line=str(pinned),
+                )
+            ]
+        )
+        monkeypatch.setattr(
+            app_matcher_mod,
+            "identity_for_pid",
+            lambda pid: ProcessIdentity(
+                pid=pid,
+                executable_path=running.resolve(),
+            ),
+        )
+        window = FakeWindow(
+            19,
+            class_group="SharedTool",
+            class_instance="SharedTool",
+            pid=4242,
+        )
+
+        match = tracker._matcher.match_result(window)
+
+        assert match is not None
+        assert match.desktop_id != "tool-v1.desktop"
+        assert match.runtime_app is not None
+        assert match.runtime_app.executable_path == str(running.resolve())
 
     def test_match_uses_class_instance_map(self, tracker_env):
         # Given


### PR DESCRIPTION
## Summary

- retain desktop launcher executable metadata and resolve process identity
- support transient runtime-only dock items and pinning
- wire PID-aware runtime identity through supported window backends