### PR TITLE
Update AI Usage for Astra and latest Claude models

### DIFF
--- a/docking/applets/aiusage/state.py
+++ b/docking/applets/aiusage/state.py
@@ -42,28 +42,39 @@ class DisplayMode(str, Enum):
 # Pricing tables
 # ---------------------------------------------------------------------------
 
-# Standard API rates in USD per million tokens. Claude cache_write represents
-# the five-minute write rate; the transcript format does not identify one-hour
-# writes. Cache reads are billed at 10% of the base input rate for both APIs.
-# Ordered most-specific first so versioned matches win.
+# Standard short-context API rates in USD per million tokens. Claude
+# cache_write represents the five-minute write rate; the transcript format does
+# not identify one-hour writes. Cache reads are normally billed at 10% of the
+# base input rate; Claude Fable 5.1 is the exception at 2.5%. Ordered
+# most-specific first so versioned matches win.
 #
-# Sources verified 2026-07-09:
+# Sources verified 2026-09-10:
 # https://platform.claude.com/docs/en/about-claude/pricing
-# https://openai.com/index/previewing-gpt-5-6-sol/
+# https://platform.claude.com/docs/en/models/fable-5-1/overview
+# https://developers.openai.com/api/docs/models
 _OPUS46 = {"input": 5.0, "output": 25.0, "cache_write": 6.25, "cache_read": 0.50}
 _OPUS4 = {"input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50}
 _FABLE5 = {"input": 10.0, "output": 50.0, "cache_write": 12.50, "cache_read": 1.0}
+_FABLE51 = {
+    "input": 10.0,
+    "output": 50.0,
+    "cache_write": 12.50,
+    "cache_read": 0.25,
+}
 
 CLAUDE_PRICING: tuple[tuple[str, dict[str, float]], ...] = (
+    ("fable-5-1", _FABLE51),
+    ("mythos-5-1", _FABLE51),
     ("fable-5", _FABLE5),
     ("mythos-5", _FABLE5),
+    ("opus-5", _OPUS46),
     ("opus-4-8", _OPUS46),
     ("opus-4-7", _OPUS46),
     ("opus-4-6", _OPUS46),
     ("opus-4-5", _OPUS46),
     ("opus-4-1", _OPUS4),
     ("opus-4", _OPUS4),
-    # Anthropic's introductory Sonnet 5 rate is published through 2026-08-31.
+    # Anthropic made Sonnet 5's introductory rate the standard rate.
     ("sonnet-5", {"input": 2, "output": 10, "cache_write": 2.50, "cache_read": 0.20}),
     ("sonnet-4-6", {"input": 3, "output": 15, "cache_write": 3.75, "cache_read": 0.30}),
     ("sonnet-4-5", {"input": 3, "output": 15, "cache_write": 3.75, "cache_read": 0.30}),
@@ -76,9 +87,10 @@ CLAUDE_PRICING: tuple[tuple[str, dict[str, float]], ...] = (
 # Models without a cached-input price use their regular input rate as a
 # defensive fallback; their usage records should not contain cached tokens.
 CODEX_PRICING: tuple[tuple[str, dict[str, float]], ...] = (
-    ("gpt-5.6-sol", {"input": 5.00, "cached": 0.50, "output": 30.00}),
-    ("gpt-5.6-terra", {"input": 2.50, "cached": 0.25, "output": 15.00}),
-    ("gpt-5.6-luna", {"input": 1.00, "cached": 0.10, "output": 6.00}),
+    ("gpt-6-astra", {"input": 10.00, "cached": 1.00, "output": 50.00}),
+    ("gpt-5.6-sol", {"input": 4.00, "cached": 0.40, "output": 20.00}),
+    ("gpt-5.6-terra", {"input": 2.00, "cached": 0.20, "output": 12.00}),
+    ("gpt-5.6-luna", {"input": 0.20, "cached": 0.02, "output": 1.20}),
     ("gpt-5.5-pro", {"input": 30.00, "cached": 30.00, "output": 180.00}),
     ("gpt-5.5", {"input": 5.00, "cached": 0.50, "output": 30.00}),
     ("gpt-5.4-pro", {"input": 30.00, "cached": 30.00, "output": 180.00}),

--- a/tests/applets/test_aiusage.py
+++ b/tests/applets/test_aiusage.py
@@ -280,8 +280,17 @@ class TestProvider:
 
 
 class TestClaudeCost:
+    def test_match_fable_5_1_before_fable_5(self):
+        assert match_model_tier(model="claude-fable-5-1") == "fable-5-1"
+
+    def test_match_mythos_5_1_before_mythos_5(self):
+        assert match_model_tier(model="claude-mythos-5-1") == "mythos-5-1"
+
     def test_match_fable_5(self):
         assert match_model_tier(model="claude-fable-5") == "fable-5"
+
+    def test_match_opus_5(self):
+        assert match_model_tier(model="claude-opus-5") == "opus-5"
 
     def test_match_opus_4_6(self):
         assert match_model_tier(model="claude-opus-4-6") == "opus-4-6"
@@ -296,6 +305,18 @@ class TestClaudeCost:
     def test_cost_for_fable_5(self):
         usage = ModelUsage(input_tokens=1_000_000, output_tokens=1_000_000)
         assert cost_for_usage(model="claude-fable-5", usage=usage) == 60.0
+
+    def test_cost_for_fable_5_1_uses_lower_cache_read_rate(self):
+        usage = ModelUsage(cache_write_tokens=1_000_000, cache_read_tokens=1_000_000)
+        assert cost_for_usage(model="claude-fable-5-1", usage=usage) == 12.75
+
+    def test_cost_for_opus_5(self):
+        usage = ModelUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+        assert cost_for_usage(model="claude-opus-5", usage=usage) == 30.0
+
+    def test_cost_for_sonnet_5_standard_rate(self):
+        usage = ModelUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+        assert cost_for_usage(model="claude-sonnet-5", usage=usage) == 12.0
 
     def test_cost_for_opus_4_legacy(self):
         usage = ModelUsage(input_tokens=1_000_000)
@@ -321,6 +342,9 @@ class TestClaudeCost:
 
 
 class TestCodexCost:
+    def test_match_gpt_6_astra(self):
+        assert match_model_tier(model="gpt-6-astra") == "gpt-6-astra"
+
     def test_match_gpt_5_6_terra(self):
         assert match_model_tier(model="gpt-5.6-terra") == "gpt-5.6-terra"
 
@@ -352,7 +376,23 @@ class TestCodexCost:
             cache_read_tokens=500_000,
             output_tokens=1_000_000,
         )
-        assert cost_for_usage(model="gpt-5.6-luna", usage=usage) == 6.55
+        assert cost_for_usage(model="gpt-5.6-luna", usage=usage) == 1.31
+
+    def test_cost_gpt5_6_sol(self):
+        usage = ModelUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+        assert cost_for_usage(model="gpt-5.6-sol", usage=usage) == 24.0
+
+    def test_cost_gpt5_6_terra(self):
+        usage = ModelUsage(input_tokens=1_000_000, output_tokens=1_000_000)
+        assert cost_for_usage(model="gpt-5.6-terra", usage=usage) == 14.0
+
+    def test_cost_gpt6_astra(self):
+        usage = ModelUsage(
+            input_tokens=1_000_000,
+            cache_read_tokens=500_000,
+            output_tokens=1_000_000,
+        )
+        assert cost_for_usage(model="gpt-6-astra", usage=usage) == 55.5
 
     def test_day_cost_mixed_providers(self):
         entry = DayEntry(


### PR DESCRIPTION
## Summary

- add GPT-6 Astra pricing to the AI Usage applet
- add Claude Fable 5.1, Mythos 5.1, and Opus 5 pricing, including the reduced Fable 5.1 cache-read rate
- refresh GPT-5.6 Sol, Terra, and Luna prices and record the permanent Claude Sonnet 5 rate
- add regression coverage for model-tier ordering and cost calculations

## Sources

- https://developers.openai.com/api/docs/pricing
- https://developers.openai.com/api/docs/models/gpt-6-astra
- https://platform.claude.com/docs/en/models/fable-5-1/overview
- https://platform.claude.com/docs/en/models/opus-5/overview
- https://claude.com/pricing