### PR TITLE
Test application platform integration paths

### DIFF
--- a/tests/applets/test_music.py
+++ b/tests/applets/test_music.py
@@ -10,6 +10,7 @@ import pytest
 
 import docking.applets.music.applet as music_applet_mod
 import docking.applets.music.state as music_state_mod
+import docking.platform.applications.registry as registry_mod
 from docking.applets.music.applet import MusicApplet
 from docking.applets.music.render import create_music_icon
 from docking.applets.music.state import (
@@ -30,6 +31,10 @@ from docking.platform.applications.types import (
     ApplicationLocation,
     ApplicationOrigin,
     TransientApplicationInfo,
+)
+from tests.platform.application_fakes import (
+    ApplicationRegistryHarness,
+    GioApplicationFake,
 )
 
 
@@ -895,6 +900,53 @@ class TestMusicApplet:
 
         launcher.launch.assert_called_once_with("org.videolan.VLC.desktop")
         backend.play_pause.assert_not_called()
+
+    def test_media_complete_handler_flows_through_real_registry_to_applet(
+        self, monkeypatch
+    ):
+        handler = GioApplicationFake(
+            "org.videolan.VLC.desktop",
+            name="VLC",
+            icon="vlc-canonical",
+            commandline="vlc %U",
+            categories="AudioVideo;",
+        )
+        harness = ApplicationRegistryHarness((handler,))
+        get_recommended = MagicMock(return_value=[])
+        get_all = MagicMock(return_value=[handler])
+        monkeypatch.setattr(
+            registry_mod.Gio.AppInfo,
+            "get_default_for_type",
+            lambda _content_type, _must_support_uris: None,
+        )
+        monkeypatch.setattr(
+            registry_mod.Gio.AppInfo,
+            "get_recommended_for_type",
+            get_recommended,
+        )
+        monkeypatch.setattr(
+            registry_mod.Gio.AppInfo,
+            "get_all_for_type",
+            get_all,
+        )
+        launcher = MagicMock()
+        launcher.launch.return_value = True
+        applet, backend, _resolver = _make_applet(
+            monkeypatch,
+            unavailable_state(),
+            registry=harness.registry,
+            launcher=launcher,
+        )
+
+        selected = harness.registry.get("org.videolan.VLC.desktop")
+        applet.on_clicked()
+
+        assert selected is not None
+        assert selected.declared_icon == "vlc-canonical"
+        launcher.launch.assert_called_once_with("org.videolan.VLC.desktop")
+        backend.play_pause.assert_not_called()
+        assert get_recommended.call_count == len(music_applet_mod.MEDIA_CONTENT_TYPES)
+        get_all.assert_called_once_with("audio/mpeg")
 
     def test_on_clicked_ignores_idle_empty_browser_mpris_service(self, monkeypatch):
         idle_browser = _state(

--- a/tests/integration/test_application_consumer_refresh.py
+++ b/tests/integration/test_application_consumer_refresh.py
@@ -1,0 +1,117 @@
+"""Cross-consumer checks for one shared application registry generation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import docking.applets.runcommand.applet as runcommand_applet_mod
+from docking.applets.applications.state import build_app_categories
+from docking.applets.runcommand.applet import RunCommandApplet
+from docking.search.coordinator import SearchCancellation, SearchRequest
+from docking.search.providers.applications import ApplicationSearchProvider
+from docking.search.types import SearchQuery
+from tests.platform.application_fakes import (
+    ApplicationRegistryHarness,
+    GioApplicationFake,
+)
+
+
+class _ApplicationRow:
+    def __init__(self, app) -> None:
+        self.app = app
+        self.child = None
+
+    def add(self, child) -> None:
+        self.child = child
+
+
+class _ApplicationList:
+    def __init__(self) -> None:
+        self.children: list[_ApplicationRow] = []
+
+    def get_children(self) -> list[_ApplicationRow]:
+        return list(self.children)
+
+    def remove(self, child: _ApplicationRow) -> None:
+        self.children.remove(child)
+
+    def add(self, child: _ApplicationRow) -> None:
+        self.children.append(child)
+
+
+def _request(text: str, generation: int) -> SearchRequest:
+    return SearchRequest(
+        query=SearchQuery(text=text, limit=20),
+        generation=generation,
+        cancellation=SearchCancellation(generation),
+    )
+
+
+def _application_ids_from_categories(registry) -> set[str]:
+    return {
+        application.desktop_id
+        for applications in build_app_categories(registry).values()
+        for application in applications
+    }
+
+
+def test_registry_generation_reaches_applications_run_and_search_consumers(
+    monkeypatch,
+):
+    alpha = GioApplicationFake(
+        "alpha.desktop",
+        name="Alpha Editor",
+        icon="alpha",
+        categories="Utility;",
+    )
+    beta = GioApplicationFake(
+        "beta.desktop",
+        name="Beta Browser",
+        icon="beta",
+        categories="Network;",
+    )
+    harness = ApplicationRegistryHarness((alpha,))
+    registry = harness.registry
+
+    monkeypatch.setattr(runcommand_applet_mod, "_ApplicationRow", _ApplicationRow)
+    run_applet = object.__new__(RunCommandApplet)
+    run_applet._application_registry = registry
+    run_applet._app_list = _ApplicationList()
+    run_applet._entry = None
+    run_applet._apps = []
+    run_applet._app_rows = []
+    run_applet._build_app_row = lambda application: application
+    run_applet._apply_app_filter = lambda _query: None
+
+    model = SimpleNamespace(visible_items=MagicMock(return_value=[]))
+    windows = SimpleNamespace(list_windows=MagicMock(return_value=()))
+    search = ApplicationSearchProvider(
+        registry=registry,
+        application_launcher=MagicMock(),
+        target_service=MagicMock(),
+        model=model,
+        windows=windows,
+        recent_docs_limit=5,
+    )
+
+    run_applet._refresh_app_list()
+    alpha_results = next(search.search(_request("Alpha", 1))).results
+
+    assert _application_ids_from_categories(registry) == {"alpha.desktop"}
+    assert [application.desktop_id for application in run_applet._apps] == [
+        "alpha.desktop"
+    ]
+    assert [result.identity.key for result in alpha_results] == ["alpha.desktop"]
+
+    harness.publish((beta,))
+    run_applet._refresh_app_list()
+    removed_results = next(search.search(_request("Alpha", 2))).results
+    beta_results = next(search.search(_request("Beta", 3))).results
+
+    assert _application_ids_from_categories(registry) == {"beta.desktop"}
+    assert [application.desktop_id for application in run_applet._apps] == [
+        "beta.desktop"
+    ]
+    assert removed_results == ()
+    assert [result.identity.key for result in beta_results] == ["beta.desktop"]

--- a/tests/platform/application_fakes.py
+++ b/tests/platform/application_fakes.py
@@ -2,15 +2,109 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from docking.platform.applications.identity import (
     LaunchProvenanceStore,
     ProcessIdentityService,
 )
+from docking.platform.applications.registry import ApplicationRegistry
 from docking.platform.applications.types import (
     ApplicationInfo,
     ApplicationLocation,
     ApplicationOrigin,
 )
+
+
+class _Icon:
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def to_string(self) -> str:
+        return self._value
+
+
+class GioApplicationFake:
+    """Small Gio desktop application double accepted by real discovery code."""
+
+    def __init__(
+        self,
+        desktop_id: str,
+        *,
+        name: str | None = None,
+        icon: str = "application-x-executable",
+        commandline: str | None = None,
+        categories: str = "Utility;",
+        filename: str = "",
+        should_show: bool = True,
+    ) -> None:
+        self.desktop_id = desktop_id
+        self._name = name or desktop_id.removesuffix(".desktop")
+        self._icon = icon
+        self._commandline = commandline or desktop_id.removesuffix(".desktop")
+        self._categories = categories
+        self._filename = filename
+        self._should_show = should_show
+
+    def get_id(self) -> str:
+        return self.desktop_id
+
+    def get_display_name(self) -> str:
+        return self._name
+
+    def get_filename(self) -> str:
+        return self._filename
+
+    def get_icon(self) -> _Icon:
+        return _Icon(self._icon)
+
+    def get_startup_wm_class(self) -> str:
+        return self.desktop_id.removesuffix(".desktop")
+
+    def get_commandline(self) -> str:
+        return self._commandline
+
+    def get_categories(self) -> str:
+        return self._categories
+
+    def get_generic_name(self) -> str:
+        return ""
+
+    def get_description(self) -> str:
+        return ""
+
+    def get_keywords(self) -> tuple[str, ...]:
+        return ()
+
+    def list_actions(self) -> tuple[str, ...]:
+        return ()
+
+    def get_is_hidden(self) -> bool:
+        return False
+
+    def get_nodisplay(self) -> bool:
+        return False
+
+    def should_show(self) -> bool:
+        return self._should_show
+
+
+class ApplicationRegistryHarness:
+    """Mutable source driving the real application registry in integration tests."""
+
+    def __init__(self, applications: Iterable[object] = ()) -> None:
+        self.applications = list(applications)
+        self.registry = ApplicationRegistry(
+            application_source=lambda: tuple(self.applications),
+            desktop_directories_source=lambda: (),
+        )
+        self.registry._desktop_app_info_for_id = lambda _desktop_id: None
+        self.registry._desktop_app_info_from_filename = lambda _path: None
+        assert self.registry.refresh()
+
+    def publish(self, applications: Iterable[object]) -> None:
+        self.applications[:] = applications
+        assert self.registry.refresh()
 
 
 def application(

--- a/tests/platform/test_cinnamon_wayland.py
+++ b/tests/platform/test_cinnamon_wayland.py
@@ -43,7 +43,7 @@ def _layer_shell() -> SimpleNamespace:
     )
 
 
-def test_muffin_window_service_publishes_read_only_state(monkeypatch):
+def test_muffin_payload_flows_through_real_matcher_to_model():
     model = _model()
     client = SimpleNamespace(
         list_windows=MagicMock(
@@ -61,30 +61,21 @@ def test_muffin_window_service_publishes_read_only_state(monkeypatch):
             )
         )
     )
+    services = identity_services()
     service = MuffinWindowService(
         model=model,
-        **identity_services(),
+        **services,
         client=client,
-    )
-    application_match = ApplicationMatch(
-        desktop_id="firefox.desktop",
-        application=None,
-        evidence=MatchEvidence(
-            method=MatchMethod.DESKTOP_ID,
-            raw_app_id="firefox",
-        ),
-    )
-    match_result = MagicMock(return_value=application_match)
-    monkeypatch.setattr(
-        service._matcher,
-        "match_result",
-        match_result,
     )
 
     service.refresh()
 
-    match_result.assert_called_once_with("firefox", process_id=None)
-    assert service._windows[42].application_match is application_match
+    application_match = service._windows[42].application_match
+    assert application_match is not None
+    assert application_match.desktop_id == "firefox.desktop"
+    assert application_match.application is services["application_registry"].get(
+        "firefox.desktop"
+    )
     snapshot = service.list_windows("firefox.desktop")[0]
     assert snapshot.active is True
     assert snapshot.urgent is True

--- a/tests/platform/test_kwin_atspi_window.py
+++ b/tests/platform/test_kwin_atspi_window.py
@@ -6,23 +6,16 @@ from unittest.mock import MagicMock
 
 from docking.platform.applications.types import ApplicationMatch
 from docking.platform.backends.kwin import atspi_window
+from tests.platform.application_fakes import identity_services
 
 
 def _service() -> tuple[atspi_window.AtspiWindowService, MagicMock]:
-    registry = MagicMock()
-    registry.generation = 1
-    registry.get.return_value = None
-    registry.get.return_value = None
-    registry.resolve_all_by_wm_class.return_value = ()
-    process_identity_service = MagicMock()
-    process_identity_service.identity_for_pid.return_value = None
     model = MagicMock()
     model.visible_items.return_value = []
     return (
         atspi_window.AtspiWindowService(
             model=model,
-            application_registry=registry,
-            process_identity_service=process_identity_service,
+            **identity_services(),
         ),
         model,
     )
@@ -43,6 +36,23 @@ def test_kwin_fallback_is_represented_as_application_match() -> None:
     assert window.application_match.application is None
     running = model.update_running.call_args.kwargs["running"]
     assert tuple(running) == ("kwin:Unregistered",)
+
+
+def test_kwin_payload_flows_through_real_matcher_to_model() -> None:
+    service, model = _service()
+    window = atspi_window._AtspiWindow("window-1")
+    window.app_name = "Alacritty"
+    window.pid = 73
+    service._windows[window.window_id.value] = window
+
+    keep_source = service._publish_running()
+
+    assert not keep_source
+    assert window.application_match is not None
+    assert window.application_match.desktop_id == "Alacritty.desktop"
+    assert window.application_match.application is not None
+    running = model.update_running.call_args.kwargs["running"]
+    assert tuple(running) == ("Alacritty.desktop",)
 
 
 def test_kwin_start_and_stop_are_idempotent(monkeypatch) -> None:

--- a/tests/platform/test_wayfire_ipc.py
+++ b/tests/platform/test_wayfire_ipc.py
@@ -123,7 +123,7 @@ def test_wayfire_ipc_client_uses_length_prefixed_json():
     assert sock.closed is True
 
 
-def test_wayfire_window_service_publishes_snapshot_and_actions(monkeypatch):
+def test_wayfire_payload_with_pid_flows_through_real_matcher_to_model():
     model = _model()
     client = FakeIpcClient(
         {
@@ -152,17 +152,12 @@ def test_wayfire_window_service_publishes_snapshot_and_actions(monkeypatch):
             "window-rules/get-focused-view": {"result": "ok", "info": {"id": 7}},
         }
     )
+    services = identity_services()
     service = WayfireWindowService(
         model=model,
-        **identity_services(),
+        **services,
         client=client,
     )
-    application_match = service._matcher.match_result(
-        "Alacritty",
-        process_id=1234,
-    )
-    match_result = MagicMock(return_value=application_match)
-    monkeypatch.setattr(service._matcher, "match_result", match_result)
 
     service.start()
 
@@ -174,8 +169,12 @@ def test_wayfire_window_service_publishes_snapshot_and_actions(monkeypatch):
     assert windows[0].geometry is not None
     assert windows[0].workspace_id == "1"
     assert windows[0].can_minimize is True
-    assert service._records[7].application_match is application_match
-    match_result.assert_called_once_with("Alacritty", process_id=1234)
+    application_match = service._records[7].application_match
+    assert application_match is not None
+    assert application_match.desktop_id == "Alacritty.desktop"
+    assert application_match.application is services["application_registry"].get(
+        "Alacritty.desktop"
+    )
     model.update_running.assert_called()
 
     assert service.activate(windows[0].id) is ActionResult.OK

--- a/tests/ui/test_dnd_integration.py
+++ b/tests/ui/test_dnd_integration.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import stat
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock, call
+
+import pytest
 
 try:
     import gi  # noqa: F401
@@ -15,10 +18,13 @@ except ModuleNotFoundError:  # pragma: no cover
     sys.modules.setdefault("gi", gi_mock)
     sys.modules.setdefault("gi.repository", gi_mock.repository)
 
+import docking.platform.applications.launcher as launcher_mod
 import docking.ui.dnd as dnd_mod
 from docking.core.config import PinnedEntry
 from docking.core.items import APP_KIND, APPLET_KIND, FILE_KIND, FOLDER_KIND
 from docking.core.position import Position
+from docking.platform.applications.identity import LaunchProvenanceStore
+from docking.platform.applications.launcher import ApplicationLauncher
 from docking.platform.applications.types import (
     ApplicationInfo,
     ApplicationLocation,
@@ -26,6 +32,7 @@ from docking.platform.applications.types import (
 )
 from docking.platform.model import DockItem
 from docking.ui.geometry import Rect
+from tests.platform.application_fakes import ApplicationRegistryStub
 
 
 def _frame(*, item_index: int = -1, insert_index: int = 0, count: int = 1):
@@ -53,6 +60,7 @@ def _application(
     wm_class: str = "application",
     exec_line: str = "/usr/bin/application",
     desktop_file=None,
+    location: ApplicationLocation = ApplicationLocation.SANDBOX,
 ) -> ApplicationInfo:
     return ApplicationInfo(
         desktop_id=desktop_id,
@@ -61,7 +69,7 @@ def _application(
         wm_class=wm_class,
         exec_line=exec_line,
         origin=ApplicationOrigin.INSTALLED,
-        location=ApplicationLocation.SANDBOX,
+        location=location,
         desktop_file=desktop_file,
         executable_path=None,
         aliases=(),
@@ -195,6 +203,80 @@ def test_selected_app_uri_drop_uses_shared_application_launcher(monkeypatch):
         "item0.desktop",
         ["file:///tmp/document.txt"],
     )
+
+
+@pytest.mark.parametrize("launch_fails", [False, True], ids=["success", "failure"])
+def test_host_uri_drop_flows_through_real_launcher_without_pinning(
+    monkeypatch, tmp_path, launch_fails
+):
+    application = _application(
+        "viewer.desktop",
+        desktop_file=Path("/run/host/usr/share/applications/viewer.desktop"),
+        location=ApplicationLocation.HOST,
+    )
+    registry = ApplicationRegistryStub((application,))
+    popen = MagicMock()
+    if launch_fails:
+        popen.side_effect = OSError("host launch failed")
+    launcher = ApplicationLauncher(
+        registry,  # type: ignore[arg-type]
+        LaunchProvenanceStore(),
+        popen=popen,
+    )
+    monkeypatch.setattr(launcher_mod, "is_flatpak", lambda: True)
+    monkeypatch.setattr(
+        launcher_mod.flatpak,
+        "host_command",
+        lambda argv: ["flatpak-spawn", "--host", *argv],
+    )
+    handler = _make_handler(
+        monkeypatch,
+        application_registry=registry,
+        application_launcher=launcher,
+    )
+    handler._drag_from = -1
+    handler._drop_committed = True
+    handler.drop_insert_index = -1
+    app_item = DockItem("viewer.desktop", kind=APP_KIND)
+    handler._geometry_builder = SimpleNamespace(
+        build_frame=lambda **_kwargs: SimpleNamespace(
+            cursor_rect=Rect(0, 0, 400, 60),
+            item_geometries=(
+                SimpleNamespace(item=app_item, draw_rect=Rect(0, 0, 48, 48)),
+            ),
+        )
+    )
+    uris = [
+        (tmp_path / "one file.txt").as_uri(),
+        (tmp_path / "two.txt").as_uri(),
+    ]
+    selection = MagicMock()
+    selection.get_uris.return_value = uris
+    finish = MagicMock()
+    monkeypatch.setattr(dnd_mod.Gtk, "drag_finish", finish)
+
+    handler._on_drag_data_received(
+        handler._drawing_area,
+        MagicMock(),
+        10,
+        10,
+        selection,
+        1,
+        77,
+    )
+
+    assert popen.call_args.args[0] == [
+        "flatpak-spawn",
+        "--host",
+        "gio",
+        "launch",
+        "/usr/share/applications/viewer.desktop",
+        *uris,
+    ]
+    handler._model.insert_pinned_item.assert_not_called()
+    handler._model.insert_pinned_application.assert_not_called()
+    handler._target_service.resolve_file.assert_not_called()
+    finish.assert_called_once_with(ANY, not launch_fails, False, 77)
 
 
 class _FakeResponseDialog:


### PR DESCRIPTION
## Summary

- exercise Music handler fallback through the real application registry
- exercise DnD host URI routing through the real application launcher on success and failure
- verify one registry generation reaches Applications, Run Application, and Search
- carry Cinnamon, Wayfire PID, and KWin payloads through the real matcher into model publication