### PR TITLE
Show recent files in shared stack

### DIFF
--- a/docking/applets/recentfiles/applet.py
+++ b/docking/applets/recentfiles/applet.py
@@ -25,12 +25,14 @@ gi.require_version("Gtk", "3.0")
 gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GdkPixbuf, GLib, Gtk
 
-from docking.applets.base import Applet
+from docking.applets.base import TargetServicesApplet
 from docking.applets.menu import menu_sections
 from docking.applets.recentfiles import meta
 from docking.i18n import _
 from docking.log import get_logger, with_context
-from docking.platform import targets
+from docking.platform.icons import IconLoader
+from docking.platform.targets import TargetService
+from docking.ui.stack import StackContent, StackEntry
 
 from .render import render_icon
 from .state import MAX_ENTRIES, RecentEntry, tooltip_text, truncate_name
@@ -41,18 +43,30 @@ if TYPE_CHECKING:
 log = with_context(get_logger(name="recentfiles"), applet_id=meta.id)
 
 
-class RecentFilesApplet(Applet):
-    """Shows recently opened files; click opens the most recent."""
+class RecentFilesApplet(TargetServicesApplet):
+    """Show recently opened files through the reusable item stack."""
 
     id = meta.id
     name = _("Recent Files")
     icon_name = "document-open-recent"
 
-    def __init__(self, icon_size: int, config: Config) -> None:
+    def __init__(
+        self,
+        icon_size: int,
+        config: Config,
+        *,
+        icon_loader: IconLoader,
+        target_service: TargetService,
+    ) -> None:
         self._entries: list[RecentEntry] = []
         self._signal_id: int | None = None
         self._refresh_entries()
-        super().__init__(icon_size, config)
+        super().__init__(
+            icon_size=icon_size,
+            config=config,
+            icon_loader=icon_loader,
+            target_service=target_service,
+        )
         self.present()
 
     def create_icon(self, size: int) -> GdkPixbuf.Pixbuf | None:
@@ -60,6 +74,22 @@ class RecentFilesApplet(Applet):
 
     def refresh_tooltip(self) -> None:
         self.item.name = tooltip_text(entries=self._entries)
+
+    def stack_content(self, icon_size: int) -> StackContent | None:
+        """Return the current recent-file snapshot for the shared stack popup."""
+        if not self._entries:
+            return None
+        return StackContent(
+            entries=tuple(
+                StackEntry(
+                    key=entry.uri,
+                    label=entry.name,
+                    icon=self._stack_icon(entry=entry, size=icon_size),
+                    activate=lambda uri=entry.uri: self._open_uri(uri=uri),
+                )
+                for entry in self._entries
+            ),
+        )
 
     def start(self, notify: Callable[[], None]) -> None:
         super().start(notify)
@@ -77,8 +107,7 @@ class RecentFilesApplet(Applet):
         """Open the most recent file."""
         if not self._entries:
             return
-        uri = self._entries[0].uri
-        targets.open_target(uri)
+        self._open_uri(uri=self._entries[0].uri)
 
     def get_menu_items(self) -> list[Gtk.MenuItem]:
         primary: list[Gtk.MenuItem] = []
@@ -111,7 +140,18 @@ class RecentFilesApplet(Applet):
         self.present()
 
     def _open_uri(self, *, uri: str) -> None:
-        targets.open_target(uri)
+        self._target_service.open_target(uri)
+
+    def _stack_icon(
+        self,
+        *,
+        entry: RecentEntry,
+        size: int,
+    ) -> GdkPixbuf.Pixbuf | None:
+        target = self._target_service.resolve_file(entry.uri, size)
+        if target is not None and target.icon is not None:
+            return target.icon
+        return self._icon_loader.load_icon("text-x-generic", size)
 
     def _clear_recent(self) -> None:
         try:

--- a/tests/applets/test_recentfiles.py
+++ b/tests/applets/test_recentfiles.py
@@ -1,5 +1,6 @@
 """Tests for the Recent Files applet."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from docking.applets.recentfiles.state import (
@@ -9,6 +10,21 @@ from docking.applets.recentfiles.state import (
     truncate_name,
 )
 from docking.core.config import Config
+
+
+def _applet(applet_class):
+    icon_loader = MagicMock()
+    icon_loader.load_icon.return_value = None
+    target_service = MagicMock()
+    target_service.icon_loader = icon_loader
+    target_service.resolve_file.return_value = None
+    target_service.open_target.return_value = False
+    return applet_class(
+        48,
+        config=Config(),
+        icon_loader=icon_loader,
+        target_service=target_service,
+    )
 
 
 class TestState:
@@ -101,7 +117,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48, config=Config())
+            applet = _applet(RecentFilesApplet)
 
         # Then
         assert len(applet._entries) == 2
@@ -118,7 +134,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48, config=Config())
+            applet = _applet(RecentFilesApplet)
 
         # Then
         assert applet._entries == []
@@ -137,11 +153,82 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48, config=Config())
+            applet = _applet(RecentFilesApplet)
 
         # Then only existing entries kept
         assert len(applet._entries) == 1
         assert applet._entries[0].name == "a.txt"
+
+    def test_stack_lists_recent_files_with_target_icons_and_opens_selection(self):
+        manager = MagicMock()
+        manager.get_items.return_value = [
+            self._make_recent_info("a.txt", "file:///a.txt", 200),
+            self._make_recent_info("b.txt", "file:///b.txt", 100),
+        ]
+        with patch(
+            "docking.applets.recentfiles.applet.Gtk.RecentManager.get_default",
+            return_value=manager,
+        ):
+            from docking.applets.recentfiles.applet import RecentFilesApplet
+
+            applet = _applet(RecentFilesApplet)
+        icons = {
+            "file:///a.txt": object(),
+            "file:///b.txt": object(),
+        }
+        applet._target_service.resolve_file.side_effect = lambda uri, _size: (
+            SimpleNamespace(icon=icons[uri])
+        )
+
+        content = applet.stack_content(32)
+
+        assert content is not None
+        assert [entry.key for entry in content.entries] == [
+            "file:///a.txt",
+            "file:///b.txt",
+        ]
+        assert [entry.label for entry in content.entries] == ["a.txt", "b.txt"]
+        assert [entry.icon for entry in content.entries] == list(icons.values())
+        content.entries[1].activate()
+        applet._target_service.open_target.assert_called_once_with("file:///b.txt")
+
+    def test_empty_stack_is_suppressed(self):
+        manager = MagicMock()
+        manager.get_items.return_value = []
+        with patch(
+            "docking.applets.recentfiles.applet.Gtk.RecentManager.get_default",
+            return_value=manager,
+        ):
+            from docking.applets.recentfiles.applet import RecentFilesApplet
+
+            applet = _applet(RecentFilesApplet)
+
+        assert applet.stack_content(32) is None
+
+    def test_recent_manager_change_refreshes_live_stack(self):
+        manager = MagicMock()
+        manager.get_items.return_value = [
+            self._make_recent_info("a.txt", "file:///a.txt", 200),
+        ]
+        with patch(
+            "docking.applets.recentfiles.applet.Gtk.RecentManager.get_default",
+            return_value=manager,
+        ):
+            from docking.applets.recentfiles.applet import RecentFilesApplet
+
+            applet = _applet(RecentFilesApplet)
+            notify = MagicMock()
+            applet.start(notify)
+            manager.get_items.return_value = [
+                self._make_recent_info("b.txt", "file:///b.txt", 300),
+            ]
+
+            applet._on_changed(manager)
+
+        content = applet.stack_content(32)
+        assert content is not None
+        assert [entry.label for entry in content.entries] == ["b.txt"]
+        notify.assert_called_once()
 
     def test_on_clicked_opens_most_recent(self):
         # Given
@@ -155,16 +242,13 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48, config=Config())
+            applet = _applet(RecentFilesApplet)
 
         # When
-        with patch(
-            "docking.applets.recentfiles.applet.targets.open_target"
-        ) as open_target:
-            applet.on_clicked()
+        applet.on_clicked()
 
         # Then
-        open_target.assert_called_once_with("file:///a.txt")
+        applet._target_service.open_target.assert_called_once_with("file:///a.txt")
 
     def test_on_clicked_noop_when_empty(self):
         # Given no entries
@@ -176,16 +260,13 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48, config=Config())
+            applet = _applet(RecentFilesApplet)
 
         # When
-        with patch(
-            "docking.applets.recentfiles.applet.targets.open_target"
-        ) as open_target:
-            applet.on_clicked()
+        applet.on_clicked()
 
         # Then
-        open_target.assert_not_called()
+        applet._target_service.open_target.assert_not_called()
 
     def test_on_clicked_handles_launch_error(self):
         # Given
@@ -199,14 +280,10 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48, config=Config())
+            applet = _applet(RecentFilesApplet)
 
         # When / Then (no exception raised)
-        with patch(
-            "docking.applets.recentfiles.applet.targets.open_target",
-            return_value=False,
-        ):
-            applet.on_clicked()
+        applet.on_clicked()
 
     def test_get_menu_items_with_entries(self):
         # Given
@@ -221,7 +298,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48, config=Config())
+            applet = _applet(RecentFilesApplet)
 
         # When
         items = applet.get_menu_items()
@@ -239,7 +316,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48, config=Config())
+            applet = _applet(RecentFilesApplet)
 
         # When
         items = applet.get_menu_items()
@@ -259,7 +336,7 @@ class TestApplet:
         ):
             from docking.applets.recentfiles.applet import RecentFilesApplet
 
-            applet = RecentFilesApplet(48, config=Config())
+            applet = _applet(RecentFilesApplet)
 
             # When start
             applet.start(lambda: None)


### PR DESCRIPTION
## Summary

- present Recent Files through the same reusable curved stack used by Devices and folder items
- resolve per-file icons and activation through the shared target and icon services
- refresh an open stack when Gtk.RecentManager changes and suppress it when empty
- preserve the existing context menu and direct-click fallback behavior