### PR TITLE
Fix X11 intelligent hide evaluation

### DIFF
--- a/docking/platform/backends/x11/impl/dodge.py
+++ b/docking/platform/backends/x11/impl/dodge.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 from contextlib import suppress
 from typing import TYPE_CHECKING, NamedTuple
@@ -23,7 +24,8 @@ import gi
 
 gi.require_version("Wnck", "3.0")
 gi.require_version("Gtk", "3.0")
-from gi.repository import GLib, Wnck
+gi.require_version("Gdk", "3.0")
+from gi.repository import Gdk, GLib, Wnck
 
 from docking.core.config import HideMode
 from docking.log import get_logger, with_context
@@ -35,6 +37,7 @@ if TYPE_CHECKING:
 log = with_context(get_logger(name="dodge"))
 
 DEBOUNCE_MS = 200
+_OWN_PID = os.getpid()
 
 _SKIP_TYPES = frozenset(
     {
@@ -85,6 +88,7 @@ class WindowDodgeMonitor(VisibilityMonitor):
         self._screen = Wnck.Screen.get_default()
         if not self._screen:
             return
+        self._force_screen_update()
         self._connect(self._screen, "active-window-changed", self._on_window_event)
         self._connect(self._screen, "window-opened", self._on_window_opened)
         self._connect(self._screen, "window-closed", self._on_window_closed)
@@ -109,7 +113,7 @@ class WindowDodgeMonitor(VisibilityMonitor):
         self._screen = None
 
     def _connect(self, obj: object, signal: str, handler: Callable) -> None:
-        sid = obj.connect(signal, handler)
+        sid = obj.connect_after(signal, handler)
         self._signal_ids.append((obj, sid))
 
     def _connect_window(self, window: Wnck.Window) -> None:
@@ -122,8 +126,8 @@ class WindowDodgeMonitor(VisibilityMonitor):
             return
         sids: list[int] = []
         try:
-            sids.append(window.connect("geometry-changed", self._on_window_event))
-            sids.append(window.connect("state-changed", self._on_window_event))
+            sids.append(window.connect_after("geometry-changed", self._on_window_event))
+            sids.append(window.connect_after("state-changed", self._on_window_event))
         except Exception as exc:
             log.debug("Failed to connect dodge monitor window signals: %s", exc)
         self._window_signal_ids[xid] = (window, sids)
@@ -153,6 +157,25 @@ class WindowDodgeMonitor(VisibilityMonitor):
     def _on_window_event(self, *_args: object) -> None:
         self._schedule_evaluate()
 
+    def _force_screen_update(self) -> None:
+        """Ask libwnck to flush pending X11 state before reading windows."""
+        if self._screen is None:
+            return
+        trapped = False
+        try:
+            Gdk.error_trap_push()
+            trapped = True
+            self._screen.force_update()
+            Gdk.flush()
+            if Gdk.error_trap_pop() != 0:
+                log.debug("Wnck force_update produced an X11 error")
+            trapped = False
+        except Exception as exc:
+            if trapped:
+                with suppress(Exception):
+                    Gdk.error_trap_pop()
+            log.debug("Failed to force Wnck update before dodge evaluation: %s", exc)
+
     def _schedule_evaluate(self) -> None:
         if self._debounce_id:
             GLib.source_remove(self._debounce_id)
@@ -167,6 +190,7 @@ class WindowDodgeMonitor(VisibilityMonitor):
 
     def _do_evaluate(self) -> bool:
         self._debounce_id = 0
+        self._force_screen_update()
         should_hide = self._evaluate()
         if should_hide != self._should_hide:
             self._should_hide = should_hide
@@ -197,7 +221,7 @@ class WindowDodgeMonitor(VisibilityMonitor):
                 active_workspace,
             )
         if mode == HideMode.DODGE_ACTIVE:
-            return self._eval_dodge_active(dock_rect, active_window)
+            return self._eval_dodge_active(dock_rect, active_window, active_workspace)
         if mode == HideMode.WINDOW_DODGE:
             return self._eval_window_dodge(dock_rect, screen, active_workspace)
         if mode == HideMode.DODGE_MAXIMIZED:
@@ -219,19 +243,28 @@ class WindowDodgeMonitor(VisibilityMonitor):
         """Hide if any window from the active app overlaps dock."""
         if not active_window:
             return False
-        try:
-            active_class = active_window.get_class_group_name()
-        except Exception as exc:
-            log.debug(
-                "Failed to read active window class for intelligent dodge: %s",
-                exc,
-            )
+
+        if self._is_dodge_candidate(active_window, active_workspace) and (
+            self._window_overlaps(active_window, dock_rect)
+        ):
+            return True
+
+        active_pid = self._window_pid(active_window)
+        active_class = self._window_class(active_window)
+        if active_pid is None and not active_class:
             return False
-        if not active_class:
-            return False
+
         for win in self._visible_windows(screen, active_workspace):
             try:
-                if win.get_class_group_name() != active_class:
+                win_pid = self._window_pid(win)
+                win_class = self._window_class(win)
+                same_process = (
+                    active_pid is not None
+                    and win_pid is not None
+                    and win_pid == active_pid
+                )
+                same_class = bool(active_class and win_class == active_class)
+                if not (same_process or same_class):
                     continue
                 if self._window_overlaps(win, dock_rect):
                     return True
@@ -243,13 +276,33 @@ class WindowDodgeMonitor(VisibilityMonitor):
                 continue
         return False
 
+    @staticmethod
+    def _window_pid(window: Wnck.Window) -> int | None:
+        try:
+            pid = int(window.get_pid())
+        except Exception as exc:
+            log.debug("Failed to read window pid for dodge overlap: %s", exc)
+            return None
+        return pid if pid > 0 else None
+
+    @staticmethod
+    def _window_class(window: Wnck.Window) -> str | None:
+        try:
+            return window.get_class_group_name() or None
+        except Exception as exc:
+            log.debug("Failed to read window class for dodge overlap: %s", exc)
+            return None
+
     def _eval_dodge_active(
         self,
         dock_rect: ScreenRect,
         active_window: Wnck.Window | None,
+        active_workspace: Wnck.Workspace | None,
     ) -> bool:
         """Hide if the active window overlaps dock."""
         if not active_window:
+            return False
+        if not self._is_dodge_candidate(active_window, active_workspace):
             return False
         return self._window_overlaps(active_window, dock_rect)
 
@@ -273,11 +326,17 @@ class WindowDodgeMonitor(VisibilityMonitor):
         active_workspace: Wnck.Workspace | None,
     ) -> bool:
         """Hide if active window is maximized or a dialog overlaps."""
+        active_pid = self._window_pid(active_window) if active_window else None
+        active_class = self._window_class(active_window) if active_window else None
         if active_window:
             try:
-                if active_window.is_maximized() and self._window_overlaps(
-                    active_window,
-                    dock_rect,
+                if (
+                    self._is_dodge_candidate(active_window, active_workspace)
+                    and self._window_is_maximized(active_window)
+                    and self._window_overlaps(
+                        active_window,
+                        dock_rect,
+                    )
                 ):
                     return True
             except Exception as exc:
@@ -286,6 +345,11 @@ class WindowDodgeMonitor(VisibilityMonitor):
             try:
                 if (
                     win.get_window_type() == Wnck.WindowType.DIALOG
+                    and self._matches_active_app(
+                        win,
+                        active_pid=active_pid,
+                        active_class=active_class,
+                    )
                     and self._window_overlaps(win, dock_rect)
                 ):
                     return True
@@ -305,21 +369,62 @@ class WindowDodgeMonitor(VisibilityMonitor):
         """Yield normal windows on active workspace that aren't minimized."""
         for win in screen.get_windows():
             try:
-                if win.is_minimized():
-                    continue
-                if win.get_window_type() in _SKIP_TYPES:
-                    continue
-                if active_workspace and not win.is_visible_on_workspace(
-                    active_workspace,
-                ):
-                    continue
-                yield win
+                if self._is_dodge_candidate(win, active_workspace):
+                    yield win
             except Exception as exc:
                 log.debug(
                     "Failed to inspect window while listing visible windows: %s",
                     exc,
                 )
                 continue
+
+    def _is_dodge_candidate(
+        self,
+        window: Wnck.Window,
+        active_workspace: Wnck.Workspace | None,
+    ) -> bool:
+        try:
+            if window.is_minimized():
+                return False
+            if window.get_window_type() in _SKIP_TYPES:
+                return False
+            if active_workspace and not window.is_visible_on_workspace(
+                active_workspace,
+            ):
+                return False
+        except Exception as exc:
+            log.debug("Failed to inspect dodge candidate window: %s", exc)
+            return False
+
+        pid = self._window_pid(window)
+        return pid != _OWN_PID
+
+    def _matches_active_app(
+        self,
+        window: Wnck.Window,
+        *,
+        active_pid: int | None,
+        active_class: str | None,
+    ) -> bool:
+        win_pid = self._window_pid(window)
+        win_class = self._window_class(window)
+        same_process = (
+            active_pid is not None and win_pid is not None and win_pid == active_pid
+        )
+        same_class = bool(active_class and win_class == active_class)
+        return same_process or same_class
+
+    @staticmethod
+    def _window_is_maximized(window: Wnck.Window) -> bool:
+        try:
+            return bool(
+                window.is_maximized()
+                or window.is_maximized_vertically()
+                or window.is_maximized_horizontally()
+            )
+        except Exception as exc:
+            log.debug("Failed to read window maximized state: %s", exc)
+        return False
 
     def _window_overlaps(
         self,

--- a/docking/ui/factory.py
+++ b/docking/ui/factory.py
@@ -207,7 +207,7 @@ def build_dock_window(
             return None
         window_pos = window_screen_position(window)
         wx, wy = window_pos.x, window_pos.y
-        dock_rect = window.geometry.build_frame().background_rect
+        dock_rect = window.geometry.build_frame().static_dock_rect
         return Rect(
             x=wx + dock_rect.x,
             y=wy + dock_rect.y,

--- a/tests/platform/test_dodge_monitor.py
+++ b/tests/platform/test_dodge_monitor.py
@@ -25,8 +25,11 @@ def _make_window(
     w: int,
     h: int,
     class_group: str = "App",
+    pid: int | None = None,
     minimized: bool = False,
     maximized: bool = False,
+    maximized_vertically: bool = False,
+    maximized_horizontally: bool = False,
     win_type=None,
     visible_on_workspace: bool = True,
 ):
@@ -34,8 +37,11 @@ def _make_window(
     win = MagicMock()
     win.get_geometry.return_value = (x, y, w, h)
     win.get_class_group_name.return_value = class_group
+    win.get_pid.return_value = pid if pid is not None else id(win)
     win.is_minimized.return_value = minimized
     win.is_maximized.return_value = maximized
+    win.is_maximized_vertically.return_value = maximized_vertically
+    win.is_maximized_horizontally.return_value = maximized_horizontally
     win.get_xid.return_value = id(win)
     win.is_visible_on_workspace.return_value = visible_on_workspace
     # Default to NORMAL type
@@ -114,6 +120,19 @@ class TestEvaluateDodgeActive:
         # Then dock stays visible
         assert result is False
 
+    def test_active_window_not_visible_on_workspace_is_ignored(self):
+        config = Config(hide_mode="dodge-active")
+        active = _make_window(
+            x=500,
+            y=0,
+            w=1000,
+            h=1080,
+            visible_on_workspace=False,
+        )
+        mon = _make_monitor(config=config, active_window=active)
+
+        assert mon._evaluate() is False
+
 
 class TestEvaluateWindowDodge:
     def test_any_window_overlapping_hides(self):
@@ -174,6 +193,23 @@ class TestEvaluateIntelligent:
         # Then dock stays visible (different app)
         assert result is False
 
+    def test_active_window_overlapping_hides_without_class_group(self):
+        config = Config(hide_mode="intelligent")
+        active = _make_window(x=500, y=0, w=1000, h=1080, class_group="")
+        mon = _make_monitor(config=config, windows=[], active_window=active)
+
+        assert mon._evaluate() is True
+
+    def test_same_process_window_overlapping_hides_without_class_group(self):
+        config = Config(hide_mode="intelligent")
+        active = _make_window(x=0, y=0, w=800, h=600, class_group="", pid=123)
+        sibling = _make_window(x=600, y=900, w=720, h=200, class_group="", pid=123)
+        mon = _make_monitor(
+            config=config, windows=[active, sibling], active_window=active
+        )
+
+        assert mon._evaluate() is True
+
     def test_no_active_window(self):
         config = Config(hide_mode="intelligent")
         win = _make_window(x=600, y=900, w=720, h=200)
@@ -203,19 +239,62 @@ class TestEvaluateDodgeMaximized:
         assert result is False
 
     def test_dialog_overlapping_hides(self):
-        # Given a dialog window overlapping dock
+        # Given an active-app dialog window overlapping dock
         config = Config(hide_mode="dodge-maximized")
         # Make the dialog type compare equal to Wnck.WindowType.DIALOG
         from gi.repository import Wnck
 
+        active = _make_window(x=0, y=0, w=800, h=600, class_group="App", pid=123)
         dialog = _make_window(
-            x=600, y=900, w=400, h=300, win_type=Wnck.WindowType.DIALOG
+            x=600,
+            y=900,
+            w=400,
+            h=300,
+            class_group="App",
+            pid=123,
+            win_type=Wnck.WindowType.DIALOG,
         )
-        mon = _make_monitor(config=config, windows=[dialog], active_window=None)
+        mon = _make_monitor(
+            config=config, windows=[active, dialog], active_window=active
+        )
         # When evaluated
         result = mon._evaluate()
         # Then dock hides
         assert result is True
+
+    def test_dialog_from_inactive_app_does_not_hide(self):
+        config = Config(hide_mode="dodge-maximized")
+        from gi.repository import Wnck
+
+        active = _make_window(x=0, y=0, w=800, h=600, class_group="Active", pid=123)
+        dialog = _make_window(
+            x=600,
+            y=900,
+            w=400,
+            h=300,
+            class_group="Other",
+            pid=456,
+            win_type=Wnck.WindowType.DIALOG,
+        )
+        mon = _make_monitor(
+            config=config, windows=[active, dialog], active_window=active
+        )
+
+        assert mon._evaluate() is False
+
+    def test_vertically_maximized_active_overlapping_hides(self):
+        config = Config(hide_mode="dodge-maximized")
+        active = _make_window(
+            x=0,
+            y=0,
+            w=1920,
+            h=1080,
+            maximized=False,
+            maximized_vertically=True,
+        )
+        mon = _make_monitor(config=config, windows=[active], active_window=active)
+
+        assert mon._evaluate() is True
 
     def test_no_active_and_no_dialog(self):
         # Given no active window and no dialog
@@ -269,6 +348,72 @@ class TestNullDockRect:
 
 
 class TestLifecycle:
+    def test_start_forces_initial_screen_update_before_connecting_windows(
+        self, monkeypatch
+    ):
+        config = Config(hide_mode="intelligent")
+        monitor = WindowDodgeMonitor(
+            config=config,
+            get_dock_rect=lambda: DOCK_RECT,
+            on_change=MagicMock(),
+        )
+        screen = MagicMock()
+        screen.get_windows.return_value = []
+        monkeypatch.setattr(
+            "docking.platform.backends.x11.impl.dodge.Wnck.Screen.get_default",
+            MagicMock(return_value=screen),
+        )
+        monkeypatch.setattr(
+            "docking.platform.backends.x11.impl.dodge.GLib.timeout_add",
+            MagicMock(return_value=99),
+        )
+
+        monitor.start()
+
+        screen.force_update.assert_called_once_with()
+
+    def test_do_evaluate_forces_screen_update_before_reading_state(self):
+        config = Config(hide_mode="dodge-active")
+        active = _make_window(x=500, y=0, w=1000, h=1080)
+        monitor = _make_monitor(config=config, active_window=active)
+        calls: list[str] = []
+        monitor._screen.force_update.side_effect = lambda: calls.append("force_update")
+        monitor._screen.get_active_window.side_effect = lambda: (
+            calls.append("get_active_window") or active
+        )
+
+        monitor._do_evaluate()
+
+        assert calls[:2] == ["force_update", "get_active_window"]
+        monitor._on_change.assert_called_once_with(True)
+
+    def test_schedule_evaluate_replaces_debounce_timer(self, monkeypatch):
+        config = Config(hide_mode="intelligent")
+        monitor = WindowDodgeMonitor(
+            config=config,
+            get_dock_rect=lambda: DOCK_RECT,
+            on_change=MagicMock(),
+        )
+        added: list[tuple[int, object]] = []
+        removed: list[int] = []
+        next_id = iter([10, 11])
+
+        monkeypatch.setattr(
+            "docking.platform.backends.x11.impl.dodge.GLib.timeout_add",
+            lambda delay, callback: added.append((delay, callback)) or next(next_id),
+        )
+        monkeypatch.setattr(
+            "docking.platform.backends.x11.impl.dodge.GLib.source_remove",
+            lambda source_id: removed.append(source_id),
+        )
+
+        monitor._schedule_evaluate()
+        monitor._schedule_evaluate()
+
+        assert [delay for delay, _callback in added] == [200, 200]
+        assert removed == [10]
+        assert monitor._debounce_id == 11
+
     def test_evaluate_now_cancels_pending_debounce_and_runs_immediately(
         self, monkeypatch
     ):
@@ -292,7 +437,7 @@ class TestLifecycle:
         assert monitor._debounce_id == 0
         monitor._do_evaluate.assert_called_once_with()
 
-    def test_stop_disconnects_window_signal_handlers(self):
+    def test_stop_disconnects_window_signal_handlers(self, monkeypatch):
         config = Config(hide_mode="window-dodge")
         monitor = WindowDodgeMonitor(
             config=config,
@@ -304,16 +449,24 @@ class TestLifecycle:
         monitor._signal_ids = [(screen, 10)]
 
         first = _make_window(x=0, y=0, w=100, h=100)
-        first.connect.side_effect = [101, 102]
+        first.connect_after.side_effect = [101, 102]
         second = _make_window(x=0, y=0, w=100, h=100)
-        second.connect.side_effect = [201, 202]
+        second.connect_after.side_effect = [201, 202]
 
         monitor._connect_window(first)
         monitor._connect_window(second)
+        monitor._debounce_id = 301
+        removed: list[int] = []
+        monkeypatch.setattr(
+            "docking.platform.backends.x11.impl.dodge.GLib.source_remove",
+            lambda source_id: removed.append(source_id),
+        )
 
         monitor.stop()
 
+        assert removed == [301]
         screen.disconnect.assert_called_once_with(10)
+        assert monitor._debounce_id == 0
         first.disconnect.assert_any_call(101)
         first.disconnect.assert_any_call(102)
         second.disconnect.assert_any_call(201)

--- a/tests/ui/test_factory.py
+++ b/tests/ui/test_factory.py
@@ -306,9 +306,15 @@ class TestBuildDockWindow:
         window = _window()
         window.get_realized.return_value = True
         window.get_position.return_value = (10, 20)
-        window.geometry.build_frame.return_value.background_rect = SimpleNamespace(
+        window.geometry.build_frame.return_value.static_dock_rect = SimpleNamespace(
             x=100,
             y=30,
+            w=300,
+            h=40,
+        )
+        window.geometry.build_frame.return_value.background_rect = SimpleNamespace(
+            x=100,
+            y=230,
             w=300,
             h=40,
         )


### PR DESCRIPTION
Summary: refresh Wnck state before evaluation, filter dodge candidates consistently, improve active-application matching, and use the static dock rectangle. 