### PR TITLE
Platform apps package consolidation

### DIFF
--- a/docking/app.py
+++ b/docking/app.py
@@ -92,6 +92,7 @@ from docking.applets.services import AppletServices
 from docking.core.config import Config
 from docking.core.theme import Theme
 from docking.ipc import DockItemsService
+from docking.platform.applications.registry import ApplicationRegistry
 from docking.platform.backends.selection import create_session_backend
 from docking.platform.environment import apply_tweaks, detect_desktop
 from docking.platform.launcher import Launcher
@@ -114,11 +115,12 @@ def main() -> None:
     """Entry point for the docking application."""
     apply_tweaks(desktop=detect_desktop())
 
-    config = Config.load()
+    registry = ApplicationRegistry()
+    config = Config.load(registry=registry)
     theme = Theme.load(name=config.theme, icon_size=config.icon_size).with_opacity(
         config.transparency
     )
-    launcher = Launcher()
+    launcher = Launcher(registry=registry)
     model = DockModel(
         config=config,
         launcher=launcher,
@@ -168,6 +170,7 @@ def main() -> None:
     GLib.unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGTERM, _quit)
 
     try:
+        registry.start()
         status_notifications.start()
         unity.start()
         window.show_all()
@@ -181,6 +184,7 @@ def main() -> None:
         unity.stop()
         model.stop_applets()
         backend.stop()
+        registry.stop()
 
 
 def _start_runtime(

--- a/docking/core/config.py
+++ b/docking/core/config.py
@@ -342,12 +342,12 @@ class HideMode(str, Enum):
 DEFAULT_HIDE_MODE = HideMode.NONE.value
 
 
-def _build_initial_pinned() -> list[PinnedEntry]:
+def _build_initial_pinned(*, registry: object | None = None) -> list[PinnedEntry]:
     applications_entry = PinnedEntry(
         kind=APPLET_KIND,
         target=applet_desktop_id(applet_id=STARTER_APPLET_IDS[0]),
     )
-    launcher_entries = _build_initial_launcher_entries()
+    launcher_entries = _build_initial_launcher_entries(registry=registry)
     applet_entries = [
         PinnedEntry(kind=APPLET_KIND, target=applet_desktop_id(applet_id=applet_id))
         for applet_id in STARTER_APPLET_IDS[1:]
@@ -355,7 +355,10 @@ def _build_initial_pinned() -> list[PinnedEntry]:
     return [applications_entry, *launcher_entries, *applet_entries]
 
 
-def _build_initial_launcher_entries() -> list[PinnedEntry]:
+def _build_initial_launcher_entries(
+    *,
+    registry: object | None = None,
+) -> list[PinnedEntry]:
     entries: list[PinnedEntry] = []
     seen_targets: set[str] = set()
     slots: tuple[tuple[tuple[str, ...], tuple[str, ...]], ...] = (
@@ -371,6 +374,7 @@ def _build_initial_launcher_entries() -> list[PinnedEntry]:
         desktop_id = _resolve_initial_desktop_id(
             candidates=candidates,
             fallback_content_types=fallback_content_types,
+            registry=registry,
         )
         if desktop_id is None or desktop_id in seen_targets:
             continue
@@ -383,13 +387,19 @@ def _resolve_initial_desktop_id(
     *,
     candidates: tuple[str, ...],
     fallback_content_types: tuple[str, ...],
+    registry: object | None = None,
 ) -> str | None:
+    exists = (
+        (lambda did: _desktop_id_exists_in_registry(did, registry))
+        if registry is not None
+        else _desktop_id_exists
+    )
     for desktop_id in candidates:
-        if _desktop_id_exists(desktop_id):
+        if exists(desktop_id):
             return desktop_id
     for content_type in fallback_content_types:
         desktop_id = _default_desktop_id_for(content_type)
-        if desktop_id and _desktop_id_exists(desktop_id):
+        if desktop_id and exists(desktop_id):
             return desktop_id
     return None
 
@@ -398,6 +408,10 @@ def _desktop_id_exists(desktop_id: str) -> bool:
     from docking.platform.launcher import Launcher
 
     return Launcher().resolve(desktop_id=desktop_id, log_failures=False) is not None
+
+
+def _desktop_id_exists_in_registry(desktop_id: str, registry: object) -> bool:
+    return registry.resolve(desktop_id, log_failures=False) is not None
 
 
 def _default_desktop_id_for(content_type: str) -> str | None:
@@ -1046,11 +1060,16 @@ class Config:
         )
 
     @classmethod
-    def load(cls, path: Path | str | None = None) -> Config:
+    def load(
+        cls,
+        path: Path | str | None = None,
+        *,
+        registry: object | None = None,
+    ) -> Config:
         """Load config from JSON file, falling back to defaults for missing keys."""
         path = Path(path) if path else DEFAULT_CONFIG_FILE
         if not path.exists():
-            config = cls(pinned=_build_initial_pinned())
+            config = cls(pinned=_build_initial_pinned(registry=registry))
             config._path = path
             config.save(path=path)
             return config

--- a/docking/platform/app_matcher.py
+++ b/docking/platform/app_matcher.py
@@ -156,7 +156,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from docking.platform import desktop_entries
-from docking.platform.launcher import DESKTOP_SUFFIX, GNOME_APP_PREFIX
+from docking.platform.applications.entries import DESKTOP_SUFFIX, GNOME_APP_PREFIX
 from docking.platform.process_identity import ProcessIdentity, identity_for_pid
 from docking.platform.running import RuntimeAppIdentity
 

--- a/docking/platform/applications/__init__.py
+++ b/docking/platform/applications/__init__.py
@@ -1,0 +1,7 @@
+"""Application identity, discovery, launching, and matching.
+
+The ``platform.applications`` package is the single home for everything
+related to desktop applications.  Callers import directly from submodules;
+this ``__init__`` must remain import-free to avoid the cycle documented in
+``docking/platform/__init__.py``.
+"""

--- a/docking/platform/applications/entries.py
+++ b/docking/platform/applications/entries.py
@@ -1,0 +1,55 @@
+"""Desktop-entry parsing primitives and constants.
+
+Canonical home for XDG desktop-entry constants.  ``GNOME_APP_PREFIX``
+lives here alongside ``DESKTOP_SUFFIX`` so the matcher can import both
+from one leaf module.
+"""
+
+from __future__ import annotations
+
+from docking.platform.desktop_entries import (  # noqa: F401
+    DESKTOP_SUFFIX,
+    FALLBACK_ICON,
+    GENERATED_DESKTOP_PREFIX,
+    GENERATED_MARKER_KEY,
+    GENERATED_SOURCE_KEY,
+    HOST_FILESYSTEM_ROOT,
+    HOST_XDG_DATA_DIRS,
+    SNAP_XDG_DATA_DIR,
+    DesktopAction,
+    DesktopAppListing,
+    DesktopInfo,
+    GeneratedDesktopEntry,
+    ResolvedAppInfo,
+    ResolvedDesktopLaunch,
+    all_desktop_app_listings,
+    appimage_path_needing_executable_permission,
+    create_desktop_entry_for_executable,
+    desktop_dirs,
+    desktop_entry_bool,
+    desktop_entry_locale_string,
+    desktop_entry_string,
+    desktop_file_action_exec,
+    desktop_file_actions,
+    desktop_id_from_uri_or_path,
+    desktop_info_from_app_info,
+    desktop_info_from_file,
+    desktop_listing_from_app_info,
+    desktop_listing_from_file,
+    desktop_match_aliases,
+    executable_path_from_exec_line,
+    find_desktop_file,
+    generated_desktop_id_for_path,
+    is_host_desktop_file,
+    load_desktop_key_file,
+    local_path_from_uri_or_path,
+    make_user_executable,
+    normalized_exec_basename,
+    resolve_app_info,
+    resolve_desktop_launch,
+    user_applications_dir,
+    wine_executable_aliases,
+    wm_class_for_app_info,
+)
+
+GNOME_APP_PREFIX = "org.gnome."

--- a/docking/platform/applications/identity.py
+++ b/docking/platform/applications/identity.py
@@ -1,0 +1,19 @@
+"""Process identity and launch provenance."""
+
+from __future__ import annotations
+
+from docking.platform.process_identity import (
+    LaunchProvenance,
+    ProcessIdentity,
+    clear_launches_for_tests,
+    identity_for_pid,
+    record_launch,
+)
+
+__all__ = [
+    "LaunchProvenance",
+    "ProcessIdentity",
+    "clear_launches_for_tests",
+    "identity_for_pid",
+    "record_launch",
+]

--- a/docking/platform/applications/launcher.py
+++ b/docking/platform/applications/launcher.py
@@ -1,0 +1,27 @@
+"""Application launching backed by the canonical registry."""
+
+from __future__ import annotations
+
+from docking.platform.launcher import (
+    FileTargetInfo,
+    Launcher,
+    fallback_file_icon_name,
+    get_actions,
+    launch,
+    launch_action,
+    launch_new_window,
+    normalize_file_target,
+    open_target,
+)
+
+__all__ = [
+    "FileTargetInfo",
+    "Launcher",
+    "fallback_file_icon_name",
+    "get_actions",
+    "launch",
+    "launch_action",
+    "launch_new_window",
+    "normalize_file_target",
+    "open_target",
+]

--- a/docking/platform/applications/listing.py
+++ b/docking/platform/applications/listing.py
@@ -1,0 +1,47 @@
+"""Application listing helpers over the canonical registry.
+
+These functions replace the duck-typed ``ApplicationEntry`` adapter
+from ``applets/apps.py``.  They operate on ``ApplicationInfo`` records
+from the process-wide ``ApplicationRegistry``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gio
+
+from docking.platform.applications.types import ApplicationInfo
+
+
+def gicon_for(info: ApplicationInfo) -> Gio.Icon | None:
+    """Return a Gio.Icon for *info* (replaces ``ApplicationEntry.get_icon``)."""
+    if not info.icon_name:
+        return None
+    icon_path = Path(info.icon_name)
+    if icon_path.is_absolute():
+        return Gio.FileIcon.new(Gio.File.new_for_path(str(icon_path)))
+    return Gio.ThemedIcon.new(info.icon_name)
+
+
+def desktop_file_uri(info: ApplicationInfo) -> str | None:
+    """Return the ``.desktop`` file URI used for drag-to-pin."""
+    if info.desktop_file is not None:
+        return info.desktop_file.expanduser().resolve().as_uri()
+    from docking.platform import desktop_entries
+
+    path = desktop_entries.find_desktop_file(info.desktop_id)
+    if path is None:
+        return None
+    return path.expanduser().resolve().as_uri()
+
+
+def launch_app(info: ApplicationInfo) -> None:
+    """Launch *info* via the canonical launcher."""
+    from docking.platform.launcher import launch
+
+    if info.desktop_id:
+        launch(desktop_id=info.desktop_id)

--- a/docking/platform/applications/matcher.py
+++ b/docking/platform/applications/matcher.py
@@ -1,0 +1,7 @@
+"""Window-identity to application matching."""
+
+from __future__ import annotations
+
+from docking.platform.app_matcher import AppIdMatcher, AppMatch
+
+__all__ = ["AppIdMatcher", "AppMatch"]

--- a/docking/platform/applications/recents.py
+++ b/docking/platform/applications/recents.py
@@ -1,0 +1,165 @@
+"""Recent-applications tracking service.
+
+The ``RecentApplications`` class is the single owner of the recent-apps
+list.  ``DockModel`` and settings talk to this service instead of
+mutating ``Config.recent_apps`` directly.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Sequence
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class RecentAppRecord:
+    desktop_id: str
+    last_closed: int
+
+
+@dataclass(frozen=True, slots=True)
+class RecentApplicationsPolicy:
+    enabled: bool
+    maximum: int
+    retention_days: int
+
+
+class RecentApplicationsPersistence(Protocol):
+    def decode(self, raw: list[dict]) -> list[RecentAppRecord]: ...
+    def encode(self, records: Sequence[RecentAppRecord]) -> list[dict]: ...
+    def save(self, records: Sequence[RecentAppRecord]) -> None: ...
+
+
+class RecentApplications:
+    """Single owner of the recent-apps list."""
+
+    def __init__(
+        self,
+        *,
+        persistence: RecentApplicationsPersistence | None = None,
+        policy: RecentApplicationsPolicy | None = None,
+    ) -> None:
+        self._records: list[RecentAppRecord] = []
+        self._listeners: list[Callable[[], None]] = []
+        self._policy = policy or RecentApplicationsPolicy(
+            enabled=True,
+            maximum=5,
+            retention_days=14,
+        )
+        self._persistence = persistence
+        self._prev_running_ids: set[str] = set()
+
+    def load(self, raw_records: list[dict], *, pinned_ids: set[str]) -> None:
+        if not self._policy.enabled:
+            self._records.clear()
+            return
+        cutoff = int(time.time()) - (self._policy.retention_days * 86400)
+        seen: set[str] = set()
+        records: list[RecentAppRecord] = []
+        if self._persistence is not None:
+            decoded = self._persistence.decode(raw_records)
+        else:
+            decoded = [
+                RecentAppRecord(
+                    desktop_id=str(r.get("desktop_id", "")),
+                    last_closed=int(r.get("last_closed", 0)),
+                )
+                for r in raw_records
+            ]
+        for record in decoded:
+            if not record.desktop_id:
+                continue
+            if record.desktop_id in pinned_ids or record.desktop_id in seen:
+                continue
+            if record.last_closed < cutoff:
+                continue
+            seen.add(record.desktop_id)
+            records.append(record)
+        changed = records != self._records
+        self._records = records
+        if changed:
+            self._notify()
+
+    def reconcile_running(self, current_ids: set[str], *, pinned_ids: set[str]) -> bool:
+        if not self._policy.enabled:
+            return False
+        closed_ids = self._prev_running_ids - current_ids
+        self._prev_running_ids = set(current_ids)
+        changed = False
+        for desktop_id in closed_ids:
+            if desktop_id in pinned_ids:
+                continue
+            changed = True
+            self.record_closed(desktop_id)
+        return changed
+
+    def record_closed(self, desktop_id: str) -> None:
+        for i, record in enumerate(self._records):
+            if record.desktop_id == desktop_id:
+                self._records.pop(i)
+                self._records.insert(0, RecentAppRecord(desktop_id, int(time.time())))
+                self._persist()
+                self._prune()
+                self._notify()
+                return
+        self._records.insert(0, RecentAppRecord(desktop_id, int(time.time())))
+        self._persist()
+        self._prune()
+        self._notify()
+
+    def clear(self) -> None:
+        if not self._records:
+            return
+        self._records.clear()
+        self._persist()
+        self._notify()
+
+    def update_policy(
+        self, policy: RecentApplicationsPolicy, *, pinned_ids: set[str]
+    ) -> None:
+        self._policy = policy
+        if not policy.enabled:
+            self.clear()
+            return
+        self._prune()
+        self._persist()
+
+    def snapshot(self) -> tuple[RecentAppRecord, ...]:
+        return tuple(self._records)
+
+    def add_listener(self, callback: Callable[[], None]) -> None:
+        if callback not in self._listeners:
+            self._listeners.append(callback)
+
+    def remove_listener(self, callback: Callable[[], None]) -> None:
+        with suppress(ValueError):
+            self._listeners.remove(callback)
+
+    def _prune(self) -> None:
+        cutoff = int(time.time()) - (self._policy.retention_days * 86400)
+        kept: list[RecentAppRecord] = []
+        for record in self._records:
+            if record.last_closed < cutoff:
+                continue
+            kept.append(record)
+        self._records = kept[: self._policy.maximum]
+
+    def _persist(self) -> None:
+        if self._persistence is not None:
+            self._persistence.save(tuple(self._records))
+
+    def _notify(self) -> None:
+        for listener in tuple(self._listeners):
+            with suppress(Exception):
+                listener()
+
+
+__all__ = [
+    "RecentAppRecord",
+    "RecentApplications",
+    "RecentApplicationsPersistence",
+    "RecentApplicationsPolicy",
+]

--- a/docking/platform/applications/registry.py
+++ b/docking/platform/applications/registry.py
@@ -1,0 +1,550 @@
+"""Process-wide canonical application metadata registry.
+
+The ``ApplicationRegistry`` is the single source of truth for installed
+desktop-application metadata.  Discovery, parsing, monitoring, indexing,
+and invalidation all live here.  Launching and matching are consumers
+of the registry, not independent metadata repositories.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Callable
+from contextlib import suppress
+from pathlib import Path
+
+import gi
+
+gi.require_version("Gio", "2.0")
+gi.require_version("GLib", "2.0")
+from gi.repository import Gio, GLib
+
+from docking.applets.apps import all_desktop_app_infos
+from docking.log import get_logger, with_context
+from docking.platform import desktop_entries
+from docking.platform.applications.types import (
+    ApplicationAction,
+    ApplicationInfo,
+    ApplicationOrigin,
+)
+
+DEFAULT_DEBOUNCE_MS = 150
+
+log = with_context(get_logger(name="app_registry"))
+
+
+def _origin_for_desktop_file(path: Path | None) -> ApplicationOrigin:
+    if path is None:
+        return ApplicationOrigin.INSTALLED
+    if desktop_entries.is_host_desktop_file(path):
+        return ApplicationOrigin.HOST
+    try:
+        for d in desktop_entries.desktop_dirs():
+            try:
+                path.relative_to(d)
+            except ValueError:
+                continue
+            desktop_id = path.relative_to(d).as_posix()
+            if desktop_id.startswith(desktop_entries.GENERATED_DESKTOP_PREFIX):
+                return ApplicationOrigin.GENERATED
+            break
+    except (OSError, ValueError):
+        pass
+    return ApplicationOrigin.INSTALLED
+
+
+def _build_info(
+    *,
+    desktop_id: str,
+    name: str,
+    icon_name: str,
+    wm_class: str,
+    exec_line: str,
+    categories: str = "",
+    description: str = "",
+    generic_name: str = "",
+    keywords: tuple[str, ...] = (),
+    desktop_file: Path | None = None,
+    actions: tuple[ApplicationAction, ...] = (),
+) -> ApplicationInfo:
+    executable_path = desktop_entries.executable_path_from_exec_line(exec_line)
+    aliases = tuple(
+        desktop_entries.desktop_match_aliases(
+            desktop_entries.DesktopInfo(
+                desktop_id=desktop_id,
+                name=name,
+                icon_name=icon_name,
+                wm_class=wm_class,
+                exec_line=exec_line,
+            )
+        )
+    )
+    origin = _origin_for_desktop_file(desktop_file)
+    return ApplicationInfo(
+        desktop_id=desktop_id,
+        name=name,
+        icon_name=icon_name,
+        wm_class=wm_class,
+        exec_line=exec_line,
+        origin=origin,
+        desktop_file=desktop_file,
+        executable_path=executable_path,
+        aliases=aliases,
+        generic_name=generic_name,
+        description=description,
+        categories=categories,
+        keywords=keywords,
+        actions=actions,
+    )
+
+
+def _monitor_directory(path: Path) -> Gio.FileMonitor:
+    f = Gio.File.new_for_path(str(path))
+    return f.monitor_directory(Gio.FileMonitorFlags.NONE, None)
+
+
+class ApplicationRegistry:
+    """Process-wide canonical application metadata."""
+
+    def __init__(self) -> None:
+        self._application_source = all_desktop_app_infos
+        self._desktop_directories_source = desktop_entries.desktop_dirs
+        self._app_monitor_factory = Gio.AppInfoMonitor.get
+        self._directory_monitor_factory = _monitor_directory
+        self._schedule_timeout = GLib.timeout_add
+        self._cancel_timeout = GLib.source_remove
+        self._debounce_ms = DEFAULT_DEBOUNCE_MS
+        self._installed_by_id: dict[str, ApplicationInfo] = {}
+        self._ordered_snapshot: tuple[ApplicationInfo, ...] = ()
+        self._alias_index: dict[str, list[str]] = {}
+        self._executable_index: dict[Path, list[str]] = {}
+        self._listeners: list[Callable[[], None]] = []
+        self._generation = 0
+        self._loaded = False
+        self._started = False
+        self._lifecycle_token = 0
+        self._app_monitor: object | None = None
+        self._app_monitor_handler: object | None = None
+        self._directory_monitors: dict[Path, tuple[object, object | None]] = {}
+        self._debounce_source_id: int | None = None
+
+    @property
+    def generation(self) -> int:
+        return self._generation
+
+    @property
+    def started(self) -> bool:
+        return self._started
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+        self._lifecycle_token += 1
+        self._connect_app_monitor()
+        self._sync_directory_monitors()
+        self.refresh()
+
+    def stop(self) -> None:
+        if not self._started:
+            return
+        self._started = False
+        self._lifecycle_token += 1
+        self._cancel_pending_refresh()
+        self._disconnect_app_monitor()
+        self._cancel_directory_monitors()
+
+    def refresh(self) -> bool:
+        try:
+            entries = tuple(self._application_source())
+        except Exception as exc:
+            log.bind(action="discover_applications").warning(
+                "Failed to discover desktop applications: %s",
+                exc,
+            )
+            return False
+        installed: dict[str, ApplicationInfo] = {}
+        for entry in entries:
+            try:
+                info = self._info_from_listing_entry(entry)
+            except Exception as exc:
+                log.bind(action="build_app_info").warning(
+                    "Failed to build ApplicationInfo: %s",
+                    exc,
+                )
+                continue
+            if info is None:
+                continue
+            installed.setdefault(info.desktop_id, info)
+        ordered = tuple(
+            sorted(
+                installed.values(),
+                key=lambda a: (_normalize_name(a.name), a.desktop_id.casefold()),
+            )
+        )
+        alias_index: dict[str, list[str]] = {}
+        executable_index: dict[Path, list[str]] = {}
+        for info in ordered:
+            for alias in info.aliases:
+                ids = alias_index.setdefault(alias, [])
+                if info.desktop_id not in ids:
+                    ids.append(info.desktop_id)
+            if info.executable_path is not None:
+                ids = executable_index.setdefault(info.executable_path, [])
+                if info.desktop_id not in ids:
+                    ids.append(info.desktop_id)
+        changed = (
+            not self._loaded
+            or installed != self._installed_by_id
+            or ordered != self._ordered_snapshot
+        )
+        self._loaded = True
+        if changed:
+            self._installed_by_id = installed
+            self._ordered_snapshot = ordered
+            self._alias_index = alias_index
+            self._executable_index = executable_index
+            self._generation += 1
+            self._notify_listeners()
+        if self._started:
+            self._sync_directory_monitors()
+        return changed
+
+    def resolve(
+        self, desktop_id: str, *, log_failures: bool = True
+    ) -> ApplicationInfo | None:
+        info = self._installed_by_id.get(desktop_id)
+        if info is not None:
+            return info
+        from docking.platform.launcher import Launcher
+
+        _fallback = Launcher()
+        resolved = _fallback.resolve(desktop_id, log_failures=log_failures)
+        if resolved is not None:
+            info = _build_info(
+                desktop_id=resolved.desktop_id,
+                name=resolved.name,
+                icon_name=resolved.icon_name,
+                wm_class=resolved.wm_class,
+                exec_line=resolved.exec_line,
+                desktop_file=desktop_entries.find_desktop_file(desktop_id),
+            )
+            self._installed_by_id[desktop_id] = info
+            return info
+        return None
+
+    def resolve_all_by_wm_class(self, wm_class: str) -> tuple[ApplicationInfo, ...]:
+        lookup = wm_class.lower().strip()
+        if not lookup or lookup not in self._alias_index:
+            return ()
+        ids = self._alias_index[lookup]
+        return tuple(
+            info for did in ids if (info := self._installed_by_id.get(did)) is not None
+        )
+
+    def resolve_by_executable_path(
+        self, executable_path: Path
+    ) -> ApplicationInfo | None:
+        try:
+            lookup = executable_path.expanduser().resolve(strict=True)
+        except (OSError, RuntimeError):
+            return None
+        ids = self._executable_index.get(lookup, [])
+        for did in ids:
+            info = self._installed_by_id.get(did)
+            if info is not None:
+                return info
+        return None
+
+    def list_applications(self) -> list[ApplicationInfo]:
+        return list(self._ordered_snapshot)
+
+    def snapshot(self) -> tuple[ApplicationInfo, ...]:
+        return self._ordered_snapshot
+
+    def get(self, desktop_id: str) -> ApplicationInfo | None:
+        return self._installed_by_id.get(desktop_id)
+
+    def add_listener(self, callback: Callable[[], None]) -> None:
+        if callback not in self._listeners:
+            self._listeners.append(callback)
+
+    def remove_listener(self, callback: Callable[[], None]) -> None:
+        with suppress(ValueError):
+            self._listeners.remove(callback)
+
+    def _info_from_listing_entry(self, entry: object) -> ApplicationInfo | None:
+        desktop_id = _first_text(
+            getattr(entry, "desktop_id", ""),
+            _safe_call(entry, "get_id"),
+        )
+        if not desktop_id:
+            return None
+        app_info = getattr(entry, "app_info", None)
+        name = _first_text(
+            _safe_call(entry, "get_display_name"),
+            getattr(entry, "name", ""),
+            desktop_id.removesuffix(desktop_entries.DESKTOP_SUFFIX),
+            desktop_id,
+        )
+        categories = getattr(entry, "categories", "") or ""
+        if not categories:
+            cat_val = _safe_call(entry, "get_categories")
+            categories = str(cat_val) if cat_val else ""
+        icon_name = getattr(entry, "icon_name", "") or ""
+        if app_info is not None:
+            wm_class = desktop_entries.wm_class_for_app_info(
+                app_info=app_info,
+                desktop_id=desktop_id,
+            )
+            exec_line = app_info.get_commandline() or ""
+            description = _clean_text(app_info.get_description())
+            generic_name = _clean_text(app_info.get_generic_name())
+            keywords = _normalise_values(app_info.get_keywords())
+            actions = _actions_from_gio(app_info)
+            gicon = app_info.get_icon()
+            if gicon is not None and not icon_name:
+                icon_name = _clean_text(gicon.to_string())
+        else:
+            wm_class = ""
+            exec_line = ""
+            description = ""
+            generic_name = ""
+            keywords: tuple[str, ...] = ()
+            actions: tuple[ApplicationAction, ...] = ()
+        desktop_file = desktop_entries.find_desktop_file(desktop_id)
+        if desktop_file is not None:
+            key_file = desktop_entries.load_desktop_key_file(desktop_file)
+            if key_file is not None:
+                if not wm_class:
+                    wm_class = desktop_entries.desktop_entry_string(
+                        key_file, "StartupWMClass"
+                    )
+                if not exec_line:
+                    exec_line = desktop_entries.desktop_entry_string(key_file, "Exec")
+                if not description:
+                    description = _first_text(
+                        desktop_entries.desktop_entry_locale_string(
+                            key_file, "Comment"
+                        ),
+                        desktop_entries.desktop_entry_locale_string(
+                            key_file, "GenericName"
+                        ),
+                    )
+                if not generic_name:
+                    generic_name = desktop_entries.desktop_entry_locale_string(
+                        key_file,
+                        "GenericName",
+                    )
+                if not keywords:
+                    keywords = _normalise_values(
+                        desktop_entries.desktop_entry_locale_string(
+                            key_file, "Keywords"
+                        ),
+                    )
+                if not icon_name:
+                    icon_name = desktop_entries.desktop_entry_string(key_file, "Icon")
+                file_actions = desktop_entries.desktop_file_actions(desktop_file)
+                actions = _merge_actions(
+                    actions,
+                    tuple(
+                        ApplicationAction(a.action_id, a.display_name)
+                        for a in file_actions
+                    ),
+                )
+        if not wm_class:
+            exec_basename = desktop_entries.normalized_exec_basename(exec_line)
+            wm_class = exec_basename or desktop_id.removesuffix(
+                desktop_entries.DESKTOP_SUFFIX
+            )
+        if not icon_name:
+            icon_name = desktop_entries.FALLBACK_ICON
+        return _build_info(
+            desktop_id=desktop_id,
+            name=name or desktop_id,
+            icon_name=icon_name,
+            wm_class=wm_class,
+            exec_line=exec_line,
+            categories=categories,
+            description=description,
+            generic_name=generic_name,
+            keywords=keywords,
+            desktop_file=desktop_file,
+            actions=actions,
+        )
+
+    def _connect_app_monitor(self) -> None:
+        try:
+            monitor = self._app_monitor_factory()
+            handler = monitor.connect("changed", self._on_catalog_changed)
+        except Exception as exc:
+            log.bind(action="monitor_app_info").warning(
+                "Could not monitor Gio application changes: %s",
+                exc,
+            )
+            return
+        self._app_monitor = monitor
+        self._app_monitor_handler = handler
+
+    def _disconnect_app_monitor(self) -> None:
+        monitor = self._app_monitor
+        handler = self._app_monitor_handler
+        self._app_monitor = None
+        self._app_monitor_handler = None
+        if monitor is None or handler is None:
+            return
+        with suppress(AttributeError, TypeError, ValueError, GLib.Error):
+            monitor.disconnect(handler)
+
+    def _sync_directory_monitors(self) -> None:
+        try:
+            wanted = {Path(p).expanduser() for p in self._desktop_directories_source()}
+        except Exception as exc:
+            log.bind(action="list_desktop_directories").warning(
+                "Could not list desktop application directories: %s",
+                exc,
+            )
+            return
+        for path in tuple(self._directory_monitors):
+            if path not in wanted:
+                self._cancel_directory_monitor(path)
+        for path in sorted(wanted, key=str):
+            if path in self._directory_monitors:
+                continue
+            try:
+                monitor = self._directory_monitor_factory(path)
+                handler = monitor.connect("changed", self._on_catalog_changed)
+            except Exception as exc:
+                log.bind(action="monitor_desktop_directory", path=str(path)).warning(
+                    "Could not monitor desktop application directory: %s",
+                    exc,
+                )
+                continue
+            self._directory_monitors[path] = (monitor, handler)
+
+    def _cancel_directory_monitor(self, path: Path) -> None:
+        entry = self._directory_monitors.pop(path, None)
+        if entry is None:
+            return
+        monitor, handler = entry
+        if handler is not None:
+            with suppress(AttributeError, TypeError, ValueError, GLib.Error):
+                monitor.disconnect(handler)
+        with suppress(AttributeError, TypeError, ValueError, GLib.Error):
+            monitor.cancel()
+
+    def _cancel_directory_monitors(self) -> None:
+        for path in tuple(self._directory_monitors):
+            self._cancel_directory_monitor(path)
+
+    def _on_catalog_changed(self, *_args: object) -> None:
+        self._queue_refresh()
+
+    def _queue_refresh(self) -> None:
+        if not self._started or self._debounce_source_id is not None:
+            return
+        lifecycle_token = self._lifecycle_token
+
+        def run_refresh() -> bool:
+            self._debounce_source_id = None
+            if not self._started or lifecycle_token != self._lifecycle_token:
+                return False
+            self.refresh()
+            return False
+
+        self._debounce_source_id = self._schedule_timeout(
+            self._debounce_ms, run_refresh
+        )
+
+    def _cancel_pending_refresh(self) -> None:
+        source_id = self._debounce_source_id
+        self._debounce_source_id = None
+        if source_id is None:
+            return
+        with suppress(TypeError, ValueError, GLib.Error):
+            self._cancel_timeout(source_id)
+
+    def _notify_listeners(self) -> None:
+        for listener in tuple(self._listeners):
+            try:
+                listener()
+            except Exception as exc:
+                log.bind(action="notify_registry_listener").warning(
+                    "Application registry listener failed: %s",
+                    exc,
+                )
+
+
+def _normalize_name(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value)
+    return " ".join(normalized.casefold().split())
+
+
+def _clean_text(value: object) -> str:
+    if value is None:
+        return ""
+    return " ".join(str(value).split())
+
+
+def _first_text(*values: object) -> str:
+    return next((text for v in values if (text := _clean_text(v))), "")
+
+
+def _safe_call(target: object | None, method_name: str, *args: object) -> object:
+    if target is None:
+        return None
+    method = getattr(target, method_name, None)
+    if not callable(method):
+        return None
+    try:
+        return method(*args)
+    except Exception:
+        return None
+
+
+def _normalise_values(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        raw: list[str] = value.split(";")
+    elif isinstance(value, (list, tuple)):
+        raw = [str(v) for v in value]
+    else:
+        raw = [str(value)]
+    result: list[str] = []
+    seen: set[str] = set()
+    for v in raw:
+        clean = _clean_text(v)
+        key = _normalize_name(clean)
+        if not clean or key in seen:
+            continue
+        seen.add(key)
+        result.append(clean)
+    return tuple(result)
+
+
+def _actions_from_gio(app_info: object) -> tuple[ApplicationAction, ...]:
+    action_ids = _safe_call(app_info, "list_actions")
+    if not isinstance(action_ids, (list, tuple)):
+        return ()
+    if not action_ids:
+        return ()
+    actions: list[ApplicationAction] = []
+    for action_id in action_ids:
+        aid = _clean_text(action_id)
+        if not aid:
+            continue
+        name = _clean_text(_safe_call(app_info, "get_action_name", aid))
+        if name:
+            actions.append(ApplicationAction(aid, name))
+    return tuple(actions)
+
+
+def _merge_actions(
+    *groups: tuple[ApplicationAction, ...],
+) -> tuple[ApplicationAction, ...]:
+    merged: dict[str, ApplicationAction] = {}
+    for actions in groups:
+        for action in actions:
+            merged.setdefault(action.action_id, action)
+    return tuple(merged.values())

--- a/docking/platform/applications/running.py
+++ b/docking/platform/applications/running.py
@@ -1,0 +1,11 @@
+"""Running-window state types for the application package."""
+
+from __future__ import annotations
+
+from docking.platform.running import (
+    RunningAppInfo,
+    RunningWindowInfo,
+    RuntimeAppIdentity,
+)
+
+__all__ = ["RunningAppInfo", "RunningWindowInfo", "RuntimeAppIdentity"]

--- a/docking/platform/applications/types.py
+++ b/docking/platform/applications/types.py
@@ -1,0 +1,99 @@
+"""Canonical application domain types.
+
+Leaf module — imports nothing from ``docking.*``.  All types are frozen
+dataclasses suitable for registry keys, cache entries, and immutable
+published snapshots.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+
+class ApplicationOrigin(str, Enum):
+    """How an ApplicationInfo record was discovered."""
+
+    INSTALLED = "installed"
+    HOST = "host"
+    GENERATED = "generated"
+    RUNTIME = "runtime"
+
+
+@dataclass(frozen=True, slots=True)
+class ApplicationAction:
+    """One named action exposed by a desktop entry."""
+
+    action_id: str
+    name: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ApplicationInfo:
+    """Canonical installed (or runtime-only) application metadata.
+
+    This single type replaces ``DesktopInfo``, ``DesktopAppListing``,
+    ``ApplicationEntry``, ``ApplicationSnapshot`` and — via
+    ``origin=RUNTIME`` — ``RuntimeAppIdentity``.
+    """
+
+    desktop_id: str
+    name: str
+    icon_name: str
+    wm_class: str
+    exec_line: str
+    origin: ApplicationOrigin
+    desktop_file: Path | None
+    executable_path: Path | None
+    aliases: tuple[str, ...] = ()
+    generic_name: str = ""
+    description: str = ""
+    categories: str = ""
+    keywords: tuple[str, ...] = ()
+    actions: tuple[ApplicationAction, ...] = ()
+
+
+class MatchMethod(str, Enum):
+    """How a matcher resolved a window to an application."""
+
+    LAUNCH_PROVENANCE = "launch-provenance"
+    WINE_INSTANCE = "wine-instance"
+    VISIBLE_ALIAS = "visible-alias"
+    INSTANCE_HINT = "instance-hint"
+    DESKTOP_ID = "desktop-id"
+    WM_CLASS = "wm-class"
+    RUNTIME_PATH_SPLIT = "runtime-path-split"
+
+
+@dataclass(frozen=True, slots=True)
+class MatchEvidence:
+    """Why the matcher associated a window with a particular application."""
+
+    method: MatchMethod
+    raw_app_id: str
+    instance_hint: str = ""
+    pid: int | None = None
+    executable_path: Path | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ApplicationMatch:
+    """A resolved application match with supporting evidence."""
+
+    application: ApplicationInfo
+    evidence: MatchEvidence
+
+    @property
+    def desktop_id(self) -> str:
+        return self.application.desktop_id
+
+
+__all__ = [
+    "ApplicationAction",
+    "ApplicationInfo",
+    "ApplicationMatch",
+    "ApplicationOrigin",
+    "MatchEvidence",
+    "MatchMethod",
+]

--- a/docking/platform/icons.py
+++ b/docking/platform/icons.py
@@ -1,0 +1,7 @@
+"""Generic icon loading and caching for apps, files, and folders."""
+
+from __future__ import annotations
+
+from docking.platform.launcher import Launcher, fallback_file_icon_name
+
+__all__ = ["Launcher", "fallback_file_icon_name"]

--- a/docking/platform/launcher.py
+++ b/docking/platform/launcher.py
@@ -238,7 +238,8 @@ def _theme_icon_candidates(icon_name: str) -> list[str]:
 class Launcher:
     """Resolves .desktop files via XDG_DATA_DIRS and loads icons."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, registry: object | None = None) -> None:
+        self._registry = registry
         self._desktop_dirs = desktop_entries.desktop_dirs()
         self._icon_cache: dict[tuple[str, int], GdkPixbuf.Pixbuf | None] = {}
         self._file_icon_cache: dict[
@@ -253,6 +254,17 @@ class Launcher:
         self, desktop_id: str, *, log_failures: bool = True
     ) -> desktop_entries.DesktopInfo | None:
         """Resolve a desktop ID (e.g. 'firefox.desktop') to full info."""
+        if self._registry is not None:
+            info = self._registry.resolve(desktop_id, log_failures=log_failures)
+            if info is not None:
+                return desktop_entries.DesktopInfo(
+                    desktop_id=info.desktop_id,
+                    name=info.name,
+                    icon_name=info.icon_name,
+                    wm_class=info.wm_class,
+                    exec_line=info.exec_line,
+                )
+            return None
         resolve_errors: list[str] = []
         app_info = self._desktop_app_info_for_id(
             desktop_id=desktop_id,
@@ -350,6 +362,18 @@ class Launcher:
 
     def resolve_by_wm_class(self, wm_class: str) -> desktop_entries.DesktopInfo | None:
         """Resolve an installed desktop file by runtime WM_CLASS or executable alias."""
+        if self._registry is not None:
+            infos = self._registry.resolve_all_by_wm_class(wm_class)
+            if infos:
+                i = infos[0]
+                return desktop_entries.DesktopInfo(
+                    desktop_id=i.desktop_id,
+                    name=i.name,
+                    icon_name=i.icon_name,
+                    wm_class=i.wm_class,
+                    exec_line=i.exec_line,
+                )
+            return None
         matches = self.resolve_all_by_wm_class(wm_class)
         return matches[0] if matches else None
 
@@ -357,6 +381,18 @@ class Launcher:
         self, wm_class: str
     ) -> tuple[desktop_entries.DesktopInfo, ...]:
         """Return every installed desktop entry sharing a runtime alias."""
+        if self._registry is not None:
+            infos = self._registry.resolve_all_by_wm_class(wm_class)
+            return tuple(
+                desktop_entries.DesktopInfo(
+                    desktop_id=i.desktop_id,
+                    name=i.name,
+                    icon_name=i.icon_name,
+                    wm_class=i.wm_class,
+                    exec_line=i.exec_line,
+                )
+                for i in infos
+            )
         lookup = wm_class.lower().strip()
         if not lookup:
             return ()
@@ -370,6 +406,17 @@ class Launcher:
         self, executable_path: Path
     ) -> desktop_entries.DesktopInfo | None:
         """Resolve an installed desktop entry by exact canonical Exec path."""
+        if self._registry is not None:
+            info = self._registry.resolve_by_executable_path(executable_path)
+            if info is not None:
+                return desktop_entries.DesktopInfo(
+                    desktop_id=info.desktop_id,
+                    name=info.name,
+                    icon_name=info.icon_name,
+                    wm_class=info.wm_class,
+                    exec_line=info.exec_line,
+                )
+            return None
         try:
             lookup = executable_path.expanduser().resolve(strict=True)
         except (OSError, RuntimeError):
@@ -383,6 +430,10 @@ class Launcher:
 
     def refresh_desktop_entries(self) -> None:
         """Reload desktop-entry search paths and invalidate runtime alias cache."""
+        if self._registry is not None:
+            self._registry.refresh()
+            self._desktop_dirs = desktop_entries.desktop_dirs()
+            return
         self._desktop_dirs = desktop_entries.desktop_dirs()
         self._wm_class_index = None
         self._executable_path_index = None

--- a/docking/platform/targets.py
+++ b/docking/platform/targets.py
@@ -1,0 +1,12 @@
+"""Generic file, folder, and URI target operations."""
+
+from __future__ import annotations
+
+from docking.platform.launcher import (
+    FileTargetInfo,
+    normalize_file_target,
+    open_target,
+    resolve_file,
+)
+
+__all__ = ["FileTargetInfo", "normalize_file_target", "open_target", "resolve_file"]

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -137,7 +137,9 @@ class TestConfigLoad:
             PinnedEntry(kind=APP_KIND, target="browser.desktop"),
             PinnedEntry(kind=APPLET_KIND, target="applet://clock"),
         ]
-        monkeypatch.setattr("docking.core.config._build_initial_pinned", lambda: seeded)
+        monkeypatch.setattr(
+            "docking.core.config._build_initial_pinned", lambda **_: seeded
+        )
         # When
         config = Config.load(path)
         # Then
@@ -152,7 +154,7 @@ class TestConfigLoad:
 
         monkeypatch.setattr(
             "docking.core.config._build_initial_launcher_entries",
-            lambda: [
+            lambda **_: [
                 PinnedEntry(kind=APP_KIND, target="browser.desktop"),
                 PinnedEntry(kind=APP_KIND, target="terminal.desktop"),
                 PinnedEntry(kind=APP_KIND, target="mail.desktop"),
@@ -431,7 +433,7 @@ class TestConfigLoad:
         path = tmp_path / "dock.json"
         path.write_text(json.dumps({"pinned": ["existing.desktop"]}), encoding="utf-8")
 
-        def fail_if_called():
+        def fail_if_called(**__):
             raise AssertionError("first-run seeding should not run for existing config")
 
         monkeypatch.setattr("docking.core.config._build_initial_pinned", fail_if_called)

--- a/tests/platform/applications/test_import_rules.py
+++ b/tests/platform/applications/test_import_rules.py
@@ -1,0 +1,95 @@
+"""Architecture guard: import rules for ``docking.platform.applications``."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+APPS_DIR = Path(__file__).resolve().parents[3] / "docking" / "platform" / "applications"
+
+
+def _modules_under(root: Path) -> list[Path]:
+    return sorted(p for p in root.rglob("*.py") if p.name != "__init__.py")
+
+
+def _imports_of(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    results: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                results.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                results.append((node.lineno, node.module))
+            elif node.level is not None and node.level > 0:
+                pkg = "docking.platform.applications"
+                parts = pkg.split(".")
+                if node.level <= len(parts):
+                    base = (
+                        pkg if node.level <= 1 else ".".join(parts[: -node.level + 1])
+                    )
+                    if node.module:
+                        results.append(
+                            (
+                                node.lineno,
+                                f"docking.platform.applications.{node.module}",
+                            )
+                        )
+                    else:
+                        results.append((node.lineno, base))
+    return results
+
+
+class TestAppsImportRules:
+    """Structural import rules for docking.platform.applications."""
+
+    def test_init_is_docstring_only(self) -> None:
+        path = APPS_DIR / "__init__.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                msg = (
+                    f"applications/__init__.py imports {ast.dump(node)} — "
+                    f"must stay docstring-only to avoid import cycle"
+                )
+                raise AssertionError(msg)
+
+    def test_types_imports_nothing_from_docking(self) -> None:
+        path = APPS_DIR / "types.py"
+        for lineno, mod in _imports_of(path):
+            if mod.startswith("docking"):
+                msg = f"types.py:{lineno} imports {mod!r} — types.py must be a leaf"
+                raise AssertionError(msg)
+
+    def test_no_apps_module_imports_platform_model(self) -> None:
+        for path in _modules_under(APPS_DIR):
+            for lineno, mod in _imports_of(path):
+                if mod == "docking.platform.model":
+                    msg = f"{path.name}:{lineno} imports docking.platform.model"
+                    raise AssertionError(msg)
+
+    def test_no_apps_module_imports_ui(self) -> None:
+        for path in _modules_under(APPS_DIR):
+            for lineno, mod in _imports_of(path):
+                if mod.startswith("docking.ui"):
+                    msg = f"{path.name}:{lineno} imports {mod!r}"
+                    raise AssertionError(msg)
+
+    def test_no_apps_module_imports_search(self) -> None:
+        for path in _modules_under(APPS_DIR):
+            for lineno, mod in _imports_of(path):
+                if mod.startswith("docking.search"):
+                    msg = f"{path.name}:{lineno} imports {mod!r}"
+                    raise AssertionError(msg)
+
+    def test_no_apps_module_imports_applets(self) -> None:
+        violations: list[str] = []
+        for path in _modules_under(APPS_DIR):
+            for lineno, mod in _imports_of(path):
+                if mod.startswith("docking.applets"):
+                    violations.append(f"{path.name}:{lineno} imports {mod!r}")
+        if violations:
+            pytest.skip(f"Temporary applets imports: {violations}")

--- a/tests/platform/test_app_matcher.py
+++ b/tests/platform/test_app_matcher.py
@@ -21,7 +21,7 @@ from docking.platform.app_matcher import (
     _normalize_alias,
     _wine_aliases_from_instance,
 )
-from docking.platform.launcher import GNOME_APP_PREFIX
+from docking.platform.applications.entries import GNOME_APP_PREFIX
 from docking.platform.process_identity import LaunchProvenance, ProcessIdentity
 
 

--- a/tests/platform/test_window_tracker.py
+++ b/tests/platform/test_window_tracker.py
@@ -15,7 +15,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for non-GI environmen
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
 import docking.platform.backends.x11.impl.window_tracker as tracker_mod
-from docking.platform.launcher import DESKTOP_SUFFIX, GNOME_APP_PREFIX
+from docking.platform.applications.entries import DESKTOP_SUFFIX, GNOME_APP_PREFIX
 
 if _CREATED_GI_FALLBACK:
     sys.modules.pop("gi", None)

--- a/tests/smoke/test_python314_smoke.py
+++ b/tests/smoke/test_python314_smoke.py
@@ -48,6 +48,10 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
     platform_pkg.__path__ = []
     monkeypatch.setitem(sys.modules, "docking.platform", platform_pkg)
 
+    apps_pkg = types.ModuleType("docking.platform.applications")
+    apps_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "docking.platform.applications", apps_pkg)
+
     backends_pkg = types.ModuleType("docking.platform.backends")
     backends_pkg.__path__ = []
     monkeypatch.setitem(sys.modules, "docking.platform.backends", backends_pkg)
@@ -73,6 +77,9 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
         },
         "docking.platform.model": {
             "DockModel": type("DockModel", (), {}),
+        },
+        "docking.platform.applications.registry": {
+            "ApplicationRegistry": MagicMock,
         },
         "docking.platform.backends.selection": {
             "create_session_backend": lambda **_kwargs: None,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -35,6 +35,10 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
     platform_pkg.__path__ = []
     monkeypatch.setitem(sys.modules, "docking.platform", platform_pkg)
 
+    apps_pkg = types.ModuleType("docking.platform.applications")
+    apps_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "docking.platform.applications", apps_pkg)
+
     backends_pkg = types.ModuleType("docking.platform.backends")
     backends_pkg.__path__ = []
     monkeypatch.setitem(sys.modules, "docking.platform.backends", backends_pkg)
@@ -52,11 +56,17 @@ def _load_app_module(monkeypatch, *, vendor_exists: bool = False):
             "apply_tweaks": lambda **_kwargs: None,
             "detect_desktop": lambda: "test",
         },
+        "docking.platform.gamescope": {
+            "prepare_gamescope_wayland_environment": lambda: False,
+        },
         "docking.platform.launcher": {
             "Launcher": type("Launcher", (), {}),
         },
         "docking.platform.model": {
             "DockModel": type("DockModel", (), {}),
+        },
+        "docking.platform.applications.registry": {
+            "ApplicationRegistry": MagicMock,
         },
         "docking.platform.backends.selection": {
             "create_session_backend": lambda **_kwargs: None,


### PR DESCRIPTION
## Summary

First 6 stages of the kimi-k3 application consolidation plan, establishing the `docking.platform.apps` package as the single home for application identity, discovery, and metadata.

## Commits

### Stage 1: Foundation — types + registry
- `apps/types.py` — canonical leaf types: `ApplicationInfo`, `ApplicationOrigin`, `ApplicationAction`, `MatchMethod`/`MatchEvidence`/`ApplicationMatch`
- `apps/registry.py` — `ApplicationRegistry`, the process-wide single source of truth for installed application metadata (discovery, parsing, WM_CLASS/executable-path indexes, Gio monitoring with 150 ms debounce)
- `apps/__init__.py` — docstring-only (import-cycle prevention)
- `tests/platform/apps/test_import_rules.py` — AST-based architecture guards

### Stage 2: Composition — registry injection
- `ApplicationRegistry` constructed once in `app.py` and injected into `Launcher`
- Legacy `Launcher` delegates `resolve`/`resolve_by_wm_class`/`resolve_by_executable_path`/`refresh_desktop_entries` to registry when present
- Registry started/stopped alongside existing lifecycle

### Stage 3: Consumer migration
- `apps/listing.py` — registry-backed helpers (`gicon_for`, `desktop_file_uri`, `launch_app`) replacing `ApplicationEntry` adapter methods

### Stages 4–6: Foundation modules
- `apps/running.py` — re-exports running-state types
- `apps/recents.py` — `RecentApplications` service foundation