### PR TITLE
Move Python 3.10 CI to Debian 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,9 +309,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - debian: "11"
+          - debian: "12"
             python: "3.10"
-            image: python:3.10-bullseye
+            image: python:3.10-bookworm
           - debian: "12"
             python: "3.12"
             image: python:3.12-bookworm


### PR DESCRIPTION
## Summary

- preserve Python 3.10 test coverage
- replace the EOL Debian 11 Bullseye container with Debian 12 Bookworm
- keep the existing Debian 12 Python 3.12 and 3.14 coverage unchanged

## Reason

Debian 11 LTS reached end-of-life on August 31, 2026. Its security metadata is now expired, causing apt installation to fail before project tests run.

Official notice: https://www.debian.org/News/2026/20260831

## Validation

- verified the official python:3.10-bookworm multi-architecture image exists
- parsed the updated workflow as YAML
- repository pre-commit hook passed
- full local suite: 4,914 passed, 1 skipped, 18 deselected