### PR TITLE
Apply safe platform cleanup simplifications

### DIFF
--- a/docking/platform/backends/x11/services/windows.py
+++ b/docking/platform/backends/x11/services/windows.py
@@ -105,14 +105,6 @@ class X11WindowService(WindowTracker, WindowService):
             return ActionResult.NOT_FOUND
         return super().close_all(desktop_id=desktop_id)
 
-    def close_focused(self, desktop_id: str) -> ActionResult:
-        """Close the active window for a desktop ID."""
-        return super().close_focused(desktop_id=desktop_id)
-
-    def toggle_focus(self, desktop_id: str) -> ActionResult:
-        """Toggle focus/minimize behavior for a desktop ID."""
-        return super().toggle_focus(desktop_id=desktop_id)
-
     def window_for_id(self, window_id: WindowId) -> Wnck.Window | None:
         """Resolve a live Wnck window by backend-neutral X11 window ID."""
         xid = self._xid_from_window_id(window_id)

--- a/docking/platform/model.py
+++ b/docking/platform/model.py
@@ -1098,16 +1098,6 @@ class DockModel:
                 return item
         return None
 
-    def matching_icon_items(self, item: DockItem) -> list[DockItem]:
-        """Return visible model-owned items sharing an icon preference key."""
-        key = icon_overrides.item_icon_key(item=item)
-        return [
-            candidate
-            for candidate in self.pinned_items + self._recent_apps + self._transient
-            if candidate.kind in {APP_KIND, FILE_KIND, FOLDER_KIND}
-            and icon_overrides.item_icon_key(item=candidate) == key
-        ]
-
     def set_custom_icon(self, item: DockItem, path: Path) -> bool:
         """Persist a custom icon for a pinned normal item and refresh matches."""
         if not self._can_edit_custom_icon(item=item):
@@ -1138,8 +1128,15 @@ class DockModel:
 
     def refresh_item_icons(self, item: DockItem) -> None:
         """Refresh icon fields for all model items sharing the same preference key."""
+        key = icon_overrides.item_icon_key(item=item)
+        candidates = [
+            candidate
+            for candidate in self.pinned_items + self._recent_apps + self._transient
+            if candidate.kind in {APP_KIND, FILE_KIND, FOLDER_KIND}
+            and icon_overrides.item_icon_key(item=candidate) == key
+        ]
         refreshed = False
-        for candidate in self.matching_icon_items(item=item):
+        for candidate in candidates:
             self._default_icon_for_item(item=candidate)
             self._apply_icon_override(item=candidate)
             refreshed = True

--- a/docking/platform/targets.py
+++ b/docking/platform/targets.py
@@ -127,15 +127,10 @@ def default_directory_app_name() -> str | None:
 
 
 class TargetService:
-    """Resolve target metadata using one composed icon-loading service."""
+    """Resolve target metadata using its owned icon-loading service."""
 
     def __init__(self, *, icon_loader: IconLoader) -> None:
         self._icon_loader = icon_loader
-
-    @property
-    def icon_loader(self) -> IconLoader:
-        """Return the icon loader shared by target metadata resolution."""
-        return self._icon_loader
 
     def normalize_file_target(self, target: str) -> str | None:
         """Delegate target normalization to the canonical module function."""

--- a/docking/ui/folder/_browser.py
+++ b/docking/ui/folder/_browser.py
@@ -109,7 +109,6 @@ class FolderBrowser:
         target_service: TargetService,
     ) -> None:
         self._target_service = target_service
-        self._icon_loader = target_service.icon_loader
         self._directory_rows: dict[tuple[str, int, bool, int], list[FolderRow]] = {}
 
     @staticmethod
@@ -231,7 +230,7 @@ class FolderBrowser:
                     size=int(info.get_size()),
                     created=int(info.get_attribute_uint64("time::created")),
                     modified=int(info.get_attribute_uint64("time::modified")),
-                    icon=self._icon_loader.resolve_file_icon(
+                    icon=self._target_service.resolve_file_icon(
                         target=child_uri,
                         gicon=icon,
                         content_type=info.get_content_type() or "",

--- a/docking/ui/folder/stack.py
+++ b/docking/ui/folder/stack.py
@@ -141,7 +141,6 @@ class FolderStackController(StackPopupController):
             dock_window=dock_window,
         )
         self._target_service = target_service
-        self._icon_loader = target_service.icon_loader
         self._browser = FolderBrowser(
             target_service=target_service,
         )

--- a/tests/applets/test_devices.py
+++ b/tests/applets/test_devices.py
@@ -137,7 +137,6 @@ def _applet(
     )
     icon_loader = MagicMock()
     target_service = MagicMock()
-    target_service.icon_loader = icon_loader
     target_service.open_target.return_value = False
     return DevicesApplet(
         48,

--- a/tests/applets/test_recentfiles.py
+++ b/tests/applets/test_recentfiles.py
@@ -16,7 +16,6 @@ def _applet(applet_class):
     icon_loader = MagicMock()
     icon_loader.load_icon.return_value = None
     target_service = MagicMock()
-    target_service.icon_loader = icon_loader
     target_service.resolve_file.return_value = None
     target_service.open_target.return_value = False
     return applet_class(

--- a/tests/integration/test_recent_apps_flow.py
+++ b/tests/integration/test_recent_apps_flow.py
@@ -68,7 +68,7 @@ def _make_dependencies(*desktop_ids: str) -> _ModelDependencies:
         application_registry=registry,
         application_launcher=MagicMock(),
         icon_loader=icon_loader,
-        target_service=MagicMock(icon_loader=icon_loader),
+        target_service=MagicMock(),
     )
 
 

--- a/tests/platform/test_model.py
+++ b/tests/platform/test_model.py
@@ -74,7 +74,7 @@ def _make_dependencies(*desktop_ids: str) -> _ModelDependencies:
         application_registry=registry,
         application_launcher=MagicMock(),
         icon_loader=icon_loader,
-        target_service=MagicMock(icon_loader=icon_loader),
+        target_service=MagicMock(),
     )
 
 

--- a/tests/platform/test_x11_window_service.py
+++ b/tests/platform/test_x11_window_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -19,6 +20,10 @@ from docking.core.config import Config
 from docking.platform.applications.running import RunningAppInfo
 from docking.platform.backends.base import ActionResult, DisplayServer, WindowId
 from docking.platform.backends.x11.services.windows import X11WindowService
+
+
+def test_window_service_remains_concrete() -> None:
+    assert not inspect.isabstract(X11WindowService)
 
 
 class FakeWorkspace:

--- a/tests/search/test_controller.py
+++ b/tests/search/test_controller.py
@@ -209,7 +209,7 @@ def _make_controller(
         )
 
     icon_loader = MagicMock()
-    target_service = MagicMock(icon_loader=icon_loader)
+    target_service = MagicMock()
     active_registry = (
         applications if application_registry is None else application_registry
     )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -402,7 +402,6 @@ class TestAppMain:
         application_launcher = model_cls.call_args.kwargs["application_launcher"]
         icon_loader = model_cls.call_args.kwargs["icon_loader"]
         target_service = model_cls.call_args.kwargs["target_service"]
-        assert target_service.icon_loader is icon_loader
         assert application_launcher.registry is registry
         assert application_launcher.provenance_store is not None
         process_identity_service = app_mod.create_session_backend.call_args.kwargs[
@@ -790,7 +789,6 @@ class TestAppMain:
         application_launcher = factory.call_args.kwargs["application_launcher"]
         icon_loader = factory.call_args.kwargs["icon_loader"]
         target_service = factory.call_args.kwargs["target_service"]
-        assert target_service.icon_loader is icon_loader
         factory.assert_called_once()
         assert factory.call_args.kwargs["application_registry"] is registry
         assert factory.call_args.kwargs["application_launcher"] is application_launcher

--- a/tests/ui/test_factory.py
+++ b/tests/ui/test_factory.py
@@ -156,7 +156,7 @@ class TestBuildDockWindow:
         application_registry = MagicMock()
         application_launcher = MagicMock()
         icon_loader = MagicMock()
-        target_service = MagicMock(icon_loader=icon_loader)
+        target_service = MagicMock()
         preview_service = MagicMock()
         surface_service = MagicMock()
         visibility_service = MagicMock()
@@ -285,7 +285,6 @@ class TestBuildDockWindow:
             factory_mod.FolderStackController.call_args.kwargs["target_service"]
             is target_service
         )
-        assert target_service.icon_loader is icon_loader
         assert (
             factory_mod.DnDHandler.call_args.kwargs["application_registry"]
             is application_registry

--- a/tests/ui/test_menu_integration.py
+++ b/tests/ui/test_menu_integration.py
@@ -767,8 +767,7 @@ def handler(monkeypatch):
     application_registry = MagicMock()
     application_launcher = MagicMock()
     application_launcher.quicklist_actions.return_value = []
-    icon_loader = MagicMock()
-    target_service = MagicMock(icon_loader=icon_loader)
+    target_service = MagicMock()
     target_service.normalize_file_target.side_effect = lambda target: (
         targets_mod.normalize_file_target(target)
     )
@@ -1105,9 +1104,7 @@ class TestItemMenus:
             "directory_has_visible_children",
             lambda **_kwargs: False,
         )
-        handler._folder_stack._icon_loader.resolve_file_icon.return_value = (
-            "folder-pixbuf"
-        )
+        handler._target_service.resolve_file_icon.return_value = "folder-pixbuf"
         item = DockItem(
             desktop_id="file:///tmp/root",
             kind=FOLDER_KIND,
@@ -1120,7 +1117,7 @@ class TestItemMenus:
         )
 
         assert rows[0]["icon"] == "folder-pixbuf"
-        handler._folder_stack._icon_loader.resolve_file_icon.assert_called_once_with(
+        handler._target_service.resolve_file_icon.assert_called_once_with(
             target="file:///tmp/docs",
             gicon=gicon,
             content_type="inode/directory",
@@ -1154,9 +1151,7 @@ class TestItemMenus:
             "directory_has_visible_children",
             lambda **_kwargs: False,
         )
-        handler._folder_stack._icon_loader.resolve_file_icon.return_value = (
-            "folder-pixbuf"
-        )
+        handler._target_service.resolve_file_icon.return_value = "folder-pixbuf"
         item = DockItem(
             desktop_id="file:///tmp/root",
             kind=FOLDER_KIND,
@@ -1173,7 +1168,7 @@ class TestItemMenus:
 
         assert first == second
         folder.enumerate_children.assert_called_once()
-        handler._folder_stack._icon_loader.resolve_file_icon.assert_called_once()
+        handler._target_service.resolve_file_icon.assert_called_once()
 
     def test_file_item_menu_opens_target(self, handler, monkeypatch):
         menu = FakeMenu()

--- a/tests/ui/test_pointer_scenarios.py
+++ b/tests/ui/test_pointer_scenarios.py
@@ -174,7 +174,7 @@ class _ScenarioHarness:
         self.application_registry.resolve_by_desktop_file.return_value = None
         self.application_launcher = MagicMock()
         self.icon_loader = MagicMock()
-        self.target_service = MagicMock(icon_loader=self.icon_loader)
+        self.target_service = MagicMock()
         self.window_tracker = MagicMock()
         self.dnd = DnDHandler(
             drawing_area=self.drawing_area,

--- a/tests/visual/render_cases.py
+++ b/tests/visual/render_cases.py
@@ -248,8 +248,7 @@ def _folder_stack_handler() -> MenuHandler:
         item_prefs={},
         save=MagicMock(),
     )
-    icon_loader = MagicMock()
-    target_service = MagicMock(icon_loader=icon_loader)
+    target_service = MagicMock()
     target_service.default_directory_app_name.return_value = "Caja"
     runtime = MagicMock()
     folder_stack = FolderStackController(


### PR DESCRIPTION
## Summary

- Remove redundant X11 forwarding overrides and internal icon-loader escape hatches
- inline the single-use icon matching helper while preserving eager snapshot behavior
- update tests and mocks, including an assertion that the X11 window service remains concrete